### PR TITLE
 Fix redeclaring private in nested class's superClass

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -103,7 +103,6 @@ const privateNameVisitor = {
     // This class redeclares some private field. We need to process the outer
     // environment with access to all the outer privates, then we can process
     // the inner environment with only the still-visible outer privates.
-    path.get("superClass").traverse(privateNameVisitor, this);
     path.get("body").traverse(privateNameNestedVisitor, {
       ...this,
       redeclared,
@@ -115,7 +114,7 @@ const privateNameVisitor = {
 
     // We'll eventually hit this class node again with the overall Class
     // Features visitor, which'll process the redeclared privates.
-    path.skip();
+    path.skipKey("body");
   },
 };
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed-redeclared/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed-redeclared/exec.js
@@ -1,0 +1,19 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      #foo = 2;
+
+      [this.#foo]() {
+      }
+    }
+
+    return new Nested();
+  }
+}
+
+const f = new Foo();
+expect(() => {
+  f.test();
+}).toThrow();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed/exec.js
@@ -1,0 +1,17 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      [this.#foo]() {
+      }
+    }
+
+    return new Nested();
+  }
+}
+
+const f = new Foo();
+expect(() => {
+  f.test();
+}).not.toThrow();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/exec.js
@@ -1,0 +1,18 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested extends class {
+      #foo = 2;
+
+      [this.#foo] = 2;
+    } {
+      #foo = 3;
+    }
+  }
+}
+
+const f = new Foo();
+expect(() => {
+  f.test();
+}).toThrow();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/input.js
@@ -1,0 +1,12 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested extends class {
+      #foo = 2;
+      [this.#foo] = 2;
+    } {
+      #foo = 3;
+    }
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
@@ -1,0 +1,56 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var _temp, _foo3;
+
+      var _babelHelpers$classPr;
+
+      var Nested = /*#__PURE__*/function (_ref) {
+        babelHelpers.inherits(Nested, _ref);
+
+        var _super = babelHelpers.createSuper(Nested);
+
+        function Nested(...args) {
+          var _this;
+
+          babelHelpers.classCallCheck(this, Nested);
+          _this = _super.call(this, ...args);
+          Object.defineProperty(babelHelpers.assertThisInitialized(_this), _foo2, {
+            writable: true,
+            value: 3
+          });
+          return _this;
+        }
+
+        return Nested;
+      }((_temp = (_babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo3)[_foo3], /*#__PURE__*/function () {
+        function _class2() {
+          babelHelpers.classCallCheck(this, _class2);
+          Object.defineProperty(this, _foo3, {
+            writable: true,
+            value: 2
+          });
+          this[_babelHelpers$classPr] = 2;
+        }
+
+        return _class2;
+      }()), _foo3 = babelHelpers.classPrivateFieldLooseKey("foo"), _temp));
+
+      var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed/exec.js
@@ -1,0 +1,18 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested extends class {
+      [this.#foo] = 2;
+    } {
+      #foo = 3;
+    }
+
+    return new Nested();
+  }
+}
+
+const f = new Foo();
+expect(() => {
+  f.test();
+}).not.toThrow();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed/input.js
@@ -1,0 +1,11 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested extends class {
+      [this.#foo] = 2;
+    } {
+      #foo = 3;
+    }
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
@@ -1,0 +1,52 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var _temp;
+
+      var _babelHelpers$classPr;
+
+      var Nested = /*#__PURE__*/function (_ref) {
+        babelHelpers.inherits(Nested, _ref);
+
+        var _super = babelHelpers.createSuper(Nested);
+
+        function Nested(...args) {
+          var _this;
+
+          babelHelpers.classCallCheck(this, Nested);
+          _this = _super.call(this, ...args);
+          Object.defineProperty(babelHelpers.assertThisInitialized(_this), _foo2, {
+            writable: true,
+            value: 3
+          });
+          return _this;
+        }
+
+        return Nested;
+      }((_temp = (_babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo], /*#__PURE__*/function () {
+        function _class2() {
+          babelHelpers.classCallCheck(this, _class2);
+          this[_babelHelpers$classPr] = 2;
+        }
+
+        return _class2;
+      }()), _temp));
+
+      var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed-redeclared/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed-redeclared/exec.js
@@ -1,0 +1,19 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      #foo = 2;
+
+      [this.#foo]() {
+      }
+    }
+
+    return new Nested();
+  }
+}
+
+const f = new Foo();
+expect(() => {
+  f.test();
+}).toThrow();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed/exec.js
@@ -1,0 +1,17 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      [this.#foo]() {
+      }
+    }
+
+    return new Nested();
+  }
+}
+
+const f = new Foo();
+expect(() => {
+  f.test();
+}).not.toThrow();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/exec.js
@@ -1,0 +1,18 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested extends class {
+      #foo = 2;
+
+      [this.#foo] = 2;
+    } {
+      #foo = 3;
+    }
+  }
+}
+
+const f = new Foo();
+expect(() => {
+  f.test();
+}).toThrow();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/input.js
@@ -1,0 +1,12 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested extends class {
+      #foo = 2;
+      [this.#foo] = 2;
+    } {
+      #foo = 3;
+    }
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
@@ -1,0 +1,61 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+
+    _foo.set(this, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var _temp, _foo3;
+
+      var _babelHelpers$classPr;
+
+      var Nested = /*#__PURE__*/function (_ref) {
+        babelHelpers.inherits(Nested, _ref);
+
+        var _super = babelHelpers.createSuper(Nested);
+
+        function Nested(...args) {
+          var _this;
+
+          babelHelpers.classCallCheck(this, Nested);
+          _this = _super.call(this, ...args);
+
+          _foo2.set(babelHelpers.assertThisInitialized(_this), {
+            writable: true,
+            value: 3
+          });
+
+          return _this;
+        }
+
+        return Nested;
+      }((_temp = (_babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo3), /*#__PURE__*/function () {
+        function _class2() {
+          babelHelpers.classCallCheck(this, _class2);
+
+          _foo3.set(this, {
+            writable: true,
+            value: 2
+          });
+
+          babelHelpers.defineProperty(this, _babelHelpers$classPr, 2);
+        }
+
+        return _class2;
+      }()), _foo3 = new WeakMap(), _temp));
+
+      var _foo2 = new WeakMap();
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed/exec.js
@@ -1,0 +1,18 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested extends class {
+      [this.#foo] = 2;
+    } {
+      #foo = 3;
+    }
+
+    return new Nested();
+  }
+}
+
+const f = new Foo();
+expect(() => {
+  f.test();
+}).not.toThrow();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed/input.js
@@ -1,0 +1,11 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested extends class {
+      [this.#foo] = 2;
+    } {
+      #foo = 3;
+    }
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
@@ -1,0 +1,55 @@
+var Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+
+    _foo.set(this, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      var _temp;
+
+      var _babelHelpers$classPr;
+
+      var Nested = /*#__PURE__*/function (_ref) {
+        babelHelpers.inherits(Nested, _ref);
+
+        var _super = babelHelpers.createSuper(Nested);
+
+        function Nested(...args) {
+          var _this;
+
+          babelHelpers.classCallCheck(this, Nested);
+          _this = _super.call(this, ...args);
+
+          _foo2.set(babelHelpers.assertThisInitialized(_this), {
+            writable: true,
+            value: 3
+          });
+
+          return _this;
+        }
+
+        return Nested;
+      }((_temp = (_babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo), /*#__PURE__*/function () {
+        function _class2() {
+          babelHelpers.classCallCheck(this, _class2);
+          babelHelpers.defineProperty(this, _babelHelpers$classPr, 2);
+        }
+
+        return _class2;
+      }()), _temp));
+
+      var _foo2 = new WeakMap();
+    }
+  }]);
+  return Foo;
+}();
+
+var _foo = new WeakMap();


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

If a nested class's `superClass` redeclares the outer class's private field and access it in a computed key, that should fail.

Follow up to #11405.