### PR TITLE
fix: isIdentifierName should reject empty string

### DIFF
--- a/packages/babel-helper-validator-identifier/src/identifier.js
+++ b/packages/babel-helper-validator-identifier/src/identifier.js
@@ -98,5 +98,5 @@ export function isIdentifierName(name: string): boolean {
       return false;
     }
   }
-  return true;
+  return !isFirst;
 }

--- a/packages/babel-helper-validator-identifier/test/identifier.spec.js
+++ b/packages/babel-helper-validator-identifier/test/identifier.spec.js
@@ -1,0 +1,22 @@
+import { isIdentifierName } from "..";
+
+describe("isIdentifierName", function() {
+  it("returns false if provided string is empty", function() {
+    expect(isIdentifierName("")).toBe(false);
+  });
+  it.each(["hello", "$", "ゆゆ式", "$20", "hello20", "_", "if"])(
+    "returns true if provided string %p is an IdentifierName",
+    function(word) {
+      expect(isIdentifierName(word)).toBe(true);
+    },
+  );
+  it.each(["+hello", "0$", "-ゆゆ式", "#_", "_#"])(
+    "returns false if provided string %p is not an IdentifierName",
+    function(word) {
+      expect(isIdentifierName(word)).toBe(false);
+    },
+  );
+  it("supports astral symbols", function() {
+    expect(isIdentifierName("x\uDB40\uDDD5")).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11338 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

This PR fixes a regression introduced at #11289 
The unit test is copied and modernized from https://github.com/estools/esutils/blob/master/test/keyword.coffee