### PR TITLE
fix @babel/traverse can't use path.remove() with noScope

### DIFF
--- a/packages/babel-traverse/src/path/removal.js
+++ b/packages/babel-traverse/src/path/removal.js
@@ -7,7 +7,9 @@ export function remove() {
   this._assertUnremoved();
 
   this.resync();
-  this._removeFromScope();
+  if (!this.opts || !this.opts.noScope) {
+    this._removeFromScope();
+  }
 
   if (this._callRemovalHooks()) {
     this._markRemoved();

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -33,4 +33,16 @@ describe("removal", function() {
       expect(generateCode(rootPath)).toBe("x = () => {};");
     });
   });
+
+  it("remove with noScope", function() {
+    const ast = parse("a=1");
+    traverse(ast, {
+      AssignmentExpression: function(path) {
+        path.remove();
+      },
+      noScope: true,
+    });
+
+    expect(generate(ast).code).toBe("");
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11128  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |Yes
| Major: Breaking Change?  |No
| Minor: New Feature?      |No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
