### PR TITLE
Fix Async Generic After Await Parsing Error

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1532,7 +1532,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const oldMaybeInArrowParameters = this.state.maybeInArrowParameters;
       const oldYieldPos = this.state.yieldPos;
       const oldAwaitPos = this.state.awaitPos;
-      this.state.maybeInArrowParameters = false;
+      this.state.maybeInArrowParameters = true;
       this.state.yieldPos = -1;
       this.state.awaitPos = -1;
 

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1528,6 +1528,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (!this.isRelational("<")) {
         return undefined;
       }
+
+      const oldMaybeInArrowParameters = this.state.maybeInArrowParameters;
+      const oldYieldPos = this.state.yieldPos;
+      const oldAwaitPos = this.state.awaitPos;
+      this.state.maybeInArrowParameters = false;
+      this.state.yieldPos = -1;
+      this.state.awaitPos = -1;
+
       const res: ?N.ArrowFunctionExpression = this.tsTryParseAndCatch(() => {
         const node: N.ArrowFunctionExpression = this.startNodeAt(
           startPos,
@@ -1540,6 +1548,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         this.expect(tt.arrow);
         return node;
       });
+
+      this.state.maybeInArrowParameters = oldMaybeInArrowParameters;
+      this.state.yieldPos = oldYieldPos;
+      this.state.awaitPos = oldAwaitPos;
 
       if (!res) {
         return undefined;

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic-after-await/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic-after-await/input.ts
@@ -1,0 +1,4 @@
+async () => {
+  await null;
+  async <T>() => null;
+};

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic-after-await/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic-after-await/output.json
@@ -12,9 +12,6 @@
       "column": 2
     }
   },
-  "errors": [
-    "SyntaxError: Await cannot be used as name inside an async function (2:2)"
-  ],
   "program": {
     "type": "Program",
     "start": 0,

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic-after-await/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic-after-await/output.json
@@ -1,0 +1,217 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 53,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 2
+    }
+  },
+  "errors": [
+    "SyntaxError: Await cannot be used as name inside an async function (2:2)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 53,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 2
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 53,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 2
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 52,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": true,
+          "params": [],
+          "body": {
+            "type": "BlockStatement",
+            "start": 12,
+            "end": 52,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 12
+              },
+              "end": {
+                "line": 4,
+                "column": 1
+              }
+            },
+            "body": [
+              {
+                "type": "ExpressionStatement",
+                "start": 16,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 13
+                  }
+                },
+                "expression": {
+                  "type": "AwaitExpression",
+                  "start": 16,
+                  "end": 26,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 12
+                    }
+                  },
+                  "argument": {
+                    "type": "NullLiteral",
+                    "start": 22,
+                    "end": 26,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 8
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 12
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "ExpressionStatement",
+                "start": 30,
+                "end": 50,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 22
+                  }
+                },
+                "expression": {
+                  "type": "ArrowFunctionExpression",
+                  "start": 30,
+                  "end": 49,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 21
+                    }
+                  },
+                  "typeParameters": {
+                    "type": "TSTypeParameterDeclaration",
+                    "start": 36,
+                    "end": 39,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 8
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 11
+                      }
+                    },
+                    "params": [
+                      {
+                        "type": "TSTypeParameter",
+                        "start": 37,
+                        "end": 38,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 10
+                          }
+                        },
+                        "name": "T"
+                      }
+                    ]
+                  },
+                  "params": [],
+                  "id": null,
+                  "generator": false,
+                  "async": true,
+                  "body": {
+                    "type": "NullLiteral",
+                    "start": 45,
+                    "end": 49,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 21
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.


For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11007
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | yes
| Documentation PR Link    | n/a
| Any Dependency Changes?  | no
| License                  | MIT

As outlined in #11007, code like the following would fail to compile:

```ts
export const foo = async () => {
  await Promise.resolve({});

  const bar = async <T>() => 'foo';
};
```

This would only happen with an `await` followed by an async arrow function with a TypeScript generic defined. @JLHwung helped me understand the issue, and [suggested the fix](https://github.com/babel/babel/issues/11007#issuecomment-574232329) I've implemented in this PR. 

In short, when parsing the snippet above, Babel would throw an `Unexpected token, expected ";"` error, which was caused by an `Await cannot be used as name inside an async function (2:2)` error. I've attempted to address this by resetting `awaitPos` in `tsTryParseGenericAsyncArrowFunction`.

Thanks in advance for any feedback, and thank you @JLHwung for your guidance on this issue!