### PR TITLE
Allow rest/spread on polyfilled or builtin iterables without `Symbol` support

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -909,7 +909,7 @@ helpers.slicedToArray = helper("7.0.0-beta.0")`
     return (
       arrayWithHoles(arr) ||
       iterableToArrayLimit(arr, i) ||
-      unsupportedIterableToArray(arr) ||
+      unsupportedIterableToArray(arr, i) ||
       nonIterableRest()
     );
   }
@@ -925,7 +925,7 @@ helpers.slicedToArrayLoose = helper("7.0.0-beta.0")`
     return (
       arrayWithHoles(arr) ||
       iterableToArrayLimitLoose(arr, i) ||
-      unsupportedIterableToArray(arr) ||
+      unsupportedIterableToArray(arr, i) ||
       nonIterableRest()
     );
   }
@@ -964,11 +964,10 @@ helpers.toConsumableArray = helper("7.0.0-beta.0")`
 `;
 
 helpers.arrayWithoutHoles = helper("7.0.0-beta.0")`
+  import arrayLikeToArray from "arrayLikeToArray";
+
   export default function _arrayWithoutHoles(arr) {
-    if (Array.isArray(arr)) {
-      for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) arr2[i] = arr[i];
-      return arr2;
-    }
+    if (Array.isArray(arr)) return arrayLikeToArray(arr);
   }
 `;
 
@@ -1035,17 +1034,24 @@ helpers.iterableToArrayLimitLoose = helper("7.0.0-beta.0")`
 `;
 
 helpers.unsupportedIterableToArray = helper("7.9.0")`
-  export default function _unsupportedIterableToArray(o) {
+  import arrayLikeToArray from "arrayLikeToArray";
+
+  export default function _unsupportedIterableToArray(o, minLen) {
     if (!o) return;
-    if (typeof o === "string") return Array.from(o);
+    if (typeof o === "string") return arrayLikeToArray(o, minLen);
     var n = Object.prototype.toString.call(o).slice(8, -1);
     if (n === "Object" && o.constructor) n = o.constructor.name;
-    if (
-      n === "Arguments" ||
-      n === "Map" ||
-      n === "Set" ||
-      /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)
-    ) return Array.from(o);
+    if (n === "Map" || n === "Set") return Array.from(n);
+    if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n))
+      return arrayLikeToArray(o, minLen);
+  }
+`;
+
+helpers.arrayLikeToArray = helper("7.9.0")`
+  export default function _arrayLikeToArray(arr, len) {
+    if (len == null || len > arr.length) len = arr.length;
+    for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
+    return arr2;
   }
 `;
 

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -902,40 +902,64 @@ helpers.temporalRef = helper("7.0.0-beta.0")`
 helpers.slicedToArray = helper("7.0.0-beta.0")`
   import arrayWithHoles from "arrayWithHoles";
   import iterableToArrayLimit from "iterableToArrayLimit";
+  import unsupportedIterableToArray from "unsupportedIterableToArray";
   import nonIterableRest from "nonIterableRest";
 
   export default function _slicedToArray(arr, i) {
-    return arrayWithHoles(arr) || iterableToArrayLimit(arr, i) || nonIterableRest();
+    return (
+      arrayWithHoles(arr) ||
+      iterableToArrayLimit(arr, i) ||
+      unsupportedIterableToArray(arr) ||
+      nonIterableRest()
+    );
   }
 `;
 
 helpers.slicedToArrayLoose = helper("7.0.0-beta.0")`
   import arrayWithHoles from "arrayWithHoles";
   import iterableToArrayLimitLoose from "iterableToArrayLimitLoose";
+  import unsupportedIterableToArray from "unsupportedIterableToArray";
   import nonIterableRest from "nonIterableRest";
 
   export default function _slicedToArrayLoose(arr, i) {
-    return arrayWithHoles(arr) || iterableToArrayLimitLoose(arr, i) || nonIterableRest();
+    return (
+      arrayWithHoles(arr) ||
+      iterableToArrayLimitLoose(arr, i) ||
+      unsupportedIterableToArray(arr) ||
+      nonIterableRest()
+    );
   }
 `;
 
 helpers.toArray = helper("7.0.0-beta.0")`
   import arrayWithHoles from "arrayWithHoles";
   import iterableToArray from "iterableToArray";
+  import unsupportedIterableToArray from "unsupportedIterableToArray";
   import nonIterableRest from "nonIterableRest";
 
   export default function _toArray(arr) {
-    return arrayWithHoles(arr) || iterableToArray(arr) || nonIterableRest();
+    return (
+      arrayWithHoles(arr) ||
+      iterableToArray(arr) ||
+      unsupportedIterableToArray(arr) ||
+      nonIterableRest()
+    );
   }
 `;
 
 helpers.toConsumableArray = helper("7.0.0-beta.0")`
   import arrayWithoutHoles from "arrayWithoutHoles";
   import iterableToArray from "iterableToArray";
