### PR TITLE
Class cannot extend async function

### DIFF
--- a/packages/babel-parser/src/parser/location.js
+++ b/packages/babel-parser/src/parser/location.js
@@ -57,6 +57,8 @@ export const Errors = Object.freeze({
   DuplicateRegExpFlags: "Duplicate regular expression flag",
   ElementAfterRest: "Rest element must be last element",
   EscapedCharNotAnIdentifier: "Invalid Unicode escape",
+  ExtendsValueNotConstructor:
+    "Class extends value %0 is not a constructor or null",
   ForInOfLoopInitializer:
     "%0 loop variable declaration may not have an initializer",
   GeneratorInSingleStatementContext:

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1648,7 +1648,19 @@ export default class StatementParser extends ExpressionParser {
   }
 
   parseClassSuper(node: N.Class): void {
-    node.superClass = this.eat(tt._extends) ? this.parseExprSubscripts() : null;
+    const superClass = this.eat(tt._extends)
+      ? this.parseExprSubscripts()
+      : null;
+    if (superClass !== null) {
+      if (superClass.type == "FunctionExpression" && superClass.async) {
+        this.raise(
+          superClass.start,
+          Errors.ExtendsValueNotConstructor,
+          this.input.slice(superClass.start, superClass.end),
+        );
+      }
+    }
+    node.superClass = superClass;
   }
 
   // Parses module export declaration.

--- a/packages/babel-parser/test/fixtures/es2016/simple-parameter-list/extend-async-function/input.js
+++ b/packages/babel-parser/test/fixtures/es2016/simple-parameter-list/extend-async-function/input.js
@@ -1,0 +1,1 @@
+class A extends async function () {} {}

--- a/packages/babel-parser/test/fixtures/es2016/simple-parameter-list/extend-async-function/output.json
+++ b/packages/babel-parser/test/fixtures/es2016/simple-parameter-list/extend-async-function/output.json
@@ -1,0 +1,122 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 39,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 39
+    }
+  },
+  "errors": [
+    "SyntaxError: Class extends value async function () {} is not a constructor or null (1:16)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 39,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 39
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 39,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 39
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": {
+          "type": "FunctionExpression",
+          "start": 16,
+          "end": 36,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 16
+            },
+            "end": {
+              "line": 1,
+              "column": 36
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": true,
+          "params": [],
+          "body": {
+            "type": "BlockStatement",
+            "start": 34,
+            "end": 36,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 34
+              },
+              "end": {
+                "line": 1,
+                "column": 36
+              }
+            },
+            "body": [],
+            "directives": []
+          }
+        },
+        "body": {
+          "type": "ClassBody",
+          "start": 37,
+          "end": 39,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 37
+            },
+            "end": {
+              "line": 1,
+              "column": 39
+            }
+          },
+          "body": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11209 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Prevents `class B extends async function () {} {}`.

Half of issue #11209 will be fixed by https://github.com/babel/babel/pull/11284, since that PR makes it a syntax error for a class to extend an async arrow function.

This PR fixes the other half of the issue, making it impossible for a class to extend an anonymous non-arrow async function.

Note: I don't know if this fix should be in Babel though, because it seems like more of a type/runtime issue rather than a syntax/parser issue?