### PR TITLE
Respect preserveComments option in tempate.ast()

### DIFF
--- a/packages/babel-template/src/options.js
+++ b/packages/babel-template/src/options.js
@@ -131,7 +131,7 @@ export function validate(opts: mixed): TemplateOpts {
     placeholderWhitelist: placeholderWhitelist || undefined,
     placeholderPattern:
       placeholderPattern == null ? undefined : placeholderPattern,
-    preserveComments: preserveComments == null ? false : preserveComments,
+    preserveComments: preserveComments == null ? undefined : preserveComments,
     syntacticPlaceholders:
       syntacticPlaceholders == null ? undefined : syntacticPlaceholders,
   };

--- a/packages/babel-template/test/index.js
+++ b/packages/babel-template/test/index.js
@@ -28,6 +28,18 @@ describe("@babel/template", function() {
     expect(generator(output).code).toBe(comments);
   });
 
+  it("should preserve comments with a flag", function() {
+    const output = template(comments, { preserveComments: true })();
+    expect(generator(output).code).toBe(comments);
+  });
+
+  it("should preserve comments with a flag when using .ast", function() {
+    const output1 = template.ast(comments, { preserveComments: true });
+    const output2 = template({ preserveComments: true }).ast(comments);
+    expect(generator(output1).code).toBe(comments);
+    expect(generator(output2).code).toBe(comments);
+  });
+
   describe("string-based", () => {
     it("should handle replacing values from an object", () => {
       const value = t.stringLiteral("some string value");
@@ -219,7 +231,7 @@ describe("@babel/template", function() {
     });
   });
 
-  describe.only(".syntacticPlaceholders", () => {
+  describe(".syntacticPlaceholders", () => {
     it("works in function body", () => {
       const output = template(`function f() %%A%%`)({
         A: t.blockStatement([]),


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9684 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | - <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`validate(opts)` added `preserveComments: false` when `preserveComments` was not present in the validated options. This caused the `NO_PLACEHOLDER` options in `builder.js` to contain `preserveComments: false`. So since `NO_PLACEHOLDER` later is merged in to the rest of the options given to template.ast() the preserveComments option was always set to false.

This PR changes `validate(opts)` so it keeps `preserveComments` undefined if it was null/undefined.
 