### PR TITLE
Manually inline the createSuper helper on older Babel versions

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -735,6 +735,7 @@ helpers.possibleConstructorReturn = helper("7.0.0-beta.0")`
   }
 `;
 
+// This is duplicated to packages/babel-plugin-transform-classes/src/inline-createSuper-helpers.js
 helpers.createSuper = helper("7.9.0")`
   import getPrototypeOf from "getPrototypeOf";
   import isNativeReflectConstruct from "isNativeReflectConstruct";

--- a/packages/babel-plugin-transform-classes/src/inline-createSuper-helpers.js
+++ b/packages/babel-plugin-transform-classes/src/inline-createSuper-helpers.js
@@ -1,0 +1,71 @@
+import { template, types as t } from "@babel/core";
+
+const helperIDs = new WeakMap();
+
+export default function addCreateSuperHelper(file) {
+  try {
+    return file.addHelper("createSuper");
+  } catch {
+    // Babel <7.9.0 doesn't support the helper.
+  }
+
+  if (helperIDs.has(file)) {
+    // t.cloneNode isn't supported in every version
+    return (t.cloneNode || t.clone)(helperIDs.get(file));
+  }
+
+  const id = file.scope.generateUidIdentifier("createSuper");
+  helperIDs.set(file, id);
+
+  const fn = helper({
+    CREATE_SUPER: id,
+    GET_PROTOTYPE_OF: file.addHelper("getPrototypeOf"),
+    POSSIBLE_CONSTRUCTOR_RETURN: file.addHelper("possibleConstructorReturn"),
+  });
+
+  file.path.unshiftContainer("body", [fn]);
+  file.scope.registerDeclaration(file.path.get("body.0"));
+
+  return t.cloneNode(id);
+}
+
+const helper = template.statement`
+  function CREATE_SUPER(Derived) {
+    function _isNativeReflectConstruct() {
+      if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+
+      // core-js@3
+      if (Reflect.construct.sham) return false;
+
+      // Proxy can't be polyfilled. Every browser implemented
+      // proxies before or at the same time as Reflect.construct,
+      // so if they support Proxy they also support Reflect.construct.
+      if (typeof Proxy === "function") return true;
+
+      // Since Reflect.construct can't be properly polyfilled, some
+      // implementations (e.g. core-js@2) don't set the correct internal slots.
+      // Those polyfills don't allow us to subclass built-ins, so we need to
+      // use our fallback implementation.
+      try {
+        // If the internal slots aren't set, this throws an error similar to
+        //   TypeError: this is not a Date object.
+        Date.prototype.toString.call(Reflect.construct(Date, [], function() {}));
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }
+
+    return function () {
+      var Super = GET_PROTOTYPE_OF(Derived), result;
+      if (isNativeReflectConstruct()) {
+        // NOTE: This doesn't work if this.__proto__.constructor has been modified.
+        var NewTarget = GET_PROTOTYPE_OF(this).constructor;
+        result = Reflect.construct(Super, arguments, NewTarget);
+      } else {
+        result = Super.apply(this, arguments);
+      }
+      return POSSIBLE_CONSTRUCTOR_RETURN(this, result);
+    }
+  }
+`;

--- a/packages/babel-plugin-transform-classes/src/inline-createSuper-helpers.js
+++ b/packages/babel-plugin-transform-classes/src/inline-createSuper-helpers.js
@@ -31,7 +31,7 @@ export default function addCreateSuperHelper(file) {
 
 const helper = template.statement`
   function CREATE_SUPER(Derived) {
-    function _isNativeReflectConstruct() {
+    function isNativeReflectConstruct() {
       if (typeof Reflect === "undefined" || !Reflect.construct) return false;
 
       // core-js@3

--- a/packages/babel-plugin-transform-classes/src/inline-createSuper-helpers.js
+++ b/packages/babel-plugin-transform-classes/src/inline-createSuper-helpers.js
@@ -10,6 +10,7 @@ export default function addCreateSuperHelper(file) {
   }
 
   if (helperIDs.has(file)) {
+    // TODO: Only use t.cloneNode in Babel 8
     // t.cloneNode isn't supported in every version
     return (t.cloneNode || t.clone)(helperIDs.get(file));
   }

--- a/packages/babel-plugin-transform-classes/src/transformClass.js
+++ b/packages/babel-plugin-transform-classes/src/transformClass.js
@@ -8,6 +8,8 @@ import * as defineMap from "@babel/helper-define-map";
 import { traverse, template, types as t } from "@babel/core";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 
+import addCreateSuperHelper from "./inline-createSuper-helpers";
+
 type ReadonlySet<T> = Set<T> | { has(val: T): boolean };
 
 function buildConstructor(classRef, constructorBody, node) {
@@ -556,7 +558,7 @@ export default function transformClass(
       t.variableDeclaration("var", [
         t.variableDeclarator(
           superFnId,
-          t.callExpression(classState.file.addHelper("createSuper"), [
+          t.callExpression(addCreateSuperHelper(classState.file), [
             t.cloneNode(classState.classRef),
           ]),
         ),


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Yes
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

1. This feels hacky
2. I love this approach: helpers should live in the plugins, not in `@babel/core`. Alternatively, plugins should have a direct dependency on `@babel/helpers` (it might be easier).