### PR TITLE
Fix logic to insert parens in return statements with comments

### DIFF
--- a/packages/babel-generator/test/fixtures/regression/11304/input.js
+++ b/packages/babel-generator/test/fixtures/regression/11304/input.js
@@ -1,0 +1,7 @@
+function f() {
+  return (
+    /*#__PURE__*/
+    //test
+    0
+  );
+}

--- a/packages/babel-generator/test/fixtures/regression/11304/options.json
+++ b/packages/babel-generator/test/fixtures/regression/11304/options.json
@@ -1,0 +1,3 @@
+{
+  "compact": true
+}

--- a/packages/babel-generator/test/fixtures/regression/11304/output.js
+++ b/packages/babel-generator/test/fixtures/regression/11304/output.js
@@ -1,0 +1,2 @@
+function f(){return/*#__PURE__*/ (//test
+0);}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11304
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Wow, this was super hard to debug :grimacing: 