### PR TITLE
fix: do not add function name when parent's operator is not `=`

### DIFF
--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -179,7 +179,7 @@ export default function({ node, parent, scope, id }, localBinding = false) {
         return;
       }
     }
-  } else if (t.isAssignmentExpression(parent)) {
+  } else if (t.isAssignmentExpression(parent, { operator: "=" })) {
     // foo = function () {};
     id = parent.left;
   } else if (!id) {

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/function-assignment/input.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/function-assignment/input.js
@@ -11,3 +11,5 @@ baz = 12;
 bar = function() {
   bar();
 };
+
+qux += function() {}

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/function-assignment/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/function-assignment/output.js
@@ -23,3 +23,5 @@ bar = function (_bar) {
 }(function () {
   bar();
 });
+
+qux += function () {};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

Per https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation, when operator is not `=`, the anonymous function expression will not be applied with NamedEvaluation.