### PR TITLE
Add onlyRemoveTypeImports to preset-typescript

### DIFF
--- a/packages/babel-preset-typescript/src/index.js
+++ b/packages/babel-preset-typescript/src/index.js
@@ -5,11 +5,12 @@ export default declare(
   (
     api,
     {
-      jsxPragma,
       allExtensions = false,
-      isTSX = false,
-      allowNamespaces,
       allowDeclareFields,
+      allowNamespaces,
+      jsxPragma,
+      isTSX = false,
+      onlyRemoveTypeImports,
     },
   ) => {
     api.assertVersion(7);
@@ -27,10 +28,11 @@ export default declare(
     }
 
     const pluginOptions = isTSX => ({
-      jsxPragma,
-      isTSX,
-      allowNamespaces,
       allowDeclareFields,
+      allowNamespaces,
+      isTSX,
+      jsxPragma,
+      onlyRemoveTypeImports,
     });
 
     return {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

Let's get this import/export types PR landed :)

I'll throw up a docs PR too, in a sec.

Sidenote, we'll want to also add this option to the plugin validation PR (https://github.com/babel/babel/pull/10927/files).