### PR TITLE
Fix evaluation order with object spread, 2

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/output.js
@@ -11,11 +11,11 @@ var d;
 var x;
 var y;
 
-_objectSpread({
+_objectSpread(_objectSpread(_objectSpread({
   x
-}, y, {
+}, y), {}, {
   a
-}, b, {
+}, b), {}, {
   c
 });
 
@@ -25,9 +25,9 @@ _objectSpread({}, {
   foo: 'bar'
 });
 
-_objectSpread({}, {
+_objectSpread(_objectSpread({}, {
   foo: 'bar'
-}, {}, {
+}), {
   bar: 'baz'
 });
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/side-effect/exec.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/side-effect/exec.js
@@ -1,4 +1,8 @@
 var k = { a: 1, b: 2 };
 var o = { a: 3, ...k, b: k.a++ };
-
 expect(o).toEqual({a: 1, b: 1});
+
+var k = { a: 1, get b() { l = { z: 9 }; return 2; } };
+var l = { c: 3 };
+var o = { ...k, ...l };
+expect(o).toEqual({ a: 1, b: 2, z: 9 });

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/side-effect/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/side-effect/output.js
@@ -25,15 +25,15 @@ function impureFunc() {
   console.log('hello');
 }
 
-var output = _objectSpread(_objectSpread(_objectSpread({}, pureA), {}, {
+var output = _objectSpread(_objectSpread(_objectSpread(_objectSpread(_objectSpread(_objectSpread({}, pureA), {}, {
   get foo() {},
 
   get bar() {}
 
-}, pureB, {}, pureC, {}), impureFunc(), {}, pureD, {
+}, pureB), pureC), impureFunc()), pureD), {}, {
   pureD
 });
 
-var simpleOutput = _objectSpread({}, pureA, {
+var simpleOutput = _objectSpread(_objectSpread({}, pureA), {}, {
   test: '1'
 }, pureB);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

When reviewing https://github.com/babel/babel/pull/11412, I noticed in the [TypeScript](https://github.com/microsoft/TypeScript/blob/eb105efdcd6db8a73f5b983bf329cb7a5eee55e1/src/compiler/transformers/es2018.ts#L272) link that there are more cases where the intermediate values can mutate the spread reference. In `{ ...obj, p }`, `obj` can contain a getter prop that mutates the `p` binding. If were to continue transforming into `_objectSpread({}, obj, { p })`, then the `p` binding will not be mutated correctly.

We may want to just abandon `objectSpread` and `objectSpread2`, and introduce `spreadWithGet` and `spreadWithGetOwnProperty` helpers to handle the exact arg as needed.