### PR TITLE
fix: add classPrivateProperties and classPrivateMethods to missing plugin helper

### DIFF
--- a/packages/babel-core/src/parser/util/missing-plugin-helper.js
+++ b/packages/babel-core/src/parser/util/missing-plugin-helper.js
@@ -11,6 +11,16 @@ const pluginNameMap = {
       url: "https://git.io/vb4SL",
     },
   },
+  classPrivateProperties: {
+    syntax: {
+      name: "@babel/plugin-syntax-class-properties",
+      url: "https://git.io/vb4yQ",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-class-properties",
+      url: "https://git.io/vb4SL",
+    },
+  },
   classPrivateMethods: {
     syntax: {
       name: "@babel/plugin-syntax-class-properties",
@@ -225,7 +235,6 @@ const pluginNameMap = {
     },
   },
 };
-pluginNameMap.classPrivateProperties = pluginNameMap.classProperties;
 
 const getNameURLCombination = ({ name, url }) => `${name} (${url})`;
 

--- a/packages/babel-core/src/parser/util/missing-plugin-helper.js
+++ b/packages/babel-core/src/parser/util/missing-plugin-helper.js
@@ -11,6 +11,16 @@ const pluginNameMap = {
       url: "https://git.io/vb4SL",
     },
   },
+  classPrivateMethods: {
+    syntax: {
+      name: "@babel/plugin-syntax-class-properties",
+      url: "https://git.io/vb4yQ",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-private-methods",
+      url: "https://git.io/JvpRG",
+    },
+  },
   decorators: {
     syntax: {
       name: "@babel/plugin-syntax-decorators",
@@ -215,6 +225,7 @@ const pluginNameMap = {
     },
   },
 };
+pluginNameMap.classPrivateProperties = pluginNameMap.classProperties;
 
 const getNameURLCombination = ({ name, url }) => `${name} (${url})`;
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Address https://babeljs.slack.com/archives/C0DFJT81H/p1586351608084800
| Tests Added + Pass?      | Yes
| License                  | MIT