### PR TITLE
Fix nested classes reference private fields

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -7,21 +7,24 @@ import optimiseCall from "@babel/helper-optimise-call-expression";
 
 import * as ts from "./typescript";
 
-export function buildPrivateNamesMap(props) {
-  const privateNamesMap = new Map();
+export function buildPrivateNamesMap(privateNamesMap, props, depth) {
   for (const prop of props) {
-    const isPrivate = prop.isPrivate();
-    const isMethod = !prop.isProperty();
-    const isInstance = !prop.node.static;
-    if (isPrivate) {
+    if (prop.isPrivate()) {
+      const isMethod = !prop.isProperty();
+      const isInstance = !prop.node.static;
       const { name } = prop.node.key.id;
-      const update = privateNamesMap.has(name)
-        ? privateNamesMap.get(name)
-        : {
-            id: prop.scope.generateUidIdentifier(name),
-            static: !isInstance,
-            method: isMethod,
-          };
+
+      let update = privateNamesMap.get(name);
+      if (!update || update.depth !== depth) {
+        update = {
+          id: prop.scope.generateUidIdentifier(name),
+          static: !isInstance,
+          method: isMethod,
+          depth,
+        };
+        privateNamesMap.set(name, update);
+      }
+
       if (prop.node.kind === "get") {
         update.getId = prop.scope.generateUidIdentifier(`get_${name}`);
       } else if (prop.node.kind === "set") {
@@ -29,13 +32,16 @@ export function buildPrivateNamesMap(props) {
       } else if (prop.node.kind === "method") {
         update.methodId = prop.scope.generateUidIdentifier(name);
       }
-      privateNamesMap.set(name, update);
     }
   }
-  return privateNamesMap;
 }
 
-export function buildPrivateNamesNodes(privateNamesMap, loose, state) {
+export function buildPrivateNamesNodes(
+  privateNamesMap,
+  loose,
+  state,
+  privateDepth,
+) {
   const initNodes = [];
 
   for (const [name, value] of privateNamesMap) {
@@ -45,7 +51,16 @@ export function buildPrivateNamesNodes(privateNamesMap, loose, state) {
     // In spec mode, only instance fields need a "private name" initializer
     // because static fields are directly assigned to a variable in the
     // buildPrivateStaticFieldInitSpec function.
-    const { id, static: isStatic, method: isMethod, getId, setId } = value;
+    const {
+      id,
+      static: isStatic,
+      method: isMethod,
+      getId,
+      setId,
+      depth,
+    } = value;
+    if (depth !== privateDepth) continue;
+
     const isAccessor = getId || setId;
     if (loose) {
       initNodes.push(
@@ -263,6 +278,7 @@ export function transformPrivateNamesUsage(
   loose,
   state,
 ) {
+  if (!privateNamesMap.size) return;
   const body = path.get("body");
 
   if (loose) {

--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -97,8 +97,8 @@ const privateNameVisitor = {
       return;
     }
 
-    // This class redeclares some private name. We need to process the outer
-    // environment with access to all the outer private, then we can process
+    // This class redeclares some private field. We need to process the outer
+    // environment with access to all the outer privates, then we can process
     // the inner environment with only the still-visible outer privates.
     path.traverse(privateNameNestedVisitor, this);
     path.traverse(privateNameVisitor, {
@@ -106,7 +106,7 @@ const privateNameVisitor = {
       privateNamesMap: visiblePrivateNames,
     });
 
-    // We'll eventually this this class node again with the overall Class
+    // We'll eventually hit this class node again with the overall Class
     // Features visitor, which'll process the redeclared privates.
     path.skip();
   },

--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -275,6 +275,8 @@ export function transformPrivateNamesUsage(
   loose,
   state,
 ) {
+  if (!privateNamesMap.size) return;
+
   const body = path.get("body");
 
   if (loose) {

--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -30,6 +30,8 @@ export { FEATURES, injectInitialization };
 const version = pkg.version.split(".").reduce((v, x) => v * 1e5 + +x, 0);
 const versionKey = "@babel/plugin-class-features/version";
 
+const privateNamesStack = [new Map()];
+
 export function createClassFeaturePlugin({
   name,
   feature,
@@ -49,141 +51,158 @@ export function createClassFeaturePlugin({
     },
 
     visitor: {
-      Class(path, state) {
-        if (this.file.get(versionKey) !== version) return;
+      Class: {
+        enter(path, state) {
+          if (this.file.get(versionKey) !== version) return;
 
-        verifyUsedFeatures(path, this.file);
-
-        const loose = isLoose(this.file, feature);
-
-        let constructor;
-        let isDecorated = hasOwnDecorators(path.node);
-        const props = [];
-        const elements = [];
-        const computedPaths = [];
-        const privateNames = new Set();
-        const body = path.get("body");
-
-        for (const path of body.get("body")) {
           verifyUsedFeatures(path, this.file);
 
-          if (path.node.computed) {
-            computedPaths.push(path);
-          }
-
-          if (path.isPrivate()) {
-            const { name } = path.node.key.id;
-            const getName = `get ${name}`;
-            const setName = `set ${name}`;
-
-            if (path.node.kind === "get") {
-              if (
-                privateNames.has(getName) ||
-                (privateNames.has(name) && !privateNames.has(setName))
-              ) {
-                throw path.buildCodeFrameError("Duplicate private field");
-              }
-
-              privateNames.add(getName).add(name);
-            } else if (path.node.kind === "set") {
-              if (
-                privateNames.has(setName) ||
-                (privateNames.has(name) && !privateNames.has(getName))
-              ) {
-                throw path.buildCodeFrameError("Duplicate private field");
-              }
-
-              privateNames.add(setName).add(name);
-            } else {
-              if (
-                (privateNames.has(name) &&
-                  !privateNames.has(getName) &&
-                  !privateNames.has(setName)) ||
-                (privateNames.has(name) &&
-                  (privateNames.has(getName) || privateNames.has(setName)))
-              ) {
-                throw path.buildCodeFrameError("Duplicate private field");
-              }
-
-              privateNames.add(name);
-            }
-          }
-
-          if (path.isClassMethod({ kind: "constructor" })) {
-            constructor = path;
-          } else {
-            elements.push(path);
-            if (path.isProperty() || path.isPrivate()) {
-              props.push(path);
-            }
-          }
-
-          if (!isDecorated) isDecorated = hasOwnDecorators(path.node);
-        }
-
-        if (!props.length && !isDecorated) return;
-
-        let ref;
-
-        if (path.isClassExpression() || !path.node.id) {
-          nameFunction(path);
-          ref = path.scope.generateUidIdentifier("class");
-        } else {
-          ref = path.node.id;
-        }
-
-        // NODE: These three functions don't support decorators yet,
-        //       but verifyUsedFeatures throws if there are both
-        //       decorators and private fields.
-        const privateNamesMap = buildPrivateNamesMap(props);
-        const privateNamesNodes = buildPrivateNamesNodes(
-          privateNamesMap,
-          loose,
-          state,
-        );
-
-        transformPrivateNamesUsage(ref, path, privateNamesMap, loose, state);
-
-        let keysNodes, staticNodes, instanceNodes, wrapClass;
-
-        if (isDecorated) {
-          staticNodes = keysNodes = [];
-          ({ instanceNodes, wrapClass } = buildDecoratedClass(
-            ref,
-            path,
-            elements,
-            this.file,
-          ));
-        } else {
-          keysNodes = extractComputedKeys(ref, path, computedPaths, this.file);
-          ({ staticNodes, instanceNodes, wrapClass } = buildFieldsInitNodes(
-            ref,
-            path.node.superClass,
-            props,
-            privateNamesMap,
-            state,
-            loose,
-          ));
-        }
-
-        if (instanceNodes.length > 0) {
-          injectInitialization(
-            path,
-            constructor,
-            instanceNodes,
-            (referenceVisitor, state) => {
-              if (isDecorated) return;
-              for (const prop of props) {
-                if (prop.node.static) continue;
-                prop.traverse(referenceVisitor, state);
-              }
-            },
+          const loose = isLoose(this.file, feature);
+          const privateNamesMap = new Map(
+            privateNamesStack[privateNamesStack.length - 1],
           );
-        }
+          privateNamesStack.push(privateNamesMap);
 
-        path = wrapClass(path);
-        path.insertBefore(keysNodes);
-        path.insertAfter([...privateNamesNodes, ...staticNodes]);
+          let constructor;
+          let isDecorated = hasOwnDecorators(path.node);
+          const props = [];
+          const elements = [];
+          const computedPaths = [];
+          const privateNames = new Set();
+          const body = path.get("body");
+
+          for (const path of body.get("body")) {
+            verifyUsedFeatures(path, this.file);
+
+            if (path.node.computed) {
+              computedPaths.push(path);
+            }
+
+            if (path.isPrivate()) {
+              const { name } = path.node.key.id;
+              const getName = `get ${name}`;
+              const setName = `set ${name}`;
+
+              if (path.node.kind === "get") {
+                if (
+                  privateNames.has(getName) ||
+                  (privateNames.has(name) && !privateNames.has(setName))
+                ) {
+                  throw path.buildCodeFrameError("Duplicate private field");
+                }
+
+                privateNames.add(getName).add(name);
+              } else if (path.node.kind === "set") {
+                if (
+                  privateNames.has(setName) ||
+                  (privateNames.has(name) && !privateNames.has(getName))
+                ) {
+                  throw path.buildCodeFrameError("Duplicate private field");
+                }
+
+                privateNames.add(setName).add(name);
+              } else {
+                if (
+                  (privateNames.has(name) &&
+                    !privateNames.has(getName) &&
+                    !privateNames.has(setName)) ||
+                  (privateNames.has(name) &&
+                    (privateNames.has(getName) || privateNames.has(setName)))
+                ) {
+                  throw path.buildCodeFrameError("Duplicate private field");
+                }
+
+                privateNames.add(name);
+              }
+            }
+
+            if (path.isClassMethod({ kind: "constructor" })) {
+              constructor = path;
+            } else {
+              elements.push(path);
+              if (path.isProperty() || path.isPrivate()) {
+                props.push(path);
+              }
+            }
+
+            if (!isDecorated) isDecorated = hasOwnDecorators(path.node);
+          }
+
+          if (!props.length && !isDecorated) return;
+
+          let ref;
+
+          if (path.isClassExpression() || !path.node.id) {
+            nameFunction(path);
+            ref = path.scope.generateUidIdentifier("class");
+          } else {
+            ref = path.node.id;
+          }
+
+          // NODE: These three functions don't support decorators yet,
+          //       but verifyUsedFeatures throws if there are both
+          //       decorators and private fields.
+          const depth = privateNamesStack.length;
+          buildPrivateNamesMap(privateNamesMap, props, depth);
+          const privateNamesNodes = buildPrivateNamesNodes(
+            privateNamesMap,
+            loose,
+            state,
+            depth,
+          );
+
+          transformPrivateNamesUsage(ref, path, privateNamesMap, loose, state);
+
+          let keysNodes, staticNodes, instanceNodes, wrapClass;
+
+          if (isDecorated) {
+            staticNodes = keysNodes = [];
+            ({ instanceNodes, wrapClass } = buildDecoratedClass(
+              ref,
+              path,
+              elements,
+              this.file,
+            ));
+          } else {
+            keysNodes = extractComputedKeys(
+              ref,
+              path,
+              computedPaths,
+              this.file,
+            );
+            ({ staticNodes, instanceNodes, wrapClass } = buildFieldsInitNodes(
+              ref,
+              path.node.superClass,
+              props,
+              privateNamesMap,
+              state,
+              loose,
+            ));
+          }
+
+          if (instanceNodes.length > 0) {
+            injectInitialization(
+              path,
+              constructor,
+              instanceNodes,
+              (referenceVisitor, state) => {
+                if (isDecorated) return;
+                for (const prop of props) {
+                  if (prop.node.static) continue;
+                  prop.traverse(referenceVisitor, state);
+                }
+              },
+            );
+          }
+
+          path = wrapClass(path);
+          path.insertBefore(keysNodes);
+          path.insertAfter([...privateNamesNodes, ...staticNodes]);
+        },
+
+        exit() {
+          privateNamesStack.pop();
+        },
       },
 
       PrivateName(path) {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed-redeclared/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed-redeclared/input.js
@@ -1,0 +1,14 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      #foo = 2;
+
+      [this.#foo]() {
+      }
+    }
+
+    this.#foo;
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed-redeclared/output.js
@@ -1,0 +1,43 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var _babelHelpers$classPr;
+
+      _babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo2)[_foo2];
+
+      var Nested = /*#__PURE__*/function () {
+        function Nested() {
+          babelHelpers.classCallCheck(this, Nested);
+          Object.defineProperty(this, _foo2, {
+            writable: true,
+            value: 2
+          });
+        }
+
+        babelHelpers.createClass(Nested, [{
+          key: _babelHelpers$classPr,
+          value: function () {}
+        }]);
+        return Nested;
+      }();
+
+      var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+
+      babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo];
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed/input.js
@@ -1,0 +1,12 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      [this.#foo]() {
+      }
+    }
+
+    this.#foo;
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed/output.js
@@ -1,0 +1,35 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var _this = this;
+
+      var Nested = /*#__PURE__*/function () {
+        function Nested() {
+          babelHelpers.classCallCheck(this, Nested);
+        }
+
+        babelHelpers.createClass(Nested, [{
+          key: babelHelpers.classPrivateFieldLooseBase(_this, _foo)[_foo],
+          value: function () {}
+        }]);
+        return Nested;
+      }();
+
+      babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo];
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-other-redeclared/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-other-redeclared/input.js
@@ -1,0 +1,18 @@
+class Foo {
+  #foo = 1;
+  #bar = 1;
+
+  test() {
+    class Nested {
+      #bar = 2;
+
+      test() {
+        this.#foo;
+        this.#bar;
+      }
+    }
+
+    this.#foo;
+    this.#bar;
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-other-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-other-redeclared/output.js
@@ -1,0 +1,49 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+    Object.defineProperty(this, _bar, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var Nested = /*#__PURE__*/function () {
+        function Nested() {
+          babelHelpers.classCallCheck(this, Nested);
+          Object.defineProperty(this, _bar2, {
+            writable: true,
+            value: 2
+          });
+        }
+
+        babelHelpers.createClass(Nested, [{
+          key: "test",
+          value: function test() {
+            babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo];
+            babelHelpers.classPrivateFieldLooseBase(this, _bar2)[_bar2];
+          }
+        }]);
+        return Nested;
+      }();
+
+      var _bar2 = babelHelpers.classPrivateFieldLooseKey("bar");
+
+      babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo];
+      babelHelpers.classPrivateFieldLooseBase(this, _bar)[_bar];
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+var _bar = babelHelpers.classPrivateFieldLooseKey("bar");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-redeclared/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-redeclared/input.js
@@ -1,0 +1,15 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      #foo = 2;
+
+      test() {
+        this.#foo;
+      }
+    }
+
+    this.#foo;
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-redeclared/output.js
@@ -1,0 +1,41 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var Nested = /*#__PURE__*/function () {
+        function Nested() {
+          babelHelpers.classCallCheck(this, Nested);
+          Object.defineProperty(this, _foo2, {
+            writable: true,
+            value: 2
+          });
+        }
+
+        babelHelpers.createClass(Nested, [{
+          key: "test",
+          value: function test() {
+            babelHelpers.classPrivateFieldLooseBase(this, _foo2)[_foo2];
+          }
+        }]);
+        return Nested;
+      }();
+
+      var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+
+      babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo];
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class/input.js
@@ -1,0 +1,13 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      test() {
+        this.#foo;
+      }
+    }
+
+    this.#foo;
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class/output.js
@@ -1,0 +1,35 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var Nested = /*#__PURE__*/function () {
+        function Nested() {
+          babelHelpers.classCallCheck(this, Nested);
+        }
+
+        babelHelpers.createClass(Nested, [{
+          key: "test",
+          value: function test() {
+            babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo];
+          }
+        }]);
+        return Nested;
+      }();
+
+      babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo];
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed-redeclared/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed-redeclared/input.js
@@ -1,0 +1,14 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      #foo = 2;
+
+      [this.#foo]() {
+      }
+    }
+
+    this.#foo;
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed-redeclared/output.js
@@ -1,0 +1,45 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+
+    _foo.set(this, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var _babelHelpers$classPr;
+
+      _babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo2);
+
+      var Nested = /*#__PURE__*/function () {
+        function Nested() {
+          babelHelpers.classCallCheck(this, Nested);
+
+          _foo2.set(this, {
+            writable: true,
+            value: 2
+          });
+        }
+
+        babelHelpers.createClass(Nested, [{
+          key: _babelHelpers$classPr,
+          value: function () {}
+        }]);
+        return Nested;
+      }();
+
+      var _foo2 = new WeakMap();
+
+      babelHelpers.classPrivateFieldGet(this, _foo);
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed/input.js
@@ -1,0 +1,12 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      [this.#foo]() {
+      }
+    }
+
+    this.#foo;
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed/output.js
@@ -1,0 +1,36 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+
+    _foo.set(this, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var _this = this;
+
+      var Nested = /*#__PURE__*/function () {
+        function Nested() {
+          babelHelpers.classCallCheck(this, Nested);
+        }
+
+        babelHelpers.createClass(Nested, [{
+          key: babelHelpers.classPrivateFieldGet(_this, _foo),
+          value: function () {}
+        }]);
+        return Nested;
+      }();
+
+      babelHelpers.classPrivateFieldGet(this, _foo);
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-other-redeclared/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-other-redeclared/input.js
@@ -1,0 +1,18 @@
+class Foo {
+  #foo = 1;
+  #bar = 1;
+
+  test() {
+    class Nested {
+      #bar = 2;
+
+      test() {
+        this.#foo;
+        this.#bar;
+      }
+    }
+
+    this.#foo;
+    this.#bar;
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-other-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-other-redeclared/output.js
@@ -1,0 +1,52 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+
+    _foo.set(this, {
+      writable: true,
+      value: 1
+    });
+
+    _bar.set(this, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var Nested = /*#__PURE__*/function () {
+        function Nested() {
+          babelHelpers.classCallCheck(this, Nested);
+
+          _bar2.set(this, {
+            writable: true,
+            value: 2
+          });
+        }
+
+        babelHelpers.createClass(Nested, [{
+          key: "test",
+          value: function test() {
+            babelHelpers.classPrivateFieldGet(this, _foo);
+            babelHelpers.classPrivateFieldGet(this, _bar2);
+          }
+        }]);
+        return Nested;
+      }();
+
+      var _bar2 = new WeakMap();
+
+      babelHelpers.classPrivateFieldGet(this, _foo);
+      babelHelpers.classPrivateFieldGet(this, _bar);
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = new WeakMap();
+
+var _bar = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-redeclared/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-redeclared/input.js
@@ -1,0 +1,15 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      #foo = 2;
+
+      test() {
+        this.#foo;
+      }
+    }
+
+    this.#foo;
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-redeclared/output.js
@@ -1,0 +1,43 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+
+    _foo.set(this, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var Nested = /*#__PURE__*/function () {
+        function Nested() {
+          babelHelpers.classCallCheck(this, Nested);
+
+          _foo2.set(this, {
+            writable: true,
+            value: 2
+          });
+        }
+
+        babelHelpers.createClass(Nested, [{
+          key: "test",
+          value: function test() {
+            babelHelpers.classPrivateFieldGet(this, _foo2);
+          }
+        }]);
+        return Nested;
+      }();
+
+      var _foo2 = new WeakMap();
+
+      babelHelpers.classPrivateFieldGet(this, _foo);
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class/input.js
@@ -1,0 +1,13 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      test() {
+        this.#foo;
+      }
+    }
+
+    this.#foo;
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class/output.js
@@ -1,0 +1,36 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+
+    _foo.set(this, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var Nested = /*#__PURE__*/function () {
+        function Nested() {
+          babelHelpers.classCallCheck(this, Nested);
+        }
+
+        babelHelpers.createClass(Nested, [{
+          key: "test",
+          value: function test() {
+            babelHelpers.classPrivateFieldGet(this, _foo);
+          }
+        }]);
+        return Nested;
+      }();
+
+      babelHelpers.classPrivateFieldGet(this, _foo);
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = new WeakMap();


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

We failed to properly handle nested private field, when only a single private field was redeclared. [Example](https://babeljs.io/repl/#?browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=MYGwhgzhAEBiD29oG8BQ1oGIBmjoF5oBGAbnSwCMwAnA4s8gFwFMJGAKeRgC2eoEoU5DKEgwAcqxYATIRnmUadAEwMFGFm3aC06-TwCWEAHQ5EZPRu5HTVahfUBfYdGcZnzoA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=stage-2&prettier=false&targets=&version=7.9.0&externalPlugins=)

When we hit a nested class that redeclares a field, we [skip the nested class](https://github.com/babel/babel/blob/070ec201bb1ab8bf78fbb3c7aff2337056bf0ae3/packages/babel-helper-create-class-features-plugin/src/fields.js#L94-L98). And when we finally traverse that nested class, we'll only have the privates that are declared by it. We've lost the ancestor's private fields!