### PR TITLE
Add path separator to `@babel/register` sourceRoot

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -41,7 +41,7 @@ function compile(code, filename) {
   const opts = new OptionManager().init(
     // sourceRoot can be overwritten
     {
-      sourceRoot: path.dirname(filename),
+      sourceRoot: path.dirname(filename) + path.sep,
       ...deepClone(transformOpts),
       filename,
     },

--- a/packages/babel-register/test/fixtures/source-map/foo/bar.js
+++ b/packages/babel-register/test/fixtures/source-map/foo/bar.js
@@ -1,0 +1,3 @@
+function add(a, b) {
+  return a + b;
+}

--- a/packages/babel-register/test/fixtures/source-map/index.js
+++ b/packages/babel-register/test/fixtures/source-map/index.js
@@ -1,0 +1,7 @@
+const { retrieveSourceMap } = require('source-map-support');
+
+const path = require.resolve('./foo/bar');
+
+require('./foo/bar');
+
+console.log(JSON.stringify(retrieveSourceMap(path)));


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

The [Source Maps R3 standard][] states that `sourceRoot` is “prepended to
the individual entries in the ‘source’ field.” If `sources` contains file
names, and `sourceRoot` is intended to refer to a directory but doesn’t end
with a trailing slash, any consumers of the source map are in for a bad
day.

[Source Maps R3 standard]: https://sourcemaps.info/spec.html

In particular, with the new `NODE_V8_COVERAGE` feature built-in to node,
using `@babel/register` results in bogus coverage data, with
`…/srcfoo.js` coming out where `…/src/foo.js` was intended.

Thanks to @bcoe for writing up [Source maps in Node.js][], it was a big
help in tracking down what was going wrong.

[Source maps in Node.js]: https://medium.com/@nodejs/source-maps-in-node-js-482872b56116

References: https://github.com/bcoe/c8/issues/161, https://github.com/babel/babel/pull/3608
