### PR TITLE
Refactor: add parser message template

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1217,10 +1217,10 @@ export default class ExpressionParser extends LValParser {
       this.expectPlugin("importMeta");
 
       if (!this.inModule) {
-        this.raise(
+        this.raiseWithData(
           id.start,
-          `import.meta may appear only with 'sourceType: "module"'`,
           { code: "BABEL_PARSER_SOURCETYPE_MODULE_REQUIRED" },
+          `import.meta may appear only with 'sourceType: "module"'`,
         );
       }
       this.sawUnambiguousESM = true;

--- a/packages/babel-parser/src/parser/location.js
+++ b/packages/babel-parser/src/parser/location.js
@@ -16,6 +16,7 @@ type ErrorContext = {
   code?: string,
 };
 
+// The Errors key follows https://cs.chromium.org/chromium/src/v8/src/common/message-template.h unless it does not exist
 export const Errors = Object.freeze({
   ArgumentsDisallowedInInitializer:
     "'arguments' is not allowed in class field initializer",

--- a/packages/babel-parser/src/parser/location.js
+++ b/packages/babel-parser/src/parser/location.js
@@ -213,7 +213,7 @@ export default class LocationParser extends CommentsParser {
 
   raiseWithData(
     pos: number,
-    data: {
+    data?: {
       missingPlugin?: Array<string>,
       code?: string,
     },
@@ -226,6 +226,7 @@ export default class LocationParser extends CommentsParser {
       ` (${loc.line}:${loc.column})`;
     return this._raise(
       Object.assign(
+        {},
         {
           loc,
           pos,

--- a/packages/babel-parser/src/parser/location.js
+++ b/packages/babel-parser/src/parser/location.js
@@ -16,7 +16,179 @@ type ErrorContext = {
   code?: string,
 };
 
-export const Errors = {};
+export const Errors = Object.freeze({
+  ArgumentsDisallowedInInitializer:
+    "'arguments' is not allowed in class field initializer",
+  AsyncFunctionInSingleStatementContext:
+    "Async functions can only be declared at the top level or inside a block",
+  AwaitBindingIdentifier:
+    "Can not use 'await' as identifier inside an async function",
+  AwaitExpressionFormalParameter:
+    "await is not allowed in async function parameters",
+  AwaitNotInAsyncFunction:
+    "Can not use keyword 'await' outside an async function",
+  BadGetterArity: "getter must not have any formal parameters",
+  BadSetterArity: "setter must have exactly one formal parameter",
+  BadSetterRestParameter:
+    "setter function argument must not be a rest parameter",
+  ConstructorClassField: "Classes may not have a field named 'constructor'",
+  ConstructorClassPrivateField:
+    "Classes may not have a private field named '#constructor'",
+  // todo: rephrase to get/set accessor
+  ConstructorIsAccessor: "Constructor can't have get/set modifier",
+  ConstructorIsAsync: "Constructor can't be an async function",
+  ConstructorIsGenerator: "Constructor can't be a generator",
+  DeclarationMissingInitializer: "%0 require an initialization value",
+  DecoratorBeforeExport:
+    "Decorators must be placed *before* the 'export' keyword. You can set the 'decoratorsBeforeExport' option to false to use the 'export @decorator class {}' syntax",
+  DecoratorConstructor:
+    "Decorators can't be used with a constructor. Did you mean '@dec class { ... }'?",
+  DecoratorExportClass:
+    "Using the export keyword between a decorator and a class is not allowed. Please use `export @dec class` instead.",
+  DecoratorSemicolon: "Decorators must not be followed by a semicolon",
+  DeletePrivateField: "Deleting a private field is not allowed",
+  DestructureNamedImport:
+    "ES2015 named imports do not destructure. Use another statement for destructuring after the import.",
+  DuplicateConstructor: "Duplicate constructor in the same class",
+  DuplicateDefaultExport: "Only one default export allowed per module.",
+  DuplicateExport:
+    "`%0` has already been exported. Exported identifiers must be unique.",
+  DuplicateProto: "Redefinition of __proto__ property",
+  DuplicateRegExpFlags: "Duplicate regular expression flag",
+  ElementAfterRest: "Rest element must be last element",
+  EscapedCharNotAnIdentifier: "Invalid Unicode escape",
+  ForInOfLoopInitializer:
+    "%0 loop variable declaration may not have an initializer",
+  GeneratorInSingleStatementContext:
+    "Generators can only be declared at the top level or inside a block",
+  IllegalBreakContinue: "Unsyntactic %0",
+  IllegalLanguageModeDirective:
+    "Illegal 'use strict' directive in function with non-simple parameter list",
+  IllegalReturn: "'return' outside of function",
+  ImportCallArgumentTrailingComma:
+    "Trailing comma is disallowed inside import(...) arguments",
+  ImportCallArity: "import() requires exactly one argument",
+  ImportCallArityLtOne: "Dynamic imports require a parameter: import('a.js')",
+  ImportCallNotNewExpression: "Cannot use new with import(...)",
+  ImportCallSpreadArgument: "... is not allowed in import()",
+  ImportMetaOutsideModule: `import.meta may appear only with 'sourceType: "module"'`,
+  ImportOutsideModule: `'import' and 'export' may appear only with 'sourceType: "module"'`,
+  InvalidCodePoint: "Code point out of bounds",
+  InvalidDigit: "Expected number in radix %0",
+  InvalidEscapeSequence: "Bad character escape sequence",
+  InvalidEscapeSequenceTemplate: "Invalid escape sequence in template",
+  InvalidEscapedReservedWord: "Escape sequence in keyword %0",
+  InvalidIdentifier: "Invalid identifier %0",
+  InvalidLhs: "Invalid left-hand side in %0",
+  InvalidLhsBinding: "Binding invalid left-hand side in %0",
+  InvalidNumber: "Invalid number",
+  InvalidOrUnexpectedToken: "Unexpected character '%0'",
+  InvalidParenthesizedAssignment: "Invalid parenthesized assignment pattern",
+  InvalidPrivateFieldResolution: "Private name #%0 is not defined",
+  InvalidPropertyBindingPattern: "Binding member expression",
+  InvalidRestAssignmentPattern: "Invalid rest operator's argument",
+  LabelRedeclaration: "Label '%0' is already declared",
+  LetInLexicalBinding:
+    "'let' is not allowed to be used as a name in 'let' or 'const' declarations.",
+  MalformedRegExpFlags: "Invalid regular expression flag",
+  MissingClassName: "A class name is required",
+  MissingEqInAssignment:
+    "Only '=' operator can be used for specifying default value.",
+  MissingUnicodeEscape: "Expecting Unicode escape sequence \\uXXXX",
+  MixingCoalesceWithLogical:
+    "Nullish coalescing operator(??) requires parens when mixing with logical operators",
+  ModuleExportUndefined: "Export '%0' is not defined",
+  MultipleDefaultsInSwitch: "Multiple default clauses",
+  NewlineAfterThrow: "Illegal newline after throw",
+  NoCatchOrFinally: "Missing catch or finally clause",
+  NumberIdentifier: "Identifier directly after number",
+  NumericSeparatorInEscapeSequence:
+    "Numeric separators are not allowed inside unicode escape sequences or hex escape sequences",
+  ObsoleteAwaitStar:
+    "await* has been removed from the async functions proposal. Use Promise.all() instead.",
+  OptionalChainingNoNew:
+    "constructors in/after an Optional Chain are not allowed",
+  OptionalChainingNoTemplate:
+    "Tagged Template Literals are not allowed in optionalChain",
+  ParamDupe: "Argument name clash",
+  PatternHasAccessor: "Object pattern can't contain getter or setter",
+  PatternHasMethod: "Object pattern can't contain methods",
+  PipelineBodyNoArrow:
+    'Unexpected arrow "=>" after pipeline body; arrow function in pipeline body must be parenthesized',
+  PipelineBodySequenceExpression:
+    "Pipeline body may not be a comma-separated sequence expression",
+  PipelineHeadSequenceExpression:
+    "Pipeline head should not be a comma-separated sequence expression",
+  PipelineTopicUnused:
+    "Pipeline is in topic style but does not use topic reference",
+  PrimaryTopicNotAllowed:
+    "Topic reference was used in a lexical context without topic binding",
+  PrimaryTopicRequiresSmartPipeline:
+    "Primary Topic Reference found but pipelineOperator not passed 'smart' for 'proposal' option.",
+  PrivateNameRedeclaration: "Duplicate private name #%0",
+  RestTrailingComma: "Unexpected trailing comma after rest element",
+  SloppyFunction:
+    "In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement",
+  StaticPrototype: "Classes may not have static property named prototype",
+  StrictDelete: "Deleting local variable in strict mode",
+  StrictEvalArguments: "Assigning to '%0' in strict mode",
+  StrictEvalArgumentsBinding: "Binding '%0' in strict mode",
+  StrictFunction:
+    "In strict mode code, functions can only be declared at top level or inside a block",
+  StrictOctalLiteral: "Octal literal in strict mode",
+  StrictWith: "'with' in strict mode",
+  SuperNotAllowed:
+    "super() is only valid inside a class constructor of a subclass. Maybe a typo in the method name ('constructor') or not extending another class?",
+  SuperPrivateField: "Private fields can't be accessed on super",
+  //todo: rephrase this error message as it is too subjective
+  TrailingDecorator: "You have trailing decorators with no method",
+  UnexpectedArgumentPlaceholder: "Unexpected argument placeholder",
+  UnexpectedAwaitAfterPipelineBody:
+    'Unexpected "await" after pipeline body; await must have parentheses in minimal proposal',
+  UnexpectedDigitAfterHash: "Unexpected digit after hash token",
+  UnexpectedImportExport:
+    "'import' and 'export' may only appear at the top level",
+  UnexpectedKeyword: "Unexpected keyword '%0'",
+  UnexpectedLeadingDecorator:
+    "Leading decorators must be attached to a class declaration",
+  UnexpectedLexicalDeclaration:
+    "Lexical declaration cannot appear in a single-statement context",
+  UnexpectedNewTarget: "new.target can only be used in functions",
+  UnexpectedNumericSeparator:
+    "A numeric separator is only allowed between two digits",
+  UnexpectedPrivateField:
+    "Private names can only be used as the name of a class element (i.e. class C { #p = 42; #m() {} } )\n or a property of member expression (i.e. this.#p).",
+  UnexpectedReservedWord: "Unexpected reserved word '%0'",
+  UnexpectedSuper: "super is only allowed in object methods and classes",
+  UnexpectedToken: "Unexpected token '%'",
+  UnexpectedTokenUnaryExponentiation:
+    "Illegal expression. Wrap left hand side or entire exponentiation in parentheses.",
+  UnsupportedBind: "Binding should be performed on object property.",
+  //todo: rephrase this error message as it is too subjective
+  UnsupportedDecoratorExport:
+    "You can only use decorators on an export when exporting a class",
+  UnsupportedDefaultExport:
+    "Only expressions, functions or classes are allowed as the `default` export.",
+  UnsupportedImport: "import can only be used in import() or import.meta",
+  UnsupportedMetaProperty: "The only valid meta property for %0 is %0.%1",
+  //todo: remove Stage 2 as we are likely to forget updating when it progressed
+  UnsupportedParameterDecorator:
+    "Stage 2 decorators cannot be used to decorate parameters",
+  UnsupportedPropertyDecorator:
+    "Stage 2 decorators disallow object literal property decorators",
+  UnsupportedSuper:
+    "super can only be used with function calls (i.e. super()) or in property accesses (i.e. super.prop or super[prop])",
+  UnterminatedComment: "Unterminated comment",
+  UnterminatedRegExp: "Unterminated regular expression",
+  UnterminatedString: "Unterminated string constant",
+  UnterminatedTemplate: "Unterminated template",
+  VarRedeclaration: "Identifier '%0' has already been declared",
+  YieldBindingIdentifier:
+    "Can not use 'yield' as identifier inside a generator",
+  YieldInParameter: "yield is not allowed in generator parameters",
+  ZeroDigitNumericSeparator:
+    "Numeric separator can not be used after leading 0",
+});
 
 export default class LocationParser extends CommentsParser {
   // Forward-declaration: defined in tokenizer/index.js

--- a/packages/babel-parser/src/parser/location.js
+++ b/packages/babel-parser/src/parser/location.js
@@ -12,7 +12,7 @@ import CommentsParser from "./comments";
 type ErrorContext = {
   pos: number,
   loc: Position,
-  missingPluginNames?: Array<string>,
+  missingPlugin?: Array<string>,
   code?: string,
 };
 
@@ -214,7 +214,7 @@ export default class LocationParser extends CommentsParser {
   raiseWithData(
     pos: number,
     data: {
-      missingPluginNames?: Array<string>,
+      missingPlugin?: Array<string>,
       code?: string,
     },
     errorTemplate: string,

--- a/packages/babel-parser/src/parser/location.js
+++ b/packages/babel-parser/src/parser/location.js
@@ -225,17 +225,7 @@ export default class LocationParser extends CommentsParser {
     const message =
       errorTemplate.replace(/%(\d+)/g, (_, i: number) => params[i]) +
       ` (${loc.line}:${loc.column})`;
-    return this._raise(
-      Object.assign(
-        {},
-        {
-          loc,
-          pos,
-        },
-        data,
-      ),
-      message,
-    );
+    return this._raise(Object.assign(({ loc, pos }: Object), data), message);
   }
 
   _raise(errorContext: ErrorContext, message: string): Error | empty {

--- a/packages/babel-parser/src/parser/lval.js
+++ b/packages/babel-parser/src/parser/lval.js
@@ -22,6 +22,7 @@ import {
 import { NodeUtils } from "./node";
 import { type BindingTypes, BIND_NONE } from "../util/scopeflags";
 import { ExpressionErrors } from "./util";
+import { Errors } from "./location";
 
 const unwrapParenthesizedExpression = (node: Node) => {
   return node.type === "ParenthesizedExpression"
@@ -62,7 +63,7 @@ export default class LValParser extends NodeUtils {
         parenthesized.type !== "Identifier" &&
         parenthesized.type !== "MemberExpression"
       ) {
-        this.raise(node.start, "Invalid parenthesized assignment pattern");
+        this.raise(node.start, Errors.InvalidParenthesizedAssignment);
       }
     }
 
@@ -114,10 +115,7 @@ export default class LValParser extends NodeUtils {
 
       case "AssignmentExpression":
         if (node.operator !== "=") {
-          this.raise(
-            node.left.end,
-            "Only '=' operator can be used for specifying default value.",
-          );
+          this.raise(node.left.end, Errors.MissingEqInAssignment);
         }
 
         node.type = "AssignmentPattern";
@@ -140,8 +138,8 @@ export default class LValParser extends NodeUtils {
     if (prop.type === "ObjectMethod") {
       const error =
         prop.kind === "get" || prop.kind === "set"
-          ? "Object pattern can't contain getter or setter"
-          : "Object pattern can't contain methods";
+          ? Errors.PatternHasAccessor
+          : Errors.PatternHasMethod;
 
       this.raise(prop.key.start, error);
     } else if (prop.type === "SpreadElement" && !isLast) {
@@ -288,10 +286,7 @@ export default class LValParser extends NodeUtils {
       } else {
         const decorators = [];
         if (this.match(tt.at) && this.hasPlugin("decorators")) {
-          this.raise(
-            this.state.start,
-            "Stage 2 decorators cannot be used to decorate parameters",
-          );
+          this.raise(this.state.start, Errors.UnsupportedParameterDecorator);
         }
         while (this.match(tt.at)) {
           decorators.push(this.parseDecorator());
@@ -361,9 +356,10 @@ export default class LValParser extends NodeUtils {
         ) {
           this.raise(
             expr.start,
-            `${bindingType === BIND_NONE ? "Assigning to" : "Binding"} '${
-              expr.name
-            }' in strict mode`,
+            bindingType === BIND_NONE
+              ? Errors.StrictEvalArguments
+              : Errors.StrictEvalArgumentsBinding,
+            expr.name,
           );
         }
 
@@ -382,16 +378,13 @@ export default class LValParser extends NodeUtils {
           const key = `_${expr.name}`;
 
           if (checkClashes[key]) {
-            this.raise(expr.start, "Argument name clash");
+            this.raise(expr.start, Errors.ParamDupe);
           } else {
             checkClashes[key] = true;
           }
         }
         if (disallowLetBinding && expr.name === "let") {
-          this.raise(
-            expr.start,
-            "'let' is not allowed to be used as a name in 'let' or 'const' declarations.",
-          );
+          this.raise(expr.start, Errors.LetInLexicalBinding);
         }
         if (!(bindingType & BIND_NONE)) {
           this.scope.declareName(expr.name, bindingType, expr.start);
@@ -400,7 +393,7 @@ export default class LValParser extends NodeUtils {
 
       case "MemberExpression":
         if (bindingType !== BIND_NONE) {
-          this.raise(expr.start, "Binding member expression");
+          this.raise(expr.start, Errors.InvalidPropertyBindingPattern);
         }
         break;
 
@@ -464,15 +457,24 @@ export default class LValParser extends NodeUtils {
         break;
 
       default: {
-        const message =
-          (bindingType === BIND_NONE
-            ? "Invalid"
-            : /* istanbul ignore next */ "Binding invalid") +
-          " left-hand side" +
-          (contextDescription
-            ? " in " + contextDescription
-            : /* istanbul ignore next */ "expression");
-        this.raise(expr.start, message);
+        if (contextDescription) {
+          this.raise(
+            expr.start,
+            bindingType === BIND_NONE
+              ? Errors.InvalidLhs
+              : Errors.InvalidLhsBinding,
+            contextDescription,
+          );
+        } else {
+          // todo: check if contextDescription is never empty
+          const message =
+            (bindingType === BIND_NONE
+              ? "Invalid"
+              : /* istanbul ignore next */ "Binding invalid") +
+            " left-hand side expression";
+
+          this.raise(expr.start, message);
+        }
       }
     }
   }
@@ -482,7 +484,7 @@ export default class LValParser extends NodeUtils {
       node.argument.type !== "Identifier" &&
       node.argument.type !== "MemberExpression"
     ) {
-      this.raise(node.argument.start, "Invalid rest operator's argument");
+      this.raise(node.argument.start, Errors.InvalidRestAssignmentPattern);
     }
   }
 
@@ -497,10 +499,10 @@ export default class LValParser extends NodeUtils {
   }
 
   raiseRestNotLast(pos: number) {
-    throw this.raise(pos, `Rest element must be last element`);
+    throw this.raise(pos, Errors.ElementAfterRest);
   }
 
   raiseTrailingCommaAfterRest(pos: number) {
-    this.raise(pos, `Unexpected trailing comma after rest element`);
+    this.raise(pos, Errors.RestTrailingComma);
   }
 }

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1728,7 +1728,7 @@ export default class StatementParser extends ExpressionParser {
 
         // export async;
         if (!this.isUnparsedContextual(next, "function")) {
-          this.unexpected(next, { label: "function" });
+          this.unexpected(next, tt._function);
         }
       }
 

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -308,12 +308,12 @@ export default class StatementParser extends ExpressionParser {
 
   assertModuleNodeAllowed(node: N.Node): void {
     if (!this.options.allowImportExportEverywhere && !this.inModule) {
-      this.raise(
+      this.raiseWithData(
         node.start,
-        `'import' and 'export' may appear only with 'sourceType: "module"'`,
         {
           code: "BABEL_PARSER_SOURCETYPE_MODULE_REQUIRED",
         },
+        `'import' and 'export' may appear only with 'sourceType: "module"'`,
       );
     }
   }

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -155,7 +155,7 @@ export default class UtilParser extends Tokenizer {
     if (!this.hasPlugin(name)) {
       throw this.raiseWithData(
         pos != null ? pos : this.state.start,
-        { missingPluginNames: [name] },
+        { missingPlugin: [name] },
         `This experimental syntax requires enabling the parser plugin: '${name}'`,
       );
     }
@@ -167,7 +167,7 @@ export default class UtilParser extends Tokenizer {
     if (!names.some(n => this.hasPlugin(n))) {
       throw this.raiseWithData(
         pos != null ? pos : this.state.start,
-        { missingPluginNames: names },
+        { missingPlugin: names },
         `This experimental syntax requires enabling one of the following parser plugin(s): '${names.join(
           ", ",
         )}'`,

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -7,6 +7,7 @@ import type { Node } from "../types";
 import { lineBreak, skipWhiteSpace } from "../util/whitespace";
 import { isIdentifierChar } from "../util/identifier";
 import * as charCodes from "charcodes";
+import { Errors } from "./location";
 
 const literal = /^('|")((?:\\?.)*?)\1/;
 
@@ -280,7 +281,7 @@ export default class UtilParser extends Tokenizer {
       this.unexpected(shorthandAssign);
     }
     if (doubleProto >= 0) {
-      this.raise(doubleProto, "Redefinition of __proto__ property");
+      this.raise(doubleProto, Errors.DuplicateProto);
     }
   }
 }

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -152,10 +152,10 @@ export default class UtilParser extends Tokenizer {
 
   expectPlugin(name: string, pos?: ?number): true {
     if (!this.hasPlugin(name)) {
-      throw this.raise(
+      throw this.raiseWithData(
         pos != null ? pos : this.state.start,
-        `This experimental syntax requires enabling the parser plugin: '${name}'`,
         { missingPluginNames: [name] },
+        `This experimental syntax requires enabling the parser plugin: '${name}'`,
       );
     }
 
@@ -164,12 +164,12 @@ export default class UtilParser extends Tokenizer {
 
   expectOnePlugin(names: Array<string>, pos?: ?number): void {
     if (!names.some(n => this.hasPlugin(n))) {
-      throw this.raise(
+      throw this.raiseWithData(
         pos != null ? pos : this.state.start,
+        { missingPluginNames: names },
         `This experimental syntax requires enabling one of the following parser plugin(s): '${names.join(
           ", ",
         )}'`,
-        { missingPluginNames: names },
       );
     }
   }

--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -45,7 +45,7 @@ const reservedTypes = new Set([
 
 /* eslint sort-keys: "error" */
 // The Errors key follows https://github.com/facebook/flow/blob/master/src/parser/parse_error.ml unless it does not exist
-const flowErrors = Object.freeze({
+const FlowErrors = Object.freeze({
   AmbiguousConditionalArrow:
     "Ambiguous expression: wrap the arrow functions in parentheses to disambiguate.",
   AmbiguousDeclareModuleKind:
@@ -245,7 +245,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         moduloLoc.line !== checksLoc.line ||
         moduloLoc.column !== checksLoc.column - 1
       ) {
-        this.raise(moduloPos, flowErrors.UnexpectedSpaceBetweenModuloChecks);
+        this.raise(moduloPos, FlowErrors.UnexpectedSpaceBetweenModuloChecks);
       }
       if (this.eat(tt.parenL)) {
         node.value = this.parseExpression();
@@ -338,7 +338,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           return this.flowParseDeclareModuleExports(node);
         } else {
           if (insideModule) {
-            this.raise(this.state.lastTokStart, flowErrors.NestedDeclareModule);
+            this.raise(this.state.lastTokStart, FlowErrors.NestedDeclareModule);
           }
           return this.flowParseDeclareModule(node);
         }
@@ -387,14 +387,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           if (!this.isContextual("type") && !this.match(tt._typeof)) {
             this.raise(
               this.state.lastTokStart,
-              flowErrors.InvalidNonTypeImportInDeclareModule,
+              FlowErrors.InvalidNonTypeImportInDeclareModule,
             );
           }
           this.parseImport(bodyNode);
         } else {
           this.expectContextual(
             "declare",
-            flowErrors.UnsupportedStatementInDeclareModule,
+            FlowErrors.UnsupportedStatementInDeclareModule,
           );
 
           bodyNode = this.flowParseDeclare(bodyNode, true);
@@ -416,7 +416,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           if (kind === "CommonJS") {
             this.raise(
               bodyElement.start,
-              flowErrors.AmbiguousDeclareModuleKind,
+              FlowErrors.AmbiguousDeclareModuleKind,
             );
           }
           kind = "ES";
@@ -424,13 +424,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           if (hasModuleExport) {
             this.raise(
               bodyElement.start,
-              flowErrors.DuplicateDeclareModuleExports,
+              FlowErrors.DuplicateDeclareModuleExports,
             );
           }
           if (kind === "ES") {
             this.raise(
               bodyElement.start,
-              flowErrors.AmbiguousDeclareModuleKind,
+              FlowErrors.AmbiguousDeclareModuleKind,
             );
           }
           kind = "CommonJS";
@@ -472,7 +472,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           const suggestion = exportSuggestions[label];
           throw this.raise(
             this.state.start,
-            flowErrors.UnsupportedDeclareExportKind,
+            FlowErrors.UnsupportedDeclareExportKind,
             label,
             suggestion,
           );
@@ -630,7 +630,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     checkNotUnderscore(word: string) {
       if (word === "_") {
-        this.raise(this.state.start, flowErrors.UnexpectedReservedUnderscore);
+        this.raise(this.state.start, FlowErrors.UnexpectedReservedUnderscore);
       }
     }
 
@@ -640,8 +640,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       this.raise(
         startLoc,
         declaration
-          ? flowErrors.AssignReservedType
-          : flowErrors.UnexpectedReservedType,
+          ? FlowErrors.AssignReservedType
+          : FlowErrors.UnexpectedReservedType,
         word,
       );
     }
@@ -726,7 +726,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         node.default = this.flowParseType();
       } else {
         if (requireDefault) {
-          this.raise(nodeStart, flowErrors.MissingTypeParamDefault);
+          this.raise(nodeStart, FlowErrors.MissingTypeParamDefault);
         }
       }
 
@@ -1061,7 +1061,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         ) {
           this.raise(
             inexactStart,
-            flowErrors.UnexpectedExplicitInexactInObject,
+            FlowErrors.UnexpectedExplicitInexactInObject,
           );
         }
       }
@@ -1104,26 +1104,26 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           if (!allowSpread) {
             this.raise(
               this.state.lastTokStart,
-              flowErrors.InexactInsideNonObject,
+              FlowErrors.InexactInsideNonObject,
             );
           } else if (!allowInexact) {
-            this.raise(this.state.lastTokStart, flowErrors.InexactInsideExact);
+            this.raise(this.state.lastTokStart, FlowErrors.InexactInsideExact);
           }
           if (variance) {
-            this.raise(variance.start, flowErrors.InexactVariance);
+            this.raise(variance.start, FlowErrors.InexactVariance);
           }
 
           return null;
         }
 
         if (!allowSpread) {
-          this.raise(this.state.lastTokStart, flowErrors.UnexpectedSpreadType);
+          this.raise(this.state.lastTokStart, FlowErrors.UnexpectedSpreadType);
         }
         if (protoStart != null) {
           this.unexpected(protoStart);
         }
         if (variance) {
-          this.raise(variance.start, flowErrors.SpreadVariance);
+          this.raise(variance.start, FlowErrors.SpreadVariance);
         }
 
         node.argument = this.flowParseType();
@@ -1495,7 +1495,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
             throw this.raise(
               this.state.start,
-              flowErrors.UnexpectedSubtractionOperand,
+              FlowErrors.UnexpectedSubtractionOperand,
             );
           }
 
@@ -1858,7 +1858,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           // e.g.   Source: a ? (b): c => (d): e => f
           //      Result 1: a ? b : (c => ((d): e => f))
           //      Result 2: a ? ((b): c => d) : (e => f)
-          this.raise(state.start, flowErrors.AmbiguousConditionalArrow);
+          this.raise(state.start, FlowErrors.AmbiguousConditionalArrow);
         }
 
         if (failed && valid.length === 1) {
@@ -2180,7 +2180,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           (!expr.extra || !expr.extra.parenthesized) &&
           (exprList.length > 1 || !isParenthesizedExpr)
         ) {
-          this.raise(expr.typeAnnotation.start, flowErrors.TypeCastInPattern);
+          this.raise(expr.typeAnnotation.start, FlowErrors.TypeCastInPattern);
         }
       }
 
@@ -2355,7 +2355,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     parseAssignableListItemTypes(param: N.Pattern): N.Pattern {
       if (this.eat(tt.question)) {
         if (param.type !== "Identifier") {
-          this.raise(param.start, flowErrors.OptionalBindingPattern);
+          this.raise(param.start, FlowErrors.OptionalBindingPattern);
         }
 
         ((param: any): N.Identifier).optional = true;
@@ -2379,7 +2379,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         node.typeAnnotation &&
         node.right.start < node.typeAnnotation.start
       ) {
-        this.raise(node.typeAnnotation.start, flowErrors.TypeBeforeInitializer);
+        this.raise(node.typeAnnotation.start, FlowErrors.TypeBeforeInitializer);
       }
 
       return node;
@@ -2503,7 +2503,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (nodeIsTypeImport && specifierIsTypeImport) {
         this.raise(
           firstIdentLoc,
-          flowErrors.ImportTypeShorthandOnlyInPureImport,
+          FlowErrors.ImportTypeShorthandOnlyInPureImport,
         );
       }
 
@@ -2681,7 +2681,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         /*:: invariant(typeParameters) */
         throw this.raise(
           typeParameters.start,
-          flowErrors.UnexpectedTokenAfterTypeParameter,
+          FlowErrors.UnexpectedTokenAfterTypeParameter,
         );
       }
 
@@ -2940,7 +2940,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     parseTopLevel(file: N.File, program: N.Program): N.File {
       const fileNode = super.parseTopLevel(file, program);
       if (this.state.hasFlowComment) {
-        this.raise(this.state.pos, flowErrors.UnterminatedFlowComment);
+        this.raise(this.state.pos, FlowErrors.UnterminatedFlowComment);
       }
       return fileNode;
     }
@@ -2948,7 +2948,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     skipBlockComment(): void {
       if (this.hasPlugin("flowComments") && this.skipFlowComment()) {
         if (this.state.hasFlowComment) {
-          this.unexpected(null, flowErrors.NestedFlowComment);
+          this.unexpected(null, FlowErrors.NestedFlowComment);
         }
         this.hasFlowCommentCompletion();
         this.state.pos += this.skipFlowComment();
@@ -3014,7 +3014,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     ): void {
       this.raise(
         pos,
-        flowErrors.EnumBooleanMemberNotInitialized,
+        FlowErrors.EnumBooleanMemberNotInitialized,
         memberName,
         enumName,
       );
@@ -3027,7 +3027,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const suggestion = memberName[0].toUpperCase() + memberName.slice(1);
       this.raise(
         pos,
-        flowErrors.EnumInvalidMemberName,
+        FlowErrors.EnumInvalidMemberName,
         memberName,
         suggestion,
         enumName,
@@ -3038,14 +3038,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       pos: number,
       { enumName, memberName }: { enumName: string, memberName: string },
     ): void {
-      this.raise(pos, flowErrors.EnumDuplicateMemberName, memberName, enumName);
+      this.raise(pos, FlowErrors.EnumDuplicateMemberName, memberName, enumName);
     }
 
     flowEnumErrorInconsistentMemberValues(
       pos: number,
       { enumName }: { enumName: string },
     ): void {
-      this.raise(pos, flowErrors.EnumInconsistentMemberValues, enumName);
+      this.raise(pos, FlowErrors.EnumInconsistentMemberValues, enumName);
     }
 
     flowEnumErrorInvalidExplicitType(
@@ -3058,8 +3058,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return this.raise(
         pos,
         suppliedType === null
-          ? flowErrors.EnumInvalidExplicitTypeUnknownSupplied
-          : flowErrors.EnumInvalidExplicitType,
+          ? FlowErrors.EnumInvalidExplicitTypeUnknownSupplied
+          : FlowErrors.EnumInvalidExplicitType,
         enumName,
         suppliedType,
       );
@@ -3074,14 +3074,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         case "boolean":
         case "number":
         case "string":
-          message = flowErrors.EnumInvalidMemberInitializerPrimaryType;
+          message = FlowErrors.EnumInvalidMemberInitializerPrimaryType;
           break;
         case "symbol":
-          message = flowErrors.EnumInvalidMemberInitializerSymbolType;
+          message = FlowErrors.EnumInvalidMemberInitializerSymbolType;
           break;
         default:
           // null
-          message = flowErrors.EnumInvalidMemberInitializerUnknownType;
+          message = FlowErrors.EnumInvalidMemberInitializerUnknownType;
       }
       return this.raise(pos, message, enumName, memberName, explicitType);
     }
@@ -3092,7 +3092,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     ): void {
       this.raise(
         pos,
-        flowErrors.EnumNumberMemberNotInitialized,
+        FlowErrors.EnumNumberMemberNotInitialized,
         enumName,
         memberName,
       );
@@ -3104,7 +3104,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     ): void {
       this.raise(
         pos,
-        flowErrors.EnumStringMemberInconsistentlyInitailized,
+        FlowErrors.EnumStringMemberInconsistentlyInitailized,
         enumName,
       );
     }

--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -44,6 +44,7 @@ const reservedTypes = new Set([
 ]);
 
 /* eslint sort-keys: "error" */
+// The Errors key follows https://github.com/facebook/flow/blob/master/src/parser/parse_error.ml unless it does not exist
 const flowErrors = Object.freeze({
   AmbiguousConditionalArrow:
     "Ambiguous expression: wrap the arrow functions in parentheses to disambiguate.",

--- a/packages/babel-parser/src/plugins/jsx/index.js
+++ b/packages/babel-parser/src/plugins/jsx/index.js
@@ -16,7 +16,7 @@ import { Errors } from "../../parser/location";
 const HEX_NUMBER = /^[\da-fA-F]+$/;
 const DECIMAL_NUMBER = /^\d+$/;
 
-const jsxErrors = Object.freeze({
+const JsxErrors = Object.freeze({
   AttributeIsEmpty:
     "JSX attributes must only be assigned a non-empty expression",
   MissingClosingTagFragment: "Expected corresponding JSX closing tag for <>",
@@ -96,7 +96,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       let chunkStart = this.state.pos;
       for (;;) {
         if (this.state.pos >= this.length) {
-          throw this.raise(this.state.start, jsxErrors.UnterminatedJsxContent);
+          throw this.raise(this.state.start, JsxErrors.UnterminatedJsxContent);
         }
 
         const ch = this.input.charCodeAt(this.state.pos);
@@ -293,7 +293,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           this.next();
           node = this.jsxParseExpressionContainer(node);
           if (node.expression.type === "JSXEmptyExpression") {
-            this.raise(node.start, jsxErrors.AttributeIsEmpty);
+            this.raise(node.start, JsxErrors.AttributeIsEmpty);
           }
           return node;
 
@@ -302,7 +302,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           return this.parseExprAtom();
 
         default:
-          throw this.raise(this.state.start, jsxErrors.UnsupportedJsxValue);
+          throw this.raise(this.state.start, JsxErrors.UnsupportedJsxValue);
       }
     }
 
@@ -457,13 +457,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           this.raise(
             // $FlowIgnore
             closingElement.start,
-            jsxErrors.MissingClosingTagFragment,
+            JsxErrors.MissingClosingTagFragment,
           );
         } else if (!isFragment(openingElement) && isFragment(closingElement)) {
           this.raise(
             // $FlowIgnore
             closingElement.start,
-            jsxErrors.MissingClosingTagElement,
+            JsxErrors.MissingClosingTagElement,
             getQualifiedJSXName(openingElement.name),
           );
         } else if (!isFragment(openingElement) && !isFragment(closingElement)) {
@@ -475,7 +475,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             this.raise(
               // $FlowIgnore
               closingElement.start,
-              jsxErrors.MissingClosingTagElement,
+              JsxErrors.MissingClosingTagElement,
               getQualifiedJSXName(openingElement.name),
             );
           }
@@ -493,7 +493,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (this.isRelational("<")) {
         throw this.raise(
           this.state.start,
-          jsxErrors.UnwrappedAdjacentJSXElements,
+          JsxErrors.UnwrappedAdjacentJSXElements,
         );
       }
 

--- a/packages/babel-parser/src/plugins/jsx/index.js
+++ b/packages/babel-parser/src/plugins/jsx/index.js
@@ -11,9 +11,22 @@ import * as N from "../../types";
 import { isIdentifierChar, isIdentifierStart } from "../../util/identifier";
 import type { Position } from "../../util/location";
 import { isNewLine } from "../../util/whitespace";
+import { Errors } from "../../parser/location";
 
 const HEX_NUMBER = /^[\da-fA-F]+$/;
 const DECIMAL_NUMBER = /^\d+$/;
+
+const jsxErrors = Object.freeze({
+  AttributeIsEmpty:
+    "JSX attributes must only be assigned a non-empty expression",
+  MissingClosingTagFragment: "Expected corresponding JSX closing tag for <>",
+  MissingClosingTagElement: "Expected corresponding JSX closing tag for <%0>",
+  UnsupportedJsxValue:
+    "JSX value should be either an expression or a quoted JSX text",
+  UnterminatedJsxContent: "Unterminated JSX contents",
+  UnwrappedAdjacentJSXElements:
+    "Adjacent JSX elements must be wrapped in an enclosing tag. Did you want a JSX fragment <>...</>?",
+});
 
 // Be aware that this file is always executed and not only when the plugin is enabled.
 // Therefore this contexts and tokens do always exist.
@@ -83,7 +96,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       let chunkStart = this.state.pos;
       for (;;) {
         if (this.state.pos >= this.length) {
-          throw this.raise(this.state.start, "Unterminated JSX contents");
+          throw this.raise(this.state.start, jsxErrors.UnterminatedJsxContent);
         }
 
         const ch = this.input.charCodeAt(this.state.pos);
@@ -143,7 +156,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       let chunkStart = ++this.state.pos;
       for (;;) {
         if (this.state.pos >= this.length) {
-          throw this.raise(this.state.start, "Unterminated string constant");
+          throw this.raise(this.state.start, Errors.UnterminatedString);
         }
 
         const ch = this.input.charCodeAt(this.state.pos);
@@ -280,10 +293,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           this.next();
           node = this.jsxParseExpressionContainer(node);
           if (node.expression.type === "JSXEmptyExpression") {
-            this.raise(
-              node.start,
-              "JSX attributes must only be assigned a non-empty expression",
-            );
+            this.raise(node.start, jsxErrors.AttributeIsEmpty);
           }
           return node;
 
@@ -292,10 +302,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           return this.parseExprAtom();
 
         default:
-          throw this.raise(
-            this.state.start,
-            "JSX value should be either an expression or a quoted JSX text",
-          );
+          throw this.raise(this.state.start, jsxErrors.UnsupportedJsxValue);
       }
     }
 
@@ -450,15 +457,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           this.raise(
             // $FlowIgnore
             closingElement.start,
-            "Expected corresponding JSX closing tag for <>",
+            jsxErrors.MissingClosingTagFragment,
           );
         } else if (!isFragment(openingElement) && isFragment(closingElement)) {
           this.raise(
             // $FlowIgnore
             closingElement.start,
-            "Expected corresponding JSX closing tag for <" +
-              getQualifiedJSXName(openingElement.name) +
-              ">",
+            jsxErrors.MissingClosingTagElement,
+            getQualifiedJSXName(openingElement.name),
           );
         } else if (!isFragment(openingElement) && !isFragment(closingElement)) {
           if (
@@ -469,9 +475,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             this.raise(
               // $FlowIgnore
               closingElement.start,
-              "Expected corresponding JSX closing tag for <" +
-                getQualifiedJSXName(openingElement.name) +
-                ">",
+              jsxErrors.MissingClosingTagElement,
+              getQualifiedJSXName(openingElement.name),
             );
           }
         }
@@ -488,8 +493,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (this.isRelational("<")) {
         throw this.raise(
           this.state.start,
-          "Adjacent JSX elements must be wrapped in an enclosing tag. " +
-            "Did you want a JSX fragment <>...</>?",
+          jsxErrors.UnwrappedAdjacentJSXElements,
         );
       }
 

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -59,7 +59,7 @@ type ParsingContext =
   | "TypeMembers"
   | "TypeParametersOrArguments";
 
-const tsErrors = Object.freeze({
+const TSErrors = Object.freeze({
   ClassMethodHasDeclare: "Class methods cannot have the 'declare' modifier",
   ClassMethodHasReadonly: "Class methods cannot have the 'readonly' modifier",
   DeclareClassFieldHasInitializer:
@@ -186,7 +186,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         if (!modifier) break;
 
         if (Object.hasOwnProperty.call(modified, modifier)) {
-          this.raise(startPos, tsErrors.DuplicateModifier, modifier);
+          this.raise(startPos, TSErrors.DuplicateModifier, modifier);
         }
         modified[modifier] = true;
       }
@@ -300,7 +300,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       this.expect(tt._import);
       this.expect(tt.parenL);
       if (!this.match(tt.string)) {
-        this.raise(this.state.start, tsErrors.UnsupportedImportTypeArgument);
+        this.raise(this.state.start, TSErrors.UnsupportedImportTypeArgument);
       }
 
       // For compatibility to estree we cannot call parseLiteral directly here
@@ -436,7 +436,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           ) {
             this.raise(
               pattern.start,
-              tsErrors.UnsupportedSignatureParameterKind,
+              TSErrors.UnsupportedSignatureParameterKind,
               pattern.type,
             );
           }
@@ -635,7 +635,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         if (elementNode.type === "TSOptionalType") {
           seenOptionalElement = true;
         } else if (seenOptionalElement && elementNode.type !== "TSRestType") {
-          this.raise(elementNode.start, tsErrors.OptionalTypeBeforeRequired);
+          this.raise(elementNode.start, TSErrors.OptionalTypeBeforeRequired);
         }
       });
 
@@ -709,7 +709,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (templateNode.expressions.length > 0) {
         this.raise(
           templateNode.expressions[0].start,
-          tsErrors.TemplateTypeHasSubstitution,
+          TSErrors.TemplateTypeHasSubstitution,
         );
       }
       node.literal = templateNode;
@@ -821,7 +821,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         case "TSArrayType":
           return;
         default:
-          this.raise(node.start, tsErrors.UnexpectedReadonly);
+          this.raise(node.start, TSErrors.UnexpectedReadonly);
       }
     }
 
@@ -1127,7 +1127,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       );
 
       if (!delimitedList.length) {
-        this.raise(originalStart, tsErrors.EmptyHeritageClauseType, descriptor);
+        this.raise(originalStart, TSErrors.EmptyHeritageClauseType, descriptor);
       }
 
       return delimitedList;
@@ -1668,7 +1668,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         if (accessibility) pp.accessibility = accessibility;
         if (readonly) pp.readonly = readonly;
         if (elt.type !== "Identifier" && elt.type !== "AssignmentPattern") {
-          this.raise(pp.start, tsErrors.UnsupportedParameterPropertyKind);
+          this.raise(pp.start, TSErrors.UnsupportedParameterPropertyKind);
         }
         pp.parameter = ((elt: any): N.Identifier | N.AssignmentPattern);
         return this.finishNode(pp, "TSParameterProperty");
@@ -1967,15 +1967,15 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         classBody.body.push(idx);
 
         if ((member: any).abstract) {
-          this.raise(member.start, tsErrors.IndexSignatureHasAbstract);
+          this.raise(member.start, TSErrors.IndexSignatureHasAbstract);
         }
         if (isStatic) {
-          this.raise(member.start, tsErrors.IndexSignatureHasStatic);
+          this.raise(member.start, TSErrors.IndexSignatureHasStatic);
         }
         if ((member: any).accessibility) {
           this.raise(
             member.start,
-            tsErrors.IndexSignatureHasAccessibility,
+            TSErrors.IndexSignatureHasAccessibility,
             (member: any).accessibility,
           );
         }
@@ -2001,11 +2001,11 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (optional) methodOrProp.optional = true;
 
       if ((methodOrProp: any).readonly && this.match(tt.parenL)) {
-        this.raise(methodOrProp.start, tsErrors.ClassMethodHasReadonly);
+        this.raise(methodOrProp.start, TSErrors.ClassMethodHasReadonly);
       }
 
       if ((methodOrProp: any).declare && this.match(tt.parenL)) {
-        this.raise(methodOrProp.start, tsErrors.ClassMethodHasDeclare);
+        this.raise(methodOrProp.start, TSErrors.ClassMethodHasDeclare);
       }
     }
 
@@ -2155,7 +2155,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       this.parseClassPropertyAnnotation(node);
 
       if (node.declare && this.match(tt.equal)) {
-        this.raise(this.state.start, tsErrors.DeclareClassFieldHasInitializer);
+        this.raise(this.state.start, TSErrors.DeclareClassFieldHasInitializer);
       }
 
       return super.parseClassProperty(node);
@@ -2166,14 +2166,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     ): N.ClassPrivateProperty {
       // $FlowIgnore
       if (node.abstract) {
-        this.raise(node.start, tsErrors.PrivateElementHasAbstract);
+        this.raise(node.start, TSErrors.PrivateElementHasAbstract);
       }
 
       // $FlowIgnore
       if (node.accessibility) {
         this.raise(
           node.start,
-          tsErrors.PrivateElementHasAccessibility,
+          TSErrors.PrivateElementHasAccessibility,
           node.accessibility,
         );
       }
@@ -2397,7 +2397,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     parseAssignableListItemTypes(param: N.Pattern) {
       if (this.eat(tt.question)) {
         if (param.type !== "Identifier") {
-          this.raise(param.start, tsErrors.PatternIsOptional);
+          this.raise(param.start, TSErrors.PatternIsOptional);
         }
 
         ((param: any): N.Identifier).optional = true;
@@ -2512,7 +2512,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       ) {
         this.raise(
           node.typeAnnotation.start,
-          tsErrors.TypeAnnotationAfterAssign,
+          TSErrors.TypeAnnotationAfterAssign,
         );
       }
 
@@ -2541,7 +2541,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             if (!this.state.maybeInArrowParameters) {
               exprList[i] = this.typeCastToParameter(expr);
             } else {
-              this.raise(expr.start, tsErrors.UnexpectedTypeCastInParameter);
+              this.raise(expr.start, TSErrors.UnexpectedTypeCastInParameter);
             }
             break;
         }
@@ -2568,7 +2568,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       for (let i = 0; i < exprList.length; i++) {
         const expr = exprList[i];
         if (expr && expr.type === "TSTypeCastExpression") {
-          this.raise(expr.start, tsErrors.UnexpectedTypeAnnotation);
+          this.raise(expr.start, TSErrors.UnexpectedTypeAnnotation);
         }
       }
 

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -27,6 +27,7 @@ import TypeScriptScopeHandler from "./scope";
 import * as charCodes from "charcodes";
 import type { ExpressionErrors } from "../../parser/util";
 import { PARAM } from "../../util/production-parameter";
+import { Errors } from "../../parser/location";
 
 type TsModifier =
   | "readonly"
@@ -57,6 +58,42 @@ type ParsingContext =
   | "TupleElementTypes"
   | "TypeMembers"
   | "TypeParametersOrArguments";
+
+const tsErrors = Object.freeze({
+  ClassMethodHasDeclare: "Class methods cannot have the 'declare' modifier",
+  ClassMethodHasReadonly: "Class methods cannot have the 'readonly' modifier",
+  DeclareClassFieldHasInitializer:
+    "'declare' class fields cannot have an initializer",
+  DuplicateModifier: "Duplicate modifier: '%0'",
+  EmptyHeritageClauseType: "'%0' list cannot be empty.",
+  IndexSignatureHasAbstract:
+    "Index signatures cannot have the 'abstract' modifier",
+  IndexSignatureHasAccessibility:
+    "Index signatures cannot have an accessibility modifier ('%0')",
+  IndexSignatureHasStatic: "Index signatures cannot have the 'static' modifier",
+  OptionalTypeBeforeRequired:
+    "A required element cannot follow an optional element.",
+  PatternIsOptional:
+    "A binding pattern parameter cannot be optional in an implementation signature.",
+  PrivateElementHasAbstract:
+    "Private elements cannot have the 'abstract' modifier.",
+  PrivateElementHasAccessibility:
+    "Private elements cannot have an accessibility modifier ('%0')",
+  TemplateTypeHasSubstitution:
+    "Template literal types cannot have any substitution",
+  TypeAnnotationAfterAssign:
+    "Type annotations must come before default assignments, e.g. instead of `age = 25: number` use `age: number = 25`",
+  UnexpectedReadonly:
+    "'readonly' type modifier is only permitted on array and tuple literal types.",
+  UnexpectedTypeAnnotation: "Did not expect a type annotation here.",
+  UnexpectedTypeCastInParameter: "Unexpected type cast in parameter position.",
+  UnsupportedImportTypeArgument:
+    "Argument in a type import must be a string literal",
+  UnsupportedParameterPropertyKind:
+    "A parameter property may not be declared using a binding pattern.",
+  UnsupportedSignatureParameterKind:
+    "Name in a signature must be an Identifier, ObjectPattern or ArrayPattern, instead got %0",
+});
 
 // Doesn't handle "void" or "null" because those are keywords, not identifiers.
 function keywordTypeFromName(
@@ -149,7 +186,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         if (!modifier) break;
 
         if (Object.hasOwnProperty.call(modified, modifier)) {
-          this.raise(startPos, `Duplicate modifier: '${modifier}'`);
+          this.raise(startPos, tsErrors.DuplicateModifier, modifier);
         }
         modified[modifier] = true;
       }
@@ -263,10 +300,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       this.expect(tt._import);
       this.expect(tt.parenL);
       if (!this.match(tt.string)) {
-        this.raise(
-          this.state.start,
-          "Argument in a type import must be a string literal",
-        );
+        this.raise(this.state.start, tsErrors.UnsupportedImportTypeArgument);
       }
 
       // For compatibility to estree we cannot call parseLiteral directly here
@@ -402,8 +436,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           ) {
             this.raise(
               pattern.start,
-              "Name in a signature must be an Identifier, ObjectPattern or ArrayPattern," +
-                `instead got ${pattern.type}`,
+              tsErrors.UnsupportedSignatureParameterKind,
+              pattern.type,
             );
           }
           return (pattern: any);
@@ -601,10 +635,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         if (elementNode.type === "TSOptionalType") {
           seenOptionalElement = true;
         } else if (seenOptionalElement && elementNode.type !== "TSRestType") {
-          this.raise(
-            elementNode.start,
-            "A required element cannot follow an optional element.",
-          );
+          this.raise(elementNode.start, tsErrors.OptionalTypeBeforeRequired);
         }
       });
 
@@ -678,7 +709,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (templateNode.expressions.length > 0) {
         this.raise(
           templateNode.expressions[0].start,
-          "Template literal types cannot have any substitution",
+          tsErrors.TemplateTypeHasSubstitution,
         );
       }
       node.literal = templateNode;
@@ -790,10 +821,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         case "TSArrayType":
           return;
         default:
-          this.raise(
-            node.start,
-            "'readonly' type modifier is only permitted on array and tuple literal types.",
-          );
+          this.raise(node.start, tsErrors.UnexpectedReadonly);
       }
     }
 
@@ -1031,7 +1059,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (containsEsc) {
         this.raise(
           this.state.lastTokStart,
-          "Escape sequence in keyword asserts",
+          Errors.InvalidEscapedReservedWord,
+          "asserts",
         );
       }
 
@@ -1098,7 +1127,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       );
 
       if (!delimitedList.length) {
-        this.raise(originalStart, `'${descriptor}' list cannot be empty.`);
+        this.raise(originalStart, tsErrors.EmptyHeritageClauseType, descriptor);
       }
 
       return delimitedList;
@@ -1639,10 +1668,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         if (accessibility) pp.accessibility = accessibility;
         if (readonly) pp.readonly = readonly;
         if (elt.type !== "Identifier" && elt.type !== "AssignmentPattern") {
-          this.raise(
-            pp.start,
-            "A parameter property may not be declared using a binding pattern.",
-          );
+          this.raise(pp.start, tsErrors.UnsupportedParameterPropertyKind);
         }
         pp.parameter = ((elt: any): N.Identifier | N.AssignmentPattern);
         return this.finishNode(pp, "TSParameterProperty");
@@ -1941,23 +1967,16 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         classBody.body.push(idx);
 
         if ((member: any).abstract) {
-          this.raise(
-            member.start,
-            "Index signatures cannot have the 'abstract' modifier",
-          );
+          this.raise(member.start, tsErrors.IndexSignatureHasAbstract);
         }
         if (isStatic) {
-          this.raise(
-            member.start,
-            "Index signatures cannot have the 'static' modifier",
-          );
+          this.raise(member.start, tsErrors.IndexSignatureHasStatic);
         }
         if ((member: any).accessibility) {
           this.raise(
             member.start,
-            `Index signatures cannot have an accessibility modifier ('${
-              (member: any).accessibility
-            }')`,
+            tsErrors.IndexSignatureHasAccessibility,
+            (member: any).accessibility,
           );
         }
 
@@ -1982,17 +2001,11 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (optional) methodOrProp.optional = true;
 
       if ((methodOrProp: any).readonly && this.match(tt.parenL)) {
-        this.raise(
-          methodOrProp.start,
-          "Class methods cannot have the 'readonly' modifier",
-        );
+        this.raise(methodOrProp.start, tsErrors.ClassMethodHasReadonly);
       }
 
       if ((methodOrProp: any).declare && this.match(tt.parenL)) {
-        this.raise(
-          methodOrProp.start,
-          "Class methods cannot have the 'declare' modifier",
-        );
+        this.raise(methodOrProp.start, tsErrors.ClassMethodHasDeclare);
       }
     }
 
@@ -2142,10 +2155,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       this.parseClassPropertyAnnotation(node);
 
       if (node.declare && this.match(tt.equal)) {
-        this.raise(
-          this.state.start,
-          "'declare' class fields cannot have an initializer",
-        );
+        this.raise(this.state.start, tsErrors.DeclareClassFieldHasInitializer);
       }
 
       return super.parseClassProperty(node);
@@ -2156,17 +2166,15 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     ): N.ClassPrivateProperty {
       // $FlowIgnore
       if (node.abstract) {
-        this.raise(
-          node.start,
-          "Private elements cannot have the 'abstract' modifier.",
-        );
+        this.raise(node.start, tsErrors.PrivateElementHasAbstract);
       }
 
       // $FlowIgnore
       if (node.accessibility) {
         this.raise(
           node.start,
-          `Private elements cannot have an accessibility modifier ('${node.accessibility}')`,
+          tsErrors.PrivateElementHasAccessibility,
+          node.accessibility,
         );
       }
 
@@ -2389,10 +2397,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     parseAssignableListItemTypes(param: N.Pattern) {
       if (this.eat(tt.question)) {
         if (param.type !== "Identifier") {
-          this.raise(
-            param.start,
-            "A binding pattern parameter cannot be optional in an implementation signature.",
-          );
+          this.raise(param.start, tsErrors.PatternIsOptional);
         }
 
         ((param: any): N.Identifier).optional = true;
@@ -2507,8 +2512,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       ) {
         this.raise(
           node.typeAnnotation.start,
-          "Type annotations must come before default assignments, " +
-            "e.g. instead of `age = 25: number` use `age: number = 25`",
+          tsErrors.TypeAnnotationAfterAssign,
         );
       }
 
@@ -2537,10 +2541,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             if (!this.state.maybeInArrowParameters) {
               exprList[i] = this.typeCastToParameter(expr);
             } else {
-              this.raise(
-                expr.start,
-                "Unexpected type cast in parameter position.",
-              );
+              this.raise(expr.start, tsErrors.UnexpectedTypeCastInParameter);
             }
             break;
         }
@@ -2567,7 +2568,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       for (let i = 0; i < exprList.length; i++) {
         const expr = exprList[i];
         if (expr && expr.type === "TSTypeCastExpression") {
-          this.raise(expr.start, "Did not expect a type annotation here.");
+          this.raise(expr.start, tsErrors.UnexpectedTypeAnnotation);
         }
       }
 

--- a/packages/babel-parser/src/util/class-scope.js
+++ b/packages/babel-parser/src/util/class-scope.js
@@ -19,7 +19,7 @@ export class ClassScope {
   undefinedPrivateNames: Map<string, number> = new Map();
 }
 
-type raiseFunction = (number, string) => void;
+type raiseFunction = (number, string, ...any) => void;
 
 export default class ClassScopeHandler {
   stack: Array<ClassScope> = [];

--- a/packages/babel-parser/src/util/class-scope.js
+++ b/packages/babel-parser/src/util/class-scope.js
@@ -5,6 +5,7 @@ import {
   CLASS_ELEMENT_FLAG_STATIC,
   type ClassElementTypes,
 } from "./scopeflags";
+import { Errors } from "../parser/location";
 
 export class ClassScope {
   // A list of private named declared in the current class
@@ -52,7 +53,7 @@ export default class ClassScopeHandler {
           current.undefinedPrivateNames.set(name, pos);
         }
       } else {
-        this.raiseUndeclaredPrivateName(name, pos);
+        this.raise(pos, Errors.InvalidPrivateFieldResolution, name);
       }
     }
   }
@@ -86,7 +87,7 @@ export default class ClassScopeHandler {
     }
 
     if (redefined) {
-      this.raise(pos, `Duplicate private name #${name}`);
+      this.raise(pos, Errors.PrivateNameRedeclaration, name);
     }
 
     classScope.privateNames.add(name);
@@ -103,11 +104,7 @@ export default class ClassScopeHandler {
       classScope.undefinedPrivateNames.set(name, pos);
     } else {
       // top-level
-      this.raiseUndeclaredPrivateName(name, pos);
+      this.raise(pos, Errors.InvalidPrivateFieldResolution, name);
     }
-  }
-
-  raiseUndeclaredPrivateName(name: string, pos: number) {
-    this.raise(pos, `Private name #${name} is not defined`);
   }
 }

--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -16,6 +16,7 @@ import {
   type BindingTypes,
 } from "./scopeflags";
 import * as N from "../types";
+import { Errors } from "../parser/location";
 
 // Start an AST node, attaching a start offset.
 export class Scope {
@@ -133,7 +134,7 @@ export default class ScopeHandler<IScope: Scope = Scope> {
     pos: number,
   ) {
     if (this.isRedeclaredInScope(scope, name, bindingType)) {
-      this.raise(pos, `Identifier '${name}' has already been declared`);
+      this.raise(pos, Errors.VarRedeclaration, name);
     }
   }
 

--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -33,7 +33,7 @@ export class Scope {
   }
 }
 
-type raiseFunction = (number, string) => void;
+type raiseFunction = (number, string, ...any) => void;
 
 // The functions in this module keep track of declared variables in the
 // current scope in order to detect duplicate variable names.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR collects the scattered babel parser error messages into a centralized message store. By doing so we can implement [expression scops](https://docs.google.com/document/d/1FAvEp9EUK-G8kHfDIEo_385Hs2SUBCYbJ5H-NnLvq8M/edit) which records different types of errors when parsing ambiguous patterns.

The naming conventions of error messages strictly follows v8's [message template](https://cs.chromium.org/chromium/src/v8/src/common/message-template.h) if they exists, otherwise I coin some phrase so PTAL on the message template. 🙏

Todo
- [x] flow plugin
- [x] typescript plugin
- [x] estree plugin
- [x] jsx plugin