### PR TITLE
fix: ensure explicit file extensions in "exports"

### DIFF
--- a/packages/babel-compat-data/package.json
+++ b/packages/babel-compat-data/package.json
@@ -12,7 +12,7 @@
     "./plugins": "./data/plugins.json",
     "./native-modules": "./data/native-modules.json",
     "./corejs2-built-ins": "./data/corejs2-built-ins.json",
-    "./corejs3-shipped-proposals": "./data/corejs3-shipped-proposals",
+    "./corejs3-shipped-proposals": "./data/corejs3-shipped-proposals.json",
     "./overlapping-plugins": "./data/overlapping-plugins.json",
     "./plugin-bugfixes": "./data/plugin-bugfixes.json"
   },


### PR DESCRIPTION
Node.js requires "exports" to use explicit file extensions.

That this was working was actually a bug in the modules implementation that will be patched soon, and I'm working on the PR for this.

Posting this PR first thing so that hopefully Babel can avoid any compat issues here when that fix finds its way downstream to a future Node.js release.

Happy to answer any questions further on this too.