### PR TITLE
refactor(babel-node): Refactor babel-node tests configuration

### DIFF
--- a/packages/babel-node/test/config.json
+++ b/packages/babel-node/test/config.json
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    "../../babel-preset-env",
+    ["../../babel-preset-react"]
+  ],
+  "plugins": [
+    "../../babel-plugin-transform-strict-mode",
+    "../../babel-plugin-transform-modules-commonjs"
+  ],
+  "only": ["../../../packages/*/test"]
+}

--- a/packages/babel-node/test/index.js
+++ b/packages/babel-node/test/index.js
@@ -20,16 +20,6 @@ const outputFileSync = function(filePath, data) {
   fs.writeFileSync(filePath, data);
 };
 
-const presetLocs = [
-  path.join(__dirname, "../../babel-preset-env"),
-  path.join(__dirname, "../../babel-preset-react"),
-].join(",");
-
-const pluginLocs = [
-  path.join(__dirname, "/../../babel-plugin-transform-strict-mode"),
-  path.join(__dirname, "/../../babel-plugin-transform-modules-commonjs"),
-].join(",");
-
 const readDir = function(loc, filter) {
   const files = {};
   if (fs.existsSync(loc)) {
@@ -105,12 +95,8 @@ const buildTest = function(binName, testName, opts) {
 
   return function(callback) {
     saveInFiles(opts.inFiles);
-
     let args = [binLoc];
-
-    args.push("--presets", presetLocs, "--plugins", pluginLocs);
-    args.push("--only", "../../../../packages/*/test");
-
+    args.push("--config-file", "../config.json");
     args = args.concat(opts.args);
 
     const spawn = child.spawn(process.execPath, args);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR is blocking https://github.com/babel/babel/pull/11436. The babel-node `require` test in #11436 which tries to parse [JSX](https://github.com/babel/babel/blob/master/packages/babel-node/test/fixtures/babel-node/require/in-files/not_node_modules.jsx) fails because of the default JSX compilation runtime change to `automatic`. To fix, I had to pass `{ runtime: 'classic' }` option to the react preset [here](https://github.com/babel/babel/blob/master/packages/babel-node/test/index.js#L25). @JLHwung suggested refactoring the test configuration setup in a separate PR against master (to not wait until #11436 waits).