### PR TITLE
Support data-type="module" to generate native <script type="module">

### DIFF
--- a/packages/babel-standalone/src/transformScriptTags.js
+++ b/packages/babel-standalone/src/transformScriptTags.js
@@ -53,6 +53,9 @@ function buildBabelOptions(script, filename) {
  */
 function run(transformFn, script) {
   const scriptEl = document.createElement("script");
+  if (typeof script.type !== "undefined") {
+    scriptEl.setAttribute("type", script.type);
+  }
   scriptEl.text = transformCode(transformFn, script);
   headEl.appendChild(scriptEl);
 }
@@ -129,6 +132,7 @@ function loadScripts(transformFn, scripts) {
     const scriptData = {
       // script.async is always true for non-JavaScript script tags
       async: script.hasAttribute("async"),
+      type: script.getAttribute("data-type"),
       error: false,
       executed: false,
       plugins: getPluginsOrPresetsFromScript(script, "data-plugins"),


### PR DESCRIPTION
If you want to use your browser's native ES module support, the `<script>` tag needs to have a `type="module"` attribute. Now, babel standalone can generate native module scripts with `<script type="text/babel" data-type="module">`

```
<!doctype html>
<html>
<head>
  <title>Babel Test</title>
</head>
<body>
  <script src="./babel.js"></script>
  <script type="text/babel" data-presets="react" data-type="module">
    /** @jsx h */
    import { h, render } from 'https://unpkg.com/preact?module';
    render(<h1>Hello World!</h1>, document.body);
  </script>
</body>
</html>
```

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes https://github.com/babel/babel/issues/9448
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | 
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
