### PR TITLE
fix: token after strict mode block is evaluated in strict mode

### DIFF
--- a/packages/babel-parser/test/fixtures/es2015/regression/11183/input.js
+++ b/packages/babel-parser/test/fixtures/es2015/regression/11183/input.js
@@ -1,0 +1,5 @@
+class X {}
+05
+
+function x() { 'use strict' }
+05

--- a/packages/babel-parser/test/fixtures/es2015/regression/11183/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/regression/11183/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "script"
+}

--- a/packages/babel-parser/test/fixtures/es2015/regression/11183/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/regression/11183/output.json
@@ -1,0 +1,242 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 47,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 2
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 47,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 2
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 10,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 10
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "X"
+          },
+          "name": "X"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 10,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 1,
+              "column": 10
+            }
+          },
+          "body": []
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 11,
+        "end": 13,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        "expression": {
+          "type": "NumericLiteral",
+          "start": 11,
+          "end": 13,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 2
+            }
+          },
+          "extra": {
+            "rawValue": 5,
+            "raw": "05"
+          },
+          "value": 5
+        }
+      },
+      {
+        "type": "FunctionDeclaration",
+        "start": 15,
+        "end": 44,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 29
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 24,
+          "end": 25,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 9
+            },
+            "end": {
+              "line": 4,
+              "column": 10
+            },
+            "identifierName": "x"
+          },
+          "name": "x"
+        },
+        "generator": false,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 28,
+          "end": 44,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 13
+            },
+            "end": {
+              "line": 4,
+              "column": 29
+            }
+          },
+          "body": [],
+          "directives": [
+            {
+              "type": "Directive",
+              "start": 30,
+              "end": 42,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 15
+                },
+                "end": {
+                  "line": 4,
+                  "column": 27
+                }
+              },
+              "value": {
+                "type": "DirectiveLiteral",
+                "start": 30,
+                "end": 42,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 27
+                  }
+                },
+                "value": "use strict",
+                "extra": {
+                  "raw": "'use strict'",
+                  "rawValue": "use strict"
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 45,
+        "end": 47,
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 2
+          }
+        },
+        "expression": {
+          "type": "NumericLiteral",
+          "start": 45,
+          "end": 47,
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 0
+            },
+            "end": {
+              "line": 5,
+              "column": 2
+            }
+          },
+          "extra": {
+            "rawValue": 5,
+            "raw": "05"
+          },
+          "value": 5
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/11183
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We're currently eating the closing bracket token of the class body before restoring the outer scope's strict mode state. This PR changes it so that we restore the out strict mode state before eating this final token.

Question: Does this seem like the correct way to fix this?
