### PR TITLE
Add `onlyRemoveTypeImports` option to `preset-typescript`

### DIFF
--- a/packages/babel-preset-typescript/src/index.js
+++ b/packages/babel-preset-typescript/src/index.js
@@ -8,6 +8,7 @@ export default declare(
       jsxPragma,
       allExtensions = false,
       isTSX = false,
+      onlyRemoveTypeImports = false,
       allowNamespaces,
       allowDeclareFields,
     },
@@ -22,6 +23,10 @@ export default declare(
       throw new Error(".isTSX must be a boolean, or undefined");
     }
 
+    if (typeof onlyRemoveTypeImports !== "boolean") {
+      throw new Error(".onlyRemoveTypeImports must be a boolean, or undefined");
+    }
+
     if (isTSX && !allExtensions) {
       throw new Error("isTSX:true requires allExtensions:true");
     }
@@ -31,6 +36,7 @@ export default declare(
       isTSX,
       allowNamespaces,
       allowDeclareFields,
+      onlyRemoveTypeImports,
     });
 
     return {

--- a/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/false/input.ts
+++ b/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/false/input.ts
@@ -1,0 +1,13 @@
+import a from "a";
+import { b } from "b";
+import { c as c2 } from "c";
+import d, { d2 } from "d";
+import e, { e3 as e4 } from "e";
+
+import {} from "f";
+import "g";
+
+import type H from "h";
+import type { I, I2 } from "i";
+import type * as J from "j";
+;

--- a/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/false/options.json
+++ b/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/false/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "presets": [["typescript", { "onlyRemoveTypeImports": false }]]
+}

--- a/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/false/output.mjs
+++ b/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/false/output.mjs
@@ -1,0 +1,3 @@
+import "f";
+import "g";
+;

--- a/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/non-boolean/input.ts
+++ b/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/non-boolean/input.ts
@@ -1,0 +1,13 @@
+import a from "a";
+import { b } from "b";
+import { c as c2 } from "c";
+import d, { d2 } from "d";
+import e, { e3 as e4 } from "e";
+
+import {} from "f";
+import "g";
+
+import type H from "h";
+import type { I, I2 } from "i";
+import type * as J from "j";
+;

--- a/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/non-boolean/options.json
+++ b/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/non-boolean/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "presets": [["typescript", { "onlyRemoveTypeImports": "not a boolean" }]],
+  "throws": ".onlyRemoveTypeImports must be a boolean, or undefined"
+}

--- a/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/true/input.ts
+++ b/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/true/input.ts
@@ -1,0 +1,13 @@
+import a from "a";
+import { b } from "b";
+import { c as c2 } from "c";
+import d, { d2 } from "d";
+import e, { e3 as e4 } from "e";
+
+import {} from "f";
+import "g";
+
+import type H from "h";
+import type { I, I2 } from "i";
+import type * as J from "j";
+;

--- a/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/true/options.json
+++ b/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/true/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "presets": [["typescript", { "onlyRemoveTypeImports": true }]]
+}

--- a/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/true/output.mjs
+++ b/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/true/output.mjs
@@ -1,0 +1,8 @@
+import a from "a";
+import { b } from "b";
+import { c as c2 } from "c";
+import d, { d2 } from "d";
+import e, { e3 as e4 } from "e";
+import "f";
+import "g";
+;

--- a/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/undefined/input.ts
+++ b/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/undefined/input.ts
@@ -1,0 +1,13 @@
+import a from "a";
+import { b } from "b";
+import { c as c2 } from "c";
+import d, { d2 } from "d";
+import e, { e3 as e4 } from "e";
+
+import {} from "f";
+import "g";
+
+import type H from "h";
+import type { I, I2 } from "i";
+import type * as J from "j";
+;

--- a/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/undefined/options.json
+++ b/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/undefined/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "presets": ["typescript"]
+}

--- a/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/undefined/output.mjs
+++ b/packages/babel-preset-typescript/test/fixtures/options-onlyRemoveTypeImports/undefined/output.mjs
@@ -1,0 +1,3 @@
+import "f";
+import "g";
+;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Refs https://github.com/babel/babel/pull/11173#issuecomment-591707329
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR adds the `onlyRemoveTypeImports` option to `babel-preset-typescript`. I added tests for this option, but I see that we haven't tested options in the past. Thoughts on this?