### PR TITLE
Add "Ping Asignees" GitHub action

### DIFF
--- a/.github/workflows/ping-assignees.yml
+++ b/.github/workflows/ping-assignees.yml
@@ -15,7 +15,7 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           bot_name: babel-bot
           days_before_warning: 14
-          days_before_unassigning: 7
+          days_before_unassigning: 70
           comment: >
             Hi, @${username}! It has been 2 weeks since your last update: are
             you still working on this issue?

--- a/.github/workflows/ping-assignees.yml
+++ b/.github/workflows/ping-assignees.yml
@@ -1,0 +1,31 @@
+name: Ping Assignees
+
+on:
+  # Every day at 0:00
+  schedule: 0 0 * * *
+
+jobs:
+  ping_assignees:
+    name: Ping Assignees
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Assignees
+        uses: babel/actions/check-assigned-issues@v2
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          bot_name: babel-bot
+          days_before_warning: 14
+          days_before_unassigning: 7
+          comment: >
+            Hi, @${username}! It has been 2 weeks since your last update: are
+            you still working on this issue?
+
+
+            If you need any help, please ask either here or on
+            [Slack](https://babeljs.slack.com/) (you can sign-up
+            [here](https://slack.babeljs.io/) for an invite)!
+            If you just need more time, please leave a comment here.
+
+
+            If I don't get any response in one week, this issue will be
+            unassigned so that other contributors can claim it.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

- Ping assignees after 2 weeks to check if they are still working on the bug
- Unassign them after 1 additional week if they don't reply

The action source is at https://github.com/babel/actions/blob/v2/check-assigned-issues/main.js

I have tested this action at https://github.com/babel/test-github-actions/issues/56 (private repo), using 5 and 2 minutes instead of 14 and 7 days.