### PR TITLE
Don't check type annotations when deciding params scope

### DIFF
--- a/packages/babel-plugin-transform-parameters/src/params.js
+++ b/packages/babel-plugin-transform-parameters/src/params.js
@@ -37,9 +37,8 @@ const iifeVisitor = {
     }
   },
   // type annotations don't use or introduce "real" bindings
-  "TypeAnnotation|TSTypeAnnotation"(path) {
-    path.skip();
-  },
+  "TypeAnnotation|TSTypeAnnotation|TypeParameterDeclaration|TSTypeParameterDeclaration": path =>
+    path.skip(),
 };
 
 export default function convertFunctionParams(path, loose) {

--- a/packages/babel-plugin-transform-parameters/src/params.js
+++ b/packages/babel-plugin-transform-parameters/src/params.js
@@ -36,6 +36,10 @@ const iifeVisitor = {
       path.stop();
     }
   },
+  // type annotations don't use or introduce "real" bindings
+  "TypeAnnotation|TSTypeAnnotation"(path) {
+    path.skip();
+  },
 };
 
 export default function convertFunctionParams(path, loose) {

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-flow/input.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-flow/input.js
@@ -1,3 +1,7 @@
 function a(b: (c) => void = {}) {
   let c;
 }
+
+function d(e = <T>() => {}) {
+  let T;
+}

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-flow/input.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-flow/input.js
@@ -1,0 +1,3 @@
+function a(b: (c) => void = {}) {
+  let c;
+}

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-flow/options.json
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-flow/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-parameters",
+    "syntax-flow"
+  ]
+}

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-flow/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-flow/output.js
@@ -1,0 +1,4 @@
+function a() {
+  let b: (c) => void = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  let c;
+}

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-flow/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-flow/output.js
@@ -2,3 +2,8 @@ function a() {
   let b: (c) => void = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   let c;
 }
+
+function d() {
+  let e = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : <T>() => {};
+  let T;
+}

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-typescript/input.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-typescript/input.js
@@ -1,3 +1,7 @@
 function a(b: (c) => void = {}) {
   let c;
 }
+
+function d(e = <T>() => {}) {
+  let T;
+}

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-typescript/input.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-typescript/input.js
@@ -1,0 +1,3 @@
+function a(b: (c) => void = {}) {
+  let c;
+}

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-typescript/options.json
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-typescript/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-parameters",
+    "syntax-typescript"
+  ]
+}

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-typescript/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-typescript/output.js
@@ -1,0 +1,4 @@
+function a() {
+  let b: (c) => void = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  let c;
+}

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-typescript/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/11344-typescript/output.js
@@ -2,3 +2,8 @@ function a() {
   let b: (c) => void = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   let c;
 }
+
+function d() {
+  let e = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : <T>() => {};
+  let T;
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11344
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Type annotations caused unnecessary usage of IIFE, because we checked if they referenced any value binding.