### PR TITLE
fix: do not push new token context when function is following dot/questionDot

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -2125,17 +2125,12 @@ export default class ExpressionParser extends LValParser {
     } else if (this.state.type.keyword) {
       name = this.state.type.keyword;
 
-      // `class` and `function` keywords push new context into this.context.
+      // `class` and `function` keywords push function-type token context into this.context.
       // But there is no chance to pop the context if the keyword is consumed
       // as an identifier such as a property name.
-      // If the previous token is a dot, this does not apply because the
-      // context-managing code already ignored the keyword
-      if (
-        (name === "class" || name === "function") &&
-        (this.state.lastTokEnd !== this.state.lastTokStart + 1 ||
-          this.input.charCodeAt(this.state.lastTokStart) !== charCodes.dot)
-      ) {
-        this.state.context.pop();
+      const context = this.state.context;
+      if (context[context.length - 1].token === "function") {
+        context.pop();
       }
     } else {
       throw this.unexpected();

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -2129,7 +2129,10 @@ export default class ExpressionParser extends LValParser {
       // But there is no chance to pop the context if the keyword is consumed
       // as an identifier such as a property name.
       const context = this.state.context;
-      if (context[context.length - 1].token === "function") {
+      if (
+        (name === "class" || name === "function") &&
+        context[context.length - 1].token === "function"
+      ) {
         context.pop();
       }
     } else {

--- a/packages/babel-parser/src/tokenizer/context.js
+++ b/packages/babel-parser/src/tokenizer/context.js
@@ -101,7 +101,10 @@ tt.incDec.updateContext = function() {
 };
 
 tt._function.updateContext = tt._class.updateContext = function(prevType) {
-  if (
+  if (prevType === tt.dot || prevType === tt.questionDot) {
+    // when function/class follows dot/questionDot, it is part of
+    // (optional)MemberExpression, then we don't need to push new token context
+  } else if (
     prevType.beforeExpr &&
     prevType !== tt.semi &&
     prevType !== tt._else &&

--- a/packages/babel-parser/test/fixtures/jsx/regression/issue-11387/input.js
+++ b/packages/babel-parser/test/fixtures/jsx/regression/issue-11387/input.js
@@ -1,0 +1,1 @@
+<div>{(this?.class, this.class, this?.function, this.function)}</div>

--- a/packages/babel-parser/test/fixtures/jsx/regression/issue-11387/options.json
+++ b/packages/babel-parser/test/fixtures/jsx/regression/issue-11387/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["jsx", "flow"]
+}

--- a/packages/babel-parser/test/fixtures/jsx/regression/issue-11387/output.json
+++ b/packages/babel-parser/test/fixtures/jsx/regression/issue-11387/output.json
@@ -1,0 +1,115 @@
+{
+  "type": "File",
+  "start":0,"end":69,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":69}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":69,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":69}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":69,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":69}},
+        "expression": {
+          "type": "JSXElement",
+          "start":0,"end":69,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":69}},
+          "openingElement": {
+            "type": "JSXOpeningElement",
+            "start":0,"end":5,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":5}},
+            "name": {
+              "type": "JSXIdentifier",
+              "start":1,"end":4,"loc":{"start":{"line":1,"column":1},"end":{"line":1,"column":4}},
+              "name": "div"
+            },
+            "attributes": [],
+            "selfClosing": false
+          },
+          "closingElement": {
+            "type": "JSXClosingElement",
+            "start":63,"end":69,"loc":{"start":{"line":1,"column":63},"end":{"line":1,"column":69}},
+            "name": {
+              "type": "JSXIdentifier",
+              "start":65,"end":68,"loc":{"start":{"line":1,"column":65},"end":{"line":1,"column":68}},
+              "name": "div"
+            }
+          },
+          "children": [
+            {
+              "type": "JSXExpressionContainer",
+              "start":5,"end":63,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":63}},
+              "expression": {
+                "type": "SequenceExpression",
+                "start":7,"end":61,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":61}},
+                "expressions": [
+                  {
+                    "type": "OptionalMemberExpression",
+                    "start":7,"end":18,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":18}},
+                    "object": {
+                      "type": "ThisExpression",
+                      "start":7,"end":11,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":11}}
+                    },
+                    "property": {
+                      "type": "Identifier",
+                      "start":13,"end":18,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":18},"identifierName":"class"},
+                      "name": "class"
+                    },
+                    "computed": false,
+                    "optional": true
+                  },
+                  {
+                    "type": "MemberExpression",
+                    "start":20,"end":30,"loc":{"start":{"line":1,"column":20},"end":{"line":1,"column":30}},
+                    "object": {
+                      "type": "ThisExpression",
+                      "start":20,"end":24,"loc":{"start":{"line":1,"column":20},"end":{"line":1,"column":24}}
+                    },
+                    "property": {
+                      "type": "Identifier",
+                      "start":25,"end":30,"loc":{"start":{"line":1,"column":25},"end":{"line":1,"column":30},"identifierName":"class"},
+                      "name": "class"
+                    },
+                    "computed": false
+                  },
+                  {
+                    "type": "OptionalMemberExpression",
+                    "start":32,"end":46,"loc":{"start":{"line":1,"column":32},"end":{"line":1,"column":46}},
+                    "object": {
+                      "type": "ThisExpression",
+                      "start":32,"end":36,"loc":{"start":{"line":1,"column":32},"end":{"line":1,"column":36}}
+                    },
+                    "property": {
+                      "type": "Identifier",
+                      "start":38,"end":46,"loc":{"start":{"line":1,"column":38},"end":{"line":1,"column":46},"identifierName":"function"},
+                      "name": "function"
+                    },
+                    "computed": false,
+                    "optional": true
+                  },
+                  {
+                    "type": "MemberExpression",
+                    "start":48,"end":61,"loc":{"start":{"line":1,"column":48},"end":{"line":1,"column":61}},
+                    "object": {
+                      "type": "ThisExpression",
+                      "start":48,"end":52,"loc":{"start":{"line":1,"column":48},"end":{"line":1,"column":52}}
+                    },
+                    "property": {
+                      "type": "Identifier",
+                      "start":53,"end":61,"loc":{"start":{"line":1,"column":53},"end":{"line":1,"column":61},"identifierName":"function"},
+                      "name": "function"
+                    },
+                    "computed": false
+                  }
+                ],
+                "extra": {
+                  "parenthesized": true,
+                  "parenStart": 6
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11387
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is based on previous work in #8972. Here we simplify the context popping logic so we can obtain a straightforward fix of #11387

When parsing `function` after dot/questionDot, we are confident that this function keyword is used as a liberal identifier instead of a keyword, so we don't have to push a new token context. Later when popping token context on parsing `function` as identifier, it suffices to check the token context type and pop only when it is a function-type context, which can only be inserted by `tt._function`. (Ditto for `tt._class`.)

 