### PR TITLE
Don't include "resolve" in @babel/standalone

### DIFF
--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -12,7 +12,8 @@
     "babel-plugin"
   ],
   "browser": {
-    "./lib/get-runtime-path/index.js": "./lib/get-runtime-path/browser.js"
+    "./lib/get-runtime-path/index.js": "./lib/get-runtime-path/browser.js",
+    "./src/get-runtime-path/index.js": "./src/get-runtime-path/browser.js"
   },
   "dependencies": {
     "@babel/helper-module-imports": "^7.8.3",

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -11,6 +11,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "browser": {
+    "./lib/get-runtime-path/index.js": "./lib/get-runtime-path/browser.js"
+  },
   "dependencies": {
     "@babel/helper-module-imports": "^7.8.3",
     "@babel/helper-plugin-utils": "^7.8.3",

--- a/packages/babel-plugin-transform-runtime/src/get-runtime-path/browser.js
+++ b/packages/babel-plugin-transform-runtime/src/get-runtime-path/browser.js
@@ -1,0 +1,7 @@
+export default function(moduleName, dirname, absoluteRuntime) {
+  if (absoluteRuntime === false) return moduleName;
+
+  throw new Error(
+    "The 'absoluteRuntime' option is not supported when using @babel/standalone.",
+  );
+}

--- a/packages/babel-plugin-transform-runtime/src/get-runtime-path/index.js
+++ b/packages/babel-plugin-transform-runtime/src/get-runtime-path/index.js
@@ -1,0 +1,30 @@
+import path from "path";
+import resolve from "resolve";
+
+export default function(moduleName, dirname, absoluteRuntime) {
+  if (absoluteRuntime === false) return moduleName;
+
+  return resolveAbsoluteRuntime(
+    moduleName,
+    path.resolve(dirname, absoluteRuntime === true ? "." : absoluteRuntime),
+  );
+}
+
+function resolveAbsoluteRuntime(moduleName: string, dirname: string) {
+  try {
+    return path
+      .dirname(resolve.sync(`${moduleName}/package.json`, { basedir: dirname }))
+      .replace(/\\/g, "/");
+  } catch (err) {
+    if (err.code !== "MODULE_NOT_FOUND") throw err;
+
+    throw Object.assign(
+      new Error(`Failed to resolve "${moduleName}" relative to "${dirname}"`),
+      {
+        code: "BABEL_RUNTIME_NOT_FOUND",
+        runtime: moduleName,
+        dirname,
+      },
+    );
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Starting from https://github.com/browserify/resolve/pull/217, `resolve` unconditionally uses the `fs` object (even if we don't call any `resolve` function).

This is a problem in `@babel/standalone` since `fs` isn't available there. However, `resolve` shouldn't have been included in `@babel/standalone` in the first place :shrug: 
