### PR TITLE
Update chokidar to v3

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -29,7 +29,7 @@
     "source-map": "^0.5.0"
   },
   "optionalDependencies": {
-    "chokidar": "^2.1.8"
+    "chokidar": "^3.3.1 || ^2.1.8"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR Link    | No
| Any Dependency Changes?  | `@babel/cli#chokidar`
| License                  | MIT

Alternate to #10741 which was closed in favor of #10747. Unfortunately #10747 can't be backported to v7. 

Bumping chokidar is important because it has a transitive dependency on `kind-of@^3.2.2`  (via `chokidar#braces#snapdragon-*`). `kind-of` prior to 6.0.2 has a security vulnerability: https://github.com/advisories/GHSA-6c8f-qphg-qjgp.
