### PR TITLE
chore: use npm install in babel-test262-runner setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
           command: |
             git clone --recurse-submodules https://github.com/babel/babel-test262-runner
             cd babel-test262-runner
-            npm i
+            npm ci
             npm i tap-mocha-reporter --save-dev
             node lib/download-node
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,8 @@ jobs:
           command: |
             git clone --recurse-submodules https://github.com/babel/babel-test262-runner
             cd babel-test262-runner
-            yarn
-            yarn add tap-mocha-reporter --dev
+            npm i
+            npm i tap-mocha-reporter --save-dev
             node lib/download-node
       - run:
           name: Download master branch Test262 artifact


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes recent test262 error: https://app.circleci.com/jobs/github/babel/babel/16405
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Test262 is breaking recently with error message
```
30993) test/language/statements/class/subclass/builtin-objects/WeakSet/super-must-be-called.js strict mode # (expected success, got runtime error):
     Error: test/language/statements/class/subclass/builtin-objects/WeakSet/super-must-be-called.js strict mode # (expected success, got runtime error)
      at ReferenceError: $262 is not defined
      at lib/run-tests/index.js:65:11
      at undefined:314:2
      at Function.vm.runInESHostContext (/tmp/A6ROkEYz45yUtYvhXw7I/f-1581006044714-1819-xbyfk6.b0ok.js:15:13)
      at Object.<anonymous> (/tmp/A6ROkEYz45yUtYvhXw7I/f-1581006044714-1819-xbyfk6.b0ok.js:26:4)
```

A recent release of `eshost` (https://github.com/bterlson/eshost/commit/d7c39a1907108fa2fe535f36ce15efaa76465edd) breaks `babel-test262-runner` where we hardcoded the context variable `$`.

https://github.com/babel/babel-test262-runner/blob/63bad42d7f10210a2498a1725356d4a28f1777e5/lib/run-tests/babel-agent-runtime.js#L23

`babel-test262-runner` uses a npm lock file where `eshost` is pin to 6.4, so this is the minimum fix that should keep things working, otherwise we keep installing latest 6.x of `eshost`.

I will update `babel-test262-runner` later with latest `eshost` support.