+  import unsupportedIterableToArray from "unsupportedIterableToArray";
   import nonIterableSpread from "nonIterableSpread";
 
   export default function _toConsumableArray(arr) {
-    return arrayWithoutHoles(arr) || iterableToArray(arr) || nonIterableSpread();
+    return (
+      arrayWithoutHoles(arr) ||
+      iterableToArray(arr) ||
+      unsupportedIterableToArray(arr) ||
+      nonIterableSpread()
+    );
   }
 `;
 
@@ -956,11 +980,7 @@ helpers.arrayWithHoles = helper("7.0.0-beta.0")`
 
 helpers.iterableToArray = helper("7.0.0-beta.0")`
   export default function _iterableToArray(iter) {
-    if (
-      typeof iter === 'string'
-      || Object.prototype.toString.call(iter) === "[object Arguments]"
-      || (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter))
-    ) return Array.from(iter);
+    if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter);
   }
 `;
 
@@ -976,10 +996,7 @@ helpers.iterableToArrayLimit = helper("7.0.0-beta.0")`
     // _i = _iterator
     // _s = _step
 
-    if (
-      (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) &&
-      Object.prototype.toString.call(arr) !== "[object Arguments]"
-    ) return;
+    if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return;
 
     var _arr = [];
     var _n = true;
@@ -1006,10 +1023,7 @@ helpers.iterableToArrayLimit = helper("7.0.0-beta.0")`
 
 helpers.iterableToArrayLimitLoose = helper("7.0.0-beta.0")`
   export default function _iterableToArrayLimitLoose(arr, i) {
-    if (
-      (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) &&
-      Object.prototype.toString.call(arr) !== "[object Arguments]"
-    ) return;
+    if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return;
 
     var _arr = [];
     for (var _iterator = arr[Symbol.iterator](), _step; !(_step = _iterator.next()).done;) {
@@ -1017,6 +1031,21 @@ helpers.iterableToArrayLimitLoose = helper("7.0.0-beta.0")`
       if (i && _arr.length === i) break;
     }
     return _arr;
