### PR TITLE
fix(babel-parser): chain off optionally chained keys named class and function

### DIFF
--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -233,7 +233,7 @@ export default class Tokenizer extends LocationParser {
       return;
     }
 
-    if (curContext.override) {
+    if (curContext?.override) {
       curContext.override(this);
     } else {
       this.getTokenFromCode(this.input.codePointAt(this.state.pos));

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -233,8 +233,9 @@ export default class Tokenizer extends LocationParser {
       return;
     }
 
-    if (curContext?.override) {
-      curContext.override(this);
+    const override = curContext?.override;
+    if (override) {
+      override(this);
     } else {
       this.getTokenFromCode(this.input.codePointAt(this.state.pos));
     }

--- a/packages/babel-parser/test/fixtures/es2020/optional-chaining/chaining-off-optionally-chained-keys-named-class-or-function/input.js
+++ b/packages/babel-parser/test/fixtures/es2020/optional-chaining/chaining-off-optionally-chained-keys-named-class-or-function/input.js
@@ -1,0 +1,4 @@
+foo?.class.bar
+foo?.function.bar
+foo?.bar?.class.bar
+foo?.function?.bar

--- a/packages/babel-parser/test/fixtures/es2020/optional-chaining/chaining-off-optionally-chained-keys-named-class-or-function/output.json
+++ b/packages/babel-parser/test/fixtures/es2020/optional-chaining/chaining-off-optionally-chained-keys-named-class-or-function/output.json
@@ -1,0 +1,469 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 71,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 18
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 71,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 18
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 14,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 14
+          }
+        },
+        "expression": {
+          "type": "OptionalMemberExpression",
+          "start": 0,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            }
+          },
+          "object": {
+            "type": "OptionalMemberExpression",
+            "start": 0,
+            "end": 10,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 10
+              }
+            },
+            "object": {
+              "type": "Identifier",
+              "start": 0,
+              "end": 3,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 3
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "property": {
+              "type": "Identifier",
+              "start": 5,
+              "end": 10,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 5
+                },
+                "end": {
+                  "line": 1,
+                  "column": 10
+                },
+                "identifierName": "class"
+              },
+              "name": "class"
+            },
+            "computed": false,
+            "optional": true
+          },
+          "property": {
+            "type": "Identifier",
+            "start": 11,
+            "end": 14,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 11
+              },
+              "end": {
+                "line": 1,
+                "column": 14
+              },
+              "identifierName": "bar"
+            },
+            "name": "bar"
+          },
+          "computed": false,
+          "optional": false
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 15,
+        "end": 32,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 17
+          }
+        },
+        "expression": {
+          "type": "OptionalMemberExpression",
+          "start": 15,
+          "end": 32,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 17
+            }
+          },
+          "object": {
+            "type": "OptionalMemberExpression",
+            "start": 15,
+            "end": 28,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 0
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            "object": {
+              "type": "Identifier",
+              "start": 15,
+              "end": 18,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 0
+                },
+                "end": {
+                  "line": 2,
+                  "column": 3
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "property": {
+              "type": "Identifier",
+              "start": 20,
+              "end": 28,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 5
+                },
+                "end": {
+                  "line": 2,
+                  "column": 13
+                },
+                "identifierName": "function"
+              },
+              "name": "function"
+            },
+            "computed": false,
+            "optional": true
+          },
+          "property": {
+            "type": "Identifier",
+            "start": 29,
+            "end": 32,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 14
+              },
+              "end": {
+                "line": 2,
+                "column": 17
+              },
+              "identifierName": "bar"
+            },
+            "name": "bar"
+          },
+          "computed": false,
+          "optional": false
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 33,
+        "end": 52,
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 19
+          }
+        },
+        "expression": {
+          "type": "OptionalMemberExpression",
+          "start": 33,
+          "end": 52,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 0
+            },
+            "end": {
+              "line": 3,
+              "column": 19
+            }
+          },
+          "object": {
+            "type": "OptionalMemberExpression",
+            "start": 33,
+            "end": 48,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 0
+              },
+              "end": {
+                "line": 3,
+                "column": 15
+              }
+            },
+            "object": {
+              "type": "OptionalMemberExpression",
+              "start": 33,
+              "end": 41,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 0
+                },
+                "end": {
+                  "line": 3,
+                  "column": 8
+                }
+              },
+              "object": {
+                "type": "Identifier",
+                "start": 33,
+                "end": 36,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 3
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "property": {
+                "type": "Identifier",
+                "start": 38,
+                "end": 41,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "identifierName": "bar"
+                },
+                "name": "bar"
+              },
+              "computed": false,
+              "optional": true
+            },
+            "property": {
+              "type": "Identifier",
+              "start": 43,
+              "end": 48,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 10
+                },
+                "end": {
+                  "line": 3,
+                  "column": 15
+                },
+                "identifierName": "class"
+              },
+              "name": "class"
+            },
+            "computed": false,
+            "optional": true
+          },
+          "property": {
+            "type": "Identifier",
+            "start": 49,
+            "end": 52,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 16
+              },
+              "end": {
+                "line": 3,
+                "column": 19
+              },
+              "identifierName": "bar"
+            },
+            "name": "bar"
+          },
+          "computed": false,
+          "optional": false
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 53,
+        "end": 71,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 18
+          }
+        },
+        "expression": {
+          "type": "OptionalMemberExpression",
+          "start": 53,
+          "end": 71,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 0
+            },
+            "end": {
+              "line": 4,
+              "column": 18
+            }
+          },
+          "object": {
+            "type": "OptionalMemberExpression",
+            "start": 53,
+            "end": 66,
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 0
+              },
+              "end": {
+                "line": 4,
+                "column": 13
+              }
+            },
+            "object": {
+              "type": "Identifier",
+              "start": 53,
+              "end": 56,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 0
+                },
+                "end": {
+                  "line": 4,
+                  "column": 3
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "property": {
+              "type": "Identifier",
+              "start": 58,
+              "end": 66,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 5
+                },
+                "end": {
+                  "line": 4,
+                  "column": 13
+                },
+                "identifierName": "function"
+              },
+              "name": "function"
+            },
+            "computed": false,
+            "optional": true
+          },
+          "property": {
+            "type": "Identifier",
+            "start": 68,
+            "end": 71,
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 15
+              },
+              "end": {
+                "line": 4,
+                "column": 18
+              },
+              "identifierName": "bar"
+            },
+            "name": "bar"
+          },
+          "computed": false,
+          "optional": true
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #11197
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Added the ability to parse expressions such as those described in #11197. (This may be considered a minor upgrade, but I would not, as it does not extend the current API as much as it restores it to its expected behavior.)