### PR TITLE
Add eslint-plugin-jest

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 module.exports = {
   root: true,
-  plugins: ["prettier", "@babel/development", "import"],
+  plugins: ["prettier", "@babel/development", "import", "jest"],
   // replace it by `@babel/internal` when `@babel/eslint-config-internal` is published
   extends: path.resolve(__dirname, "eslint/babel-eslint-config-internal"),
   rules: {
@@ -38,6 +38,14 @@ module.exports = {
       env: {
         jest: true,
       },
+      extends: "plugin:jest/recommended",
+      rules: {
+        "jest/expect-expect": "off",
+        "jest/no-identical-title": "off",
+        "jest/no-standalone-expect": "off",
+        "jest/no-test-callback": "off",
+        "jest/valid-describe": "off"
+      }
     },
     {
       files: ["packages/babel-plugin-*/src/index.js"],

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ lint-ts-ci: bootstrap-flowcheck
 lint: lint-js lint-ts
 
 lint-js:
-	$(YARN) eslint scripts $(SOURCES) '*.js' --format=codeframe
+	BABEL_ENV=test $(YARN) eslint scripts $(SOURCES) '*.js' --format=codeframe
 
 lint-ts:
 	scripts/lint-ts-typings.sh

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -283,10 +283,12 @@ describe("babylon-to-espree", () => {
     assert.strictEqual(babylonAST.tokens[3].value, "#");
   });
 
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip("empty program with line comment", () => {
     parseAndAssertSame("// single comment");
   });
 
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip("empty program with block comment", () => {
     parseAndAssertSame("  /* multiline\n * comment\n*/");
   });

--- a/eslint/babel-eslint-tests/test/integration/eslint/eslint.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/eslint.js
@@ -1252,6 +1252,7 @@ describe("verify", () => {
   // This two tests are disabled, as the feature to visit properties when
   // there is a spread/rest operator has been removed as it caused problems
   // with other rules #249
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip("visits excluded properties left of spread #95", () => {
     verifyAndAssertMessages(
       "var originalObject = {}; var {field1, field2, ...clone} = originalObject;",
@@ -1259,6 +1260,7 @@ describe("verify", () => {
     );
   });
 
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip("visits excluded properties left of spread #210", () => {
     verifyAndAssertMessages(
       "const props = { yo: 'yo' }; const { ...otherProps } = props;",
@@ -1569,9 +1571,9 @@ describe("verify", () => {
     verifyAndAssertMessages("with (arguments) { length; }", {}, [], "script");
   });
 
-  xit("with does crash parsing in module mode (strict on) #171", () => {
+  it("with does crash parsing in module mode (strict on) #171", () => {
     verifyAndAssertMessages("with (arguments) { length; }", {}, [
-      "1:1 Parsing error: 'with' in strict mode",
+      /'with' in strict mode/,
     ]);
   });
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-import-resolver-node": "^0.3.2",
     "eslint-plugin-flowtype": "^3.8.2",
     "eslint-plugin-import": "^2.17.2",
+    "eslint-plugin-jest": "^23.7.0",
     "eslint-plugin-prettier": "^3.1.0",
     "fancy-log": "^1.3.3",
     "flow-bin": "^0.108.0",

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -94,8 +94,8 @@ describe("option-manager", () => {
       expect(() => {
         loadOptions({
           plugins: [[plugin, null]],
-        }).toThrow(/.plugins[0][1] must be an object, false, or undefined/);
-      });
+        });
+      }).toThrow(".plugins[0][1] must be an object, false, or undefined");
 
       expect(calls).toEqual([]);
     });
@@ -140,8 +140,8 @@ describe("option-manager", () => {
       expect(() => {
         loadOptions({
           presets: [preset, preset],
-        }).toThrow(/Duplicate plugin\/preset detected/);
-      });
+        });
+      }).toThrow(/Duplicate plugin\/preset detected/);
       expect(calls).toEqual([]);
     });
 

--- a/packages/babel-plugin-syntax-decorators/test/index.js
+++ b/packages/babel-plugin-syntax-decorators/test/index.js
@@ -33,7 +33,7 @@ describe("'decoratorsBeforeExport' option", function() {
     expect(makeParser("", { decoratorsBeforeExport: "before" })).toThrow();
   });
 
-  test.skip("is required", function() {
+  test("is required", function() {
     expect(makeParser("", { legacy: false })).toThrow(/decoratorsBeforeExport/);
   });
 

--- a/packages/babel-template/test/index.js
+++ b/packages/babel-template/test/index.js
@@ -219,7 +219,7 @@ describe("@babel/template", function() {
     });
   });
 
-  describe.only(".syntacticPlaceholders", () => {
+  describe(".syntacticPlaceholders", () => {
     it("works in function body", () => {
       const output = template(`function f() %%A%%`)({
         A: t.blockStatement([]),
@@ -302,12 +302,10 @@ describe("@babel/template", function() {
         });
 
         it("replaces identifiers", () => {
-          expect(() => {
-            const output = template(`FOO`)({
-              FOO: t.numericLiteral(1),
-            });
-            expect(generator(output).code).toMatchInlineSnapshot(`"1;"`);
+          const output = template(`FOO`)({
+            FOO: t.numericLiteral(1),
           });
+          expect(generator(output).code).toMatchInlineSnapshot(`"1;"`);
         });
 
         it("doesn't mix placeholder styles", () => {

--- a/packages/babel-traverse/test/__snapshots__/scope.js.snap
+++ b/packages/babel-traverse/test/__snapshots__/scope.js.snap
@@ -4,7 +4,11 @@ exports[`scope duplicate bindings catch const 1`] = `"Duplicate declaration \\"e
 
 exports[`scope duplicate bindings catch let 1`] = `"Duplicate declaration \\"e\\""`;
 
+exports[`scope duplicate bindings global class/const 1`] = `"Duplicate declaration \\"foo\\""`;
+
 exports[`scope duplicate bindings global class/function 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global class/let 1`] = `"Duplicate declaration \\"foo\\""`;
 
 exports[`scope duplicate bindings global const/class 1`] = `"Duplicate declaration \\"foo\\""`;
 
@@ -16,10 +20,18 @@ exports[`scope duplicate bindings global const/let 1`] = `"Duplicate declaration
 
 exports[`scope duplicate bindings global const/var 1`] = `"Duplicate declaration \\"foo\\""`;
 
+exports[`scope duplicate bindings global function/class 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global function/let 1`] = `"Duplicate declaration \\"foo\\""`;
+
 exports[`scope duplicate bindings global let/class 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global let/const 1`] = `"Duplicate declaration \\"foo\\""`;
 
 exports[`scope duplicate bindings global let/function 1`] = `"Duplicate declaration \\"foo\\""`;
 
 exports[`scope duplicate bindings global let/let 1`] = `"Duplicate declaration \\"foo\\""`;
 
 exports[`scope duplicate bindings global let/var 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global var/let 1`] = `"Duplicate declaration \\"foo\\""`;

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -422,7 +422,11 @@ describe("scope", () => {
           }
         });
 
-        /*if (kind1 !== kind2) {
+        if (kind1 !== kind2) {
+          //todo: remove the if whitelist
+          if (kind1 === "const" && (kind2 === "function" || kind2 === "var")) {
+            continue;
+          }
           it(`${kind2}/${kind1}`, () => {
             const ast = createAST(kind2, kind1);
 
@@ -432,7 +436,7 @@ describe("scope", () => {
               expect(() => getPath(ast)).toThrowErrorMatchingSnapshot();
             }
           });
-        }*/
+        }
       }
     });
   });

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -196,7 +196,8 @@ describe("traverse", function() {
       expect(skipped).toBe(true);
     });
 
-    // Skipped: see the comment in the `NodePath.requque` method.
+    // Skipped: see the comment in the `NodePath.requeue` method.
+    // eslint-disable-next-line jest/no-disabled-tests
     it.skip("skipped and requeued paths should be visited", function() {
       const ast = parse("id");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,6 +1910,11 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/json-schema@^7.0.3":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
+  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1948,6 +1953,28 @@
   integrity sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/experimental-utils@^2.5.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.0.tgz#d5ca732f22c009e515ba09fcceb5f2127d841568"
+  integrity sha512-zwpg6zEOPbhB3+GaQfufzlMUOO6GXCNZq6skk+b2ZkZAIoBhVoanWK255BS1g5x9bMwHpLhX0Rpn5Fc3NdCZdg==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.19.0"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/typescript-estree@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.19.0.tgz#6bd7310b9827e04756fe712909f26956aac4b196"
+  integrity sha512-n6/Xa37k0jQdwpUszffi19AlNbVCR0sdvCs3DmSKMD7wBttKY31lhD2fug5kMD91B2qW4mQldaTEc1PEzvGu8w==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
 
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
@@ -4229,6 +4256,13 @@ eslint-plugin-import@^2.17.2:
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
 
+eslint-plugin-jest@^23.7.0:
+  version "23.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.7.0.tgz#84d5603b6e745b59898cb6750df6a44782a39b04"
+  integrity sha512-zkiyGlvJeHNjAEz8FaIxTXNblJJ/zj3waNbYbgflK7K6uy0cpE5zJBt/JpJtOBGM/UGkC6BqsQ4n0y7kQ2HA8w==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^2.5.0"
+
 eslint-plugin-prettier@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz#507b8562410d02a03f0ddc949c616f877852f2ba"
@@ -5133,7 +5167,7 @@ glob-watcher@^5.0.3:
     just-debounce "^1.0.0"
     object.defaults "^1.1.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -10378,10 +10412,17 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
-tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Added `eslint-plugin-jest` to root devDependencies
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR introduces `eslint-plugin-jest` to lint our test sources. It catches several test source bugs. Note that some rules are disabled as the change is not that straightforward and thus better toggle on later.