### PR TITLE
fix(transform-react-constant-elements): wrap hoisted values to enable tree-shaking

### DIFF
--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/output.js
@@ -6,9 +6,9 @@ function action() {
 
 var _ref =
 /*#__PURE__*/
-React.createElement(Contact, {
+(() => React.createElement(Contact, {
   title: title
-});
+}))();
 
 function _action() {
   _action = babelHelpers.asyncToGenerator(function* () {

--- a/packages/babel-plugin-transform-react-constant-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.js
@@ -111,7 +111,14 @@ export default declare((api, options) => {
           const hoisted = path.hoist();
 
           if (hoisted) {
-            annotateAsPure(hoisted);
+            const iife = t.callExpression(
+              t.arrowFunctionExpression([], hoisted.node),
+              [],
+            );
+
+            annotateAsPure(iife);
+
+            hoisted.replaceWith(iife);
           }
         }
       },

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-2/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-2/output.mjs
@@ -1,17 +1,25 @@
 var _ref =
 /*#__PURE__*/
-<div>child</div>;
+(() => <div>child</div>)();
 
 const AppItem = () => {
   return _ref;
 };
 
+var _ref3 =
+/*#__PURE__*/
+(() => <p>Parent</p>)();
+
+var _ref4 =
+/*#__PURE__*/
+(() => <AppItem />)();
+
 var _ref2 =
 /*#__PURE__*/
-<div>
-        <p>Parent</p>
-        <AppItem />
-      </div>;
+(() => <div>
+        {_ref3}
+        {_ref4}
+      </div>)();
 
 export default class App extends React.Component {
   render() {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-3/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-3/output.js
@@ -1,10 +1,10 @@
 var _ref2 =
 /*#__PURE__*/
-<div>child</div>;
+(() => <div>child</div>)();
 
 var _ref3 =
 /*#__PURE__*/
-<p>Parent</p>;
+(() => <p>Parent</p>)();
 
 (function () {
   class App extends React.Component {
@@ -17,10 +17,13 @@ var _ref3 =
   const AppItem = () => {
     return _ref2;
   },
+        _ref4 =
+  /*#__PURE__*/
+  (() => <AppItem />)(),
         _ref =
   /*#__PURE__*/
-  <div>
+  (() => <div>
           {_ref3}
-          <AppItem />
-        </div>;
+          {_ref4}
+        </div>)();
 });

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-4/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-4/output.js
@@ -1,22 +1,26 @@
 var _ref =
 /*#__PURE__*/
-<div>child</div>;
+(() => <div>child</div>)();
 
 var _ref3 =
 /*#__PURE__*/
-<p>Parent</p>;
+(() => <p>Parent</p>)();
 
 (function () {
   const AppItem = () => {
     return _ref;
   };
 
+  var _ref4 =
+  /*#__PURE__*/
+  (() => <AppItem />)();
+
   var _ref2 =
   /*#__PURE__*/
-  <div>
+  (() => <div>
           {_ref3}
-          <AppItem />
-        </div>;
+          {_ref4}
+        </div>)();
 
   class App extends React.Component {
     render() {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope/output.mjs
@@ -7,14 +7,21 @@ export default class App extends React.Component {
 
 var _ref2 =
 /*#__PURE__*/
-<div>child</div>;
+(() => <div>child</div>)();
+
+var _ref3 =
+/*#__PURE__*/
+(() => <p>Parent</p>)();
 
 const AppItem = () => {
   return _ref2;
 },
+      _ref4 =
+/*#__PURE__*/
+(() => <AppItem />)(),
       _ref =
 /*#__PURE__*/
-<div>
-        <p>Parent</p>
-        <AppItem />
-      </div>;
+(() => <div>
+        {_ref3}
+        {_ref4}
+      </div>)();

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/children/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/children/output.js
@@ -1,6 +1,6 @@
 var _ref =
 /*#__PURE__*/
-<span />;
+(() => <span />)();
 
 var Foo = React.createClass({
   render: function () {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/output.mjs
@@ -2,7 +2,7 @@ import React from 'react'; // Regression test for https://github.com/babel/babel
 
 var _ref =
 /*#__PURE__*/
-<div />;
+(() => <div />)();
 
 class BugReport extends React.Component {
   constructor(...args) {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/compound-assignment/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/compound-assignment/output.mjs
@@ -3,11 +3,11 @@ import Loader from 'loader';
 
 var _ref =
 /*#__PURE__*/
-<Loader className="full-height" />;
+(() => <Loader className="full-height" />)();
 
 var _ref2 =
 /*#__PURE__*/
-<Loader className="p-y-5" />;
+(() => <Loader className="p-y-5" />)();
 
 const errorComesHere = () => _ref,
       thisWorksFine = () => _ref2;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/constructor/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/constructor/output.js
@@ -2,7 +2,7 @@ var Foo = require("Foo");
 
 var _ref =
 /*#__PURE__*/
-<Foo />;
+(() => <Foo />)();
 
 function render() {
   return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/deep-constant-violation/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/deep-constant-violation/output.js
@@ -1,10 +1,10 @@
 var _ref =
 /*#__PURE__*/
-<b></b>;
+(() => <b></b>)();
 
 var _ref2 =
 /*#__PURE__*/
-<span></span>;
+(() => <span></span>)();
 
 function render() {
   var children = _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-class/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-class/output.mjs
@@ -6,13 +6,16 @@ export default Parent;
 
 var _ref2 =
 /*#__PURE__*/
-<div className="child">
+(() => <div className="child">
     ChildTextContent
-  </div>;
+  </div>)();
 
 let Child = () => _ref2,
+    _ref3 =
+/*#__PURE__*/
+(() => <Child />)(),
     _ref =
 /*#__PURE__*/
-<div className="parent">
-    <Child />
-  </div>;
+(() => <div className="parent">
+    {_ref3}
+  </div>)();

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-declaration/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-declaration/output.js
@@ -2,7 +2,7 @@ function render() {
   const bar = "bar",
         _ref =
   /*#__PURE__*/
-  <foo bar={bar} />,
+  (() => <foo bar={bar} />)(),
         renderFoo = () => _ref;
 
   return renderFoo();
@@ -14,7 +14,7 @@ function render() {
         baz = "baz",
         _ref2 =
   /*#__PURE__*/
-  <foo bar={bar} baz={baz} />;
+  (() => <foo bar={bar} baz={baz} />)();
 
   return renderFoo();
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params-2/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params-2/output.js
@@ -3,7 +3,7 @@ function render() {
 
   var _ref =
   /*#__PURE__*/
-  <Component title={title} />;
+  (() => <Component title={title} />)();
 
   return () => _ref;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params/output.js
@@ -2,7 +2,7 @@ function render(Component) {
   var text = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '',
       _ref =
   /*#__PURE__*/
-  <Component text={text} />;
+  (() => <Component text={text} />)();
 
   return function () {
     return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-hoc/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-hoc/output.mjs
@@ -8,16 +8,20 @@ export default Parent;
 
 var _ref2 =
 /*#__PURE__*/
-<div className="child">
+(() => <div className="child">
     ChildTextContent
-  </div>;
+  </div>)();
 
 let Child = () => _ref2;
 
 Child = HOC(Child);
 
+var _ref3 =
+/*#__PURE__*/
+(() => <Child />)();
+
 var _ref =
 /*#__PURE__*/
-<div className="parent">
-    <Child />
-  </div>;
+(() => <div className="parent">
+    {_ref3}
+  </div>)();

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/function-parameter/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/function-parameter/output.js
@@ -1,7 +1,7 @@
 function render(text) {
   var _ref =
   /*#__PURE__*/
-  <foo>{text}</foo>;
+  (() => <foo>{text}</foo>)();
 
   return function () {
     return _ref;
@@ -13,7 +13,7 @@ var Foo2 = require("Foo");
 function createComponent(text) {
   var _ref2 =
   /*#__PURE__*/
-  <Foo2>{text}</Foo2>;
+  (() => <Foo2>{text}</Foo2>)();
 
   return function render() {
     return _ref2;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/global-reference/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/global-reference/output.js
@@ -1,6 +1,6 @@
 var _ref =
 /*#__PURE__*/
-<div foo={notDeclared}></div>;
+(() => <div foo={notDeclared}></div>)();
 
 var Foo = React.createClass({
   render: function render() {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/html-element/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/html-element/output.js
@@ -1,14 +1,18 @@
 var _ref =
 /*#__PURE__*/
-<foo />;
+(() => <foo />)();
 
 function render() {
   return _ref;
 }
 
+var _ref3 =
+/*#__PURE__*/
+(() => <input type="checkbox" checked={true} />)();
+
 var _ref2 =
 /*#__PURE__*/
-<div className="foo"><input type="checkbox" checked={true} /></div>;
+(() => <div className="foo">{_ref3}</div>)();
 
 function render() {
   return _ref2;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/inline-elements/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/inline-elements/output.js
@@ -4,7 +4,7 @@ function _jsx(type, props, key, children) { if (!REACT_ELEMENT_TYPE) { REACT_ELE
 
 var _ref =
 /*#__PURE__*/
-_jsx("foo", {});
+(() => _jsx("foo", {}))();
 
 function render() {
   return _ref;
@@ -15,7 +15,7 @@ function render() {
 
   var _ref2 =
   /*#__PURE__*/
-  _jsx("foo", {}, void 0, text);
+  (() => _jsx("foo", {}, void 0, text))();
 
   return function () {
     return _ref2;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/inner-declaration/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/inner-declaration/output.js
@@ -3,7 +3,7 @@ function render() {
 
   var _ref =
   /*#__PURE__*/
-  <foo>{text}</foo>;
+  (() => <foo>{text}</foo>)();
 
   return function () {
     return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-constant/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-constant/output.js
@@ -3,7 +3,7 @@ function render() {
 
   var _ref =
   /*#__PURE__*/
-  <this.component />;
+  (() => <this.component />)();
 
   return () => _ref;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/output.js
@@ -1,6 +1,6 @@
 var _ref =
 /*#__PURE__*/
-<span>Sub Component</span>;
+(() => <span>Sub Component</span>)();
 
 class Component extends React.Component {
   constructor(...args) {
@@ -10,7 +10,7 @@ class Component extends React.Component {
 
     var _ref2 =
     /*#__PURE__*/
-    <this.subComponent />;
+    (() => <this.subComponent />)();
 
     this.render = () => _ref2;
   }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/output.js
@@ -1,6 +1,6 @@
 var _ref =
 /*#__PURE__*/
-<span>Sub Component</span>;
+(() => <span>Sub Component</span>)();
 
 const els = {
   subComponent: () => _ref
@@ -8,7 +8,7 @@ const els = {
 
 var _ref2 =
 /*#__PURE__*/
-<els.subComponent />;
+(() => <els.subComponent />)();
 
 class Component extends React.Component {
   constructor(...args) {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/param-and-var/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/param-and-var/output.js
@@ -2,7 +2,7 @@ function fn(Component, obj) {
   var data = obj.data,
       _ref =
   /*#__PURE__*/
-  <Component prop={data} />;
+  (() => <Component prop={data} />)();
 
   return () => _ref;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-multi/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-multi/output.js
@@ -5,7 +5,7 @@ function render(_ref) {
 
   var _ref2 =
   /*#__PURE__*/
-  <Component text={text} className={className} id={id} />;
+  (() => <Component text={text} className={className} id={id} />)();
 
   return () => _ref2;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/output.js
@@ -6,7 +6,7 @@ function render(_ref) {
 
   var _ref2 =
   /*#__PURE__*/
-  <Component text={text} className={className} id={id} />;
+  (() => <Component text={text} className={className} id={id} />)();
 
   // intentionally ignoring props
   return () => _ref2;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure/output.js
@@ -3,7 +3,7 @@ function render(_ref) {
 
   var _ref2 =
   /*#__PURE__*/
-  <Component text={text} />;
+  (() => <Component text={text} />)();
 
   return () => _ref2;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-reference/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-reference/output.js
@@ -1,7 +1,7 @@
 function render(text) {
   var _ref =
   /*#__PURE__*/
-  <div>{text}</div>;
+  (() => <div>{text}</div>)();
 
   return function () {
     return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-2/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-2/output.js
@@ -1,7 +1,7 @@
 function render(offset) {
   var _ref =
   /*#__PURE__*/
-  <div tabIndex={offset + 1} />;
+  (() => <div tabIndex={offset + 1} />)();
 
   return function () {
     return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-3/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-3/output.js
@@ -2,7 +2,7 @@ const OFFSET = 3;
 
 var _ref =
 /*#__PURE__*/
-<div tabIndex={OFFSET + 1} />;
+(() => <div tabIndex={OFFSET + 1} />)();
 
 var Foo = React.createClass({
   render: function () {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-whitelist-member/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-whitelist-member/output.mjs
@@ -2,9 +2,9 @@ import Intl from 'react-intl';
 
 var _ref =
 /*#__PURE__*/
-<Intl.FormattedMessage id="someMessage.foo" defaultMessage={"Some text, " + "and some more too. {someValue}"} description="A test message for babel." values={{
+(() => <Intl.FormattedMessage id="someMessage.foo" defaultMessage={"Some text, " + "and some more too. {someValue}"} description="A test message for babel." values={{
   someValue: "A value."
-}} />;
+}} />)();
 
 var Foo = React.createClass({
   render: function () {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-whitelist/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-whitelist/output.js
@@ -1,8 +1,8 @@
 var _ref =
 /*#__PURE__*/
-<FormattedMessage id="someMessage.foo" defaultMessage={"Some text, " + "and some more too. {someValue}"} description="A test message for babel." values={{
+(() => <FormattedMessage id="someMessage.foo" defaultMessage={"Some text, " + "and some more too. {someValue}"} description="A test message for babel." values={{
   someValue: "A value."
-}} />;
+}} />)();
 
 var Foo = React.createClass({
   render: function () {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression/output.js
@@ -1,6 +1,6 @@
 var _ref =
 /*#__PURE__*/
-<div data-text={"Some text, " + "and some more too."} />;
+(() => <div data-text={"Some text, " + "and some more too."} />)();
 
 var Foo = React.createClass({
   render: function () {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/reassignment/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/reassignment/output.js
@@ -3,7 +3,7 @@ function render(text) {
 
   var _ref =
   /*#__PURE__*/
-  <div>{text}</div>;
+  (() => <div>{text}</div>)();
 
   return function () {
     return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/output.mjs
@@ -9,4 +9,4 @@ export default class B {}
 
 var _ref =
 /*#__PURE__*/
-React.createElement(B, null);
+(() => React.createElement(B, null))();

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/output.mjs
@@ -9,4 +9,4 @@ export class B {}
 
 var _ref =
 /*#__PURE__*/
-React.createElement(B, null);
+(() => React.createElement(B, null))();

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/text-children/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/text-children/output.js
@@ -1,8 +1,8 @@
 var _ref =
 /*#__PURE__*/
-<div className="class-name">
+(() => <div className="class-name">
       Text
-    </div>;
+    </div>)();
 
 var Foo = React.createClass({
   render: function () {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/var/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/var/output.js
@@ -2,7 +2,7 @@ function fn(Component) {
   var data = "prop",
       _ref =
   /*#__PURE__*/
-  <Component prop={data} />;
+  (() => <Component prop={data} />)();
 
   return () => _ref;
 }

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/optimisation.react.constant-elements/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/optimisation.react.constant-elements/output.js
@@ -1,10 +1,18 @@
+var _ref3 =
+/*#__PURE__*/
+(() => <img src="/img/logo/logo-96x36.png" />)();
+
+var _ref2 =
+/*#__PURE__*/
+(() => <a className="navbar-brand" href="/">
+        {_ref3}
+      </a>)();
+
 var _ref =
 /*#__PURE__*/
-<div className="navbar-header">
-      <a className="navbar-brand" href="/">
-        <img src="/img/logo/logo-96x36.png" />
-      </a>
-    </div>;
+(() => <div className="navbar-header">
+      {_ref2}
+    </div>)();
 
 let App =
 /*#__PURE__*/


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11037 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | I don't think, plugin output is different but it should not be a breaking change
| Minor: New Feature?      | No
| Tests Added + Pass?      | Updated output snapshots
| Any Dependency Changes?  | No
| License                  | MIT

As described in https://github.com/babel/babel/issues/11037, the current code generated by @babel/plugin-transform-react-constant-elements is not tree-shakable since the `#__PURE__` annotation only works on function calls (https://github.com/terser/terser/issues/513).

The proposed solution (https://github.com/terser/terser/issues/513#issuecomment-554685420) is to wrap the hoisted values in an IIFE to make them tree-shakable. This is what this change intent to do.

No new tests were added but the existing snapshots were updated to match the new output.
