### PR TITLE
Remove backward compatibility for union types

### DIFF
--- a/packages/babel-traverse/src/path/inference/inferer-reference.js
+++ b/packages/babel-traverse/src/path/inference/inferer-reference.js
@@ -95,7 +95,7 @@ function getTypeAnnotationBindingConstantViolations(binding, path, name) {
     return;
   }
 
-  if (t.isTSTypeAnnotation(types[0]) && t.createTSUnionType) {
+  if (t.isTSTypeAnnotation(types[0])) {
     return t.createTSUnionType(types);
   }
 
@@ -211,7 +211,7 @@ function getConditionalAnnotation(binding, path, name) {
   }
 
   if (types.length) {
-    if (t.isTSTypeAnnotation(types[0]) && t.createTSUnionType) {
+    if (t.isTSTypeAnnotation(types[0])) {
       return {
         typeAnnotation: t.createTSUnionType(types),
         ifStatement,

--- a/packages/babel-traverse/src/path/inference/inferer-reference.js
+++ b/packages/babel-traverse/src/path/inference/inferer-reference.js
@@ -99,11 +99,7 @@ function getTypeAnnotationBindingConstantViolations(binding, path, name) {
     return t.createTSUnionType(types);
   }
 
-  if (t.createFlowUnionType) {
-    return t.createFlowUnionType(types);
-  }
-
-  return t.createUnionTypeAnnotation(types);
+  return t.createFlowUnionType(types);
 }
 
 function getConstantViolationsBefore(binding, path, functions) {
@@ -218,15 +214,8 @@ function getConditionalAnnotation(binding, path, name) {
       };
     }
 
-    if (t.createFlowUnionType) {
-      return {
-        typeAnnotation: t.createFlowUnionType(types),
-        ifStatement,
-      };
-    }
-
     return {
-      typeAnnotation: t.createUnionTypeAnnotation(types),
+      typeAnnotation: t.createFlowUnionType(types),
       ifStatement,
     };
   }

--- a/packages/babel-traverse/src/path/inference/inferers.js
+++ b/packages/babel-traverse/src/path/inference/inferers.js
@@ -92,11 +92,7 @@ export function LogicalExpression() {
     return t.createTSUnionType(argumentTypes);
   }
 
-  if (t.createFlowUnionType) {
-    return t.createFlowUnionType(argumentTypes);
-  }
-
-  return t.createUnionTypeAnnotation(argumentTypes);
+  return t.createFlowUnionType(argumentTypes);
 }
 
 export function ConditionalExpression() {
@@ -109,11 +105,7 @@ export function ConditionalExpression() {
     return t.createTSUnionType(argumentTypes);
   }
 
-  if (t.createFlowUnionType) {
-    return t.createFlowUnionType(argumentTypes);
-  }
-
-  return t.createUnionTypeAnnotation(argumentTypes);
+  return t.createFlowUnionType(argumentTypes);
 }
 
 export function SequenceExpression() {

--- a/packages/babel-traverse/src/path/inference/inferers.js
+++ b/packages/babel-traverse/src/path/inference/inferers.js
@@ -88,7 +88,7 @@ export function LogicalExpression() {
     this.get("right").getTypeAnnotation(),
   ];
 
-  if (t.isTSTypeAnnotation(argumentTypes[0]) && t.createTSUnionType) {
+  if (t.isTSTypeAnnotation(argumentTypes[0])) {
     return t.createTSUnionType(argumentTypes);
   }
 
@@ -105,7 +105,7 @@ export function ConditionalExpression() {
     this.get("alternate").getTypeAnnotation(),
   ];
 
-  if (t.isTSTypeAnnotation(argumentTypes[0]) && t.createTSUnionType) {
+  if (t.isTSTypeAnnotation(argumentTypes[0])) {
     return t.createTSUnionType(argumentTypes);
   }
 

--- a/packages/babel-types/scripts/generators/flow.js
+++ b/packages/babel-types/scripts/generators/flow.js
@@ -127,8 +127,6 @@ lines.push(
   // eslint-disable-next-line max-len
   `declare function createTypeAnnotationBasedOnTypeof(type: 'string' | 'number' | 'undefined' | 'boolean' | 'function' | 'object' | 'symbol'): ${NODE_PREFIX}TypeAnnotation`,
   // eslint-disable-next-line max-len
-  `declare function createUnionTypeAnnotation(types: Array<${NODE_PREFIX}FlowType>): ${NODE_PREFIX}UnionTypeAnnotation`,
-  // eslint-disable-next-line max-len
   `declare function createFlowUnionType(types: Array<${NODE_PREFIX}FlowType>): ${NODE_PREFIX}UnionTypeAnnotation`,
   // this smells like "internal API"
   // eslint-disable-next-line max-len

--- a/packages/babel-types/scripts/generators/typescript.js
+++ b/packages/babel-types/scripts/generators/typescript.js
@@ -143,11 +143,9 @@ lines.push(
   // builders/
   // eslint-disable-next-line max-len
   `export function createTypeAnnotationBasedOnTypeof(type: 'string' | 'number' | 'undefined' | 'boolean' | 'function' | 'object' | 'symbol'): StringTypeAnnotation | VoidTypeAnnotation | NumberTypeAnnotation | BooleanTypeAnnotation | GenericTypeAnnotation`,
-  `export function createUnionTypeAnnotation<T extends FlowType>(types: [T]): T`,
   `export function createFlowUnionType<T extends FlowType>(types: [T]): T`,
   // this probably misbehaves if there are 0 elements, and it's not a UnionTypeAnnotation if there's only 1
   // it is possible to require "2 or more" for this overload ([T, T, ...T[]]) but it requires typescript 3.0
-  `export function createUnionTypeAnnotation(types: ReadonlyArray<FlowType>): UnionTypeAnnotation`,
   `export function createFlowUnionType(types: ReadonlyArray<FlowType>): UnionTypeAnnotation`,
   // this smells like "internal API"
   // eslint-disable-next-line max-len

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -9,7 +9,6 @@ export * from "./asserts/generated";
 
 // builders
 export { default as createTypeAnnotationBasedOnTypeof } from "./builders/flow/createTypeAnnotationBasedOnTypeof";
-export { default as createUnionTypeAnnotation } from "./builders/flow/createFlowUnionType";
 export { default as createFlowUnionType } from "./builders/flow/createFlowUnionType";
 export { default as createTSUnionType } from "./builders/typescript/createTSUnionType";
 export * from "./builders/generated";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | Yes ⚠️
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

Several requests regards TypeScript union types saved backward compatibility
Here I remove them for major update (Babel 8)

Related issue:
* https://github.com/babel/babel/issues/9530

Related PRs:
* https://github.com/babel/babel/pull/11378
* https://github.com/babel/babel/pull/11448