### PR TITLE
[preset-typescript] Fix private members type annotations

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -78,7 +78,12 @@ export default declare(
           if (!node.decorators) {
             path.remove();
           }
-        } else if (!allowDeclareFields && !node.value && !node.decorators) {
+        } else if (
+          !allowDeclareFields &&
+          !node.value &&
+          !node.decorators &&
+          !t.isClassPrivateProperty(node)
+        ) {
           path.remove();
         }
 
@@ -325,13 +330,16 @@ export default declare(
           // class transform would transform the class, causing more specific
           // visitors to not run.
           path.get("body.body").forEach(child => {
-            if (child.isClassMethod()) {
+            if (child.isClassMethod() || child.isClassPrivateMethod()) {
               if (child.node.kind === "constructor") {
                 classMemberVisitors.constructor(child, path);
               } else {
                 classMemberVisitors.method(child, path);
               }
-            } else if (child.isClassProperty()) {
+            } else if (
+              child.isClassProperty() ||
+              child.isClassPrivateProperty()
+            ) {
               classMemberVisitors.field(child, path);
             }
           });

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/methods/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/methods/input.ts
@@ -1,4 +1,5 @@
 class C {
+    #m(x: number): void {}
     m(): void;
     public m(x?: number, ...y: number[]): void {}
     public constructor() {}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/methods/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/methods/options.json
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "transform-typescript",
-    ["syntax-decorators", { "legacy": true }],
     "syntax-class-properties"
   ]
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/methods/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/methods/output.js
@@ -1,4 +1,6 @@
 class C {
+  #m(x) {}
+
   m(x, ...y) {}
 
   constructor() {}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/input.ts
@@ -6,4 +6,6 @@ class C {
     @foo e: number = 3;
     f!: number;
     @foo g!: number;
+    #h: string;
+    #i: number = 10;
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/output.js
@@ -7,4 +7,6 @@ class C {
   e = 3;
   @foo
   g;
+  #h;
+  #i = 10;
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11310
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

This PR fixes the bug when typescript transformer leaves type annotations for private properties. It does two main things:
- Removes annotation for property that has initializer
- Removes annotation and keeps private property declared if there is no initializer.
  ```typescript
  class Foo {
    #bar: string;
  }
  ```
  By default typescript transformer removes such properties, but we need to preserve them according to the spec.
  ```js
   class Foo {
    #bar;
   }
   ```