### PR TITLE
Silence dynamic import() warnings in tests

### DIFF
--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/options.json
@@ -1,4 +1,5 @@
 {
+  "validateLogs": true,
   "presets": [
     [
       "env",

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/stderr.txt
@@ -1,0 +1,1 @@
+Dynamic import can only be supported when transforming ES modules to AMD, CommonJS or SystemJS. Only the parser plugin will be enabled.

--- a/packages/babel-preset-env/test/fixtures/top-level-await/supported/options.json
+++ b/packages/babel-preset-env/test/fixtures/top-level-await/supported/options.json
@@ -2,6 +2,7 @@
   "caller": {
     "name": "test-fixture",
     "supportsStaticESM": true,
+    "supportsDynamicImport": true,
     "supportsTopLevelAwait": true
   },
   "presets": ["env"]

--- a/packages/babel-preset-env/test/fixtures/top-level-await/unsupported/options.json
+++ b/packages/babel-preset-env/test/fixtures/top-level-await/unsupported/options.json
@@ -2,6 +2,7 @@
   "caller": {
     "name": "test-fixture",
     "supportsStaticESM": true,
+    "supportsDynamicImport": true,
     "supportsTopLevelAwait": false
   },
   "presets": ["env"],


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In `preset-env` tests there were 3 unhandled warnings. They weren't a big deal, but just a bit annoying.