+  }
+`;
+
+helpers.unsupportedIterableToArray = helper("7.9.0")`
+  export default function _unsupportedIterableToArray(o) {
+    if (!o) return;
+    if (typeof o === "string") return Array.from(o);
+    var n = Object.prototype.toString.call(o).slice(8, -1);
+    if (n === "Object" && o.constructor) n = o.constructor.name;
+    if (
+      n === "Arguments" ||
+      n === "Map" ||
+      n === "Set" ||
+      /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)
+    ) return Array.from(o);
   }
 `;
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7199/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7199/output.js
@@ -4,11 +4,13 @@ var _foo = _interopRequireDefault(require("foo"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { if ((typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) && Object.prototype.toString.call(arr) !== "[object Arguments]") return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _unsupportedIterableToArray(o) { if (!o) return; if (typeof o === "string") return Array.from(o); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Arguments" || n === "Map" || n === "Set" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Array.from(o); }
+
+function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7199/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7199/output.js
@@ -4,11 +4,13 @@ var _foo = _interopRequireDefault(require("foo"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr) || _nonIterableRest(); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _unsupportedIterableToArray(o) { if (!o) return; if (typeof o === "string") return Array.from(o); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Arguments" || n === "Map" || n === "Set" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Array.from(o); }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(n); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
 
 function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 

--- a/packages/babel-preset-env/test/fixtures/preset-options/browserslist-defaults-not-ie/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/browserslist-defaults-not-ie/output.js
@@ -1,10 +1,12 @@
 "use strict";
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { if ((typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) && Object.prototype.toString.call(arr) !== "[object Arguments]") return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _unsupportedIterableToArray(o) { if (!o) return; if (typeof o === "string") return Array.from(o); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Arguments" || n === "Map" || n === "Set" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Array.from(o); }
+
+function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 

--- a/packages/babel-preset-env/test/fixtures/preset-options/browserslist-defaults-not-ie/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/browserslist-defaults-not-ie/output.js
@@ -1,10 +1,12 @@
 "use strict";
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr) || _nonIterableRest(); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _unsupportedIterableToArray(o) { if (!o) return; if (typeof o === "string") return Array.from(o); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Arguments" || n === "Map" || n === "Set" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Array.from(o); }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(n); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
 function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 

--- a/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/output.js
+++ b/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/output.js
@@ -1,8 +1,10 @@
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { if ((typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) && Object.prototype.toString.call(arr) !== "[object Arguments]") return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _unsupportedIterableToArray(o) { if (!o) return; if (typeof o === "string") return Array.from(o); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Arguments" || n === "Map" || n === "Set" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Array.from(o); }
+
+function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 

--- a/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/output.js
+++ b/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/output.js
@@ -1,8 +1,10 @@
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr) || _nonIterableRest(); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _unsupportedIterableToArray(o) { if (!o) return; if (typeof o === "string") return Array.from(o); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Arguments" || n === "Map" || n === "Set" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Array.from(o); }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(n); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
 function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 

--- a/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
@@ -2,5 +2,5 @@ import _Array$from from "../../core-js/array/from";
 import _isIterable from "../../core-js/is-iterable";
 import _Symbol from "../../core-js/symbol";
 export default function _iterableToArray(iter) {
-  if (typeof iter === 'string' || Object.prototype.toString.call(iter) === "[object Arguments]" || typeof _Symbol !== "undefined" && _isIterable(Object(iter))) return _Array$from(iter);
+  if (typeof _Symbol !== "undefined" && _isIterable(Object(iter))) return _Array$from(iter);
 }

--- a/packages/babel-runtime-corejs2/helpers/esm/toArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/toArray.js
@@ -1,6 +1,7 @@
 import arrayWithHoles from "./arrayWithHoles";
 import iterableToArray from "./iterableToArray";
+import unsupportedIterableToArray from "./unsupportedIterableToArray";
 import nonIterableRest from "./nonIterableRest";
 export default function _toArray(arr) {
-  return arrayWithHoles(arr) || iterableToArray(arr) || nonIterableRest();
+  return arrayWithHoles(arr) || iterableToArray(arr) || unsupportedIterableToArray(arr) || nonIterableRest();
 }

--- a/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/iterableToArray.js
@@ -5,7 +5,7 @@ var _isIterable = require("../core-js/is-iterable");
 var _Symbol = require("../core-js/symbol");
 
 function _iterableToArray(iter) {
-  if (typeof iter === 'string' || Object.prototype.toString.call(iter) === "[object Arguments]" || typeof _Symbol !== "undefined" && _isIterable(Object(iter))) return _Array$from(iter);
+  if (typeof _Symbol !== "undefined" && _isIterable(Object(iter))) return _Array$from(iter);
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime-corejs2/helpers/toArray.js
+++ b/packages/babel-runtime-corejs2/helpers/toArray.js
@@ -2,10 +2,12 @@ var arrayWithHoles = require("./arrayWithHoles");
 
 var iterableToArray = require("./iterableToArray");
 
+var unsupportedIterableToArray = require("./unsupportedIterableToArray");
+
 var nonIterableRest = require("./nonIterableRest");
 
 function _toArray(arr) {
-  return arrayWithHoles(arr) || iterableToArray(arr) || nonIterableRest();
+  return arrayWithHoles(arr) || iterableToArray(arr) || unsupportedIterableToArray(arr) || nonIterableRest();
 }
 
 module.exports = _toArray;

--- a/packages/babel-runtime/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime/helpers/esm/iterableToArray.js
@@ -1,3 +1,3 @@
 export default function _iterableToArray(iter) {
-  if (typeof iter === 'string' || Object.prototype.toString.call(iter) === "[object Arguments]" || typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter);
+  if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter);
 }

--- a/packages/babel-runtime/helpers/esm/toArray.js
+++ b/packages/babel-runtime/helpers/esm/toArray.js
@@ -1,6 +1,7 @@
 import arrayWithHoles from "./arrayWithHoles";
 import iterableToArray from "./iterableToArray";
+import unsupportedIterableToArray from "./unsupportedIterableToArray";
 import nonIterableRest from "./nonIterableRest";
 export default function _toArray(arr) {
-  return arrayWithHoles(arr) || iterableToArray(arr) || nonIterableRest();
+  return arrayWithHoles(arr) || iterableToArray(arr) || unsupportedIterableToArray(arr) || nonIterableRest();
 }

--- a/packages/babel-runtime/helpers/iterableToArray.js
+++ b/packages/babel-runtime/helpers/iterableToArray.js
@@ -1,5 +1,5 @@
 function _iterableToArray(iter) {
-  if (typeof iter === 'string' || Object.prototype.toString.call(iter) === "[object Arguments]" || typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter);
+  if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter);
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime/helpers/toArray.js
+++ b/packages/babel-runtime/helpers/toArray.js
@@ -2,10 +2,12 @@ var arrayWithHoles = require("./arrayWithHoles");
 
 var iterableToArray = require("./iterableToArray");
 
+var unsupportedIterableToArray = require("./unsupportedIterableToArray");
+
 var nonIterableRest = require("./nonIterableRest");
 
 function _toArray(arr) {
-  return arrayWithHoles(arr) || iterableToArray(arr) || nonIterableRest();
+  return arrayWithHoles(arr) || iterableToArray(arr) || unsupportedIterableToArray(arr) || nonIterableRest();
 }
 
 module.exports = _toArray;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9277
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Currently, when `Symbol` is not supported, we allow using rest/spread with:
- arrays
- strings
- arguments

With this PR, it will be also possible to use it with
- maps
- sets
- binary arrays

While in old browsers es6 builtins would still need to be polyfilled, it's way
easier to polyfill them because `Symbol` cannot be reliably polyfilled.

I didn't use `instanceof` because:
- it doesn't work with polyfills not attached to the global scope
- when using Babel to load polyfills, it would force the inclusion of `Map` and `Set` polyfills even if they are not used

Downside: the current approach of relying on `toString || construcor.name` doesn't work with subclasses.

---

Depends on https://github.com/babel/babel/pull/11264 (mostly to avoid merge conflicts, it shouldn't be a problem because the other PR is straightforward).
I'm marking this as a draft until that PR is merged, but this is ready for review.