### PR TITLE
Remove config hack for old Node compatibility

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -154,44 +154,24 @@ module.exports = function(api) {
   return config;
 };
 
-// !!! WARNING !!! Hacks are coming
-
 // import() uses file:// URLs for absolute imports, while require() uses
 // file paths.
 // Since this isn't handled by @babel/plugin-transform-modules-commonjs,
 // we must handle it here.
-// However, fileURLToPath is only supported starting from Node.js 10.
-// In older versions, we can remove the pathToFileURL call so that it keeps
-// the original absolute path.
 // NOTE: This plugin must run before @babel/plugin-transform-modules-commonjs,
 // and assumes that the target is the current node version.
 function dynamicImportUrlToPath({ template }) {
-  const currentNodeSupportsURL = !!require("url").pathToFileURL;
-
-  if (currentNodeSupportsURL) {
-    return {
-      visitor: {
-        CallExpression(path) {
-          if (path.get("callee").isImport()) {
-            path.get("arguments.0").replaceWith(
-              template.expression.ast`
-              require("url").fileURLToPath(${path.node.arguments[0]})
-            `
-            );
-          }
-        },
+  return {
+    visitor: {
+      CallExpression(path) {
+        if (path.get("callee").isImport()) {
+          path.get("arguments.0").replaceWith(
+            template.expression.ast`
+            require("url").fileURLToPath(${path.node.arguments[0]})
+          `
+          );
+        }
       },
-    };
-  } else {
-    // TODO: Remove in Babel 8 (it's not needed when using Node 10)
-    return {
-      visitor: {
-        CallExpression(path) {
-          if (path.get("callee").isIdentifier({ name: "pathToFileURL" })) {
-            path.replaceWith(path.get("arguments.0"));
-          }
-        },
-      },
-    };
-  }
+    },
+  };
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This removes the logic introduced in https://github.com/babel/babel/pull/11193, since it was only needed for Node 6-8.