### PR TITLE
Add "Statement" as alias to Flow enum declaration

### DIFF
--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -468,7 +468,7 @@ defineType("VoidTypeAnnotation", {
 
 // Enums
 defineType("EnumDeclaration", {
-  aliases: ["Declaration"],
+  aliases: ["Statement", "Declaration"],
   visitor: ["id", "body"],
   fields: {
     id: validateType("Identifier"),

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -3613,6 +3613,7 @@ export function isStatement(node: ?Object, opts?: Object): boolean {
     "InterfaceDeclaration" === nodeType ||
     "OpaqueType" === nodeType ||
     "TypeAlias" === nodeType ||
+    "EnumDeclaration" === nodeType ||
     "TSDeclareFunction" === nodeType ||
     "TSInterfaceDeclaration" === nodeType ||
     "TSTypeAliasDeclaration" === nodeType ||


### PR DESCRIPTION
In Babel types, if something is a declaration it should also be listed as a statement. (e.g. see the definition of function declarations, variable declarations, etc.) I missed doing this when defining the type.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
