### PR TITLE
Disallow babel.transformFromAst synchronously

### DIFF
--- a/packages/babel-core/src/parse.js
+++ b/packages/babel-core/src/parse.js
@@ -39,9 +39,11 @@ export const parse: Parse = (function parse(code, opts, callback) {
     opts = undefined;
   }
 
-  // For backward-compat with Babel 7's early betas, we allow sync parsing when
-  // no callback is given. Will be dropped in some future Babel major version.
-  if (callback === undefined) return parseRunner.sync(code, opts);
+  if (callback === undefined) {
+    throw new Error(
+      "Starting from Babel 8.0.0, the 'parse' function expects a callback. If you need to call it synchronously, please use 'parseSync",
+    );
+  }
 
   parseRunner.errback(code, opts, callback);
 }: Function);

--- a/packages/babel-core/src/transform-ast.js
+++ b/packages/babel-core/src/transform-ast.js
@@ -19,10 +19,6 @@ type TransformFromAst = {
     opts: ?InputOptions,
     callback: FileResultCallback,
   ): void,
-
-  // Here for backward-compatibility. Ideally use ".transformSync" if you want
-  // a synchronous API.
-  (ast: AstRoot, code: string, opts: ?InputOptions): FileResult | null,
 };
 
 const transformFromAstRunner = gensync<
@@ -46,12 +42,6 @@ export const transformFromAst: TransformFromAst = (function transformFromAst(
   if (typeof opts === "function") {
     callback = opts;
     opts = undefined;
-  }
-
-  // For backward-compat with Babel 6, we allow sync transformation when
-  // no callback is given. Will be dropped in some future Babel major version.
-  if (callback === undefined) {
-    return transformFromAstRunner.sync(ast, code, opts);
   }
 
   transformFromAstRunner.errback(ast, code, opts, callback);

--- a/packages/babel-core/src/transform-ast.js
+++ b/packages/babel-core/src/transform-ast.js
@@ -19,6 +19,10 @@ type TransformFromAst = {
     opts: ?InputOptions,
     callback: FileResultCallback,
   ): void,
+
+  // Here for backward-compatibility. Ideally use ".transformSync" if you want
+  // a synchronous API.
+  (ast: AstRoot, code: string, opts: ?InputOptions): FileResult | null,
 };
 
 const transformFromAstRunner = gensync<
@@ -42,6 +46,12 @@ export const transformFromAst: TransformFromAst = (function transformFromAst(
   if (typeof opts === "function") {
     callback = opts;
     opts = undefined;
+  }
+
+  if (callback === undefined) {
+    throw new Error(
+      "Starting from Babel 8.0.0, the 'transformFromAst' function expects a callback. If you need to call it synchronously, please use 'transformFromAstSync",
+    );
   }
 
   transformFromAstRunner.errback(ast, code, opts, callback);

--- a/packages/babel-core/src/transform-file.js
+++ b/packages/babel-core/src/transform-file.js
@@ -42,6 +42,20 @@ const transformFileRunner = gensync<[string, ?InputOptions], FileResult | null>(
     return yield* run(config, code);
   },
 );
+export const transformFile: Transform = (function transform(code, opts, callback) {
+  if (typeof opts === "function") {
+    callback = opts;
+    opts = undefined;
+  }
+
+  if (callback === undefined) {
+    throw new Error(
+      "Starting from Babel 8.0.0, the 'transformFile' function expects a callback. If you need to call it synchronously, please use 'transformFileSync",
+    );
+  }
+
+  transformFileRunner.errback(code, opts, callback);
+}: Function);
 
 export const transformFile: TransformFile = transformFileRunner.errback;
 export const transformFileSync = transformFileRunner.sync;

--- a/packages/babel-core/src/transform.js
+++ b/packages/babel-core/src/transform.js
@@ -33,9 +33,11 @@ export const transform: Transform = (function transform(code, opts, callback) {
     opts = undefined;
   }
 
-  // For backward-compat with Babel 6, we allow sync transformation when
-  // no callback is given. Will be dropped in some future Babel major version.
-  if (callback === undefined) return transformRunner.sync(code, opts);
+  if (callback === undefined) {
+    throw new Error(
+      "Starting from Babel 8.0.0, the 'transform' function expects a callback. If you need to call it synchronously, please use 'transformSync",
+    );
+  }
 
   transformRunner.errback(code, opts, callback);
 }: Function);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Part of Babel 8 Release plan 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes
| Minor: New Feature?      |
| Tests Added + Pass?      | No
| Documentation PR Link    |
| Any Dependency Changes?  | No
| License                  | MIT

Allows babel.transformFromAst to run only asynchronously by removing the part of the code required for running it synchronously i.e. with callback functions. 
