### PR TITLE
fix: allow logical assignment operators in AssignmentExpression

### DIFF
--- a/packages/babel-types/src/constants/index.js
+++ b/packages/babel-types/src/constants/index.js
@@ -45,6 +45,7 @@ export const ASSIGNMENT_OPERATORS = [
   "=",
   "+=",
   ...NUMBER_BINARY_OPERATORS.map(op => op + "="),
+  ...LOGICAL_OPERATORS.map(op => op + "="),
 ];
 
 export const BOOLEAN_UNARY_OPERATORS = ["delete", "!"];


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | When `BABEL_TYPES_8_BREAKING` is enabled, logical assignment operators should be allowed when constructing an AssignmentExpression.
| Patch: Bug Fix?          | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
A follow-up to #10917, which validates assignment expression [here](https://github.com/babel/babel/pull/10917/files#diff-757f0f7d11a836d10acb09283e7b06aaR48).