### PR TITLE
Canary build of packages using CodeSandbox CI + mini repl

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "bootstrap",
+  "installCommand": "codesandbox",
   "buildCommand": false,
-  "sandboxes": ["kypop"]
+  "sandboxes": ["kypop", "hk4lv"]
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,6 @@
 {
   "installCommand": "codesandbox",
   "buildCommand": false,
-  "sandboxes": ["kypop", "hk4lv"],
+  "sandboxes": ["9d0wg"],
   "packages": ["packages/*"]
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,6 @@
 {
   "installCommand": "codesandbox",
   "buildCommand": false,
-  "sandboxes": ["kypop", "hk4lv"]
+  "sandboxes": ["kypop", "hk4lv"],
+  "packages": ["packages/*"]
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "scripts": {
     "bootstrap": "make bootstrap",
+    "codesandbox": "make bootstrap-only; make build-no-bundle",
     "build": "make build",
     "fix": "make fix",
     "lint": "make lint",


### PR DESCRIPTION
Done with @nicolo-ribaudo! Got to learn more about Next, CodeSandbox, babel-standalone 😄  

> Did some tests earlier on local fork https://github.com/hzoo/babel/pull/3

Current Babel template (forked @CompuIves one in https://github.com/babel/babel/pull/10639): https://codesandbox.io/s/babel-repl-9d0wg

- not using babel-standalone since I don't want to bundle (takes too long), so it just publishes the built files
- we just manually required all the plugins/presets so they are available

---

cc @CompuIves 

Integrating this got me thinking about some feature requests:
- being able to change the codesandbox bot comment
- can you programmatically generate templates based on the PR