### PR TITLE
remove `< x.y.z` engines specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
 
 install: skip
 before_script:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install make; fi
 
 script:

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "@lerna/collect-updates": "https://github.com/babel/lerna.git#babel-collect-updates"
   },
   "engines": {
-    "node": ">= 6.9.0 < 14.0.0",
-    "npm": ">= 3.x <= 6.x",
+    "node": ">= 6.9.0",
+    "npm": ">= 3.x",
     "yarn": ">=0.27.5 || >=1.0.0-20170811"
   },
   "lint-staged": {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Here we remove the `< x.y.z` in the root project engine specifications. This also aligns to what we did in `@babel/core`. Hopefully it should fix our failing master due to the release of Node.js 14.