### PR TITLE
Skip newlines around inline `#__PURE__` annotations

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1155/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1155/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2765/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2765/output.js
@@ -1,9 +1,7 @@
 function f() {
   var _this = this;
 
-  let g =
-  /*#__PURE__*/
-  function () {
+  let g = /*#__PURE__*/function () {
     var _ref = babelHelpers.asyncToGenerator(function* () {
       _this;
     });
@@ -19,9 +17,7 @@ class Class {
     var _this2 = this;
 
     return babelHelpers.asyncToGenerator(function* () {
-      var c =
-      /*#__PURE__*/
-      function () {
+      var c = /*#__PURE__*/function () {
         var _ref2 = babelHelpers.asyncToGenerator(function* (b) {
           _this2;
         });

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/output.js
@@ -15,9 +15,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   function Foo() {
     _classCallCheck(this, Foo);
   }
@@ -25,9 +23,7 @@ function () {
   _createClass(Foo, [{
     key: "bar",
     value: function () {
-      var _bar = _asyncToGenerator(
-      /*#__PURE__*/
-      regeneratorRuntime.mark(function _callee() {
+      var _bar = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
         var baz;
         return regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) {
@@ -61,9 +57,7 @@ function foo() {
 }
 
 function _foo() {
-  _foo = _asyncToGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee3() {
+  _foo = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee3() {
     var bar, _bar2;
 
     return regeneratorRuntime.wrap(function _callee3$(_context3) {
@@ -71,9 +65,7 @@ function _foo() {
         switch (_context3.prev = _context3.next) {
           case 0:
             _bar2 = function _ref2() {
-              _bar2 = _asyncToGenerator(
-              /*#__PURE__*/
-              regeneratorRuntime.mark(function _callee2() {
+              _bar2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2() {
                 var baz;
                 return regeneratorRuntime.wrap(function _callee2$(_context2) {
                   while (1) {

--- a/packages/babel-core/test/fixtures/transformation/source-maps/class/output.js
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/class/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function () {
+var Test = /*#__PURE__*/function () {
   "use strict";
 
   function Test() {

--- a/packages/babel-core/test/fixtures/transformation/source-maps/class/source-mappings.json
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/class/source-mappings.json
@@ -4,7 +4,7 @@
     "column": 10
   },
   "generated": {
-    "line": 13,
+    "line": 11,
     "column": 15
   }
 }]

--- a/packages/babel-plugin-external-helpers/test/fixtures/opts/whitelist/output.js
+++ b/packages/babel-plugin-external-helpers/test/fixtures/opts/whitelist/output.js
@@ -1,8 +1,6 @@
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-let Foo =
-/*#__PURE__*/
-function () {
+let Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/async-in-params/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/async-in-params/output.js
@@ -3,9 +3,7 @@ function g() {
 }
 
 function _g() {
-  _g = babelHelpers.wrapAsyncGenerator(function* (x =
-  /*#__PURE__*/
-  babelHelpers.asyncToGenerator(function* () {
+  _g = babelHelpers.wrapAsyncGenerator(function* (x = /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
     yield 1;
   })) {
     yield babelHelpers.awaitAsyncGenerator(2);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
@@ -10,9 +10,7 @@ let Hello = function Hello() {
   };
 };
 
-let Outer =
-/*#__PURE__*/
-function (_Hello) {
+let Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
   function Outer() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
@@ -1,8 +1,6 @@
 "use strict";
 
-let Hello =
-/*#__PURE__*/
-function () {
+let Hello = /*#__PURE__*/function () {
   function Hello() {
     babelHelpers.classCallCheck(this, Hello);
   }
@@ -16,9 +14,7 @@ function () {
   return Hello;
 }();
 
-let Outer =
-/*#__PURE__*/
-function (_Hello) {
+let Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
   function Outer() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/assignment/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/assignment/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/call/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/canonical/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/canonical/output.js
@@ -1,6 +1,4 @@
-var Point =
-/*#__PURE__*/
-function () {
+var Point = /*#__PURE__*/function () {
   "use strict";
 
   function Point(x = 0, y = 0) {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
@@ -10,9 +10,7 @@ var Foo = function Foo() {
 
 var _prop = babelHelpers.classPrivateFieldLooseKey("prop");
 
-var Bar =
-/*#__PURE__*/
-function (_Foo) {
+var Bar = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   babelHelpers.inherits(Bar, _Foo);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
@@ -1,6 +1,4 @@
-var Child =
-/*#__PURE__*/
-function (_Parent) {
+var Child = /*#__PURE__*/function (_Parent) {
   "use strict";
 
   babelHelpers.inherits(Child, _Parent);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/private-in-derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/private-in-derived/output.js
@@ -7,9 +7,7 @@ var Outer = function Outer() {
     value: void 0
   });
 
-  var Test =
-  /*#__PURE__*/
-  function (_babelHelpers$classPr) {
+  var Test = /*#__PURE__*/function (_babelHelpers$classPr) {
     babelHelpers.inherits(Test, _babelHelpers$classPr);
 
     function Test() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-call/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-expression/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-statement/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/update/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/update/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/assignment/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/assignment/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/call/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/canonical/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/canonical/output.js
@@ -1,6 +1,4 @@
-var Point =
-/*#__PURE__*/
-function () {
+var Point = /*#__PURE__*/function () {
   "use strict";
 
   function Point(x = 0, y = 0) {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
@@ -11,9 +11,7 @@ var Foo = function Foo() {
 
 var _prop = new WeakMap();
 
-var Bar =
-/*#__PURE__*/
-function (_Foo) {
+var Bar = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   babelHelpers.inherits(Bar, _Foo);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
@@ -1,6 +1,4 @@
-var Child =
-/*#__PURE__*/
-function (_Parent) {
+var Child = /*#__PURE__*/function (_Parent) {
   "use strict";
 
   babelHelpers.inherits(Child, _Parent);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/private-in-derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/private-in-derived/output.js
@@ -8,9 +8,7 @@ var Outer = function Outer() {
     value: void 0
   });
 
-  var Test =
-  /*#__PURE__*/
-  function (_babelHelpers$classPr) {
+  var Test = /*#__PURE__*/function (_babelHelpers$classPr) {
     babelHelpers.inherits(Test, _babelHelpers$classPr);
 
     function Test() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-call/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
@@ -1,6 +1,4 @@
-var A =
-/*#__PURE__*/
-function () {
+var A = /*#__PURE__*/function () {
   "use strict";
 
   function A() {
@@ -16,9 +14,7 @@ function () {
   return A;
 }();
 
-var B =
-/*#__PURE__*/
-function (_A) {
+var B = /*#__PURE__*/function (_A) {
   "use strict";
 
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/update/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/update/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/computed/output.js
@@ -15,9 +15,7 @@ _ref3 = /regex/;
 _baz = baz;
 _ref4 = `template${expression}`;
 
-var MyClass =
-/*#__PURE__*/
-function () {
+var MyClass = /*#__PURE__*/function () {
   "use strict";
 
   function MyClass() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/derived/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/output.js
@@ -1,6 +1,4 @@
-var Child =
-/*#__PURE__*/
-function (_Parent) {
+var Child = /*#__PURE__*/function (_Parent) {
   "use strict";
 
   babelHelpers.inherits(Child, _Parent);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/non-block-arrow-func/output.mjs
@@ -1,9 +1,7 @@
 export default (param => {
   var _class, _temp;
 
-  return _temp = _class =
-  /*#__PURE__*/
-  function () {
+  return _temp = _class = /*#__PURE__*/function () {
     function App() {
       babelHelpers.classCallCheck(this, App);
     }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T6719/output.js
@@ -1,9 +1,7 @@
 function withContext(ComposedComponent) {
   var _class, _temp;
 
-  return _temp = _class =
-  /*#__PURE__*/
-  function (_Component) {
+  return _temp = _class = /*#__PURE__*/function (_Component) {
     "use strict";
 
     babelHelpers.inherits(WithContext, _Component);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T7364/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T7364/output.mjs
@@ -2,9 +2,7 @@ class MyClass {
   constructor() {
     var _this = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
+    this.myAsyncMethod = /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
       console.log(_this);
     });
   }
@@ -15,9 +13,7 @@ class MyClass {
   constructor() {
     var _this2 = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
+    this.myAsyncMethod = /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
       console.log(_this2);
     });
   }
@@ -28,9 +24,7 @@ export default class MyClass3 {
   constructor() {
     var _this3 = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
+    this.myAsyncMethod = /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
       console.log(_this3);
     });
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-super/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-super/output.js
@@ -6,9 +6,7 @@ var A = function A() {
 
 A.prop = 1;
 
-var B =
-/*#__PURE__*/
-function (_A) {
+var B = /*#__PURE__*/function (_A) {
   "use strict";
 
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-call/output.js
@@ -1,6 +1,4 @@
-var A =
-/*#__PURE__*/
-function () {
+var A = /*#__PURE__*/function () {
   "use strict";
 
   function A() {
@@ -16,9 +14,7 @@ function () {
   return A;
 }();
 
-var B =
-/*#__PURE__*/
-function (_A) {
+var B = /*#__PURE__*/function (_A) {
   "use strict";
 
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-expression/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-statement/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/assignment/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/assignment/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/call/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed-without-block/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed-without-block/output.js
@@ -3,9 +3,7 @@ var createClass = k => {
 
   var _k;
 
-  return _temp = (_k = k(),
-  /*#__PURE__*/
-  function () {
+  return _temp = (_k = k(), /*#__PURE__*/function () {
     "use strict";
 
     function _class2() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed/output.js
@@ -15,9 +15,7 @@ _ref3 = /regex/;
 _baz = baz;
 _ref4 = `template${expression}`;
 
-var MyClass =
-/*#__PURE__*/
-function () {
+var MyClass = /*#__PURE__*/function () {
   "use strict";
 
   function MyClass() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-multiple-supers/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
@@ -1,6 +1,4 @@
-var Child =
-/*#__PURE__*/
-function (_Parent) {
+var Child = /*#__PURE__*/function (_Parent) {
   "use strict";
 
   babelHelpers.inherits(Child, _Parent);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/non-block-arrow-func/output.mjs
@@ -1,9 +1,7 @@
 export default (param => {
   var _class, _temp;
 
-  return _temp = _class =
-  /*#__PURE__*/
-  function () {
+  return _temp = _class = /*#__PURE__*/function () {
     function App() {
       babelHelpers.classCallCheck(this, App);
     }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T6719/output.js
@@ -1,9 +1,7 @@
 function withContext(ComposedComponent) {
   var _class, _temp;
 
-  return _temp = _class =
-  /*#__PURE__*/
-  function (_Component) {
+  return _temp = _class = /*#__PURE__*/function (_Component) {
     "use strict";
 
     babelHelpers.inherits(WithContext, _Component);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T7364/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T7364/output.mjs
@@ -2,9 +2,7 @@ class MyClass {
   constructor() {
     var _this = this;
 
-    babelHelpers.defineProperty(this, "myAsyncMethod",
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
+    babelHelpers.defineProperty(this, "myAsyncMethod", /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
       console.log(_this);
     }));
   }
@@ -15,9 +13,7 @@ class MyClass {
   constructor() {
     var _this2 = this;
 
-    babelHelpers.defineProperty(this, "myAsyncMethod",
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
+    babelHelpers.defineProperty(this, "myAsyncMethod", /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
       console.log(_this2);
     }));
   }
@@ -28,9 +24,7 @@ export default class MyClass3 {
   constructor() {
     var _this3 = this;
 
-    babelHelpers.defineProperty(this, "myAsyncMethod",
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
+    babelHelpers.defineProperty(this, "myAsyncMethod", /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
       console.log(_this3);
     }));
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-super/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-super/output.js
@@ -6,9 +6,7 @@ var A = function A() {
 
 babelHelpers.defineProperty(A, "prop", 1);
 
-var B =
-/*#__PURE__*/
-function (_A) {
+var B = /*#__PURE__*/function (_A) {
   "use strict";
 
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
@@ -1,6 +1,4 @@
-var A =
-/*#__PURE__*/
-function () {
+var A = /*#__PURE__*/function () {
   "use strict";
 
   function A() {
@@ -16,9 +14,7 @@ function () {
   return A;
 }();
 
-var B =
-/*#__PURE__*/
-function (_A) {
+var B = /*#__PURE__*/function (_A) {
   "use strict";
 
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/update/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/update/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
@@ -23,9 +23,7 @@ var Test = function Test() {
 
   _classCallCheck(this, Test);
 
-  var Other =
-  /*#__PURE__*/
-  function (_Test) {
+  var Other = /*#__PURE__*/function (_Test) {
     _inherits(Other, _Test);
 
     function Other() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T6719/output.js
@@ -1,9 +1,7 @@
 function withContext(ComposedComponent) {
   var _class, _temp;
 
-  return _temp = _class =
-  /*#__PURE__*/
-  function (_Component) {
+  return _temp = _class = /*#__PURE__*/function (_Component) {
     "use strict";
 
     babelHelpers.inherits(WithContext, _Component);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T7364/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T7364/output.mjs
@@ -2,9 +2,7 @@ class MyClass {
   constructor() {
     var _this = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
+    this.myAsyncMethod = /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
       console.log(_this);
     });
   }
@@ -15,9 +13,7 @@ class MyClass {
   constructor() {
     var _this2 = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
+    this.myAsyncMethod = /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
       console.log(_this2);
     });
   }
@@ -28,9 +24,7 @@ export default class MyClass3 {
   constructor() {
     var _this3 = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
+    this.myAsyncMethod = /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
       console.log(_this3);
     });
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/decorator-interop/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/decorator-interop/output.js
@@ -16,9 +16,7 @@ function _initializerWarningHelper(descriptor, context) { throw new Error('Decor
 
 function dec() {}
 
-let A = (_class = (_temp = (_Symbol$search = Symbol.search,
-/*#__PURE__*/
-function () {
+let A = (_class = (_temp = (_Symbol$search = Symbol.search, /*#__PURE__*/function () {
   "use strict";
 
   function A() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/output.js
@@ -25,9 +25,7 @@ function generateAsyncAction(type) {
   return request;
 }
 
-var A =
-/*#__PURE__*/
-function (_B) {
+var A = /*#__PURE__*/function (_B) {
   "use strict";
 
   _inherits(A, _B);

--- a/packages/babel-plugin-proposal-function-bind/test/fixtures/regression/T6984/output.js
+++ b/packages/babel-plugin-proposal-function-bind/test/fixtures/regression/T6984/output.js
@@ -8,9 +8,7 @@ function _one() {}
 
 function _two() {}
 
-let Test1 =
-/*#__PURE__*/
-function () {
+let Test1 = /*#__PURE__*/function () {
   "use strict";
 
   function Test1() {

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/output.js
@@ -4,9 +4,7 @@ let TestClass = {
   testMethodFailure() {
     var _this = this;
 
-    return new Promise(
-    /*#__PURE__*/
-    function () {
+    return new Promise( /*#__PURE__*/function () {
       var _ref = babelHelpers.asyncToGenerator(function* (resolve) {
         console.log(_this);
         setTimeout(resolve, 1000);

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-with-regenerator-spec/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-with-regenerator-spec/output.js
@@ -1,8 +1,6 @@
 var _this = this;
 
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee() {
+babelHelpers.asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
   return regeneratorRuntime.wrap(function _callee$(_context) {
     while (1) switch (_context.prev = _context.next) {
       case 0:
@@ -15,9 +13,7 @@ regeneratorRuntime.mark(function _callee() {
     }
   }, _callee);
 }))();
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee2() {
+babelHelpers.asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2() {
   return regeneratorRuntime.wrap(function _callee2$(_context2) {
     while (1) switch (_context2.prev = _context2.next) {
       case 0:
@@ -34,9 +30,7 @@ regeneratorRuntime.mark(function _callee2() {
 
 /*#__PURE__*/
 (function () {
-  var _notIIFE = babelHelpers.asyncToGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee3() {
+  var _notIIFE = babelHelpers.asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee3() {
     return regeneratorRuntime.wrap(function _callee3$(_context3) {
       while (1) switch (_context3.prev = _context3.next) {
         case 0:
@@ -58,9 +52,7 @@ regeneratorRuntime.mark(function _callee2() {
 })();
 
 /*#__PURE__*/
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee4() {
+babelHelpers.asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee4() {
   return regeneratorRuntime.wrap(function _callee4$(_context4) {
     while (1) switch (_context4.prev = _context4.next) {
       case 0:

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-with-regenerator/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-with-regenerator/output.js
@@ -1,6 +1,4 @@
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee() {
+babelHelpers.asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
   return regeneratorRuntime.wrap(function _callee$(_context) {
     while (1) switch (_context.prev = _context.next) {
       case 0:
@@ -13,9 +11,7 @@ regeneratorRuntime.mark(function _callee() {
     }
   }, _callee);
 }))();
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee2() {
+babelHelpers.asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2() {
   return regeneratorRuntime.wrap(function _callee2$(_context2) {
     while (1) switch (_context2.prev = _context2.next) {
       case 0:
@@ -31,9 +27,7 @@ regeneratorRuntime.mark(function _callee2() {
 
 /*#__PURE__*/
 (function () {
-  var _notIIFE = babelHelpers.asyncToGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee3() {
+  var _notIIFE = babelHelpers.asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee3() {
     return regeneratorRuntime.wrap(function _callee3$(_context3) {
       while (1) switch (_context3.prev = _context3.next) {
         case 0:
@@ -55,9 +49,7 @@ regeneratorRuntime.mark(function _callee2() {
 })();
 
 /*#__PURE__*/
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee4() {
+babelHelpers.asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee4() {
   return regeneratorRuntime.wrap(function _callee4$(_context4) {
     while (1) switch (_context4.prev = _context4.next) {
       case 0:

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/output.js
@@ -11,13 +11,9 @@ function _s() {
       args[_key - 1] = arguments[_key];
     }
 
-    let t =
-    /*#__PURE__*/
-    function () {
+    let t = /*#__PURE__*/function () {
       var _ref = babelHelpers.asyncToGenerator(function* (y, a) {
-        let r =
-        /*#__PURE__*/
-        function () {
+        let r = /*#__PURE__*/function () {
           var _ref2 = babelHelpers.asyncToGenerator(function* (z, b) {
             yield z;
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/expression/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/expression/output.js
@@ -1,6 +1,4 @@
-var foo =
-/*#__PURE__*/
-function () {
+var foo = /*#__PURE__*/function () {
   var _ref = babelHelpers.asyncToGenerator(function* () {
     var wat = yield bar();
   });
@@ -10,9 +8,7 @@ function () {
   };
 }();
 
-var foo2 =
-/*#__PURE__*/
-function () {
+var foo2 = /*#__PURE__*/function () {
   var _ref2 = babelHelpers.asyncToGenerator(function* () {
     var wat = yield bar();
   });
@@ -21,9 +17,7 @@ function () {
     return _ref2.apply(this, arguments);
   };
 }(),
-    bar =
-/*#__PURE__*/
-function () {
+    bar = /*#__PURE__*/function () {
   var _ref3 = babelHelpers.asyncToGenerator(function* () {
     var wat = yield foo();
   });

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/output.js
@@ -1,6 +1,4 @@
-var foo =
-/*#__PURE__*/
-function () {
+var foo = /*#__PURE__*/function () {
   var _bar = babelHelpers.asyncToGenerator(function* () {
     console.log(bar);
   });

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/no-parameters-and-no-id/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/no-parameters-and-no-id/output.js
@@ -1,3 +1,1 @@
-foo(
-/*#__PURE__*/
-babelHelpers.asyncToGenerator(function* () {}));
+foo( /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {}));

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/expression/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/expression/output.js
@@ -1,8 +1,6 @@
 var _coroutine = require("bluebird").coroutine;
 
-var foo =
-/*#__PURE__*/
-function () {
+var foo = /*#__PURE__*/function () {
   var _ref = _coroutine(function* () {
     var wat = yield bar();
   });

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/named-expression/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/named-expression/output.js
@@ -1,8 +1,6 @@
 var _coroutine = require("bluebird").coroutine;
 
-var foo =
-/*#__PURE__*/
-function () {
+var foo = /*#__PURE__*/function () {
   var _bar = _coroutine(function* () {
     console.log(bar);
   });

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-arrow-export/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-arrow-export/output.js
@@ -5,9 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _default =
-/*#__PURE__*/
-babelHelpers.asyncToGenerator(function* () {
+var _default = /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
   return yield foo();
 });
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/output.js
@@ -4,9 +4,7 @@ function action() {
   return _action.apply(this, arguments);
 }
 
-var _ref =
-/*#__PURE__*/
-React.createElement(Contact, {
+var _ref = /*#__PURE__*/React.createElement(Contact, {
   title: title
 });
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/output.js
@@ -4,9 +4,7 @@ class Test {
 
     return babelHelpers.asyncToGenerator(function* () {
       console.log(_this);
-      setTimeout(
-      /*#__PURE__*/
-      babelHelpers.asyncToGenerator(function* () {
+      setTimeout( /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
         console.log(_this);
       }));
     })();
@@ -17,9 +15,7 @@ class Test {
 
     return babelHelpers.asyncToGenerator(function* () {
       console.log(_this2);
-      setTimeout(
-      /*#__PURE__*/
-      function () {
+      setTimeout( /*#__PURE__*/function () {
         var _ref2 = babelHelpers.asyncToGenerator(function* (arg) {
           console.log(_this2);
         });
@@ -36,9 +32,7 @@ class Test {
 
     return babelHelpers.asyncToGenerator(function* () {
       console.log(_this3);
-      setTimeout(
-      /*#__PURE__*/
-      babelHelpers.asyncToGenerator(function* () {
+      setTimeout( /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
         console.log(_this3);
       }));
     })();
@@ -49,9 +43,7 @@ class Test {
 
     return babelHelpers.asyncToGenerator(function* () {
       console.log(_this4);
-      setTimeout(
-      /*#__PURE__*/
-      function () {
+      setTimeout( /*#__PURE__*/function () {
         var _ref4 = babelHelpers.asyncToGenerator(function* (arg) {
           console.log(_this4);
         });

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7194/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7194/output.js
@@ -1,7 +1,5 @@
 function f() {
-  g(
-  /*#__PURE__*/
-  babelHelpers.asyncToGenerator(function* () {
+  g( /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
     var _this = this;
 
     c(function () {

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/gh-6923/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/gh-6923/output.js
@@ -3,17 +3,13 @@ function foo() {
 }
 
 function _foo() {
-  _foo = babelHelpers.asyncToGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee2() {
+  _foo = babelHelpers.asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2() {
     return regeneratorRuntime.wrap(function _callee2$(_context2) {
       while (1) switch (_context2.prev = _context2.next) {
         case 0:
           /*#__PURE__*/
           (function () {
-            var _ref = babelHelpers.asyncToGenerator(
-            /*#__PURE__*/
-            regeneratorRuntime.mark(function _callee(number) {
+            var _ref = babelHelpers.asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(number) {
               var tmp;
               return regeneratorRuntime.wrap(function _callee$(_context) {
                 while (1) switch (_context.prev = _context.next) {

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
@@ -12,9 +12,7 @@ function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || func
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
-var List =
-/*#__PURE__*/
-function (_Array) {
+var List = /*#__PURE__*/function (_Array) {
   "use strict";
 
   _inheritsLoose(List, _Array);

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/shadowed/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/shadowed/output.js
@@ -4,9 +4,7 @@ let Array = function Array() {
   babelHelpers.classCallCheck(this, Array);
 };
 
-let List =
-/*#__PURE__*/
-function (_Array) {
+let List = /*#__PURE__*/function (_Array) {
   "use strict";
 
   babelHelpers.inherits(List, _Array);

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
@@ -18,9 +18,7 @@ function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || func
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
-var List =
-/*#__PURE__*/
-function (_Array) {
+var List = /*#__PURE__*/function (_Array) {
   "use strict";
 
   _inherits(List, _Array);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-data-defined-on-parent/output.js
@@ -2,9 +2,7 @@
 
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {}
 
   var _proto = Base.prototype;
@@ -18,9 +16,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-getter-defined-on-parent/output.js
@@ -6,9 +6,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {}
 
   _createClass(Base, [{
@@ -28,9 +26,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/output.js
@@ -4,9 +4,7 @@ function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.crea
 
 let Base = function Base() {};
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/output.js
@@ -6,9 +6,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {}
 
   _createClass(Base, [{
@@ -21,9 +19,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-data-defined-on-parent/output.js
@@ -6,9 +6,7 @@ let Base = function Base() {};
 
 Base.prototype.test = 1;
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-getter-defined-on-parent/output.js
@@ -6,9 +6,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {}
 
   _createClass(Base, [{
@@ -24,9 +22,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-not-defined-on-parent/output.js
@@ -4,9 +4,7 @@ function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.crea
 
 let Base = function Base() {};
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-setter-defined-on-parent/output.js
@@ -6,9 +6,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {}
 
   _createClass(Base, [{
@@ -21,9 +19,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-assign/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-assign/output.js
@@ -22,9 +22,7 @@ const proper = {
 
 };
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-update/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-update/output.js
@@ -22,9 +22,7 @@ const proper = {
 
 };
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-data-defined-on-parent/output.js
@@ -10,9 +10,7 @@ Object.defineProperty(Base.prototype, 'test', {
   configurable: true
 });
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-getter-defined-on-parent/output.js
@@ -8,9 +8,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 let called = false;
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {}
 
   _createClass(Base, [{
@@ -26,9 +24,7 @@ function () {
 
 ;
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-data-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-data-on-obj/output.js
@@ -4,9 +4,7 @@ function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.crea
 
 let Base = function Base() {};
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-getter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-getter-on-obj/output.js
@@ -10,9 +10,7 @@ let Base = function Base() {};
 
 let called = false;
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-not-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-not-on-obj/output.js
@@ -4,9 +4,7 @@ function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.crea
 
 let Base = function Base() {};
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-setter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-setter-on-obj/output.js
@@ -10,9 +10,7 @@ let Base = function Base() {};
 
 let value = 2;
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-setter-defined-on-parent/output.js
@@ -8,9 +8,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 let value = 1;
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {}
 
   _createClass(Base, [{
@@ -23,9 +21,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-data-defined-on-parent/output.js
@@ -20,9 +20,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {
     _classCallCheck(this, Base);
   }
@@ -39,9 +37,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-getter-defined-on-parent/output.js
@@ -20,9 +20,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {
     _classCallCheck(this, Base);
   }
@@ -42,9 +40,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/output.js
@@ -24,9 +24,7 @@ let Base = function Base() {
   _classCallCheck(this, Base);
 };
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-setter-defined-on-parent/output.js
@@ -20,9 +20,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {
     _classCallCheck(this, Base);
   }
@@ -37,9 +35,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
@@ -26,9 +26,7 @@ let Base = function Base() {
 
 Base.prototype.test = 1;
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
@@ -20,9 +20,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {
     _classCallCheck(this, Base);
   }
@@ -38,9 +36,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
@@ -24,9 +24,7 @@ let Base = function Base() {
   _classCallCheck(this, Base);
 };
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
@@ -20,9 +20,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {
     _classCallCheck(this, Base);
   }
@@ -37,9 +35,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-assign/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-assign/output.js
@@ -48,9 +48,7 @@ const proper = {
 
 };
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-update/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-update/output.js
@@ -48,9 +48,7 @@ const proper = {
 
 };
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
@@ -34,9 +34,7 @@ Object.defineProperty(Base.prototype, 'test', {
   configurable: true
 });
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
@@ -24,9 +24,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {
     _classCallCheck(this, Base);
   }
@@ -43,9 +41,7 @@ function () {
 
 ;
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
@@ -28,9 +28,7 @@ let Base = function Base() {
   _classCallCheck(this, Base);
 };
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
@@ -28,9 +28,7 @@ let Base = function Base() {
   _classCallCheck(this, Base);
 };
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
@@ -28,9 +28,7 @@ let Base = function Base() {
   _classCallCheck(this, Base);
 };
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
@@ -30,9 +30,7 @@ let Base = function Base() {
 
 let value = 2;
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
@@ -26,9 +26,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 let value = 1;
 
-let Base =
-/*#__PURE__*/
-function () {
+let Base = /*#__PURE__*/function () {
   function Base() {
     _classCallCheck(this, Base);
   }
@@ -43,9 +41,7 @@ function () {
   return Base;
 }();
 
-let Obj =
-/*#__PURE__*/
-function (_Base) {
+let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
   function Obj() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-constructor/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-constructor/output.js
@@ -4,9 +4,7 @@ let A = function A() {
   console.log('a');
 };
 
-let B =
-/*#__PURE__*/
-function () {
+let B = /*#__PURE__*/function () {
   "use strict";
 
   function B() {}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-superClass/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-superClass/output.js
@@ -6,9 +6,7 @@ let B = function B() {
   "use strict";
 };
 
-let A =
-/*#__PURE__*/
-function (_B) {
+let A = /*#__PURE__*/function (_B) {
   "use strict";
 
   _inheritsLoose(A, _B);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function (_Foo) {
+var Test = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   babelHelpers.inheritsLoose(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-properties/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function (_Foo) {
+var Test = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   babelHelpers.inheritsLoose(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/blockstatement-with-use-strict-directive/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/blockstatement-with-use-strict-directive/output.js
@@ -1,9 +1,7 @@
 function t() {
   "use strict";
 
-  var Foo =
-  /*#__PURE__*/
-  function () {
+  var Foo = /*#__PURE__*/function () {
     function Foo() {}
 
     var _proto = Foo.prototype;

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/calling-super-properties/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function (_Foo) {
+var Test = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   babelHelpers.inheritsLoose(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/constructor-order/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/constructor-order/output.js
@@ -1,6 +1,4 @@
-var x =
-/*#__PURE__*/
-function () {
+var x = /*#__PURE__*/function () {
   "use strict";
 
   var _proto = x.prototype;

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/default-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/default-super/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function () {
+var Test = /*#__PURE__*/function () {
   "use strict";
 
   function Test() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-must-call-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-must-call-super/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inheritsLoose(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/output.js
@@ -1,6 +1,4 @@
-var Child =
-/*#__PURE__*/
-function (_Base) {
+var Child = /*#__PURE__*/function (_Base) {
   "use strict";
 
   babelHelpers.inheritsLoose(Child, _Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-object/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-object/output.js
@@ -1,6 +1,4 @@
-var Child =
-/*#__PURE__*/
-function (_Base) {
+var Child = /*#__PURE__*/function (_Base) {
   "use strict";
 
   babelHelpers.inheritsLoose(Child, _Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/literal-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/literal-key/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/method-return-type-annotation/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/method-return-type-annotation/output.js
@@ -1,7 +1,5 @@
 // @flow
-var C =
-/*#__PURE__*/
-function () {
+var C = /*#__PURE__*/function () {
   "use strict";
 
   function C() {}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/method-reuse-prototype/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/method-reuse-prototype/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function () {
+var Test = /*#__PURE__*/function () {
   "use strict";
 
   function Test() {}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/program-with-use-strict-directive/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/program-with-use-strict-directive/output.js
@@ -1,8 +1,6 @@
 "use strict";
 
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   function Foo() {}
 
   var _proto = Foo.prototype;

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class-id-member-expression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class-id-member-expression/output.js
@@ -1,6 +1,4 @@
-var BaseController =
-/*#__PURE__*/
-function (_Chaplin$Controller) {
+var BaseController = /*#__PURE__*/function (_Chaplin$Controller) {
   "use strict";
 
   babelHelpers.inheritsLoose(BaseController, _Chaplin$Controller);
@@ -12,9 +10,7 @@ function (_Chaplin$Controller) {
   return BaseController;
 }(Chaplin.Controller);
 
-var BaseController2 =
-/*#__PURE__*/
-function (_Chaplin$Controller$A) {
+var BaseController2 = /*#__PURE__*/function (_Chaplin$Controller$A) {
   "use strict";
 
   babelHelpers.inheritsLoose(BaseController2, _Chaplin$Controller$A);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function (_Foo) {
+var Test = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   babelHelpers.inheritsLoose(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/super-destructuring-array-pattern-1/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/super-destructuring-array-pattern-1/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/super-destructuring-array-pattern/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/super-destructuring-array-pattern/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/super-destructuring-object-pattern-1/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/super-destructuring-object-pattern-1/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/super-destructuring-object-pattern/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/super-destructuring-object-pattern/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {}

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/2663/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/2663/output.js
@@ -12,9 +12,7 @@ var _events = require("events");
 var _binarySerializer = babelHelpers.interopRequireDefault(require("./helpers/binary-serializer"));
 
 // import ...
-var Connection =
-/*#__PURE__*/
-function (_EventEmitter) {
+var Connection = /*#__PURE__*/function (_EventEmitter) {
   babelHelpers.inherits(Connection, _EventEmitter);
 
   function Connection(endpoint, joinKey, joinData, roomId) {

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/2694/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/2694/output.js
@@ -7,9 +7,7 @@ exports["default"] = void 0;
 
 var _BaseFoo2 = babelHelpers.interopRequireDefault(require("./BaseFoo"));
 
-var SubFoo =
-/*#__PURE__*/
-function (_BaseFoo) {
+var SubFoo = /*#__PURE__*/function (_BaseFoo) {
   babelHelpers.inherits(SubFoo, _BaseFoo);
 
   function SubFoo() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/2775/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/2775/output.js
@@ -7,9 +7,7 @@ exports["default"] = void 0;
 
 var _react = babelHelpers.interopRequireDefault(require("react"));
 
-var RandomComponent =
-/*#__PURE__*/
-function (_Component) {
+var RandomComponent = /*#__PURE__*/function (_Component) {
   babelHelpers.inherits(RandomComponent, _Component);
 
   function RandomComponent() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
@@ -9,9 +9,7 @@ var b = function b() {
   babelHelpers.classCallCheck(this, b);
 };
 
-var a1 =
-/*#__PURE__*/
-function (_b) {
+var a1 = /*#__PURE__*/function (_b) {
   babelHelpers.inherits(a1, _b);
 
   function a1() {
@@ -30,9 +28,7 @@ function (_b) {
   return a1;
 }(b);
 
-var a2 =
-/*#__PURE__*/
-function (_b2) {
+var a2 = /*#__PURE__*/function (_b2) {
   babelHelpers.inherits(a2, _b2);
 
   function a2() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
@@ -1,6 +1,4 @@
-var Point =
-/*#__PURE__*/
-function () {
+var Point = /*#__PURE__*/function () {
   "use strict";
 
   function Point() {
@@ -16,9 +14,7 @@ function () {
   return Point;
 }();
 
-var ColorPoint =
-/*#__PURE__*/
-function (_Point) {
+var ColorPoint = /*#__PURE__*/function (_Point) {
   "use strict";
 
   babelHelpers.inherits(ColorPoint, _Point);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5817/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5817/output.js
@@ -1,6 +1,4 @@
-var A =
-/*#__PURE__*/
-function (_B) {
+var A = /*#__PURE__*/function (_B) {
   "use strict";
 
   babelHelpers.inherits(A, _B);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/8499/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/8499/output.js
@@ -9,9 +9,7 @@ this.HTMLElement = function () {
 
 var constructor;
 
-var CustomElement =
-/*#__PURE__*/
-function (_HTMLElement) {
+var CustomElement = /*#__PURE__*/function (_HTMLElement) {
   "use strict";
 
   babelHelpers.inherits(CustomElement, _HTMLElement);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T2494/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T2494/output.js
@@ -1,7 +1,5 @@
 var x = {
-  Foo:
-  /*#__PURE__*/
-  function (_Foo) {
+  Foo: /*#__PURE__*/function (_Foo) {
     "use strict";
 
     babelHelpers.inherits(_class, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T2997/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T2997/output.js
@@ -4,9 +4,7 @@ var A = function A() {
   babelHelpers.classCallCheck(this, A);
 };
 
-var B =
-/*#__PURE__*/
-function (_A) {
+var B = /*#__PURE__*/function (_A) {
   "use strict";
 
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T6712/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T6712/output.js
@@ -1,6 +1,4 @@
-var A =
-/*#__PURE__*/
-function () {
+var A = /*#__PURE__*/function () {
   "use strict";
 
   function A() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T6750/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T6750/output.js
@@ -6,9 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 exports["default"] = _default;
 
 function _default() {
-  return (
-    /*#__PURE__*/
-    function () {
+  return (/*#__PURE__*/function () {
       function Select() {
         babelHelpers.classCallCheck(this, Select);
       }

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T6755/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T6755/output.js
@@ -2,21 +2,15 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
-var Example =
-/*#__PURE__*/
-function () {
+var Example = /*#__PURE__*/function () {
   "use strict";
 
   function Example() {}
 
   var _proto = Example.prototype;
 
-  _proto.test1 =
-  /*#__PURE__*/
-  function () {
-    var _test = _asyncToGenerator(
-    /*#__PURE__*/
-    regeneratorRuntime.mark(function _callee() {
+  _proto.test1 = /*#__PURE__*/function () {
+    var _test = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
       return regeneratorRuntime.wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
@@ -39,9 +33,7 @@ function () {
     return test1;
   }();
 
-  _proto.test2 =
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function test2() {
+  _proto.test2 = /*#__PURE__*/regeneratorRuntime.mark(function test2() {
     return regeneratorRuntime.wrap(function test2$(_context2) {
       while (1) {
         switch (_context2.prev = _context2.next) {

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T7010/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T7010/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo(val) {

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T7537/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T7537/output.js
@@ -18,9 +18,7 @@ var B = function B() {
   _classCallCheck(this, B);
 };
 
-var A =
-/*#__PURE__*/
-function (_B) {
+var A = /*#__PURE__*/function (_B) {
   "use strict";
 
   _inherits(A, _B);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function (_Foo) {
+var Test = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function (_Foo) {
+var Test = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function (_Foo) {
+var Test = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/computed-methods/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/computed-methods/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/constructor/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/constructor/output.js
@@ -5,9 +5,7 @@ var Test = function Test() {
   this.state = "test";
 };
 
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/default-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/default-super/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function () {
+var Test = /*#__PURE__*/function () {
   "use strict";
 
   function Test() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-3/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-4/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-4/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/output.js
@@ -1,6 +1,4 @@
-var Child =
-/*#__PURE__*/
-function (_Base) {
+var Child = /*#__PURE__*/function (_Base) {
   "use strict";
 
   babelHelpers.inherits(Child, _Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-object/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-object/output.js
@@ -1,6 +1,4 @@
-var Child =
-/*#__PURE__*/
-function (_Base) {
+var Child = /*#__PURE__*/function (_Base) {
   "use strict";
 
   babelHelpers.inherits(Child, _Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/export-super-class/output.mjs
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/export-super-class/output.mjs
@@ -1,6 +1,4 @@
-var _default =
-/*#__PURE__*/
-function (_A) {
+var _default = /*#__PURE__*/function (_A) {
   babelHelpers.inherits(_default, _A);
 
   function _default() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/instance-getter-and-setter/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/instance-getter-and-setter/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function () {
+var Test = /*#__PURE__*/function () {
   "use strict";
 
   function Test() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/instance-getter/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/instance-getter/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function () {
+var Test = /*#__PURE__*/function () {
   "use strict";
 
   function Test() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/instance-method/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/instance-method/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function () {
+var Test = /*#__PURE__*/function () {
   "use strict";
 
   function Test() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/instance-setter/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/instance-setter/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function () {
+var Test = /*#__PURE__*/function () {
   "use strict";
 
   function Test() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/method-return-type-annotation/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/method-return-type-annotation/output.js
@@ -1,7 +1,5 @@
 // @flow
-var C =
-/*#__PURE__*/
-function () {
+var C = /*#__PURE__*/function () {
   "use strict";
 
   function C() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/name-method-collision/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/name-method-collision/output.js
@@ -2,9 +2,7 @@
 
 var _a2 = require("./a");
 
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/output.js
@@ -10,9 +10,7 @@ var Hello = function Hello() {
   };
 };
 
-var Outer =
-/*#__PURE__*/
-function (_Hello) {
+var Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
   function Outer() {
@@ -22,9 +20,7 @@ function (_Hello) {
 
     babelHelpers.classCallCheck(this, Outer);
 
-    var Inner =
-    /*#__PURE__*/
-    function () {
+    var Inner = /*#__PURE__*/function () {
       function Inner() {
         babelHelpers.classCallCheck(this, Inner);
       }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
@@ -1,8 +1,6 @@
 "use strict";
 
-var Hello =
-/*#__PURE__*/
-function () {
+var Hello = /*#__PURE__*/function () {
   function Hello() {
     babelHelpers.classCallCheck(this, Hello);
   }
@@ -16,9 +14,7 @@ function () {
   return Hello;
 }();
 
-var Outer =
-/*#__PURE__*/
-function (_Hello) {
+var Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
   function Outer() {
@@ -27,9 +23,7 @@ function (_Hello) {
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Outer).call(this));
 
-    var Inner =
-    /*#__PURE__*/
-    function () {
+    var Inner = /*#__PURE__*/function () {
       function Inner() {
         babelHelpers.classCallCheck(this, Inner);
       }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/output.js
@@ -10,9 +10,7 @@ var Hello = function Hello() {
   };
 };
 
-var Outer =
-/*#__PURE__*/
-function (_Hello) {
+var Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
   function Outer() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
@@ -1,8 +1,6 @@
 "use strict";
 
-var Hello =
-/*#__PURE__*/
-function () {
+var Hello = /*#__PURE__*/function () {
   function Hello() {
     babelHelpers.classCallCheck(this, Hello);
   }
@@ -16,9 +14,7 @@ function () {
   return Hello;
 }();
 
-var Outer =
-/*#__PURE__*/
-function (_Hello) {
+var Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
   function Outer() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/relaxed-method-coercion/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/relaxed-method-coercion/output.js
@@ -1,7 +1,5 @@
 // #1649
-var Foo =
-/*#__PURE__*/
-function () {
+var Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/statement/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/statement/output.js
@@ -12,9 +12,7 @@ var BaseView = function BaseView() {
   this.autoRender = true;
 };
 
-var BaseView =
-/*#__PURE__*/
-function () {
+var BaseView = /*#__PURE__*/function () {
   "use strict";
 
   function BaseView() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/static/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/static/output.js
@@ -1,6 +1,4 @@
-var A =
-/*#__PURE__*/
-function () {
+var A = /*#__PURE__*/function () {
   "use strict";
 
   function A() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-anonymous/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-anonymous/output.js
@@ -1,6 +1,4 @@
-var TestEmpty =
-/*#__PURE__*/
-function (_ref) {
+var TestEmpty = /*#__PURE__*/function (_ref) {
   "use strict";
 
   babelHelpers.inherits(TestEmpty, _ref);
@@ -11,9 +9,7 @@ function (_ref) {
   }
 
   return TestEmpty;
-}(
-/*#__PURE__*/
-function () {
+}( /*#__PURE__*/function () {
   "use strict";
 
   function _class() {
@@ -23,9 +19,7 @@ function () {
   return _class;
 }());
 
-var TestConstructorOnly =
-/*#__PURE__*/
-function (_ref2) {
+var TestConstructorOnly = /*#__PURE__*/function (_ref2) {
   "use strict";
 
   babelHelpers.inherits(TestConstructorOnly, _ref2);
@@ -36,9 +30,7 @@ function (_ref2) {
   }
 
   return TestConstructorOnly;
-}(
-/*#__PURE__*/
-function () {
+}( /*#__PURE__*/function () {
   "use strict";
 
   function _class2() {
@@ -48,9 +40,7 @@ function () {
   return _class2;
 }());
 
-var TestMethodOnly =
-/*#__PURE__*/
-function (_ref3) {
+var TestMethodOnly = /*#__PURE__*/function (_ref3) {
   "use strict";
 
   babelHelpers.inherits(TestMethodOnly, _ref3);
@@ -61,9 +51,7 @@ function (_ref3) {
   }
 
   return TestMethodOnly;
-}(
-/*#__PURE__*/
-function () {
+}( /*#__PURE__*/function () {
   "use strict";
 
   function _class3() {
@@ -77,9 +65,7 @@ function () {
   return _class3;
 }());
 
-var TestConstructorAndMethod =
-/*#__PURE__*/
-function (_ref4) {
+var TestConstructorAndMethod = /*#__PURE__*/function (_ref4) {
   "use strict";
 
   babelHelpers.inherits(TestConstructorAndMethod, _ref4);
@@ -90,9 +76,7 @@ function (_ref4) {
   }
 
   return TestConstructorAndMethod;
-}(
-/*#__PURE__*/
-function () {
+}( /*#__PURE__*/function () {
   "use strict";
 
   function _class4() {
@@ -106,9 +90,7 @@ function () {
   return _class4;
 }());
 
-var TestMultipleMethods =
-/*#__PURE__*/
-function (_ref5) {
+var TestMultipleMethods = /*#__PURE__*/function (_ref5) {
   "use strict";
 
   babelHelpers.inherits(TestMultipleMethods, _ref5);
@@ -119,9 +101,7 @@ function (_ref5) {
   }
 
   return TestMultipleMethods;
-}(
-/*#__PURE__*/
-function () {
+}( /*#__PURE__*/function () {
   "use strict";
 
   function _class5() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-id-member-expression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-id-member-expression/output.js
@@ -1,6 +1,4 @@
-var BaseController =
-/*#__PURE__*/
-function (_Chaplin$Controller) {
+var BaseController = /*#__PURE__*/function (_Chaplin$Controller) {
   "use strict";
 
   babelHelpers.inherits(BaseController, _Chaplin$Controller);
@@ -13,9 +11,7 @@ function (_Chaplin$Controller) {
   return BaseController;
 }(Chaplin.Controller);
 
-var BaseController2 =
-/*#__PURE__*/
-function (_Chaplin$Controller$A) {
+var BaseController2 = /*#__PURE__*/function (_Chaplin$Controller$A) {
   "use strict";
 
   babelHelpers.inherits(BaseController2, _Chaplin$Controller$A);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class/output.js
@@ -1,6 +1,4 @@
-var Test =
-/*#__PURE__*/
-function (_Foo) {
+var Test = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
@@ -14,9 +14,7 @@ function _superPropBase(object, property) { while (!Object.prototype.hasOwnPrope
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   _inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
@@ -14,9 +14,7 @@ function _superPropBase(object, property) { while (!Object.prototype.hasOwnPrope
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   _inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/output.js
@@ -1,6 +1,4 @@
-var Foo =
-/*#__PURE__*/
-function (_Bar) {
+var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/output.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/output.js
@@ -1,7 +1,5 @@
 // @flow
-var C =
-/*#__PURE__*/
-function () {
+var C = /*#__PURE__*/function () {
   "use strict";
 
   function C() {}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/output.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/output.js
@@ -1,7 +1,5 @@
 // @flow
-var C =
-/*#__PURE__*/
-function () {
+var C = /*#__PURE__*/function () {
   "use strict";
 
   function C() {

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/output.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/output.js
@@ -1,6 +1,4 @@
-var C =
-/*#__PURE__*/
-function () {
+var C = /*#__PURE__*/function () {
   "use strict";
 
   function C() {}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/output.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/output.js
@@ -1,6 +1,4 @@
-var C =
-/*#__PURE__*/
-function () {
+var C = /*#__PURE__*/function () {
   "use strict";
 
   function C() {

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/class-method/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/class-method/output.js
@@ -1,6 +1,4 @@
-let Foo =
-/*#__PURE__*/
-function () {
+let Foo = /*#__PURE__*/function () {
   "use strict";
 
   function Foo() {

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-2/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-2/output.js
@@ -7,9 +7,7 @@ exports.default = void 0;
 
 var _last2 = babelHelpers.interopRequireDefault(require("lodash/last"));
 
-let Container =
-/*#__PURE__*/
-function () {
+let Container = /*#__PURE__*/function () {
   function Container() {
     babelHelpers.classCallCheck(this, Container);
   }

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-3/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-3/output.js
@@ -7,9 +7,7 @@ exports.default = void 0;
 
 var _store = require("./store");
 
-let Login =
-/*#__PURE__*/
-function (_React$Component) {
+let Login = /*#__PURE__*/function (_React$Component) {
   babelHelpers.inherits(Login, _React$Component);
 
   function Login() {

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules/output.js
@@ -2,9 +2,7 @@
 
 var _events2 = babelHelpers.interopRequireDefault(require("events"));
 
-let Template =
-/*#__PURE__*/
-function () {
+let Template = /*#__PURE__*/function () {
   function Template() {
     babelHelpers.classCallCheck(this, Template);
   }

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-iife-4253/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-iife-4253/output.js
@@ -1,6 +1,4 @@
-var Ref =
-/*#__PURE__*/
-function () {
+var Ref = /*#__PURE__*/function () {
   "use strict";
 
   function Ref() {

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-iife-self/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-iife-self/output.js
@@ -1,6 +1,4 @@
-var Ref =
-/*#__PURE__*/
-function () {
+var Ref = /*#__PURE__*/function () {
   "use strict";
 
   function Ref() {
@@ -12,9 +10,7 @@ function () {
   return Ref;
 }();
 
-var X =
-/*#__PURE__*/
-function () {
+var X = /*#__PURE__*/function () {
   "use strict";
 
   function X() {

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/iife-this-9385/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/iife-this-9385/output.js
@@ -11,9 +11,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-var Test =
-/*#__PURE__*/
-function () {
+var Test = /*#__PURE__*/function () {
   function Test() {
     _classCallCheck(this, Test);
   }

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/iife-this/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/iife-this/output.js
@@ -1,8 +1,6 @@
 var a;
 
-var Test =
-/*#__PURE__*/
-function () {
+var Test = /*#__PURE__*/function () {
   "use strict";
 
   function Test() {

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-async-arrow-functions/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-async-arrow-functions/output.js
@@ -1,6 +1,4 @@
-var concat =
-/*#__PURE__*/
-function () {
+var concat = /*#__PURE__*/function () {
   var _ref = babelHelpers.asyncToGenerator(function* () {
     var x = arguments.length <= 0 ? undefined : arguments[0];
     var y = arguments.length <= 1 ? undefined : arguments[1];
@@ -11,9 +9,7 @@ function () {
   };
 }();
 
-var x =
-/*#__PURE__*/
-function () {
+var x = /*#__PURE__*/function () {
   var _ref2 = babelHelpers.asyncToGenerator(function* () {
     if (noNeedToWork) return 0;
 

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-nested-iife/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-nested-iife/output.js
@@ -1,8 +1,6 @@
 function broken(x) {
   if (true) {
-    var Foo =
-    /*#__PURE__*/
-    function (_Bar) {
+    var Foo = /*#__PURE__*/function (_Bar) {
       "use strict";
 
       babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/4209/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/4209/output.js
@@ -8,9 +8,7 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-var Thing =
-/*#__PURE__*/
-function () {
+var Thing = /*#__PURE__*/function () {
   function Thing() {
     _classCallCheck(this, Thing);
   }

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -29,9 +29,7 @@ function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || func
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-var App =
-/*#__PURE__*/
-function (_Component) {
+var App = /*#__PURE__*/function (_Component) {
   _inherits(App, _Component);
 
   function App() {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-2/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-2/output.mjs
@@ -1,14 +1,10 @@
-var _ref =
-/*#__PURE__*/
-<div>child</div>;
+var _ref = /*#__PURE__*/<div>child</div>;
 
 const AppItem = () => {
   return _ref;
 };
 
-var _ref2 =
-/*#__PURE__*/
-<div>
+var _ref2 = /*#__PURE__*/<div>
         <p>Parent</p>
         <AppItem />
       </div>;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-3/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-3/output.js
@@ -1,10 +1,6 @@
-var _ref2 =
-/*#__PURE__*/
-<div>child</div>;
+var _ref2 = /*#__PURE__*/<div>child</div>;
 
-var _ref3 =
-/*#__PURE__*/
-<p>Parent</p>;
+var _ref3 = /*#__PURE__*/<p>Parent</p>;
 
 (function () {
   class App extends React.Component {
@@ -17,9 +13,7 @@ var _ref3 =
   const AppItem = () => {
     return _ref2;
   },
-        _ref =
-  /*#__PURE__*/
-  <div>
+        _ref = /*#__PURE__*/<div>
           {_ref3}
           <AppItem />
         </div>;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-4/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope-4/output.js
@@ -1,19 +1,13 @@
-var _ref =
-/*#__PURE__*/
-<div>child</div>;
+var _ref = /*#__PURE__*/<div>child</div>;
 
-var _ref3 =
-/*#__PURE__*/
-<p>Parent</p>;
+var _ref3 = /*#__PURE__*/<p>Parent</p>;
 
 (function () {
   const AppItem = () => {
     return _ref;
   };
 
-  var _ref2 =
-  /*#__PURE__*/
-  <div>
+  var _ref2 = /*#__PURE__*/<div>
           {_ref3}
           <AppItem />
         </div>;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope/output.mjs
@@ -5,16 +5,12 @@ export default class App extends React.Component {
 
 }
 
-var _ref2 =
-/*#__PURE__*/
-<div>child</div>;
+var _ref2 = /*#__PURE__*/<div>child</div>;
 
 const AppItem = () => {
   return _ref2;
 },
-      _ref =
-/*#__PURE__*/
-<div>
+      _ref = /*#__PURE__*/<div>
         <p>Parent</p>
         <AppItem />
       </div>;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/children/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/children/output.js
@@ -1,6 +1,4 @@
-var _ref =
-/*#__PURE__*/
-<span />;
+var _ref = /*#__PURE__*/<span />;
 
 var Foo = React.createClass({
   render: function () {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/output.mjs
@@ -1,8 +1,6 @@
 import React from 'react'; // Regression test for https://github.com/babel/babel/issues/5552
 
-var _ref =
-/*#__PURE__*/
-<div />;
+var _ref = /*#__PURE__*/<div />;
 
 class BugReport extends React.Component {
   constructor(...args) {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/compound-assignment/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/compound-assignment/output.mjs
@@ -1,13 +1,9 @@
 import React from 'react';
 import Loader from 'loader';
 
-var _ref =
-/*#__PURE__*/
-<Loader className="full-height" />;
+var _ref = /*#__PURE__*/<Loader className="full-height" />;
 
-var _ref2 =
-/*#__PURE__*/
-<Loader className="p-y-5" />;
+var _ref2 = /*#__PURE__*/<Loader className="p-y-5" />;
 
 const errorComesHere = () => _ref,
       thisWorksFine = () => _ref2;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/constructor/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/constructor/output.js
@@ -1,8 +1,6 @@
 var Foo = require("Foo");
 
-var _ref =
-/*#__PURE__*/
-<Foo />;
+var _ref = /*#__PURE__*/<Foo />;
 
 function render() {
   return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/deep-constant-violation/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/deep-constant-violation/output.js
@@ -1,10 +1,6 @@
-var _ref =
-/*#__PURE__*/
-<b></b>;
+var _ref = /*#__PURE__*/<b></b>;
 
-var _ref2 =
-/*#__PURE__*/
-<span></span>;
+var _ref2 = /*#__PURE__*/<span></span>;
 
 function render() {
   var children = _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-class/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-class/output.mjs
@@ -4,15 +4,11 @@ const Parent = ({}) => _ref;
 
 export default Parent;
 
-var _ref2 =
-/*#__PURE__*/
-<div className="child">
+var _ref2 = /*#__PURE__*/<div className="child">
     ChildTextContent
   </div>;
 
 let Child = () => _ref2,
-    _ref =
-/*#__PURE__*/
-<div className="parent">
+    _ref = /*#__PURE__*/<div className="parent">
     <Child />
   </div>;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-declaration/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-declaration/output.js
@@ -1,8 +1,6 @@
 function render() {
   const bar = "bar",
-        _ref =
-  /*#__PURE__*/
-  <foo bar={bar} />,
+        _ref = /*#__PURE__*/<foo bar={bar} />,
         renderFoo = () => _ref;
 
   return renderFoo();
@@ -12,9 +10,7 @@ function render() {
   const bar = "bar",
         renderFoo = () => _ref2,
         baz = "baz",
-        _ref2 =
-  /*#__PURE__*/
-  <foo bar={bar} baz={baz} />;
+        _ref2 = /*#__PURE__*/<foo bar={bar} baz={baz} />;
 
   return renderFoo();
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params-2/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params-2/output.js
@@ -1,9 +1,7 @@
 function render() {
   var title = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
 
-  var _ref =
-  /*#__PURE__*/
-  <Component title={title} />;
+  var _ref = /*#__PURE__*/<Component title={title} />;
 
   return () => _ref;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params/output.js
@@ -1,8 +1,6 @@
 function render(Component) {
   var text = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '',
-      _ref =
-  /*#__PURE__*/
-  <Component text={text} />;
+      _ref = /*#__PURE__*/<Component text={text} />;
 
   return function () {
     return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-hoc/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-hoc/output.mjs
@@ -6,9 +6,7 @@ const Parent = ({}) => _ref;
 
 export default Parent;
 
-var _ref2 =
-/*#__PURE__*/
-<div className="child">
+var _ref2 = /*#__PURE__*/<div className="child">
     ChildTextContent
   </div>;
 
@@ -16,8 +14,6 @@ let Child = () => _ref2;
 
 Child = HOC(Child);
 
-var _ref =
-/*#__PURE__*/
-<div className="parent">
+var _ref = /*#__PURE__*/<div className="parent">
     <Child />
   </div>;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/function-parameter/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/function-parameter/output.js
@@ -1,7 +1,5 @@
 function render(text) {
-  var _ref =
-  /*#__PURE__*/
-  <foo>{text}</foo>;
+  var _ref = /*#__PURE__*/<foo>{text}</foo>;
 
   return function () {
     return _ref;
@@ -11,9 +9,7 @@ function render(text) {
 var Foo2 = require("Foo");
 
 function createComponent(text) {
-  var _ref2 =
-  /*#__PURE__*/
-  <Foo2>{text}</Foo2>;
+  var _ref2 = /*#__PURE__*/<Foo2>{text}</Foo2>;
 
   return function render() {
     return _ref2;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/global-reference/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/global-reference/output.js
@@ -1,6 +1,4 @@
-var _ref =
-/*#__PURE__*/
-<div foo={notDeclared}></div>;
+var _ref = /*#__PURE__*/<div foo={notDeclared}></div>;
 
 var Foo = React.createClass({
   render: function render() {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/html-element/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/html-element/output.js
@@ -1,14 +1,10 @@
-var _ref =
-/*#__PURE__*/
-<foo />;
+var _ref = /*#__PURE__*/<foo />;
 
 function render() {
   return _ref;
 }
 
-var _ref2 =
-/*#__PURE__*/
-<div className="foo"><input type="checkbox" checked={true} /></div>;
+var _ref2 = /*#__PURE__*/<div className="foo"><input type="checkbox" checked={true} /></div>;
 
 function render() {
   return _ref2;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/inline-elements/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/inline-elements/output.js
@@ -2,9 +2,7 @@ var REACT_ELEMENT_TYPE;
 
 function _jsx(type, props, key, children) { if (!REACT_ELEMENT_TYPE) { REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol["for"] && Symbol["for"]("react.element") || 0xeac7; } var defaultProps = type && type.defaultProps; var childrenLength = arguments.length - 3; if (!props && childrenLength !== 0) { props = { children: void 0 }; } if (childrenLength === 1) { props.children = children; } else if (childrenLength > 1) { var childArray = new Array(childrenLength); for (var i = 0; i < childrenLength; i++) { childArray[i] = arguments[i + 3]; } props.children = childArray; } if (props && defaultProps) { for (var propName in defaultProps) { if (props[propName] === void 0) { props[propName] = defaultProps[propName]; } } } else if (!props) { props = defaultProps || {}; } return { $$typeof: REACT_ELEMENT_TYPE, type: type, key: key === undefined ? null : '' + key, ref: null, props: props, _owner: null }; }
 
-var _ref =
-/*#__PURE__*/
-_jsx("foo", {});
+var _ref = /*#__PURE__*/_jsx("foo", {});
 
 function render() {
   return _ref;
@@ -13,9 +11,7 @@ function render() {
 function render() {
   var text = getText();
 
-  var _ref2 =
-  /*#__PURE__*/
-  _jsx("foo", {}, void 0, text);
+  var _ref2 = /*#__PURE__*/_jsx("foo", {}, void 0, text);
 
   return function () {
     return _ref2;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/inner-declaration/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/inner-declaration/output.js
@@ -1,9 +1,7 @@
 function render() {
   var text = getText();
 
-  var _ref =
-  /*#__PURE__*/
-  <foo>{text}</foo>;
+  var _ref = /*#__PURE__*/<foo>{text}</foo>;
 
   return function () {
     return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-constant/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-constant/output.js
@@ -1,9 +1,7 @@
 function render() {
   this.component = "div";
 
-  var _ref =
-  /*#__PURE__*/
-  <this.component />;
+  var _ref = /*#__PURE__*/<this.component />;
 
   return () => _ref;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/output.js
@@ -1,6 +1,4 @@
-var _ref =
-/*#__PURE__*/
-<span>Sub Component</span>;
+var _ref = /*#__PURE__*/<span>Sub Component</span>;
 
 class Component extends React.Component {
   constructor(...args) {
@@ -8,9 +6,7 @@ class Component extends React.Component {
 
     this.subComponent = () => _ref;
 
-    var _ref2 =
-    /*#__PURE__*/
-    <this.subComponent />;
+    var _ref2 = /*#__PURE__*/<this.subComponent />;
 
     this.render = () => _ref2;
   }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/output.js
@@ -1,14 +1,10 @@
-var _ref =
-/*#__PURE__*/
-<span>Sub Component</span>;
+var _ref = /*#__PURE__*/<span>Sub Component</span>;
 
 const els = {
   subComponent: () => _ref
 };
 
-var _ref2 =
-/*#__PURE__*/
-<els.subComponent />;
+var _ref2 = /*#__PURE__*/<els.subComponent />;
 
 class Component extends React.Component {
   constructor(...args) {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/param-and-var/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/param-and-var/output.js
@@ -1,8 +1,6 @@
 function fn(Component, obj) {
   var data = obj.data,
-      _ref =
-  /*#__PURE__*/
-  <Component prop={data} />;
+      _ref = /*#__PURE__*/<Component prop={data} />;
 
   return () => _ref;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-multi/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-multi/output.js
@@ -3,9 +3,7 @@ function render(_ref) {
       className = _ref.className,
       id = _ref.id;
 
-  var _ref2 =
-  /*#__PURE__*/
-  <Component text={text} className={className} id={id} />;
+  var _ref2 = /*#__PURE__*/<Component text={text} className={className} id={id} />;
 
   return () => _ref2;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/output.js
@@ -4,9 +4,7 @@ function render(_ref) {
       id = _ref.id,
       props = babelHelpers.objectWithoutProperties(_ref, ["text", "className", "id"]);
 
-  var _ref2 =
-  /*#__PURE__*/
-  <Component text={text} className={className} id={id} />;
+  var _ref2 = /*#__PURE__*/<Component text={text} className={className} id={id} />;
 
   // intentionally ignoring props
   return () => _ref2;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure/output.js
@@ -1,9 +1,7 @@
 function render(_ref) {
   let text = _ref.text;
 
-  var _ref2 =
-  /*#__PURE__*/
-  <Component text={text} />;
+  var _ref2 = /*#__PURE__*/<Component text={text} />;
 
   return () => _ref2;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-reference/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-reference/output.js
@@ -1,7 +1,5 @@
 function render(text) {
-  var _ref =
-  /*#__PURE__*/
-  <div>{text}</div>;
+  var _ref = /*#__PURE__*/<div>{text}</div>;
 
   return function () {
     return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-2/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-2/output.js
@@ -1,7 +1,5 @@
 function render(offset) {
-  var _ref =
-  /*#__PURE__*/
-  <div tabIndex={offset + 1} />;
+  var _ref = /*#__PURE__*/<div tabIndex={offset + 1} />;
 
   return function () {
     return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-3/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-3/output.js
@@ -1,8 +1,6 @@
 const OFFSET = 3;
 
-var _ref =
-/*#__PURE__*/
-<div tabIndex={OFFSET + 1} />;
+var _ref = /*#__PURE__*/<div tabIndex={OFFSET + 1} />;
 
 var Foo = React.createClass({
   render: function () {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-whitelist-member/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-whitelist-member/output.mjs
@@ -1,8 +1,6 @@
 import Intl from 'react-intl';
 
-var _ref =
-/*#__PURE__*/
-<Intl.FormattedMessage id="someMessage.foo" defaultMessage={"Some text, " + "and some more too. {someValue}"} description="A test message for babel." values={{
+var _ref = /*#__PURE__*/<Intl.FormattedMessage id="someMessage.foo" defaultMessage={"Some text, " + "and some more too. {someValue}"} description="A test message for babel." values={{
   someValue: "A value."
 }} />;
 

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-whitelist/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-whitelist/output.js
@@ -1,6 +1,4 @@
-var _ref =
-/*#__PURE__*/
-<FormattedMessage id="someMessage.foo" defaultMessage={"Some text, " + "and some more too. {someValue}"} description="A test message for babel." values={{
+var _ref = /*#__PURE__*/<FormattedMessage id="someMessage.foo" defaultMessage={"Some text, " + "and some more too. {someValue}"} description="A test message for babel." values={{
   someValue: "A value."
 }} />;
 

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression/output.js
@@ -1,6 +1,4 @@
-var _ref =
-/*#__PURE__*/
-<div data-text={"Some text, " + "and some more too."} />;
+var _ref = /*#__PURE__*/<div data-text={"Some text, " + "and some more too."} />;
 
 var Foo = React.createClass({
   render: function () {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/reassignment/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/reassignment/output.js
@@ -1,9 +1,7 @@
 function render(text) {
   text += "yes";
 
-  var _ref =
-  /*#__PURE__*/
-  <div>{text}</div>;
+  var _ref = /*#__PURE__*/<div>{text}</div>;
 
   return function () {
     return _ref;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/output.mjs
@@ -7,6 +7,4 @@ class A {
 
 export default class B {}
 
-var _ref =
-/*#__PURE__*/
-React.createElement(B, null);
+var _ref = /*#__PURE__*/React.createElement(B, null);

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/output.mjs
@@ -7,6 +7,4 @@ class A {
 
 export class B {}
 
-var _ref =
-/*#__PURE__*/
-React.createElement(B, null);
+var _ref = /*#__PURE__*/React.createElement(B, null);

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/text-children/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/text-children/output.js
@@ -1,6 +1,4 @@
-var _ref =
-/*#__PURE__*/
-<div className="class-name">
+var _ref = /*#__PURE__*/<div className="class-name">
       Text
     </div>;
 

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/var/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/var/output.js
@@ -1,8 +1,6 @@
 function fn(Component) {
   var data = "prop",
-      _ref =
-  /*#__PURE__*/
-  <Component prop={data} />;
+      _ref = /*#__PURE__*/<Component prop={data} />;
 
   return () => _ref;
 }

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/optimisation.react.constant-elements/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/optimisation.react.constant-elements/output.js
@@ -1,14 +1,10 @@
-var _ref =
-/*#__PURE__*/
-<div className="navbar-header">
+var _ref = /*#__PURE__*/<div className="navbar-header">
       <a className="navbar-brand" href="/">
         <img src="/img/logo/logo-96x36.png" />
       </a>
     </div>;
 
-let App =
-/*#__PURE__*/
-function (_React$Component) {
+let App = /*#__PURE__*/function (_React$Component) {
   "use strict";
 
   babelHelpers.inherits(App, _React$Component);

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/computed-properties/example/output.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/computed-properties/example/output.js
@@ -1,8 +1,6 @@
 var o = {
   foo() {
-    return (
-      /*#__PURE__*/
-      regeneratorRuntime.mark(function _callee() {
+    return (/*#__PURE__*/regeneratorRuntime.mark(function _callee() {
         return regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) switch (_context.prev = _context.next) {
             case 0:

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/output.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/output.js
@@ -3,11 +3,7 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 function test(fn) {
-  return (
-    /*#__PURE__*/
-    _asyncToGenerator(
-    /*#__PURE__*/
-    regeneratorRuntime.mark(function _callee() {
+  return (/*#__PURE__*/_asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
       var _args = arguments;
       return regeneratorRuntime.wrap(function _callee$(_context) {
         while (1) {

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/6733/output.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/6733/output.js
@@ -5,9 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = _callee;
 
-var _marked =
-/*#__PURE__*/
-regeneratorRuntime.mark(_callee);
+var _marked = /*#__PURE__*/regeneratorRuntime.mark(_callee);
 
 function _callee() {
   var x;

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/output.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/output.js
@@ -1,8 +1,6 @@
 var _regeneratorRuntime = require("@babel/runtime/regenerator");
 
-var _marked =
-/*#__PURE__*/
-_regeneratorRuntime.mark(fn);
+var _marked = /*#__PURE__*/_regeneratorRuntime.mark(fn);
 
 Object.keys({});
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/full/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/full/output.mjs
@@ -1,9 +1,7 @@
 import _regeneratorRuntime from "@babel/runtime-corejs2/regenerator";
 import _Symbol from "@babel/runtime-corejs2/core-js/symbol";
 
-var _marked =
-/*#__PURE__*/
-_regeneratorRuntime.mark(giveWord);
+var _marked = /*#__PURE__*/_regeneratorRuntime.mark(giveWord);
 
 import foo, * as bar from "someModule";
 export const myWord = _Symbol("abc");

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules-helpers/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules-helpers/output.js
@@ -8,9 +8,7 @@ var _createClass2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpe
 
 var _foo = _interopRequireDefault(require("foo"));
 
-let Example =
-/*#__PURE__*/
-function () {
+let Example = /*#__PURE__*/function () {
   function Example() {
     (0, _classCallCheck2.default)(this, Example);
   }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/regenerator-runtime/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/regenerator-runtime/output.js
@@ -1,8 +1,6 @@
 var _regeneratorRuntime = require("@babel/runtime-corejs2/regenerator");
 
-void
-/*#__PURE__*/
-_regeneratorRuntime.mark(function _callee() {
+void /*#__PURE__*/_regeneratorRuntime.mark(function _callee() {
   return _regeneratorRuntime.wrap(function _callee$(_context) {
     while (1) switch (_context.prev = _context.next) {
       case 0:

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/full/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/full/output.mjs
@@ -1,9 +1,7 @@
 import _regeneratorRuntime from "@babel/runtime-corejs3/regenerator";
 import _Symbol from "@babel/runtime-corejs3/core-js-stable/symbol";
 
-var _marked =
-/*#__PURE__*/
-_regeneratorRuntime.mark(giveWord);
+var _marked = /*#__PURE__*/_regeneratorRuntime.mark(giveWord);
 
 import foo, * as bar from "someModule";
 export const myWord = _Symbol("abc");

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-helpers/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-helpers/output.js
@@ -8,9 +8,7 @@ var _createClass2 = _interopRequireDefault(require("@babel/runtime-corejs3/helpe
 
 var _foo = _interopRequireDefault(require("foo"));
 
-let Example =
-/*#__PURE__*/
-function () {
+let Example = /*#__PURE__*/function () {
   function Example() {
     (0, _classCallCheck2.default)(this, Example);
   }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/regenerator-runtime/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/regenerator-runtime/output.js
@@ -1,8 +1,6 @@
 var _regeneratorRuntime = require("@babel/runtime-corejs3/regenerator");
 
-void
-/*#__PURE__*/
-_regeneratorRuntime.mark(function _callee() {
+void /*#__PURE__*/_regeneratorRuntime.mark(function _callee() {
   return _regeneratorRuntime.wrap(function _callee$(_context) {
     while (1) switch (_context.prev = _context.next) {
       case 0:

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/full/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/full/output.mjs
@@ -1,8 +1,6 @@
 import _regeneratorRuntime from "@babel/runtime/regenerator";
 
-var _marked =
-/*#__PURE__*/
-_regeneratorRuntime.mark(giveWord);
+var _marked = /*#__PURE__*/_regeneratorRuntime.mark(giveWord);
 
 import foo, * as bar from "someModule";
 export const myWord = Symbol("abc");

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/output.js
@@ -8,9 +8,7 @@ var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/creat
 
 var _foo = _interopRequireDefault(require("foo"));
 
-let Example =
-/*#__PURE__*/
-function () {
+let Example = /*#__PURE__*/function () {
   function Example() {
     (0, _classCallCheck2.default)(this, Example);
   }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/regenerator-runtime/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/regenerator-runtime/output.js
@@ -1,8 +1,6 @@
 var _regeneratorRuntime = require("@babel/runtime/regenerator");
 
-void
-/*#__PURE__*/
-_regeneratorRuntime.mark(function _callee() {
+void /*#__PURE__*/_regeneratorRuntime.mark(function _callee() {
   return _regeneratorRuntime.wrap(function _callee$(_context) {
     while (1) switch (_context.prev = _context.next) {
       case 0:

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs-useES6Modules/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs-useES6Modules/output.mjs
@@ -3,9 +3,7 @@ import _possibleConstructorReturn from "@babel/runtime-corejs2/helpers/esm/possi
 import _getPrototypeOf from "@babel/runtime-corejs2/helpers/esm/getPrototypeOf";
 import _inherits from "@babel/runtime-corejs2/helpers/esm/inherits";
 
-let Foo =
-/*#__PURE__*/
-function (_Bar) {
+let Foo = /*#__PURE__*/function (_Bar) {
   _inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs/output.mjs
@@ -3,9 +3,7 @@ import _possibleConstructorReturn from "@babel/runtime-corejs2/helpers/possibleC
 import _getPrototypeOf from "@babel/runtime-corejs2/helpers/getPrototypeOf";
 import _inherits from "@babel/runtime-corejs2/helpers/inherits";
 
-let Foo =
-/*#__PURE__*/
-function (_Bar) {
+let Foo = /*#__PURE__*/function (_Bar) {
   _inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/output.js
@@ -6,9 +6,7 @@ var _getPrototypeOf = require("@babel/runtime/helpers/getPrototypeOf");
 
 var _inherits = require("@babel/runtime/helpers/inherits");
 
-let Foo =
-/*#__PURE__*/
-function (_Bar) {
+let Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   _inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs/output.js
@@ -6,9 +6,7 @@ var _getPrototypeOf = require("@babel/runtime/helpers/getPrototypeOf");
 
 var _inherits = require("@babel/runtime/helpers/inherits");
 
-let Foo =
-/*#__PURE__*/
-function (_Bar) {
+let Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   _inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs-auto/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs-auto/output.mjs
@@ -3,9 +3,7 @@ import _possibleConstructorReturn from "@babel/runtime/helpers/esm/possibleConst
 import _getPrototypeOf from "@babel/runtime/helpers/esm/getPrototypeOf";
 import _inherits from "@babel/runtime/helpers/esm/inherits";
 
-let Foo =
-/*#__PURE__*/
-function (_Bar) {
+let Foo = /*#__PURE__*/function (_Bar) {
   _inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs/output.mjs
@@ -3,9 +3,7 @@ import _possibleConstructorReturn from "@babel/runtime/helpers/esm/possibleConst
 import _getPrototypeOf from "@babel/runtime/helpers/esm/getPrototypeOf";
 import _inherits from "@babel/runtime/helpers/esm/inherits";
 
-let Foo =
-/*#__PURE__*/
-function (_Bar) {
+let Foo = /*#__PURE__*/function (_Bar) {
   _inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-with-class-and-super/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-with-class-and-super/output.js
@@ -10,9 +10,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
-let Employee =
-/*#__PURE__*/
-function (_Person) {
+let Employee = /*#__PURE__*/function (_Person) {
   "use strict";
 
   _inherits(Employee, _Person);

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-with-class/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-with-class/output.js
@@ -1,8 +1,6 @@
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-let Person =
-/*#__PURE__*/
-function () {
+let Person = /*#__PURE__*/function () {
   "use strict";
 
   function Person(name) {

--- a/packages/babel-preset-env/test/fixtures/corejs2/entry-shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/corejs2/entry-shippedProposals/output.js
@@ -342,9 +342,7 @@ function agf() {
 }
 
 function _agf() {
-  _agf = _wrapAsyncGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
+  _agf = _wrapAsyncGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
     return regeneratorRuntime.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async/output.mjs
@@ -11,9 +11,7 @@ function a() {
 }
 
 function _a() {
-  _a = _asyncToGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
+  _a = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
     return regeneratorRuntime.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-generator/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-generator/output.mjs
@@ -1,8 +1,6 @@
 import "regenerator-runtime/runtime";
 
-var _marked =
-/*#__PURE__*/
-regeneratorRuntime.mark(a);
+var _marked = /*#__PURE__*/regeneratorRuntime.mark(a);
 
 function a() {
   return regeneratorRuntime.wrap(function a$(_context) {

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-shippedProposals/output.js
@@ -74,9 +74,7 @@ function agf() {
 }
 
 function _agf() {
-  _agf = _wrapAsyncGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
+  _agf = _wrapAsyncGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
     return regeneratorRuntime.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-async/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-async/output.mjs
@@ -11,9 +11,7 @@ function a() {
 }
 
 function _a() {
-  _a = _asyncToGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
+  _a = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
     return regeneratorRuntime.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-generator/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-generator/output.mjs
@@ -1,8 +1,6 @@
 import "regenerator-runtime/runtime";
 
-var _marked =
-/*#__PURE__*/
-regeneratorRuntime.mark(a);
+var _marked = /*#__PURE__*/regeneratorRuntime.mark(a);
 
 function a() {
   return regeneratorRuntime.wrap(function a$(_context) {

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
@@ -22,9 +22,7 @@ function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || func
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
-var MyDate =
-/*#__PURE__*/
-function (_Date) {
+var MyDate = /*#__PURE__*/function (_Date) {
   _inherits(MyDate, _Date);
 
   function MyDate(time) {

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
@@ -44,9 +44,7 @@ function agf() {
 }
 
 function _agf() {
-  _agf = _wrapAsyncGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
+  _agf = _wrapAsyncGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
     return regeneratorRuntime.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes&nbsp; https://github.com/babel/babel/pull/11126#discussion_r377603838
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR is mostly to improve the output readability, since the unindented newlines looked really bad.

I special-cased `/*#__PURE__*/` annotations because I think that we should preserve the old behavior for normal comments.