### PR TITLE
Throw error for TypeScript `declare const enum`

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/enum.js
+++ b/packages/babel-plugin-transform-typescript/src/enum.js
@@ -3,13 +3,13 @@ import { template } from "@babel/core";
 
 export default function transpileEnum(path, t) {
   const { node } = path;
+  if (node.const) {
+    throw path.buildCodeFrameError("'const' enums are not supported.");
+  }
+
   if (node.declare) {
     path.remove();
     return;
-  }
-
-  if (node.const) {
-    throw path.buildCodeFrameError("'const' enums are not supported.");
   }
 
   const name = node.id.name;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/declarations/const-enum/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/declarations/const-enum/input.ts
@@ -1,0 +1,1 @@
+declare const enum E {}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/declarations/const-enum/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/declarations/const-enum/options.json
@@ -1,0 +1,1 @@
+{ "throws": "'const' enums are not supported." }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10785 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 👍
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In #10785 @fiesh reported that `declare const enum` was transpiling as if it was `declare enum`. Since we don't support `const enum`, an error should be thrown whether it has `declare` or not.