### PR TITLE
Make `isReferenced` return false for method parameter name

### DIFF
--- a/packages/babel-types/src/validators/isReferenced.js
+++ b/packages/babel-types/src/validators/isReferenced.js
@@ -67,7 +67,7 @@ export default function isReferenced(
       if (parent.value === node) {
         return !grandparent || grandparent.type !== "ObjectPattern";
       }
-      if (parent.params && parent.params.indexOf(node) !== -1) {
+      if (parent.params.includes(node)) {
         return false;
       }
       return true;

--- a/packages/babel-types/src/validators/isReferenced.js
+++ b/packages/babel-types/src/validators/isReferenced.js
@@ -45,6 +45,15 @@ export default function isReferenced(
     case "PrivateName":
       return false;
 
+    // no: class { NODE() {} }
+    // yes: class { [NODE]() {} }
+    // no: class { foo(NODE) {} }
+    case "ClassMethod":
+    case "ClassPrivateMethod":
+    case "ObjectMethod":
+      if (parent.params.includes(node)) {
+        return false;
+      }
     // yes: { [NODE]: "" }
     // no: { NODE: "" }
     // depends: { NODE }
@@ -55,20 +64,11 @@ export default function isReferenced(
     // yes: class { key = NODE; }
     case "ClassProperty":
     case "ClassPrivateProperty":
-    // no: class { NODE() {} }
-    // yes: class { [NODE]() {} }
-    // no: class { foo(NODE) {} }
-    case "ClassMethod":
-    case "ClassPrivateMethod":
-    case "ObjectMethod":
       if (parent.key === node) {
         return !!parent.computed;
       }
       if (parent.value === node) {
         return !grandparent || grandparent.type !== "ObjectPattern";
-      }
-      if (parent.params.includes(node)) {
-        return false;
       }
       return true;
 

--- a/packages/babel-types/src/validators/isReferenced.js
+++ b/packages/babel-types/src/validators/isReferenced.js
@@ -67,12 +67,8 @@ export default function isReferenced(
       if (parent.value === node) {
         return !grandparent || grandparent.type !== "ObjectPattern";
       }
-      if (parent.params) {
-        for (const param of parent.params) {
-          if (param === node) {
-            return false;
-          }
-        }
+      if (parent.params && parent.params.indexOf(node) !== -1) {
+        return false;
       }
       return true;
 

--- a/packages/babel-types/src/validators/isReferenced.js
+++ b/packages/babel-types/src/validators/isReferenced.js
@@ -54,6 +54,8 @@ export default function isReferenced(
       if (parent.params.includes(node)) {
         return false;
       }
+    // Fall-through to next case clause to check whether the node is the method's name.
+
     // yes: { [NODE]: "" }
     // no: { NODE: "" }
     // depends: { NODE }

--- a/packages/babel-types/src/validators/isReferenced.js
+++ b/packages/babel-types/src/validators/isReferenced.js
@@ -57,6 +57,7 @@ export default function isReferenced(
     case "ClassPrivateProperty":
     // no: class { NODE() {} }
     // yes: class { [NODE]() {} }
+    // no: class { foo(NODE) {} }
     case "ClassMethod":
     case "ClassPrivateMethod":
     case "ObjectMethod":
@@ -65,6 +66,13 @@ export default function isReferenced(
       }
       if (parent.value === node) {
         return !grandparent || grandparent.type !== "ObjectPattern";
+      }
+      if (parent.params) {
+        for (const param of parent.params) {
+          if (param === node) {
+            return false;
+          }
+        }
       }
       return true;
 

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -179,6 +179,74 @@ describe("validators", function() {
         expect(t.isReferenced(node, parent)).toBe(true);
       });
     });
+
+    describe("ObjectMethod", function() {
+      it("returns false if node is method key", function() {
+        const node = t.identifier("A");
+        const parent = t.objectMethod("method", node, [], t.blockStatement([]));
+
+        expect(t.isReferenced(node, parent)).toBe(false);
+      });
+
+      it("returns true if node is computed method key", function() {
+        const node = t.identifier("A");
+        const parent = t.objectMethod(
+          "method",
+          node,
+          [],
+          t.blockStatement([]),
+          true,
+        );
+
+        expect(t.isReferenced(node, parent)).toBe(true);
+      });
+
+      it("returns false if node is method param", function() {
+        const node = t.identifier("A");
+        const parent = t.objectMethod(
+          "method",
+          t.identifier("foo"),
+          [node],
+          t.blockStatement([]),
+        );
+
+        expect(t.isReferenced(node, parent)).toBe(false);
+      });
+    });
+
+    describe("ClassMethod", function() {
+      it("returns false if node is method key", function() {
+        const node = t.identifier("A");
+        const parent = t.classMethod("method", node, [], t.blockStatement([]));
+
+        expect(t.isReferenced(node, parent)).toBe(false);
+      });
+
+      it("returns true if node is computed method key", function() {
+        const node = t.identifier("A");
+        const parent = t.classMethod(
+          "method",
+          node,
+          [],
+          t.blockStatement([]),
+          true,
+        );
+
+        expect(t.isReferenced(node, parent)).toBe(true);
+      });
+
+      it("returns false if node is method param", function() {
+        const node = t.identifier("A");
+        const parent = t.classMethod(
+          "method",
+          t.identifier("foo"),
+          [node],
+          t.blockStatement([]),
+        );
+
+        expect(t.isReferenced(node, parent)).toBe(false);
+      });
+    });
   });
 
   describe("isBinding", function() {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11087 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The `isReferenced` method (if I understand correctly) tries to determine if a given node is a reference to the value stored in some variable, as opposed to being e.g. a declaration of a variable or the left-hand-side of an assignment. As described in issue #11087, it currently misidentifies method parameter names as references; this fixes that.

The logic in `isReferenced` is based on the type of the parent node, and currently Object/ClassProperty and Object/Class(Private)Method parent nodes are handled by the same case block. That block checks for when the child node is the `key` of the property/method node, and for when it's part of an ObjectPattern, but otherwise returns true. This change adds a check for when the child node is part of the `params` list of the parent node.