### PR TITLE
Memoize call expressions in optional chains in loose mode

### DIFF
--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -83,8 +83,8 @@ export default declare((api, options) => {
 
           // Ensure call expressions have the proper `this`
           // `foo.bar()` has context `foo`.
-          if (isCall && isSimpleMemberExpression(chain)) {
-            if (loose) {
+          if (isCall) {
+            if (loose && isSimpleMemberExpression(chain)) {
               // To avoid a Function#call, we can instead re-grab the property from the context object.
               // `a.?b.?()` translates roughly to `_a.b != null && _a.b()`
               node.callee = chain;

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -7,6 +7,15 @@ export default declare((api, options) => {
 
   const { loose = false } = options;
 
+  function isSimpleMemberExpression(expression) {
+    return (
+      t.isIdentifier(expression) ||
+      (t.isMemberExpression(expression) &&
+        !expression.computed &&
+        isSimpleMemberExpression(expression.object))
+    );
+  }
+
   return {
     name: "proposal-optional-chaining",
     inherits: syntaxOptionalChaining,
@@ -50,9 +59,10 @@ export default declare((api, options) => {
 
           let ref;
           let check;
-          if (loose && isCall) {
+          if (loose && isCall && isSimpleMemberExpression(node.callee)) {
             // If we are using a loose transform (avoiding a Function#call) and we are at the call,
-            // we can avoid a needless memoize.
+            // we can avoid a needless memoize. We only do this if the callee is a simple member
+            // expression, to avoid multiple calls to nested call expressions.
             check = ref = chain;
           } else {
             ref = scope.maybeGenerateMemoised(chain);

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -83,12 +83,12 @@ export default declare((api, options) => {
 
           // Ensure call expressions have the proper `this`
           // `foo.bar()` has context `foo`.
-          if (isCall) {
+          if (isCall && t.isMemberExpression(chain)) {
             if (loose && isSimpleMemberExpression(chain)) {
               // To avoid a Function#call, we can instead re-grab the property from the context object.
               // `a.?b.?()` translates roughly to `_a.b != null && _a.b()`
               node.callee = chain;
-            } else if (chain.object) {
+            } else {
               // Otherwise, we need to memoize the context object, and change the call into a Function#call.
               // `a.?b.?()` translates roughly to `(_b = _a.b) != null && _b.call(_a)`
               const { object } = chain;

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/memoize-loose/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/memoize-loose/input.js
@@ -9,6 +9,12 @@ function test(foo) {
 
   foo.get(bar)?.()
 
+  foo.bar()?.()
+  foo[bar]()?.()
+
+  foo.bar().baz?.()
+  foo[bar]().baz?.()
+
   foo.bar?.(foo.bar, false)
 
   foo?.bar?.(foo.bar, true)

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/memoize-loose/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/memoize-loose/input.js
@@ -7,6 +7,8 @@ function test(foo) {
 
   foo?.bar()
 
+  foo.get(bar)?.()
+
   foo.bar?.(foo.bar, false)
 
   foo?.bar?.(foo.bar, true)

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/memoize-loose/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/memoize-loose/output.js
@@ -1,5 +1,5 @@
 function test(foo) {
-  var _foo$bar, _foo$get, _foo$bar2, _foo$bar3, _foo$bar$baz, _foo$bar$baz2, _foo$bar4, _foo$bar5, _foo$bar6, _foo$bar7;
+  var _foo$bar, _foo$get, _foo$bar2, _foo$bar3, _foo$bar$baz, _foo$bar4, _foo$bar$baz2, _foo$bar5, _foo$bar6, _foo$bar7, _foo$bar8, _foo$bar9;
 
   foo == null ? void 0 : foo.bar;
   foo == null ? void 0 : (_foo$bar = foo.bar) == null ? void 0 : _foo$bar.baz;
@@ -8,12 +8,12 @@ function test(foo) {
   (_foo$get = foo.get(bar)) == null ? void 0 : _foo$get();
   (_foo$bar2 = foo.bar()) == null ? void 0 : _foo$bar2();
   (_foo$bar3 = foo[bar]()) == null ? void 0 : _foo$bar3();
-  (_foo$bar$baz = foo.bar().baz) == null ? void 0 : _foo$bar$baz();
-  (_foo$bar$baz2 = foo[bar]().baz) == null ? void 0 : _foo$bar$baz2();
+  (_foo$bar$baz = (_foo$bar4 = foo.bar()).baz) == null ? void 0 : _foo$bar$baz.call(_foo$bar4);
+  (_foo$bar$baz2 = (_foo$bar5 = foo[bar]()).baz) == null ? void 0 : _foo$bar$baz2.call(_foo$bar5);
   foo.bar == null ? void 0 : foo.bar(foo.bar, false);
   foo == null ? void 0 : foo.bar == null ? void 0 : foo.bar(foo.bar, true);
-  (_foo$bar4 = foo.bar) == null ? void 0 : _foo$bar4.baz(foo.bar, false);
-  foo == null ? void 0 : (_foo$bar5 = foo.bar) == null ? void 0 : _foo$bar5.baz(foo.bar, true);
-  (_foo$bar6 = foo.bar) == null ? void 0 : _foo$bar6.baz == null ? void 0 : _foo$bar6.baz(foo.bar, false);
-  foo == null ? void 0 : (_foo$bar7 = foo.bar) == null ? void 0 : _foo$bar7.baz == null ? void 0 : _foo$bar7.baz(foo.bar, true);
+  (_foo$bar6 = foo.bar) == null ? void 0 : _foo$bar6.baz(foo.bar, false);
+  foo == null ? void 0 : (_foo$bar7 = foo.bar) == null ? void 0 : _foo$bar7.baz(foo.bar, true);
+  (_foo$bar8 = foo.bar) == null ? void 0 : _foo$bar8.baz == null ? void 0 : _foo$bar8.baz(foo.bar, false);
+  foo == null ? void 0 : (_foo$bar9 = foo.bar) == null ? void 0 : _foo$bar9.baz == null ? void 0 : _foo$bar9.baz(foo.bar, true);
 }

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/memoize-loose/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/memoize-loose/output.js
@@ -1,10 +1,11 @@
 function test(foo) {
-  var _foo$bar, _foo$bar2, _foo$bar3, _foo$bar4, _foo$bar5;
+  var _foo$bar, _foo$get, _foo$bar2, _foo$bar3, _foo$bar4, _foo$bar5;
 
   foo == null ? void 0 : foo.bar;
   foo == null ? void 0 : (_foo$bar = foo.bar) == null ? void 0 : _foo$bar.baz;
   foo == null ? void 0 : foo(foo);
   foo == null ? void 0 : foo.bar();
+  (_foo$get = foo.get(bar)) == null ? void 0 : _foo$get();
   foo.bar == null ? void 0 : foo.bar(foo.bar, false);
   foo == null ? void 0 : foo.bar == null ? void 0 : foo.bar(foo.bar, true);
   (_foo$bar2 = foo.bar) == null ? void 0 : _foo$bar2.baz(foo.bar, false);

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/memoize-loose/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/memoize-loose/output.js
@@ -1,15 +1,19 @@
 function test(foo) {
-  var _foo$bar, _foo$get, _foo$bar2, _foo$bar3, _foo$bar4, _foo$bar5;
+  var _foo$bar, _foo$get, _foo$bar2, _foo$bar3, _foo$bar$baz, _foo$bar$baz2, _foo$bar4, _foo$bar5, _foo$bar6, _foo$bar7;
 
   foo == null ? void 0 : foo.bar;
   foo == null ? void 0 : (_foo$bar = foo.bar) == null ? void 0 : _foo$bar.baz;
   foo == null ? void 0 : foo(foo);
   foo == null ? void 0 : foo.bar();
   (_foo$get = foo.get(bar)) == null ? void 0 : _foo$get();
+  (_foo$bar2 = foo.bar()) == null ? void 0 : _foo$bar2();
+  (_foo$bar3 = foo[bar]()) == null ? void 0 : _foo$bar3();
+  (_foo$bar$baz = foo.bar().baz) == null ? void 0 : _foo$bar$baz();
+  (_foo$bar$baz2 = foo[bar]().baz) == null ? void 0 : _foo$bar$baz2();
   foo.bar == null ? void 0 : foo.bar(foo.bar, false);
   foo == null ? void 0 : foo.bar == null ? void 0 : foo.bar(foo.bar, true);
-  (_foo$bar2 = foo.bar) == null ? void 0 : _foo$bar2.baz(foo.bar, false);
-  foo == null ? void 0 : (_foo$bar3 = foo.bar) == null ? void 0 : _foo$bar3.baz(foo.bar, true);
-  (_foo$bar4 = foo.bar) == null ? void 0 : _foo$bar4.baz == null ? void 0 : _foo$bar4.baz(foo.bar, false);
-  foo == null ? void 0 : (_foo$bar5 = foo.bar) == null ? void 0 : _foo$bar5.baz == null ? void 0 : _foo$bar5.baz(foo.bar, true);
+  (_foo$bar4 = foo.bar) == null ? void 0 : _foo$bar4.baz(foo.bar, false);
+  foo == null ? void 0 : (_foo$bar5 = foo.bar) == null ? void 0 : _foo$bar5.baz(foo.bar, true);
+  (_foo$bar6 = foo.bar) == null ? void 0 : _foo$bar6.baz == null ? void 0 : _foo$bar6.baz(foo.bar, false);
+  foo == null ? void 0 : (_foo$bar7 = foo.bar) == null ? void 0 : _foo$bar7.baz == null ? void 0 : _foo$bar7.baz(foo.bar, true);
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11084  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

Previously, in loose mode, we weren't memoizing optional call expressions. This resulted in code like `a.get(b)?.();` being compiled to `a.get(b) == null ? void 0 : a.get(b)();`, which repeats a function call.

This MR changes the behaviour so that memoization is only skipped when no work is done by the call's callee.