### PR TITLE
Support custom parserOpts for babel parser in @babel/eslint-parser

### DIFF
--- a/eslint/babel-eslint-parser/src/configuration.js
+++ b/eslint/babel-eslint-parser/src/configuration.js
@@ -30,18 +30,34 @@ export function normalizeBabelParseConfig(options) {
     exclude: options.babelOptions.exclude,
     ignore: options.babelOptions.ignore,
     only: options.babelOptions.only,
-    parserOpts: {
-      allowImportExportEverywhere: options.allowImportExportEverywhere,
-      allowReturnOutsideFunction: true,
-      allowSuperOutsideMethod: true,
-      ranges: true,
-      tokens: true,
-      plugins: ["estree"],
-    },
+    parserOpts: normalizeBabelParserOptions(options),
     caller: {
       name: "@babel/eslint-parser",
     },
   };
+
+  function normalizeBabelParserOptions(options) {
+    const parserOpts = options.babelOptions.parserOpts || {};
+    const parserPlugins = parserOpts.plugins || [];
+
+    const normalizedParserOptions = Object.assign(
+      {
+        allowReturnOutsideFunction: true,
+        allowSuperOutsideMethod: true,
+        ranges: true,
+        tokens: true,
+      },
+      parserOpts,
+    );
+
+    normalizedParserOptions.plugins = ["estree", ...parserPlugins];
+    if (options.allowImportExportEverywhere !== undefined) {
+      normalizedParserOptions.allowImportExportEverywhere =
+        options.allowImportExportEverywhere;
+    }
+
+    return normalizedParserOptions;
+  }
 
   if (options.requireConfigFile !== false) {
     const config = loadPartialConfig(parseOptions);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A<!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | N/A
| Major: Breaking Change?  | N/A
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

The README for `@babel/eslint-parser` states:

> - `babelOptions` passes through Babel's configuration [loading](https://babeljs.io/docs/en/options#config-loading-options) and [merging](https://babeljs.io/docs/en/options#config-merging-options) options (for instance, in case of a monorepo). When not defined, @babel/eslint-parser will use Babel's default configuration file resolution logic.

However, this hasn't exactly been true, because you can't override *all* of the babel parser's options. With this, there's now capability to use neat features like the `flowComments` plugin to lint flow comments just like flow typings.
