### PR TITLE
Mark `wrapNativeSuper` and `wrapRegExp` as pure

### DIFF
--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -18,6 +18,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-annotate-as-pure": "^7.8.3",
     "@babel/helper-regex": "^7.8.3",
     "regexpu-core": "^4.6.0"
   },

--- a/packages/babel-helper-create-regexp-features-plugin/src/index.js
+++ b/packages/babel-helper-create-regexp-features-plugin/src/index.js
@@ -11,6 +11,7 @@ import { generateRegexpuOptions } from "./util";
 import pkg from "../package.json";
 import { types as t } from "@babel/core";
 import { pullFlag } from "@babel/helper-regex";
+import annotateAsPure from "@babel/helper-annotate-as-pure";
 
 // Note: Versions are represented as an integer. e.g. 7.1.5 is represented
 //       as 70000100005. This method is easier than using a semver-parsing
@@ -68,12 +69,13 @@ export function createRegExpFeaturePlugin({ name, feature, options = {} }) {
           runtime &&
           !isRegExpTest(path)
         ) {
-          path.replaceWith(
-            t.callExpression(this.addHelper("wrapRegExp"), [
-              node,
-              t.valueToNode(namedCaptureGroups),
-            ]),
-          );
+          const call = t.callExpression(this.addHelper("wrapRegExp"), [
+            node,
+            t.valueToNode(namedCaptureGroups),
+          ]);
+          annotateAsPure(call);
+
+          path.replaceWith(call);
         }
         if (hasFeature(features, FEATURES.unicodeFlag)) {
           pullFlag(node, "u");

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
@@ -22,4 +22,4 @@ var List = /*#__PURE__*/function (_Array) {
   }
 
   return List;
-}(_wrapNativeSuper(Array));
+}( /*#__PURE__*/_wrapNativeSuper(Array));

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
@@ -30,4 +30,4 @@ var List = /*#__PURE__*/function (_Array) {
   }
 
   return List;
-}(_wrapNativeSuper(Array));
+}( /*#__PURE__*/_wrapNativeSuper(Array));

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/8499/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/8499/output.js
@@ -20,7 +20,7 @@ var CustomElement = /*#__PURE__*/function (_HTMLElement) {
   }
 
   return CustomElement;
-}(babelHelpers.wrapNativeSuper(HTMLElement));
+}( /*#__PURE__*/babelHelpers.wrapNativeSuper(HTMLElement));
 
 ;
 new CustomElement();

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/test/fixtures/wrapper/basic/output.js
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/test/fixtures/wrapper/basic/output.js
@@ -1,3 +1,3 @@
-"foo".match(babelHelpers.wrapRegExp(/(.)\1/, {
+"foo".match( /*#__PURE__*/babelHelpers.wrapRegExp(/(.)\1/, {
   double: 1
 }));

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/test/fixtures/wrapper/skips-anonymous-capturing-groups/output.js
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/test/fixtures/wrapper/skips-anonymous-capturing-groups/output.js
@@ -1,3 +1,3 @@
-"abba".match(babelHelpers.wrapRegExp(/(.)(.)\2\1/, {
+"abba".match( /*#__PURE__*/babelHelpers.wrapRegExp(/(.)(.)\2\1/, {
   n: 2
 }));

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
@@ -32,6 +32,6 @@ var MyDate = /*#__PURE__*/function (_Date) {
   }
 
   return MyDate;
-}(_wrapNativeSuper(Date));
+}( /*#__PURE__*/_wrapNativeSuper(Date));
 
 var myDate = new MyDate();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Technically there are also other pure helpers (e.g. `asyncToGenerator`), but annotating them won't help minifiers because their result is always directly used by the compiled output.