### PR TITLE
Add stricter Optional Chain node validation

### DIFF
--- a/packages/babel-types/src/definitions/experimental.js
+++ b/packages/babel-types/src/definitions/experimental.js
@@ -1,5 +1,6 @@
 // @flow
 import defineType, {
+  assertOptionalChainStart,
   assertEach,
   assertNodeType,
   assertValueType,
@@ -104,7 +105,9 @@ defineType("OptionalMemberExpression", {
       default: false,
     },
     optional: {
-      validate: assertValueType("boolean"),
+      validate: !process.env.BABEL_TYPES_8_BREAKING
+        ? assertValueType("boolean")
+        : chain(assertValueType("boolean"), assertOptionalChainStart()),
     },
   },
 });
@@ -150,7 +153,9 @@ defineType("OptionalCallExpression", {
       ),
     },
     optional: {
-      validate: assertValueType("boolean"),
+      validate: !process.env.BABEL_TYPES_8_BREAKING
+        ? assertValueType("boolean")
+        : chain(assertValueType("boolean"), assertOptionalChainStart()),
     },
     typeArguments: {
       validate: assertNodeType("TypeParameterInstantiation"),

--- a/packages/babel-types/src/definitions/utils.js
+++ b/packages/babel-types/src/definitions/utils.js
@@ -188,7 +188,8 @@ export function assertShape(shape: { [string]: FieldOptions }): Validator {
 
 export function assertOptionalChainStart(): Validator {
   function validate(node) {
-    for (let current = node; current; ) {
+    let current = node;
+    while (node) {
       const { type } = current;
       if (type === "OptionalCallExpression") {
         if (current.optional) return;
@@ -206,7 +207,7 @@ export function assertOptionalChainStart(): Validator {
     }
 
     throw new TypeError(
-      `Non-optional ${node.type} must chain from an optional OptionalMemberExpression or OptionalCallExpression`,
+      `Non-optional ${node.type} must chain from an optional OptionalMemberExpression or OptionalCallExpression. Found chain from ${current?.type}`,
     );
   }
 

--- a/packages/babel-types/src/definitions/utils.js
+++ b/packages/babel-types/src/definitions/utils.js
@@ -186,6 +186,33 @@ export function assertShape(shape: { [string]: FieldOptions }): Validator {
   return validate;
 }
 
+export function assertOptionalChainStart(): Validator {
+  function validate(node) {
+    for (let current = node; current; ) {
+      const { type } = current;
+      if (type === "OptionalCallExpression") {
+        if (current.optional) return;
+        current = current.callee;
+        continue;
+      }
+
+      if (type === "OptionalMemberExpression") {
+        if (current.optional) return;
+        current = current.object;
+        continue;
+      }
+
+      break;
+    }
+
+    throw new TypeError(
+      `Non-optional ${node.type} must chain from an optional OptionalMemberExpression or OptionalCallExpression`,
+    );
+  }
+
+  return validate;
+}
+
 export function chain(...fns: Array<Validator>): Validator {
   function validate(...args) {
     for (const fn of fns) {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  | yes
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Optional chains cannot start with `optional: false`. Somewhere in the `object`/`callee` tree, there must be an optional with `optional: true`.