### PR TITLE
Update Purish aliases

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -568,7 +568,7 @@ defineType("BooleanLiteral", {
 defineType("RegExpLiteral", {
   builder: ["pattern", "flags"],
   deprecatedAlias: "RegexLiteral",
-  aliases: ["Expression", "Literal"],
+  aliases: ["Expression", "Pureish", "Literal"],
   fields: {
     pattern: {
       validate: assertValueType("string"),

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -124,7 +124,7 @@ defineType("ClassExpression", {
     "implements",
     "decorators",
   ],
-  aliases: ["Scopable", "Class", "Expression", "Pureish"],
+  aliases: ["Scopable", "Class", "Expression"],
   fields: {
     id: {
       validate: assertNodeType("Identifier"),
@@ -175,7 +175,7 @@ defineType("ClassExpression", {
 
 defineType("ClassDeclaration", {
   inherits: "ClassExpression",
-  aliases: ["Scopable", "Class", "Statement", "Declaration", "Pureish"],
+  aliases: ["Scopable", "Class", "Statement", "Declaration"],
   fields: {
     declare: {
       validate: assertValueType("boolean"),

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -3847,9 +3847,8 @@ export function isPureish(node: ?Object, opts?: Object): boolean {
     "NumericLiteral" === nodeType ||
     "NullLiteral" === nodeType ||
     "BooleanLiteral" === nodeType ||
+    "RegExpLiteral" === nodeType ||
     "ArrowFunctionExpression" === nodeType ||
-    "ClassExpression" === nodeType ||
-    "ClassDeclaration" === nodeType ||
     "BigIntLiteral" === nodeType ||
     (nodeType === "Placeholder" && "StringLiteral" === node.expectedNode)
   ) {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | ?
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

- Adds `Purish` to `RegexLiteral`, since it can't cause any side-effects.
- Removes `Purish` from `ClassExpression` and `ClassDeclaration`, since they can be impure with static class fields.

