### PR TITLE
Simplify scope.hasReferences implementation

### DIFF
--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -662,13 +662,7 @@ export default class Scope {
   }
 
   hasReference(name: string): boolean {
-    let scope = this;
-
-    do {
-      if (scope.references[name]) return true;
-    } while ((scope = scope.parent));
-
-    return false;
+    return !!this.getProgramParent().references[name];
   }
 
   isPure(node, constantsOnly?: boolean) {


### PR DESCRIPTION
`references` are only ever registered on the program scope, so there is no need to iterate through all parent scopes - we can just jump to the program one