### PR TITLE
fix: object-rest-spread should not transform export array rest

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -329,7 +329,7 @@ export default declare((api, opts) => {
 
         const hasRest = declaration
           .get("declarations")
-          .some(path => hasRestElement(path.get("id")));
+          .some(path => hasObjectPatternRestElement(path.get("id")));
         if (!hasRest) return;
 
         const specifiers = [];

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/export/input.mjs
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/export/input.mjs
@@ -2,4 +2,4 @@
 export var { b, ...c } = asdf2;
 // Skip
 export var { bb, cc } = ads;
-export var [ dd, ee ] = ads;
+export var [ dd, ee, ...ff ] = ads;

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/export/output.mjs
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/export/output.mjs
@@ -9,4 +9,4 @@ export var {
   bb,
   cc
 } = ads;
-export var [dd, ee] = ads;
+export var [dd, ee, ...ff] = ads;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I found this issue when reading the source.