### PR TITLE
Restore default pragmas in preset-react for classic runtime

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/src/transform-classic.js
+++ b/packages/babel-plugin-transform-react-jsx/src/transform-classic.js
@@ -41,7 +41,7 @@ export default declare((api, options) => {
 
     post(state, pass) {
       state.callee = pass.get("jsxIdentifier")();
-      state.pure = PURE_ANNOTATION ?? !pass.get("pragmaSet");
+      state.pure = PURE_ANNOTATION ?? pass.get("pragma") === DEFAULT.pragma;
     },
 
     throwIfNamespace: THROW_IF_NAMESPACE,
@@ -74,6 +74,7 @@ export default declare((api, options) => {
       state.set("jsxIdentifier", createIdentifierParser(pragma));
       state.set("jsxFragIdentifier", createIdentifierParser(pragmaFrag));
       state.set("usedFragment", false);
+      state.set("pragma", pragma);
       state.set("pragmaSet", pragmaSet);
       state.set("pragmaFragSet", pragmaFragSet);
     },

--- a/packages/babel-preset-react/src/index.js
+++ b/packages/babel-preset-react/src/index.js
@@ -8,15 +8,21 @@ import transformReactJSXSelf from "@babel/plugin-transform-react-jsx-self";
 export default declare((api, opts) => {
   api.assertVersion(7);
 
+  let { pragma, pragmaFrag } = opts;
+
   const {
-    pragma,
-    pragmaFrag,
     pure,
     throwIfNamespace = true,
     useSpread,
     runtime = "classic",
     importSource,
   } = opts;
+
+  // TODO: (Babel 8) Remove setting these defaults
+  if (runtime === "classic") {
+    pragma = pragma || "React.createElement";
+    pragmaFrag = pragmaFrag || "React.Fragment";
+  }
 
   // TODO: (Babel 8) Don't cast these options but validate it
   const development = !!opts.development;

--- a/packages/babel-preset-react/test/fixtures/preset-options/runtime-classic-pragma-no-frag/input.js
+++ b/packages/babel-preset-react/test/fixtures/preset-options/runtime-classic-pragma-no-frag/input.js
@@ -1,0 +1,3 @@
+/** @jsx jsx */
+
+const Foo = <></>;

--- a/packages/babel-preset-react/test/fixtures/preset-options/runtime-classic-pragma-no-frag/options.json
+++ b/packages/babel-preset-react/test/fixtures/preset-options/runtime-classic-pragma-no-frag/options.json
@@ -1,0 +1,3 @@
+{
+  "presets": ["react"]
+}

--- a/packages/babel-preset-react/test/fixtures/preset-options/runtime-classic-pragma-no-frag/output.js
+++ b/packages/babel-preset-react/test/fixtures/preset-options/runtime-classic-pragma-no-frag/output.js
@@ -1,0 +1,2 @@
+/** @jsx jsx */
+const Foo = jsx(React.Fragment, null);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Ref: https://github.com/babel/babel/issues/11321, https://github.com/mdx-js/mdx/issues/990, https://github.com/gatsbyjs/gatsby/issues/22500
