### PR TITLE
Fixed useBuiltIns and modules validation when using 'false' as option

### DIFF
--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -167,8 +167,7 @@ export const validateModulesOption = (
   modulesOpt: ModuleOption = ModulesOption.auto,
 ) => {
   invariant(
-    ModulesOption[modulesOpt.toString()] ||
-      ModulesOption[modulesOpt.toString()] === ModulesOption.false,
+    ModulesOption[modulesOpt.toString()] || modulesOpt === ModulesOption.false,
     `Invalid Option: The 'modules' option must be one of \n` +
       ` - 'false' to indicate no module processing\n` +
       ` - a specific module type: 'commonjs', 'amd', 'umd', 'systemjs'` +
@@ -184,7 +183,7 @@ export const validateUseBuiltInsOption = (
 ) => {
   invariant(
     UseBuiltInsOption[builtInsOpt.toString()] ||
-      UseBuiltInsOption[builtInsOpt.toString()] === UseBuiltInsOption.false,
+      builtInsOpt === UseBuiltInsOption.false,
     `Invalid Option: The 'useBuiltIns' option must be either
     'false' (default) to indicate no polyfill,
     '"entry"' to indicate replacing the entry polyfill, or

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -6,6 +6,7 @@ const {
   checkDuplicateIncludeExcludes,
   validateBoolOption,
   validateModulesOption,
+  validateUseBuiltInsOption,
   normalizePluginName,
 } = normalizeOptions;
 describe("normalize-options", () => {
@@ -242,9 +243,35 @@ describe("normalize-options", () => {
       }).toThrow();
     });
 
+    it("`'false'` option is invalid", () => {
+      expect(() => {
+        validateModulesOption("false");
+      }).toThrow();
+    });
+
     it("array option is invalid", () => {
       expect(() => {
         validateModulesOption([]);
+      }).toThrow();
+    });
+  });
+
+  describe("validateUseBuiltInsOptions", () => {
+    it("usage option is valid", () => {
+      expect(validateUseBuiltInsOption("usage")).toBe("usage");
+    });
+
+    it("entry option is valid", () => {
+      expect(validateUseBuiltInsOption("entry")).toBe("entry");
+    });
+
+    it("`false` option returns false", () => {
+      expect(validateUseBuiltInsOption(false)).toBe(false);
+    });
+
+    it("`'false'` option is invalid", () => {
+      expect(() => {
+        validateUseBuiltInsOption("false");
       }).toThrow();
     });
   });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11352 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Fixes the case when 'false' as string is provided for `useBuiltIns` or `modules` option by not converting the supplied option to string when it's 'false', and comparing it directly.