### PR TITLE
Allow for-of on polyfilled or builtin iterables without `Symbol` support

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1072,6 +1072,8 @@ helpers.nonIterableRest = helper("7.0.0-beta.0")`
 `;
 
 helpers.createForOfIteratorHelper = helper("7.9.0")`
+  import unsupportedIterableToArray from "unsupportedIterableToArray";
+
   // s: start (create the iterator)
   // n: next
   // e: error (called whenever something throws)
@@ -1080,7 +1082,7 @@ helpers.createForOfIteratorHelper = helper("7.9.0")`
   export default function _createForOfIteratorHelper(o) {
     if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) {
       // Fallback for engines without symbol support
-      if (Array.isArray(o)) {
+      if (Array.isArray(o) || (o = unsupportedIterableToArray(o))) {
         var i = 0;
         var F = function(){};
         return {
@@ -1124,12 +1126,14 @@ helpers.createForOfIteratorHelper = helper("7.9.0")`
 `;
 
 helpers.createForOfIteratorHelperLoose = helper("7.9.0")`
+  import unsupportedIterableToArray from "unsupportedIterableToArray";
+
   export default function _createForOfIteratorHelperLoose(o) {
     var i = 0;
 
     if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) {
       // Fallback for engines without symbol support
-      if (Array.isArray(o))
+      if (Array.isArray(o) || (o = unsupportedIterableToArray(o)))
         return function() {
           if (i >= o.length) return { done: true };
           return { done: false, value: o[i++] };

--- a/packages/babel-plugin-transform-for-of/test/fixtures/loose-exec/arguments-symbol-unsupported.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/loose-exec/arguments-symbol-unsupported.js
@@ -1,0 +1,18 @@
+function getArgs() { return arguments; }
+
+let args = getArgs(1, 2, 3);
+let res = [];
+
+// Simulate old environment
+delete args[Symbol.iterator];
+let _Symbol = Symbol;
+Symbol = void 0;
+
+try {
+  for (let i of args) res.push(i);
+
+  expect(res).toEqual([1, 2, 3]);
+} finally {
+  Symbol = _Symbol;
+}
+

--- a/packages/babel-plugin-transform-for-of/test/fixtures/spec-exec/arguments-symbol-unsupported.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/spec-exec/arguments-symbol-unsupported.js
@@ -1,0 +1,18 @@
+function getArgs() { return arguments; }
+
+let args = getArgs(1, 2, 3);
+let res = [];
+
+// Simulate old environment
+delete args[Symbol.iterator];
+let _Symbol = Symbol;
+Symbol = void 0;
+
+try {
+  for (let i of args) res.push(i);
+
+  expect(res).toEqual([1, 2, 3]);
+} finally {
+  Symbol = _Symbol;
+}
+

--- a/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/output.js
+++ b/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/output.js
@@ -2,15 +2,15 @@ function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArra
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(n); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
 function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
-function _createForOfIteratorHelper(o) { if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o)) { var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var it, normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
+function _createForOfIteratorHelper(o) { if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (o = _unsupportedIterableToArray(o))) { var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var it, normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(n); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
 // https://github.com/babel/babel/issues/7557
 var _iterator = _createForOfIteratorHelper(c),


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is basically what comes out by "merging" https://github.com/babel/babel/pull/11268 and https://github.com/babel/babel/pull/11263 together.
