### PR TITLE
fix: search for browserslist if esmodules is falsy

### DIFF
--- a/packages/babel-helper-compilation-targets/src/index.js
+++ b/packages/babel-helper-compilation-targets/src/index.js
@@ -184,13 +184,15 @@ export default function getTargets(
     targets.browsers = Object.keys(supportsESModules)
       .map(browser => `${browser} ${supportsESModules[browser]}`)
       .join(", ");
+  } else {
+    // remove falsy esmodules to fix `hasTargets` below
+    delete targets.esmodules
   }
 
   // Parse browsers target via browserslist
   const browsersquery = validateBrowsers(targets.browsers);
 
-  const hasTargets = targets.esmodules ||
-    Object.keys(targets).filter(value => value !== TargetNames.esmodules).length > 0;
+  const hasTargets = Object.keys(targets).length > 0;
   const shouldParseBrowsers = !!targets.browsers;
   const shouldSearchForConfig =
     !options.ignoreBrowserslistConfig && !hasTargets;

--- a/packages/babel-helper-compilation-targets/src/index.js
+++ b/packages/babel-helper-compilation-targets/src/index.js
@@ -186,7 +186,7 @@ export default function getTargets(
       .join(", ");
   } else {
     // remove falsy esmodules to fix `hasTargets` below
-    delete targets.esmodules
+    delete targets.esmodules;
   }
 
   // Parse browsers target via browserslist

--- a/packages/babel-helper-compilation-targets/src/index.js
+++ b/packages/babel-helper-compilation-targets/src/index.js
@@ -189,7 +189,8 @@ export default function getTargets(
   // Parse browsers target via browserslist
   const browsersquery = validateBrowsers(targets.browsers);
 
-  const hasTargets = Object.keys(targets).length > 0;
+  const hasTargets = targets.esmodules ||
+    Object.keys(targets).filter(value => value !== TargetNames.esmodules).length > 0;
   const shouldParseBrowsers = !!targets.browsers;
   const shouldSearchForConfig =
     !options.ignoreBrowserslistConfig && !hasTargets;

--- a/packages/babel-helper-compilation-targets/src/index.js
+++ b/packages/babel-helper-compilation-targets/src/index.js
@@ -184,10 +184,10 @@ export default function getTargets(
     targets.browsers = Object.keys(supportsESModules)
       .map(browser => `${browser} ${supportsESModules[browser]}`)
       .join(", ");
-  } else {
-    // remove falsy esmodules to fix `hasTargets` below
-    delete targets.esmodules;
   }
+
+  // Remove esmodules after being consumed to fix `hasTargets` below
+  delete targets.esmodules;
 
   // Parse browsers target via browserslist
   const browsersquery = validateBrowsers(targets.browsers);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11123 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | Maybe for some user
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR Link    | No <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

As stated in issue #11123, with targets

```js
{
  presets: [
    [
      '@babel/preset-env',
      {
        targets: {
          esmodules: false
        }
      }
    ]
  ]
}
```

babel won't search for browserslist config