### PR TITLE
refactor: remove redundant contextDescription empty check

### DIFF
--- a/packages/babel-parser/src/parser/lval.js
+++ b/packages/babel-parser/src/parser/lval.js
@@ -457,24 +457,13 @@ export default class LValParser extends NodeUtils {
         break;
 
       default: {
-        if (contextDescription) {
-          this.raise(
-            expr.start,
-            bindingType === BIND_NONE
-              ? Errors.InvalidLhs
-              : Errors.InvalidLhsBinding,
-            contextDescription,
-          );
-        } else {
-          // todo: check if contextDescription is never empty
-          const message =
-            (bindingType === BIND_NONE
-              ? "Invalid"
-              : /* istanbul ignore next */ "Binding invalid") +
-            " left-hand side expression";
-
-          this.raise(expr.start, message);
-        }
+        this.raise(
+          expr.start,
+          bindingType === BIND_NONE
+            ? Errors.InvalidLhs
+            : Errors.InvalidLhsBinding,
+          contextDescription,
+        );
       }
     }
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

This PR removes redundant `contextDescription` empty checks because

1) The `checkLVal` signature denotes `contextDescription` to be required parameter. Passing `undefined` or `null` to `checkLVal` should result in a flow error.
2) I manually checked all `checkLVal` usage, none of them passing empty `contextDescription`
3) No test is broken from this change