### PR TITLE
fix(parser): add missing @babel/types dependency

### DIFF
--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -33,6 +33,9 @@
     "charcodes": "^0.2.0",
     "unicode-12.0.0": "^0.7.9"
   },
+  "dependencies": {
+    "@babel/types": "^7.8.3"
+  },
   "bin": {
     "parser": "./bin/babel-parser.js"
   }


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Any Dependency Changes?  | Yes
| License                  | MIT

Jest (@SimenB) is testing Yarn 2 (https://github.com/facebook/jest/pull/9476) and their TypeScript build failed because `@babel/parser` is missing a dependency on `@babel/types`.