### PR TITLE
Don't use ES6 in the for-of helper

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1102,19 +1102,19 @@ helpers.createForOfIteratorHelper = helper("7.9.0")`
     var it, normalCompletion = true, didErr = false, err;
 
     return {
-      s() {
+      s: function() {
         it = o[Symbol.iterator]();
       },
-      n() {
+      n: function() {
         var step = it.next();
         normalCompletion = step.done;
         return step;
       },
-      e(e) {
+      e: function(e) {
         didErr = true;
         err = e;
       },
-      f() {
+      f: function() {
         try {
           if (!normalCompletion && it.return != null) it.return();
         } finally {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11301 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The problem is that we don't compile the helpers when using Rollup (I think). `@babel/runtime` and inline helpers don't have this problem because they are transpiled.
