### PR TITLE
Pass URLs to import() rather than paths

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const currentNodeSupportsURL = !!require("url").pathToFileURL;
+
 module.exports = function(api) {
   const env = api.env();
 
@@ -108,7 +110,11 @@ module.exports = function(api) {
       ["@babel/plugin-proposal-optional-chaining", { loose: true }],
       ["@babel/plugin-proposal-nullish-coalescing-operator", { loose: true }],
 
-      compileDynamicImport ? dynamicImportUrlToPath : null,
+      // See eslint/babel-eslint-parser/test/index.js#L80 to understand why
+      // we need the currentNodeSupportsURL check.
+      compileDynamicImport && currentNodeSupportsURL
+        ? dynamicImportUrlToPath
+        : null,
       compileDynamicImport ? "@babel/plugin-proposal-dynamic-import" : null,
 
       convertESM ? "@babel/transform-modules-commonjs" : null,

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const currentNodeSupportsURL = !!require("url").pathToFileURL;
-
 module.exports = function(api) {
   const env = api.env();
 
@@ -110,11 +108,7 @@ module.exports = function(api) {
       ["@babel/plugin-proposal-optional-chaining", { loose: true }],
       ["@babel/plugin-proposal-nullish-coalescing-operator", { loose: true }],
 
-      // See eslint/babel-eslint-parser/test/index.js#L80 to understand why
-      // we need the currentNodeSupportsURL check.
-      compileDynamicImport && currentNodeSupportsURL
-        ? dynamicImportUrlToPath
-        : null,
+      compileDynamicImport ? dynamicImportUrlToPath : null,
       compileDynamicImport ? "@babel/plugin-proposal-dynamic-import" : null,
 
       convertESM ? "@babel/transform-modules-commonjs" : null,
@@ -160,23 +154,44 @@ module.exports = function(api) {
   return config;
 };
 
+// !!! WARNING !!! Hacks are coming
+
 // import() uses file:// URLs for absolute imports, while require() uses
 // file paths.
 // Since this isn't handled by @babel/plugin-transform-modules-commonjs,
 // we must handle it here.
-// NOTE: This plugin must run before @babel/plugin-transform-modules-commonjs
+// However, fileURLToPath is only supported starting from Node.js 10.
+// In older versions, we can remove the pathToFileURL call so that it keeps
+// the original absolute path.
+// NOTE: This plugin must run before @babel/plugin-transform-modules-commonjs,
+// and assumes that the target is the current node version.
 function dynamicImportUrlToPath({ template }) {
-  return {
-    visitor: {
-      CallExpression(path) {
-        if (path.get("callee").isImport()) {
-          path.get("arguments.0").replaceWith(
-            template.expression.ast`
+  const currentNodeSupportsURL = !!require("url").pathToFileURL;
+
+  if (currentNodeSupportsURL) {
+    return {
+      visitor: {
+        CallExpression(path) {
+          if (path.get("callee").isImport()) {
+            path.get("arguments.0").replaceWith(
+              template.expression.ast`
               require("url").fileURLToPath(${path.node.arguments[0]})
             `
-          );
-        }
+            );
+          }
+        },
       },
-    },
-  };
+    };
+  } else {
+    // TODO: Remove in Babel 8 (it's not needed when using Node 10)
+    return {
+      visitor: {
+        CallExpression(path) {
+          if (path.get("callee").isIdentifier({ name: "pathToFileURL" })) {
+            path.replaceWith(path.get("arguments.0"));
+          }
+        },
+      },
+    };
+  }
 }

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -72,7 +72,18 @@ describe("Babel and Espree", () => {
     const espreePath = require.resolve("espree", {
       paths: [path.dirname(require.resolve("eslint"))],
     });
-    espree = await import(pathToFileURL(espreePath));
+
+    // Dynamic import on Node.js needs a file URL, not a path.
+    // However, pathToFileURL is only supported starting from Node.js 10.
+    // In older versions, we can pass an absolute path to import() and configure
+    // babel.config.js so that import() is transpiled to something that works
+    // with absolute paths.
+    if (!pathToFileURL) {
+      // TODO: Remove in Babel 8
+      espree = await import(espreePath);
+    } else {
+      espree = await import(pathToFileURL(espreePath));
+    }
   });
 
   describe("compatibility", () => {

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -73,17 +73,7 @@ describe("Babel and Espree", () => {
       paths: [path.dirname(require.resolve("eslint"))],
     });
 
-    // Dynamic import on Node.js needs a file URL, not a path.
-    // However, pathToFileURL is only supported starting from Node.js 10.
-    // In older versions, we can pass an absolute path to import() and configure
-    // babel.config.js so that import() is transpiled to something that works
-    // with absolute paths.
-    if (!pathToFileURL) {
-      // TODO: Remove in Babel 8
-      espree = await import(espreePath);
-    } else {
-      espree = await import(pathToFileURL(espreePath));
-    }
+    espree = await import(pathToFileURL(espreePath));
   });
 
   describe("compatibility", () => {

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -1,4 +1,5 @@
 import path from "path";
+import { pathToFileURL } from "url";
 import escope from "eslint-scope";
 import unpad from "dedent";
 import { parseForESLint } from "../src";
@@ -71,7 +72,7 @@ describe("Babel and Espree", () => {
     const espreePath = require.resolve("espree", {
       paths: [path.dirname(require.resolve("eslint"))],
     });
-    espree = await import(espreePath);
+    espree = await import(pathToFileURL(espreePath));
   });
 
   describe("compatibility", () => {

--- a/packages/babel-core/src/config/files/module-types.js
+++ b/packages/babel-core/src/config/files/module-types.js
@@ -1,6 +1,7 @@
 import { isAsync, waitFor } from "../../gensync-utils/async";
 import type { Handler } from "gensync";
 import path from "path";
+import { pathToFileURL } from "url";
 
 let import_;
 try {
@@ -55,6 +56,8 @@ async function loadMjsDefault(filepath: string) {
     );
   }
 
-  const module = await import_(filepath);
+  // import() expects URLs, not file paths.
+  // https://github.com/nodejs/node/issues/31710
+  const module = await import_(pathToFileURL(filepath));
   return module.default;
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Native `import()` expects an URL, but we were passing it an absolute file path. It worked on linux, but fails on windows because `C:` is parsed as an URL protocol.

https://github.com/nodejs/node/issues/31710

We don't have tests for this, because Jest doesn't support native `import()` yet.