### PR TITLE
chore: fix build-babel exclude in gulpfile

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -60,7 +60,7 @@ function buildBabel(exclude, sourcesGlob = defaultSourcesGlob) {
   let stream = gulp.src(sourcesGlob, { base: __dirname });
 
   if (exclude) {
-    const filters = exclude.map(p => `!**/${p}/**`);
+    const filters = exclude.map(p => `!**/${p.src}/**`);
     filters.unshift("**");
     stream = stream.pipe(filter(filters));
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | the published babel-parser artifacts include unrolled up files: https://unpkg.com/browse/@babel/parser@7.7.5/lib/
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes an artifacts regression introduced at #10779, where the `exclude` schema is changed from string to an object, but is forgotten to sync with `buildBabel`.

Testing:
Run `make prepublish-build && ll packages/babel-parser/lib` on my local env:
```
total 712
-rw-r--r--  1 jh  staff  363469 20 Mar 14:57 index.js
```
