### PR TITLE
Disable e2e-babel-old-version test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,9 +199,9 @@ workflows:
       - e2e-babel:
           requires:
             - publish-verdaccio
-      - e2e-babel-old-version:
-          requires:
-            - publish-verdaccio
+      # - e2e-babel-old-version:
+      #     requires:
+      #       - publish-verdaccio
       - e2e-create-react-app:
           requires:
             - publish-verdaccio


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Since Babel 8 is expected to break compatibility with Babel 7.0.0, it doesn't make sense to test it.

For example, it (correctly) fails in https://github.com/babel/babel/pull/11468