### PR TITLE
Typescript: Preserve decorated definite class properties

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -74,7 +74,9 @@ export default declare(
             );
           }
 
-          path.remove();
+          if (!node.decorators) {
+            path.remove();
+          }
         } else if (!allowDeclareFields && !node.value && !node.decorators) {
           path.remove();
         }
@@ -84,6 +86,7 @@ export default declare(
         if (node.readonly) node.readonly = null;
         if (node.optional) node.optional = null;
         if (node.typeAnnotation) node.typeAnnotation = null;
+        if (node.definite) node.definite = null;
       },
       method({ node }) {
         if (node.accessibility) node.accessibility = null;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/input.ts
@@ -5,4 +5,5 @@ class C {
     @foo d: number;
     @foo e: number = 3;
     f!: number;
+    @foo g!: number;
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/output.js
@@ -5,4 +5,6 @@ class C {
   d;
   @foo
   e = 3;
+  @foo
+  g;
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is a follow-up to #8238, but for class properties marked as definite (using the non-null assertion `!`)

### Current behavior:
The `babel-plugin-transform-typescript` removes class properties marked as definite regardless if decorators are assigned to it or not.

```ts
// Original
class C {
  @foo
  d;
  @foo
  e = 3;
  @foo
  f!;
}

// Transformed
class C {
  @foo
  d;
  @foo
  e = 3;
  // <-- Missing `f` field
}
```

### Expected behavior:
The babel-plugin-transform-typescript should only remove a definite class property if it has no decorators.

```ts
// Original
class C {
  @foo
  d;
  @foo
  e = 3;
  @foo
  f!;
}

// Transformed
class C {
  @foo
  d;
  @foo
  e = 3;
  @foo
  f;
}
```