### PR TITLE
chore: remove unused graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint-plugin-prettier": "^3.1.2",
     "fancy-log": "^1.3.3",
     "flow-bin": "^0.108.0",
-    "graceful-fs": "^4.1.15",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "gulp-filter": "^5.1.0",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Removed `graceful-fs` as I can't imports in our code base
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
