### PR TITLE
fix auto import error with whitespace JSXText

### DIFF
--- a/packages/babel-helper-builder-react-jsx-experimental/src/index.js
+++ b/packages/babel-helper-builder-react-jsx-experimental/src/index.js
@@ -303,12 +303,8 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
       "JSXElement|JSXFragment"(path) {
         if (path.type === "JSXFragment") imports.add("Fragment");
         const openingPath = path.get("openingElement");
-        const validChildren = openingPath.parent.children.filter(
-          child =>
-            !t.isJSXEmptyExpression(child) &&
-            !(t.isJSXText(child) && child.value.trim() === ""),
-        );
 
+        const validChildren = t.react.buildChildren(openingPath.parent);
         let importName;
         if (path.type === "JSXElement" && shouldUseCreateElement(path)) {
           importName = "createElement";

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/weird-symbols/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/weird-symbols/input.js
@@ -1,0 +1,5 @@
+class MobileHomeActivityTaskPriorityIcon extends React.PureComponent {
+  render() {
+    return <Text>&nbsp;{this.props.value}&nbsp;</Text>;
+  }
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/weird-symbols/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/weird-symbols/output.mjs
@@ -1,0 +1,10 @@
+import { jsxs as _jsxs } from "react/jsx-runtime";
+
+class MobileHomeActivityTaskPriorityIcon extends React.PureComponent {
+  render() {
+    return /*#__PURE__*/_jsxs(Text, {
+      children: ["\xA0", this.props.value, "\xA0"]
+    });
+  }
+
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReactClassic/weird-symbols/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReactClassic/weird-symbols/input.js
@@ -1,0 +1,7 @@
+/** @jsxRuntime classic */
+
+class MobileHomeActivityTaskPriorityIcon extends React.PureComponent {
+  render() {
+    return <Text>&nbsp;{this.props.value}&nbsp;</Text>;
+  }
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReactClassic/weird-symbols/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReactClassic/weird-symbols/output.js
@@ -1,0 +1,7 @@
+/** @jsxRuntime classic */
+class MobileHomeActivityTaskPriorityIcon extends React.PureComponent {
+  render() {
+    return /*#__PURE__*/React.createElement(Text, null, "\xA0", this.props.value, "\xA0");
+  }
+
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/weird-symbols/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/weird-symbols/input.js
@@ -1,0 +1,7 @@
+/** @jsxRuntime classic */
+
+class MobileHomeActivityTaskPriorityIcon extends React.PureComponent {
+  render() {
+    return <Text>&nbsp;{this.props.value}&nbsp;</Text>;
+  }
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/weird-symbols/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/weird-symbols/output.js
@@ -1,0 +1,7 @@
+/** @jsxRuntime classic */
+class MobileHomeActivityTaskPriorityIcon extends React.PureComponent {
+  render() {
+    return /*#__PURE__*/React.createElement(Text, null, "\xA0", this.props.value, "\xA0");
+  }
+
+}


### PR DESCRIPTION
The new JSX auto import React has a bug where it ignores valid whitespace text when calculating whether to import `jsx` or `jsxs`. This fixes it by stripping JSXText the same way that `t.react.buildChildren` strips JSXText so that the children calculated are consistent with each other.