### PR TITLE
handle objectMethod in scope.isPure

### DIFF
--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -723,7 +723,7 @@ export default class Scope {
         if (!this.isPure(prop, constantsOnly)) return false;
       }
       return true;
-    } else if (t.isClassMethod(node)) {
+    } else if (t.isMethod(node)) {
       if (node.computed && !this.isPure(node.key, constantsOnly)) return false;
       if (node.kind === "get" || node.kind === "set") return false;
       return true;

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -203,11 +203,17 @@ describe("scope", () => {
 
     it("purity", function() {
       expect(
-        getPath("({ x: 1 })")
+        getPath("({ x: 1, foo() { return 1 } })")
           .get("body")[0]
           .get("expression")
           .isPure(),
       ).toBeTruthy();
+      expect(
+        getPath("class X { get foo() { return 1 } }")
+          .get("body")[0]
+          .get("expression")
+          .isPure(),
+      ).toBeFalsy();
       expect(
         getPath("`${a}`")
           .get("body")[0]


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |  Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Currently, `ObjectMethod` is not aligned with `ClassMethod`.

reference: https://github.com/babel/babel/pull/11412#discussion_r410699837