### PR TITLE
fix: report missing plugins on type exports

### DIFF
--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1845,7 +1845,7 @@ export default class StatementParser extends ExpressionParser {
         const l = this.lookahead();
         // If we see any variable name other than `from` after `type` keyword,
         // we consider it as flow/typescript type exports
-        // note that this approach may fail on some pedentic cases
+        // note that this approach may fail on some pedantic cases
         // export type from = number
         if (
           (l.type === tt.name && l.value !== "from") ||

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1834,11 +1834,12 @@ export default class StatementParser extends ExpressionParser {
 
   isExportDefaultSpecifier(): boolean {
     if (this.match(tt.name)) {
-      if (this.state.value === "async" || this.state.value === "let") {
+      const value = this.state.value;
+      if (value === "async" || value === "let") {
         return false;
       }
       if (
-        (this.state.value === "type" || this.state.value === "interface") &&
+        (value === "type" || value === "interface") &&
         !this.state.containsEsc
       ) {
         const l = this.lookahead();

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1834,10 +1834,27 @@ export default class StatementParser extends ExpressionParser {
 
   isExportDefaultSpecifier(): boolean {
     if (this.match(tt.name)) {
-      return this.state.value !== "async" && this.state.value !== "let";
-    }
-
-    if (!this.match(tt._default)) {
+      if (this.state.value === "async" || this.state.value === "let") {
+        return false;
+      }
+      if (
+        (this.state.value === "type" || this.state.value === "interface") &&
+        !this.state.containsEsc
+      ) {
+        const l = this.lookahead();
+        // If we see any variable name other than `from` after `type` keyword,
+        // we consider it as flow/typescript type exports
+        // note that this approach may fail on some pedentic cases
+        // export type from = number
+        if (
+          (l.type === tt.name && l.value !== "from") ||
+          l.type === tt.braceL
+        ) {
+          this.expectOnePlugin(["flow", "typescript"]);
+          return false;
+        }
+      }
+    } else if (!this.match(tt._default)) {
       return false;
     }
 

--- a/packages/babel-parser/test/fixtures/flow/expect-plugin/export-interface/input.js
+++ b/packages/babel-parser/test/fixtures/flow/expect-plugin/export-interface/input.js
@@ -1,0 +1,1 @@
+export interface Foo {}

--- a/packages/babel-parser/test/fixtures/flow/expect-plugin/export-interface/options.json
+++ b/packages/babel-parser/test/fixtures/flow/expect-plugin/export-interface/options.json
@@ -1,0 +1,7 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "jsx"
+  ],
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (1:7)"
+}

--- a/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type-named/input.js
+++ b/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type-named/input.js
@@ -1,0 +1,2 @@
+var Foo;
+export type { Foo };

--- a/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type-named/options.json
+++ b/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type-named/options.json
@@ -1,0 +1,7 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "jsx"
+  ],
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (2:7)"
+}

--- a/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type/input.js
+++ b/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type/input.js
@@ -1,0 +1,1 @@
+export type Foo = number;

--- a/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type/options.json
+++ b/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type/options.json
@@ -1,0 +1,7 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "jsx"
+  ],
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (1:7)"
+}

--- a/packages/babel-parser/test/fixtures/flow/expect-plugin/options.json
+++ b/packages/babel-parser/test/fixtures/flow/expect-plugin/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-interface/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-interface/input.js
@@ -1,0 +1,1 @@
+export interface Foo {}

--- a/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-interface/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-interface/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (1:7)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type-named/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type-named/input.js
@@ -1,0 +1,2 @@
+var Foo;
+export type { Foo };

--- a/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type-named/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type-named/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (2:7)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type/input.js
@@ -1,0 +1,1 @@
+export type Foo = number;

--- a/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (1:7)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/expect-plugin/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/expect-plugin/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7954, closes #8080, fixes #11331
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR throws more helpful errors on type exports supported by both Flow and TypeScript
```js
export type Foo = number;
```

It is also considered as a bug fix as type exports should never be considered as exportDefault from clause.

To simplify the parser logic, the current approach does not warn missing flow helpers for the following pedantic case:
```js
export type from = number;
```
which means it will still throw missing `exportDefaultFrom` plugins though it is a valid type exports. I think this situation still acceptable and practically only those flow codes with such statements as the first one will trigger this issue.