### PR TITLE
chore: specify dependency rule of check-compat-data-ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,13 +95,16 @@ bootstrap-flowcheck: bootstrap-only
 	$(YARN) gulp build-babel-types
 	$(MAKE) build-typings
 
-lint-ci: lint-js-ci lint-ts-ci check-compat-data
+lint-ci: lint-js-ci lint-ts-ci check-compat-data-ci
 
 lint-js-ci: bootstrap-only
 	$(MAKE) lint-js
 
 lint-ts-ci: bootstrap-flowcheck
 	$(MAKE) lint-ts
+
+check-compat-data-ci: bootstrap-only
+	$(MAKE) check-compat-data
 
 lint: lint-js lint-ts
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes recent CI failure: https://travis-ci.com/babel/babel/jobs/289014352
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`check-compat-data` depends on `bootstrap-only` otherwise `semver` is not available to be imported from build scripts. This PR adds a new rule `check-compat-data-ci` with correct dependency.