### PR TITLE
Add estree parsing support for `export * as A`

### DIFF
--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -407,4 +407,28 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
       super.toReferencedListDeep(exprList, isParenthesizedExpr);
     }
+
+    parseExport(node: N.Node) {
+      super.parseExport(node);
+
+      switch (node.type) {
+        case "ExportAllDeclaration":
+          node.exported = null;
+          break;
+
+        case "ExportNamedDeclaration":
+          if (
+            node.specifiers.length === 1 &&
+            node.specifiers[0].type === "ExportNamespaceSpecifier"
+          ) {
+            node.type = "ExportAllDeclaration";
+            node.exported = node.specifiers[0].exported;
+            delete node.specifiers;
+          }
+
+          break;
+      }
+
+      return node;
+    }
   };

--- a/packages/babel-parser/test/fixtures/estree/export/batch/input.js
+++ b/packages/babel-parser/test/fixtures/estree/export/batch/input.js
@@ -1,0 +1,1 @@
+export * from "foo";

--- a/packages/babel-parser/test/fixtures/estree/export/batch/output.json
+++ b/packages/babel-parser/test/fixtures/estree/export/batch/output.json
@@ -1,0 +1,67 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 20,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 20
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 20,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 20
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportAllDeclaration",
+        "start": 0,
+        "end": 20,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 20
+          }
+        },
+        "source": {
+          "type": "Literal",
+          "start": 14,
+          "end": 19,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 1,
+              "column": 19
+            }
+          },
+          "value": "foo",
+          "raw": "\"foo\""
+        },
+        "exported": null
+      }
+    ]
+  }
+}

--- a/packages/babel-parser/test/fixtures/estree/export/ns-from/input.js
+++ b/packages/babel-parser/test/fixtures/estree/export/ns-from/input.js
@@ -1,0 +1,1 @@
+export * as A from 'test';

--- a/packages/babel-parser/test/fixtures/estree/export/ns-from/output.json
+++ b/packages/babel-parser/test/fixtures/estree/export/ns-from/output.json
@@ -1,0 +1,83 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 26,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 26
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 26,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 26
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportAllDeclaration",
+        "start": 0,
+        "end": 26,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 26
+          }
+        },
+        "source": {
+          "type": "Literal",
+          "start": 19,
+          "end": 25,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 19
+            },
+            "end": {
+              "line": 1,
+              "column": 25
+            }
+          },
+          "value": "test",
+          "raw": "'test'"
+        },
+        "exported": {
+          "type": "Identifier",
+          "start": 12,
+          "end": 13,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 12
+            },
+            "end": {
+              "line": 1,
+              "column": 13
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        }
+      }
+    ]
+  }
+}

--- a/packages/babel-parser/test/fixtures/estree/export/options.json
+++ b/packages/babel-parser/test/fixtures/estree/export/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["estree"],
+  "sourceType": "module"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Y
| Tests Added + Pass?      | Y
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

Ref: estree/estree#205