### PR TITLE
Fix e2e publish test when branching from an older version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ ifneq ("$(I_AM_USING_VERDACCIO)", "I_AM_SURE")
 	exit 1
 endif
 	$(MAKE) prepublish-build
-	$(YARN) lerna version patch --force-publish=$(FORCE_PUBLISH)  --no-push --yes --tag-version-prefix="version-e2e-test-"
+	$(YARN) lerna version $(VERSION) --force-publish=$(FORCE_PUBLISH)  --no-push --yes --tag-version-prefix="version-e2e-test-"
 	$(YARN) lerna publish from-git --registry http://localhost:4873 --yes --tag-version-prefix="version-e2e-test-"
 	$(MAKE) clean
 

--- a/scripts/integration-tests/publish-local.sh
+++ b/scripts/integration-tests/publish-local.sh
@@ -43,9 +43,9 @@ VERSION=$(
 
 I_AM_USING_VERDACCIO=I_AM_SURE VERSION="$VERSION" make publish-test
 
-publishESLintPkg babel-eslint-config-internal VERSION
-publishESLintPkg babel-eslint-parser VERSION
-publishESLintPkg babel-eslint-plugin VERSION
-publishESLintPkg babel-eslint-plugin-development VERSION
+publishESLintPkg babel-eslint-config-internal "$VERSION"
+publishESLintPkg babel-eslint-parser "$VERSION"
+publishESLintPkg babel-eslint-plugin "$VERSION"
+publishESLintPkg babel-eslint-plugin-development "$VERSION"
 
 cleanup

--- a/scripts/integration-tests/publish-local.sh
+++ b/scripts/integration-tests/publish-local.sh
@@ -13,7 +13,7 @@ source utils/cleanup.sh
 
 function publishESLintPkg {
   cd eslint/$1
-  yarn version --patch --no-git-tag-version
+  yarn version $2 --no-git-tag-version
   cd ../..
   make -j publish-eslint PKG=$1
 }
@@ -35,11 +35,17 @@ make -j bootstrap-only
 startLocalRegistry "$PWD"/scripts/integration-tests/verdaccio-config.yml
 loginLocalRegistry
 
+# This script gets the last @babel/standalone version (because it's always published),
+# and then increases by one the patch number
+VERSION=$(
+  node -p "'$(npm view @babel/standalone version)'.replace(/(?<=\\d+\\.\\d+\\.)\\d+/, x => ++x)"
+)
+
 I_AM_USING_VERDACCIO=I_AM_SURE make publish-test
 
-publishESLintPkg babel-eslint-config-internal
-publishESLintPkg babel-eslint-parser
-publishESLintPkg babel-eslint-plugin
-publishESLintPkg babel-eslint-plugin-development
+publishESLintPkg babel-eslint-config-internal VERSION
+publishESLintPkg babel-eslint-parser VERSION
+publishESLintPkg babel-eslint-plugin VERSION
+publishESLintPkg babel-eslint-plugin-development VERSION
 
 cleanup

--- a/scripts/integration-tests/publish-local.sh
+++ b/scripts/integration-tests/publish-local.sh
@@ -13,7 +13,7 @@ source utils/cleanup.sh
 
 function publishESLintPkg {
   cd eslint/$1
-  yarn version $2 --no-git-tag-version
+  yarn version --new-version $2 --no-git-tag-version
   cd ../..
   make -j publish-eslint PKG=$1
 }

--- a/scripts/integration-tests/publish-local.sh
+++ b/scripts/integration-tests/publish-local.sh
@@ -41,7 +41,7 @@ VERSION=$(
   node -p "'$(npm view @babel/standalone version)'.replace(/(?<=\\d+\\.\\d+\\.)\\d+/, x => ++x)"
 )
 
-I_AM_USING_VERDACCIO=I_AM_SURE make publish-test
+I_AM_USING_VERDACCIO=I_AM_SURE VERSION="$VERSION" make publish-test
 
 publishESLintPkg babel-eslint-config-internal VERSION
 publishESLintPkg babel-eslint-parser VERSION


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | All the e2e tests which start failing after a new version
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The current e2e tests publish a new patch version starting from the PR branch. However, when the PR has an older version than the last published one, the tests fail with `Cannot publish ...@undefined over existing version` ([example](https://app.circleci.com/pipelines/github/babel/babel/2280/workflows/c0726398-65e3-4cac-90d2-b0b6e41f0b0b/jobs/19810)).

I have created this PR forking from 7.9.0, let's see if it works.