### PR TITLE
Fixed issue with programPath.scope.references not being registered back correctly after scope re-crawling

### DIFF
--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -609,6 +609,8 @@ export default class Scope {
     const ids = path.getOuterBindingIdentifiers(true);
 
     for (const name of Object.keys(ids)) {
+      parent.references[name] = true;
+
       for (const id of (ids[name]: Array<Object>)) {
         const local = this.getOwnBinding(name);
 
@@ -619,8 +621,6 @@ export default class Scope {
 
           this.checkBlockScopedCollisions(local, kind, name, id);
         }
-
-        parent.references[name] = true;
 
         // A redeclaration of an existing variable is a modification
         if (local) {

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -303,6 +303,24 @@ describe("scope", () => {
 
       expect(path.scope.bindings.a).toBe(path.get("body[0]").scope.bindings.a);
     });
+
+    it("references after re-crawling", function() {
+      const path = getPath("function Foo() { var _jsx; }");
+
+      path.scope.crawl();
+      path.scope.crawl();
+
+      expect(path.scope.references._jsx).toBeTruthy();
+    });
+
+    test("generateUid collision check after re-crawling", function() {
+      const path = getPath("function Foo() { var _jsx; }");
+
+      path.scope.crawl();
+      path.scope.crawl();
+
+      expect(path.scope.generateUid("jsx")).toBe("_jsx2");
+    });
   });
 
   describe("duplicate bindings", () => {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | fixes https://github.com/babel/babel/issues/11320
| Patch: Bug Fix?          | x
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | no
| License                  | MIT

References were not correctly registered back on subsequent crawls for cases when bindings were already registered on some inner scopes.
