### PR TITLE
Parse declare modifier around accessibility modifiers

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1922,8 +1922,16 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       state: { hadConstructor: boolean },
       constructorAllowsSuper: boolean,
     ): void {
+      const preDeclare = this.tsParseModifier(["declare"]);
       const accessibility = this.parseAccessModifier();
       if (accessibility) member.accessibility = accessibility;
+      const startPos = this.state.start;
+      const postDeclare = this.tsParseModifier(["declare"]);
+      if (preDeclare && postDeclare) {
+        this.raise(startPos, "Duplicate modifier: 'declare'");
+      } else if (preDeclare || postDeclare) {
+        member.declare = true;
+      }
 
       super.parseClassMember(classBody, member, state, constructorAllowsSuper);
     }

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -139,7 +139,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
      *    this.tsParseModifiers(node, ["abstract", "readonly"]);
      */
     tsParseModifiers<T: TsModifier>(
-      modified: N.ClassMember,
+      modified: { [key: TsModifier]: ?true },
       allowedModifiers: T[],
     ): void {
       while (true) {

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-field-modifiers/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-field-modifiers/input.ts
@@ -1,0 +1,11 @@
+class A {
+  declare static foo;
+  static declare foo0: string;
+
+  declare public foo1;
+  public declare foo2;
+
+  declare public static foo4;
+  public declare static foo3;
+  public static declare foo5;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-field-modifiers/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-field-modifiers/output.json
@@ -1,0 +1,372 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 202,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 202,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 11,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 202,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 11,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 202,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 11,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 12,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 21
+                }
+              },
+              "declare": true,
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start": 27,
+                "end": 30,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 20
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start": 34,
+              "end": 62,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 30
+                }
+              },
+              "declare": true,
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start": 49,
+                "end": 53,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 21
+                  },
+                  "identifierName": "foo0"
+                },
+                "name": "foo0"
+              },
+              "computed": false,
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 53,
+                "end": 61,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 29
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSStringKeyword",
+                  "start": 55,
+                  "end": 61,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 23
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 29
+                    }
+                  }
+                }
+              },
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start": 66,
+              "end": 86,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 22
+                }
+              },
+              "accessibility": "public",
+              "declare": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 81,
+                "end": 85,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 21
+                  },
+                  "identifierName": "foo1"
+                },
+                "name": "foo1"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start": 89,
+              "end": 109,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 2
+                },
+                "end": {
+                  "line": 6,
+                  "column": 22
+                }
+              },
+              "accessibility": "public",
+              "declare": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 104,
+                "end": 108,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 21
+                  },
+                  "identifierName": "foo2"
+                },
+                "name": "foo2"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start": 113,
+              "end": 140,
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 2
+                },
+                "end": {
+                  "line": 8,
+                  "column": 29
+                }
+              },
+              "accessibility": "public",
+              "declare": true,
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start": 135,
+                "end": 139,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 28
+                  },
+                  "identifierName": "foo4"
+                },
+                "name": "foo4"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start": 143,
+              "end": 170,
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 2
+                },
+                "end": {
+                  "line": 9,
+                  "column": 29
+                }
+              },
+              "accessibility": "public",
+              "declare": true,
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start": 165,
+                "end": 169,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 28
+                  },
+                  "identifierName": "foo3"
+                },
+                "name": "foo3"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start": 173,
+              "end": 200,
+              "loc": {
+                "start": {
+                  "line": 10,
+                  "column": 2
+                },
+                "end": {
+                  "line": 10,
+                  "column": 29
+                }
+              },
+              "accessibility": "public",
+              "declare": true,
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start": 195,
+                "end": 199,
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 28
+                  },
+                  "identifierName": "foo5"
+                },
+                "name": "foo5"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/duplicate-modifier-1/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/duplicate-modifier-1/input.ts
@@ -1,0 +1,3 @@
+class A {
+  declare public declare foo;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/duplicate-modifier-1/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/duplicate-modifier-1/output.json
@@ -1,0 +1,124 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 41,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "errors": [
+    "SyntaxError: Duplicate modifier: 'declare' (2:17)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 41,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 41,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 41,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 12,
+              "end": 39,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 29
+                }
+              },
+              "accessibility": "public",
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 35,
+                "end": 38,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 25
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 28
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/duplicate-modifier-2/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/duplicate-modifier-2/input.ts
@@ -1,0 +1,3 @@
+class A {
+  declare public static declare foo;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/duplicate-modifier-2/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/duplicate-modifier-2/output.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 41,
+  "end": 48,
   "loc": {
     "start": {
       "line": 1,
@@ -13,12 +13,12 @@
     }
   },
   "errors": [
-    "SyntaxError: Duplicate modifier: 'declare' (2:17)"
+    "SyntaxError: Duplicate modifier: 'declare' (2:24)"
   ],
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 41,
+    "end": 48,
     "loc": {
       "start": {
         "line": 1,
@@ -35,7 +35,7 @@
       {
         "type": "ClassDeclaration",
         "start": 0,
-        "end": 41,
+        "end": 48,
         "loc": {
           "start": {
             "line": 1,
@@ -67,7 +67,7 @@
         "body": {
           "type": "ClassBody",
           "start": 8,
-          "end": 41,
+          "end": 48,
           "loc": {
             "start": {
               "line": 1,
@@ -82,7 +82,7 @@
             {
               "type": "ClassProperty",
               "start": 12,
-              "end": 39,
+              "end": 46,
               "loc": {
                 "start": {
                   "line": 2,
@@ -90,24 +90,24 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 29
+                  "column": 36
                 }
               },
               "declare": true,
               "accessibility": "public",
-              "static": false,
+              "static": true,
               "key": {
                 "type": "Identifier",
-                "start": 35,
-                "end": 38,
+                "start": 42,
+                "end": 45,
                 "loc": {
                   "start": {
                     "line": 2,
-                    "column": 25
+                    "column": 32
                   },
                   "end": {
                     "line": 2,
-                    "column": 28
+                    "column": 35
                   },
                   "identifierName": "foo"
                 },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11145 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we parse the `declare` modifier before/after the accessibility modifiers `public/private/protected`. The `tsParseModifiers` now checks against the modified node instead of the modifier temporary object, so we can check across different runs. 

This PR is a follow-up to #10484. 