### PR TITLE
Update compat table script

### DIFF
--- a/packages/babel-compat-data/data/corejs2-built-ins.json
+++ b/packages/babel-compat-data/data/corejs2-built-ins.json
@@ -8,7 +8,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "5",
-    "electron": "0.35"
+    "electron": "0.32"
   },
   "es6.array.every": {
     "chrome": "5",
@@ -22,7 +22,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.array.fill": {
     "chrome": "45",
@@ -33,7 +33,7 @@
     "node": "4",
     "ios": "8",
     "samsung": "5",
-    "electron": "0.35"
+    "electron": "0.32"
   },
   "es6.array.filter": {
     "chrome": "5",
@@ -47,7 +47,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.array.find": {
     "chrome": "45",
@@ -58,7 +58,7 @@
     "node": "4",
     "ios": "8",
     "samsung": "5",
-    "electron": "0.35"
+    "electron": "0.32"
   },
   "es6.array.find-index": {
     "chrome": "45",
@@ -69,7 +69,7 @@
     "node": "4",
     "ios": "8",
     "samsung": "5",
-    "electron": "0.35"
+    "electron": "0.32"
   },
   "es7.array.flat-map": {
     "chrome": "69",
@@ -80,7 +80,7 @@
     "node": "11",
     "ios": "12",
     "samsung": "10",
-    "electron": "4.2"
+    "electron": "4"
   },
   "es6.array.for-each": {
     "chrome": "5",
@@ -94,7 +94,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.array.from": {
     "chrome": "51",
@@ -130,7 +130,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.array.is-array": {
     "chrome": "5",
@@ -144,7 +144,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.array.iterator": {
     "chrome": "38",
@@ -155,7 +155,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.array.last-index-of": {
     "chrome": "5",
@@ -169,7 +169,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.array.map": {
     "chrome": "5",
@@ -183,7 +183,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.array.of": {
     "chrome": "45",
@@ -194,7 +194,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "5",
-    "electron": "0.35"
+    "electron": "0.32"
   },
   "es6.array.reduce": {
     "chrome": "5",
@@ -208,7 +208,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.array.reduce-right": {
     "chrome": "5",
@@ -222,7 +222,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.array.some": {
     "chrome": "5",
@@ -236,7 +236,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.array.sort": {
     "chrome": "63",
@@ -248,7 +248,7 @@
     "ie": "9",
     "ios": "12",
     "samsung": "8",
-    "electron": "3.1"
+    "electron": "3"
   },
   "es6.array.species": {
     "chrome": "51",
@@ -273,7 +273,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.date.to-iso-string": {
     "chrome": "5",
@@ -287,7 +287,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.date.to-json": {
     "chrome": "5",
@@ -300,7 +300,7 @@
     "android": "4",
     "ios": "10",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.date.to-primitive": {
     "chrome": "47",
@@ -325,7 +325,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.function.bind": {
     "chrome": "7",
@@ -339,7 +339,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "5"
+    "electron": "0.20"
   },
   "es6.function.has-instance": {
     "chrome": "51",
@@ -363,7 +363,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.map": {
     "chrome": "51",
@@ -385,7 +385,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.asinh": {
     "chrome": "38",
@@ -396,7 +396,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.atanh": {
     "chrome": "38",
@@ -407,7 +407,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.cbrt": {
     "chrome": "38",
@@ -418,7 +418,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.clz32": {
     "chrome": "38",
@@ -429,7 +429,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.cosh": {
     "chrome": "38",
@@ -440,7 +440,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.expm1": {
     "chrome": "38",
@@ -451,7 +451,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.fround": {
     "chrome": "38",
@@ -462,7 +462,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.hypot": {
     "chrome": "38",
@@ -473,7 +473,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.imul": {
     "chrome": "30",
@@ -485,7 +485,7 @@
     "android": "4.4",
     "ios": "7",
     "samsung": "2",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.log1p": {
     "chrome": "38",
@@ -496,7 +496,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.log10": {
     "chrome": "38",
@@ -507,7 +507,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.log2": {
     "chrome": "38",
@@ -518,7 +518,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.sign": {
     "chrome": "38",
@@ -529,7 +529,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.sinh": {
     "chrome": "38",
@@ -540,7 +540,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.tanh": {
     "chrome": "38",
@@ -551,7 +551,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.math.trunc": {
     "chrome": "38",
@@ -562,7 +562,7 @@
     "node": "0.12",
     "ios": "8",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.number.constructor": {
     "chrome": "41",
@@ -573,7 +573,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   },
   "es6.number.epsilon": {
     "chrome": "34",
@@ -584,7 +584,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "2",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.number.is-finite": {
     "chrome": "19",
@@ -596,7 +596,7 @@
     "android": "4.1",
     "ios": "9",
     "samsung": "1.5",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.number.is-integer": {
     "chrome": "34",
@@ -607,7 +607,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "2",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.number.is-nan": {
     "chrome": "19",
@@ -619,7 +619,7 @@
     "android": "4.1",
     "ios": "9",
     "samsung": "1.5",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.number.is-safe-integer": {
     "chrome": "34",
@@ -630,7 +630,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "2",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.number.max-safe-integer": {
     "chrome": "34",
@@ -641,7 +641,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "2",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.number.min-safe-integer": {
     "chrome": "34",
@@ -652,7 +652,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "2",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.number.parse-float": {
     "chrome": "34",
@@ -663,7 +663,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "2",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.number.parse-int": {
     "chrome": "34",
@@ -674,7 +674,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "2",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.object.assign": {
     "chrome": "49",
@@ -685,7 +685,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.object.create": {
     "chrome": "5",
@@ -699,7 +699,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es7.object.define-getter": {
     "chrome": "62",
@@ -710,7 +710,7 @@
     "node": "8.10",
     "ios": "9",
     "samsung": "8",
-    "electron": "3.1"
+    "electron": "3"
   },
   "es7.object.define-setter": {
     "chrome": "62",
@@ -721,7 +721,7 @@
     "node": "8.10",
     "ios": "9",
     "samsung": "8",
-    "electron": "3.1"
+    "electron": "3"
   },
   "es6.object.define-property": {
     "chrome": "5",
@@ -735,7 +735,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.object.define-properties": {
     "chrome": "5",
@@ -749,7 +749,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es7.object.entries": {
     "chrome": "54",
@@ -771,7 +771,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "4",
-    "electron": "0.31"
+    "electron": "0.30"
   },
   "es6.object.get-own-property-descriptor": {
     "chrome": "44",
@@ -782,7 +782,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "4",
-    "electron": "0.31"
+    "electron": "0.30"
   },
   "es7.object.get-own-property-descriptors": {
     "chrome": "54",
@@ -815,7 +815,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "4",
-    "electron": "0.31"
+    "electron": "0.30"
   },
   "es7.object.lookup-getter": {
     "chrome": "62",
@@ -826,7 +826,7 @@
     "node": "8.10",
     "ios": "9",
     "samsung": "8",
-    "electron": "3.1"
+    "electron": "3"
   },
   "es7.object.lookup-setter": {
     "chrome": "62",
@@ -837,7 +837,7 @@
     "node": "8.10",
     "ios": "9",
     "samsung": "8",
-    "electron": "3.1"
+    "electron": "3"
   },
   "es6.object.prevent-extensions": {
     "chrome": "44",
@@ -848,7 +848,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "4",
-    "electron": "0.31"
+    "electron": "0.30"
   },
   "es6.object.to-string": {
     "chrome": "57",
@@ -871,7 +871,7 @@
     "android": "4.1",
     "ios": "9",
     "samsung": "1.5",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.object.is-frozen": {
     "chrome": "44",
@@ -882,7 +882,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "4",
-    "electron": "0.31"
+    "electron": "0.30"
   },
   "es6.object.is-sealed": {
     "chrome": "44",
@@ -893,7 +893,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "4",
-    "electron": "0.31"
+    "electron": "0.30"
   },
   "es6.object.is-extensible": {
     "chrome": "44",
@@ -904,7 +904,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "4",
-    "electron": "0.31"
+    "electron": "0.30"
   },
   "es6.object.keys": {
     "chrome": "40",
@@ -926,7 +926,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "4",
-    "electron": "0.31"
+    "electron": "0.30"
   },
   "es6.object.set-prototype-of": {
     "chrome": "34",
@@ -938,7 +938,7 @@
     "ie": "11",
     "ios": "9",
     "samsung": "2",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es7.object.values": {
     "chrome": "54",
@@ -971,7 +971,7 @@
     "node": "10",
     "ios": "11.3",
     "samsung": "8",
-    "electron": "3.1"
+    "electron": "3"
   },
   "es6.reflect.apply": {
     "chrome": "49",
@@ -982,7 +982,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.construct": {
     "chrome": "49",
@@ -993,7 +993,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.define-property": {
     "chrome": "49",
@@ -1004,7 +1004,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.delete-property": {
     "chrome": "49",
@@ -1015,7 +1015,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.get": {
     "chrome": "49",
@@ -1026,7 +1026,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.get-own-property-descriptor": {
     "chrome": "49",
@@ -1037,7 +1037,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.get-prototype-of": {
     "chrome": "49",
@@ -1048,7 +1048,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.has": {
     "chrome": "49",
@@ -1059,7 +1059,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.is-extensible": {
     "chrome": "49",
@@ -1070,7 +1070,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.own-keys": {
     "chrome": "49",
@@ -1081,7 +1081,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.prevent-extensions": {
     "chrome": "49",
@@ -1092,7 +1092,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.set": {
     "chrome": "49",
@@ -1103,7 +1103,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.reflect.set-prototype-of": {
     "chrome": "49",
@@ -1114,7 +1114,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.regexp.constructor": {
     "chrome": "50",
@@ -1136,7 +1136,7 @@
     "node": "6",
     "ios": "9",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "es6.regexp.match": {
     "chrome": "50",
@@ -1224,7 +1224,7 @@
     "node": "10",
     "ios": "12",
     "samsung": "8",
-    "electron": "3.1"
+    "electron": "3"
   },
   "es6.string.anchor": {
     "chrome": "5",
@@ -1237,7 +1237,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.big": {
     "chrome": "5",
@@ -1250,7 +1250,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.blink": {
     "chrome": "5",
@@ -1263,7 +1263,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.bold": {
     "chrome": "5",
@@ -1276,7 +1276,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.code-point-at": {
     "chrome": "41",
@@ -1287,7 +1287,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   },
   "es6.string.ends-with": {
     "chrome": "41",
@@ -1298,7 +1298,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   },
   "es6.string.fixed": {
     "chrome": "5",
@@ -1311,7 +1311,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.fontcolor": {
     "chrome": "5",
@@ -1324,7 +1324,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.fontsize": {
     "chrome": "5",
@@ -1337,7 +1337,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.from-code-point": {
     "chrome": "41",
@@ -1348,7 +1348,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   },
   "es6.string.includes": {
     "chrome": "41",
@@ -1359,7 +1359,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   },
   "es6.string.italics": {
     "chrome": "5",
@@ -1372,7 +1372,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.iterator": {
     "chrome": "38",
@@ -1383,7 +1383,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "es6.string.link": {
     "chrome": "5",
@@ -1396,7 +1396,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es7.string.pad-start": {
     "chrome": "57",
@@ -1429,7 +1429,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   },
   "es6.string.repeat": {
     "chrome": "41",
@@ -1440,7 +1440,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   },
   "es6.string.small": {
     "chrome": "5",
@@ -1453,7 +1453,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.starts-with": {
     "chrome": "41",
@@ -1464,7 +1464,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   },
   "es6.string.strike": {
     "chrome": "5",
@@ -1477,7 +1477,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.sub": {
     "chrome": "5",
@@ -1490,7 +1490,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.sup": {
     "chrome": "5",
@@ -1503,7 +1503,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.string.trim": {
     "chrome": "5",
@@ -1517,7 +1517,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es7.string.trim-left": {
     "chrome": "66",
@@ -1528,7 +1528,7 @@
     "node": "10",
     "ios": "12",
     "samsung": "9",
-    "electron": "3.1"
+    "electron": "3"
   },
   "es7.string.trim-right": {
     "chrome": "66",
@@ -1539,7 +1539,7 @@
     "node": "10",
     "ios": "12",
     "samsung": "9",
-    "electron": "3.1"
+    "electron": "3"
   },
   "es6.typed.array-buffer": {
     "chrome": "51",
@@ -1564,7 +1564,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "1.1"
+    "electron": "0.20"
   },
   "es6.typed.int8-array": {
     "chrome": "51",

--- a/packages/babel-compat-data/data/plugin-bugfixes.json
+++ b/packages/babel-compat-data/data/plugin-bugfixes.json
@@ -30,7 +30,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "bugfix/transform-edge-default-parameters": {
     "chrome": "49",
@@ -41,7 +41,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "transform-function-name": {
     "chrome": "51",
@@ -74,7 +74,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "bugfix/transform-safari-block-shadowing": {
     "chrome": "49",
@@ -86,7 +86,7 @@
     "ie": "11",
     "ios": "11",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "bugfix/transform-safari-for-shadowing": {
     "chrome": "49",
@@ -98,7 +98,7 @@
     "ie": "11",
     "ios": "11",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "transform-template-literals": {
     "chrome": "41",
@@ -109,7 +109,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   },
   "bugfix/transform-tagged-template-caching": {
     "chrome": "41",
@@ -120,6 +120,6 @@
     "node": "4",
     "ios": "13",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   }
 }

--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -7,7 +7,8 @@
     "safari": "13",
     "node": "12.5",
     "ios": "13",
-    "electron": "6.1"
+    "samsung": "11",
+    "electron": "6"
   },
   "proposal-nullish-coalescing-operator": {
     "chrome": "80",
@@ -36,7 +37,7 @@
     "node": "10",
     "ios": "12",
     "samsung": "9",
-    "electron": "3.1"
+    "electron": "3"
   },
   "proposal-optional-catch-binding": {
     "chrome": "66",
@@ -47,7 +48,7 @@
     "node": "10",
     "ios": "11.3",
     "samsung": "9",
-    "electron": "3.1"
+    "electron": "3"
   },
   "transform-parameters": {
     "chrome": "49",
@@ -58,7 +59,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "proposal-async-generator-functions": {
     "chrome": "63",
@@ -69,7 +70,7 @@
     "node": "10",
     "ios": "12",
     "samsung": "8",
-    "electron": "3.1"
+    "electron": "3"
   },
   "proposal-object-rest-spread": {
     "chrome": "60",
@@ -80,7 +81,7 @@
     "node": "8.3",
     "ios": "11.3",
     "samsung": "8",
-    "electron": "2.1"
+    "electron": "2"
   },
   "transform-dotall-regex": {
     "chrome": "62",
@@ -90,7 +91,7 @@
     "node": "8.10",
     "ios": "11.3",
     "samsung": "8",
-    "electron": "3.1"
+    "electron": "3"
   },
   "proposal-unicode-property-regex": {
     "chrome": "64",
@@ -100,7 +101,7 @@
     "node": "10",
     "ios": "11.3",
     "samsung": "9",
-    "electron": "3.1"
+    "electron": "3"
   },
   "transform-named-capturing-groups-regex": {
     "chrome": "64",
@@ -110,7 +111,7 @@
     "node": "10",
     "ios": "11.3",
     "samsung": "9",
-    "electron": "3.1"
+    "electron": "3"
   },
   "transform-async-to-generator": {
     "chrome": "55",
@@ -143,7 +144,7 @@
     "node": "4",
     "ios": "13",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   },
   "transform-literals": {
     "chrome": "44",
@@ -154,7 +155,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "4",
-    "electron": "0.31"
+    "electron": "0.30"
   },
   "transform-function-name": {
     "chrome": "51",
@@ -188,7 +189,7 @@
     "ie": "11",
     "ios": "10",
     "samsung": "3.4",
-    "electron": "0.24"
+    "electron": "0.22"
   },
   "transform-classes": {
     "chrome": "46",
@@ -221,7 +222,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "4",
-    "electron": "0.29"
+    "electron": "0.28"
   },
   "transform-duplicate-keys": {
     "chrome": "42",
@@ -232,7 +233,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "3.4",
-    "electron": "0.27"
+    "electron": "0.25"
   },
   "transform-computed-properties": {
     "chrome": "44",
@@ -243,7 +244,7 @@
     "node": "4",
     "ios": "8",
     "samsung": "4",
-    "electron": "0.31"
+    "electron": "0.30"
   },
   "transform-for-of": {
     "chrome": "51",
@@ -265,7 +266,7 @@
     "node": "6",
     "ios": "10",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "transform-unicode-regex": {
     "chrome": "50",
@@ -309,7 +310,7 @@
     "node": "6",
     "ios": "11",
     "samsung": "5",
-    "electron": "1"
+    "electron": "0.37"
   },
   "transform-typeof-symbol": {
     "chrome": "38",
@@ -320,7 +321,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "3",
-    "electron": "0.2"
+    "electron": "0.20"
   },
   "transform-new-target": {
     "chrome": "46",
@@ -356,7 +357,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "5"
+    "electron": "0.20"
   },
   "transform-property-literals": {
     "chrome": "7",
@@ -370,7 +371,7 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "5"
+    "electron": "0.20"
   },
   "transform-reserved-words": {
     "chrome": "13",
@@ -384,6 +385,6 @@
     "ios": "6",
     "phantom": "2",
     "samsung": "1",
-    "electron": "0.2"
+    "electron": "0.20"
   }
 }

--- a/packages/babel-compat-data/scripts/build-bugfixes-targets.js
+++ b/packages/babel-compat-data/scripts/build-bugfixes-targets.js
@@ -7,7 +7,6 @@ const path = require("path");
 const {
   getLowestImplementedVersion,
   environments,
-  addOperaAndElectron,
   writeFile,
 } = require("./utils-build-data");
 
@@ -58,10 +57,6 @@ for (const [replaced, features] of Object.entries(allReplacedFeatures)) {
       generatedTargets[replaced][env] = stillNotSupported;
     }
   }
-}
-
-for (const plugin of Object.values(generatedTargets)) {
-  addOperaAndElectron(plugin);
 }
 
 for (const [filename, data] of [

--- a/packages/babel-compat-data/scripts/download-compat-table.sh
+++ b/packages/babel-compat-data/scripts/download-compat-table.sh
@@ -16,5 +16,5 @@ fi
 
 rm -rf build/compat-table
 mkdir -p build
-git clone --branch=gh-pages --single-branch --shallow-since=2020-04-20 https://github.com/kangax/compat-table.git build/compat-table
+git clone --branch=gh-pages --single-branch --shallow-since=2020-04-01 https://github.com/kangax/compat-table.git build/compat-table
 cd build/compat-table && git checkout -qf $COMPAT_TABLE_COMMIT

--- a/packages/babel-compat-data/scripts/download-compat-table.sh
+++ b/packages/babel-compat-data/scripts/download-compat-table.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-COMPAT_TABLE_COMMIT=df1466b4ddae4c1c9d8b385332a800eeb7f28049
+COMPAT_TABLE_COMMIT=9e07df3875d8416af85cf523716519e9dd1e5e44
 GIT_HEAD=build/compat-table/.git/HEAD
 
 if [ -d "build/compat-table" ]; then

--- a/packages/babel-compat-data/scripts/utils-build-data.js
+++ b/packages/babel-compat-data/scripts/utils-build-data.js
@@ -1,122 +1,41 @@
 "use strict";
 
 const fs = require("fs");
-const semver = require("semver");
-const flattenDeep = require("lodash/flattenDeep");
+const flatMap = require("lodash/flatMap");
 const mapValues = require("lodash/mapValues");
-const pickBy = require("lodash/pickBy");
-const { unreleasedLabels } = require("@babel/helper-compilation-targets");
+const findLastIndex = require("lodash/findLastIndex");
 const electronToChromiumVersions = require("electron-to-chromium").versions;
 
-const electronToChromiumKeys = Object.keys(
-  electronToChromiumVersions
-).reverse();
-
-const chromiumToElectronMap = electronToChromiumKeys.reduce((all, electron) => {
-  all[electronToChromiumVersions[electron]] = +electron;
-  return all;
-}, {});
-chromiumToElectronMap["0"] = "0";
-const chromiumToElectronVersions = Object.keys(chromiumToElectronMap);
-
-const findClosestElectronVersion = targetVersion => {
-  const chromiumVersionsLength = chromiumToElectronVersions.length;
-  const maxChromium = +chromiumToElectronVersions[chromiumVersionsLength - 1];
-  if (targetVersion > maxChromium) return null;
-
-  const closestChrome = chromiumToElectronVersions.find(
-    version => targetVersion <= version
-  );
-  return chromiumToElectronMap[closestChrome];
-};
-
-exports.chromiumToElectron = chromium =>
-  chromiumToElectronMap[chromium] || findClosestElectronVersion(chromium);
-
-const renameTests = (tests, getName, category) =>
-  tests.map(test =>
-    Object.assign({}, test, { name: getName(test.name), category })
-  );
-
-// The following is adapted from compat-table:
-// https://github.com/kangax/compat-table/blob/gh-pages/build.js
-//
-// It parses and interpolates data so environments that "equal" other
-// environments (node4 and chrome45), as well as familial relationships (edge
-// and ie11) can be handled properly.
-
 const envs = require("../build/compat-table/environments");
+const parseEnvsVersions = require("../build/compat-table/build-utils/parse-envs-versions");
+const interpolateAllResults = require("../build/compat-table/build-utils/interpolate-all-results");
+const compareVersions = require("../build/compat-table/build-utils/compare-versions");
 
-const byTestSuite = suite => browser => {
-  return Array.isArray(browser.test_suites)
-    ? browser.test_suites.indexOf(suite) > -1
-    : true;
-};
+// Add Electron to the list of environments
+Object.keys(electronToChromiumVersions).forEach(electron => {
+  const chrome = electronToChromiumVersions[electron];
 
-const compatSources = ["es5", "es6", "es2016plus", "esnext"].reduce(
-  (result, source) => {
-    const data = require(`../build/compat-table/data-${source}`);
-    data.browsers = pickBy(envs, byTestSuite(source));
-    result.push(data);
-    return result;
-  },
-  []
-);
+  const electronId = `electron${electron.replace(".", "_")}`;
+  let chromeId = `chrome${chrome}`;
 
-const interpolateAllResults = (rawBrowsers, tests) => {
-  const interpolateResults = res => {
-    let browser;
-    let prevBrowser;
-    let result;
-    let prevResult;
-    let prevBid;
+  // This is missing
+  if (chromeId === "chrome82") chromeId = "chrome81";
+  if (!envs[chromeId]) {
+    throw new Error(
+      `Electron ${electron} inherits from Chrome ${chrome}, which is not defined.`
+    );
+  }
 
-    for (const bid in rawBrowsers) {
-      // For browsers that are essentially equal to other browsers,
-      // copy over the results.
-      browser = rawBrowsers[bid];
-      if (browser.equals && res[bid] === undefined) {
-        result = res[browser.equals];
-        res[bid] =
-          browser.ignore_flagged && result === "flagged" ? false : result;
-        // For each browser, check if the previous browser has the same
-        // browser full name (e.g. Firefox) or family name (e.g. Chakra) as this one.
-      } else if (
-        prevBrowser &&
-        (prevBrowser.full.replace(/,.+$/, "") ===
-          browser.full.replace(/,.+$/, "") ||
-          (browser.family !== undefined &&
-            prevBrowser.family === browser.family))
-      ) {
-        // For each test, check if the previous browser has a result
-        // that this browser lacks.
-        result = res[bid];
-        prevResult = res[prevBid];
-        if (prevResult !== undefined && result === undefined) {
-          res[bid] = prevResult;
-        }
-      }
-      prevBrowser = browser;
-      prevBid = bid;
-    }
-  };
+  envs[electronId] = { equals: chromeId };
+});
 
-  // Now print the results.
-  tests.forEach(function(t) {
-    // Calculate the result totals for tests which consist solely of subtests.
-    if ("subtests" in t) {
-      t.subtests.forEach(function(e) {
-        interpolateResults(e.res);
-      });
-    } else {
-      interpolateResults(t.res);
-    }
-  });
-};
+const envsVersions = parseEnvsVersions(envs);
 
-compatSources.forEach(({ browsers, tests }) =>
-  interpolateAllResults(browsers, tests)
-);
+const compatSources = ["es5", "es6", "es2016plus", "esnext"].map(source => {
+  const data = require(`../build/compat-table/data-${source}`);
+  interpolateAllResults(data.tests, envs);
+  return data;
+});
 
 // End of compat-table code adaptation
 
@@ -132,23 +51,20 @@ exports.environments = [
   "ios",
   "phantom",
   "samsung",
+  "electron",
 ];
 
-const compatibilityTests = flattenDeep(
-  compatSources.map(data =>
-    data.tests.map(test => {
-      return test.subtests
-        ? [
-            test,
-            renameTests(
-              test.subtests,
-              name => test.name + " / " + name,
-              test.category
-            ),
-          ]
-        : test;
-    })
-  )
+const compatibilityTests = flatMap(compatSources, data =>
+  flatMap(data.tests, test => {
+    if (!test.subtests) return test;
+
+    return test.subtests.map(subtest =>
+      Object.assign({}, subtest, {
+        name: test.name + " / " + subtest.name,
+        group: test.name,
+      })
+    );
+  })
 );
 
 exports.getLowestImplementedVersion = (
@@ -156,124 +72,35 @@ exports.getLowestImplementedVersion = (
   env,
   exclude = () => false
 ) => {
-  const tests = compatibilityTests
-    .filter(test => {
-      return (
-        (features.indexOf(test.name) >= 0 ||
-          // for features === ["DataView"]
-          // it covers "DataView (Int8)" and "DataView (UInt8)"
-          (features.length === 1 && test.name.indexOf(features[0]) === 0)) &&
-        !exclude(test.name)
-      );
-    })
-    .reduce((result, test) => {
-      if (!test.subtests) {
-        result.push({
-          name: test.name,
-          res: test.res,
-        });
-      } else {
-        test.subtests.forEach(subtest => {
-          if (!exclude(`${test.name} / ${subtest.name}`)) {
-            result.push({
-              name: `${test.name} /${subtest.name}`,
-              res: subtest.res,
-            });
-          }
-        });
-      }
-
-      return result;
-    }, []);
-
-  const unreleasedLabelForEnv = unreleasedLabels[env];
-  const envTests = tests.map(({ res: test }, i) => {
-    const reportedVersions = Object.keys(test)
-      .filter(t => t.startsWith(env))
-      .map(t => {
-        const version = t.replace(/_/g, ".").replace(env, "");
-        return {
-          version,
-          semver: semver.coerce(version) || version,
-          // Babel assumes strict mode
-          implements: tests[i].res[t] === true || tests[i].res[t] === "strict",
-        };
-      })
-      // version must be label from the unreleasedLabels (like tp) or number.
-      .filter(
-        version =>
-          unreleasedLabelForEnv === version.version ||
-          !isNaN(parseFloat(version.version))
-      )
-      // Sort in desc order, with unreleasedLabelForEnv coming last.
-      .sort(({ semver: av }, { semver: bv }) => {
-        if (av === unreleasedLabelForEnv) return -1;
-        if (bv === unreleasedLabelForEnv) return 1;
-        if (semver.gt(av, bv)) return -1;
-        if (semver.gt(bv, av)) return 1;
-        return 0;
-      });
-
-    // Find the lowest version such that all higher versions implement it.
-    // Eg, given { chrome70: true, chrome60: false, chrome50: true }, the
-    // lowest version is chrome70, not chrome50.
-    let lowest = null;
-    for (const version of reportedVersions) {
-      if (!version.implements) {
-        break;
-      }
-      lowest = version;
-    }
-    return lowest;
+  const tests = compatibilityTests.filter(test => {
+    // TODO (Babel 9): Use ||=, &&=
+    let ok = features.includes(test.name);
+    ok = ok || (test.group && features.includes(test.group));
+    ok = ok || (features.length === 1 && test.name.startsWith(features[0]));
+    ok = ok && !exclude(test.name);
+    return ok;
   });
 
-  const envFiltered = envTests.filter(t => t);
-  if (envTests.length > envFiltered.length || envTests.length === 0) {
-    // envTests.forEach((test, i) => {
-    //   if (!test) {
-    //     // print unsupported features
-    //     if (env === 'node') {
-    //       console.log(`ENV(${env}): ${tests[i].name}`);
-    //     }
-    //   }
-    // });
-    return null;
-  }
+  const envTests = tests.map(({ res }) => {
+    const lastNotImplemented = findLastIndex(
+      envsVersions[env],
+      // Babel assumes strict mode
+      ({ id }) => !(res[id] === true || res[id] === "strict")
+    );
 
-  const result = envFiltered.reduce((a, b) => {
-    if (a.semver === unreleasedLabelForEnv) return a;
-    if (b.semver === unreleasedLabelForEnv) return b;
-
-    return semver.lt(a.semver, b.semver) ? b : a;
+    return envsVersions[env][lastNotImplemented + 1];
   });
-  if (result.version.endsWith(".0")) {
-    // NOTE(bng): A number of environments in compat-table changed to
-    // include a trailing zero (node10 -> node10_0), so for now stripping
-    // it to be consistent
-    return result.version.slice(0, -2);
-  }
-  return result.version;
-};
 
-exports.addOperaAndElectron = plugin => {
-  if (plugin.chrome) {
-    // add opera
-    if (plugin.chrome >= 28) {
-      plugin.opera = (plugin.chrome - 13).toString();
-    } else if (!plugin.opera) {
-      if (plugin.chrome <= 23) {
-        plugin.opera = "15";
-      } else if (plugin.chrome <= 27) {
-        plugin.opera = "16";
-      }
-    }
+  if (envTests.length === 0 || envTests.some(t => !t)) return null;
 
-    // add electron
-    const electronVersion = exports.chromiumToElectron(plugin.chrome);
-    if (electronVersion) {
-      plugin.electron = electronVersion.toString();
-    }
-  }
+  const result = envTests.reduce((a, b) => {
+    return compareVersions(a, b) > 0 ? a : b;
+  });
+
+  // NOTE(bng): A number of environments in compat-table changed to
+  // include a trailing zero (node10 -> node10_0), so for now stripping
+  // it to be consistent
+  return result.version.join(".").replace(/\.0$/, "");
 };
 
 exports.generateData = (environments, features) => {
@@ -290,8 +117,6 @@ exports.generateData = (environments, features) => {
       const version = exports.getLowestImplementedVersion(options, env);
       if (version) plugin[env] = version;
     });
-
-    exports.addOperaAndElectron(plugin);
 
     return plugin;
   });

--- a/packages/babel-preset-env/test/fixtures/corejs2/entry-electron/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/entry-electron/output.mjs
@@ -1,6 +1,5 @@
 import "core-js/modules/es7.array.flat-map";
 import "core-js/modules/es6.array.sort";
-import "core-js/modules/es6.function.bind";
 import "core-js/modules/es7.object.define-getter";
 import "core-js/modules/es7.object.define-setter";
 import "core-js/modules/es7.object.entries";

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -34,42 +34,21 @@ Using plugins:
   transform-destructuring { "electron":"0.36" }
   transform-block-scoping { "electron":"0.36" }
   transform-regenerator { "electron":"0.36" }
-  transform-member-expression-literals { "electron":"0.36" }
-  transform-property-literals { "electron":"0.36" }
   transform-modules-commonjs { "electron":"0.36" }
   proposal-dynamic-import { "electron":"0.36" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/input.mjs] Replaced @babel/polyfill entries with the following polyfills:
-  es6.array.every { "electron":"0.36" }
-  es6.array.filter { "electron":"0.36" }
   es7.array.flat-map { "electron":"0.36" }
-  es6.array.for-each { "electron":"0.36" }
   es6.array.from { "electron":"0.36" }
-  es6.array.index-of { "electron":"0.36" }
-  es6.array.is-array { "electron":"0.36" }
-  es6.array.last-index-of { "electron":"0.36" }
-  es6.array.map { "electron":"0.36" }
-  es6.array.reduce { "electron":"0.36" }
-  es6.array.reduce-right { "electron":"0.36" }
-  es6.array.some { "electron":"0.36" }
   es6.array.sort { "electron":"0.36" }
   es6.array.species { "electron":"0.36" }
-  es6.date.now { "electron":"0.36" }
-  es6.date.to-iso-string { "electron":"0.36" }
-  es6.date.to-json { "electron":"0.36" }
-  es6.date.to-string { "electron":"0.36" }
-  es6.function.bind { "electron":"0.36" }
   es6.function.has-instance { "electron":"0.36" }
-  es6.function.name { "electron":"0.36" }
   es6.map { "electron":"0.36" }
   es6.object.assign { "electron":"0.36" }
-  es6.object.create { "electron":"0.36" }
   es7.object.define-getter { "electron":"0.36" }
   es7.object.define-setter { "electron":"0.36" }
-  es6.object.define-property { "electron":"0.36" }
-  es6.object.define-properties { "electron":"0.36" }
   es7.object.entries { "electron":"0.36" }
   es7.object.get-own-property-descriptors { "electron":"0.36" }
   es7.object.lookup-getter { "electron":"0.36" }
@@ -101,26 +80,11 @@ Using polyfills with `entry` option:
   es6.set { "electron":"0.36" }
   es6.symbol { "electron":"0.36" }
   es7.symbol.async-iterator { "electron":"0.36" }
-  es6.string.anchor { "electron":"0.36" }
-  es6.string.big { "electron":"0.36" }
-  es6.string.blink { "electron":"0.36" }
-  es6.string.bold { "electron":"0.36" }
-  es6.string.fixed { "electron":"0.36" }
-  es6.string.fontcolor { "electron":"0.36" }
-  es6.string.fontsize { "electron":"0.36" }
-  es6.string.italics { "electron":"0.36" }
-  es6.string.link { "electron":"0.36" }
   es7.string.pad-start { "electron":"0.36" }
   es7.string.pad-end { "electron":"0.36" }
-  es6.string.small { "electron":"0.36" }
-  es6.string.strike { "electron":"0.36" }
-  es6.string.sub { "electron":"0.36" }
-  es6.string.sup { "electron":"0.36" }
-  es6.string.trim { "electron":"0.36" }
   es7.string.trim-left { "electron":"0.36" }
   es7.string.trim-right { "electron":"0.36" }
   es6.typed.array-buffer { "electron":"0.36" }
-  es6.typed.data-view { "electron":"0.36" }
   es6.typed.int8-array { "electron":"0.36" }
   es6.typed.uint8-array { "electron":"0.36" }
   es6.typed.uint8-clamped-array { "electron":"0.36" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -50,8 +50,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "electron":"0.36", "ie":"10" }
-  transform-member-expression-literals { "electron":"0.36" }
-  transform-property-literals { "electron":"0.36" }
   transform-modules-commonjs { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-dynamic-import { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
 
@@ -59,34 +57,19 @@ Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/input.mjs] Replaced @babel/polyfill entries with the following polyfills:
   es6.array.copy-within { "ie":"10" }
-  es6.array.every { "electron":"0.36" }
   es6.array.fill { "ie":"10" }
-  es6.array.filter { "electron":"0.36" }
   es6.array.find { "ie":"10" }
   es6.array.find-index { "ie":"10" }
   es7.array.flat-map { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  es6.array.for-each { "electron":"0.36" }
   es6.array.from { "electron":"0.36", "ie":"10", "node":"6.1" }
   es7.array.includes { "ie":"10" }
-  es6.array.index-of { "electron":"0.36" }
-  es6.array.is-array { "electron":"0.36" }
   es6.array.iterator { "ie":"10" }
-  es6.array.last-index-of { "electron":"0.36" }
-  es6.array.map { "electron":"0.36" }
   es6.array.of { "ie":"10" }
-  es6.array.reduce { "electron":"0.36" }
-  es6.array.reduce-right { "electron":"0.36" }
-  es6.array.some { "electron":"0.36" }
   es6.array.sort { "chrome":"54", "electron":"0.36", "node":"6.1" }
   es6.array.species { "electron":"0.36", "ie":"10", "node":"6.1" }
-  es6.date.now { "electron":"0.36" }
-  es6.date.to-iso-string { "electron":"0.36" }
-  es6.date.to-json { "electron":"0.36" }
   es6.date.to-primitive { "ie":"10" }
-  es6.date.to-string { "electron":"0.36" }
-  es6.function.bind { "electron":"0.36" }
   es6.function.has-instance { "electron":"0.36", "ie":"10", "node":"6.1" }
-  es6.function.name { "electron":"0.36", "ie":"10" }
+  es6.function.name { "ie":"10" }
   es6.map { "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.math.acosh { "ie":"10" }
   es6.math.asinh { "ie":"10" }
@@ -116,11 +99,8 @@ Using polyfills with `entry` option:
   es6.number.parse-float { "ie":"10" }
   es6.number.parse-int { "ie":"10" }
   es6.object.assign { "electron":"0.36", "ie":"10" }
-  es6.object.create { "electron":"0.36" }
   es7.object.define-getter { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es7.object.define-setter { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  es6.object.define-property { "electron":"0.36" }
-  es6.object.define-properties { "electron":"0.36" }
   es7.object.entries { "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.object.freeze { "ie":"10" }
   es6.object.get-own-property-descriptor { "ie":"10" }
@@ -164,34 +144,32 @@ Using polyfills with `entry` option:
   es6.set { "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.symbol { "electron":"0.36", "ie":"10", "node":"6.1" }
   es7.symbol.async-iterator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  es6.string.anchor { "electron":"0.36", "ie":"10" }
-  es6.string.big { "electron":"0.36", "ie":"10" }
-  es6.string.blink { "electron":"0.36", "ie":"10" }
-  es6.string.bold { "electron":"0.36", "ie":"10" }
+  es6.string.anchor { "ie":"10" }
+  es6.string.big { "ie":"10" }
+  es6.string.blink { "ie":"10" }
+  es6.string.bold { "ie":"10" }
   es6.string.code-point-at { "ie":"10" }
   es6.string.ends-with { "ie":"10" }
-  es6.string.fixed { "electron":"0.36", "ie":"10" }
-  es6.string.fontcolor { "electron":"0.36", "ie":"10" }
-  es6.string.fontsize { "electron":"0.36", "ie":"10" }
+  es6.string.fixed { "ie":"10" }
+  es6.string.fontcolor { "ie":"10" }
+  es6.string.fontsize { "ie":"10" }
   es6.string.from-code-point { "ie":"10" }
   es6.string.includes { "ie":"10" }
-  es6.string.italics { "electron":"0.36", "ie":"10" }
+  es6.string.italics { "ie":"10" }
   es6.string.iterator { "ie":"10" }
-  es6.string.link { "electron":"0.36", "ie":"10" }
+  es6.string.link { "ie":"10" }
   es7.string.pad-start { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es7.string.pad-end { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.string.raw { "ie":"10" }
   es6.string.repeat { "ie":"10" }
-  es6.string.small { "electron":"0.36", "ie":"10" }
+  es6.string.small { "ie":"10" }
   es6.string.starts-with { "ie":"10" }
-  es6.string.strike { "electron":"0.36", "ie":"10" }
-  es6.string.sub { "electron":"0.36", "ie":"10" }
-  es6.string.sup { "electron":"0.36", "ie":"10" }
-  es6.string.trim { "electron":"0.36" }
+  es6.string.strike { "ie":"10" }
+  es6.string.sub { "ie":"10" }
+  es6.string.sup { "ie":"10" }
   es7.string.trim-left { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es7.string.trim-right { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.typed.array-buffer { "electron":"0.36", "ie":"10", "node":"6.1" }
-  es6.typed.data-view { "electron":"0.36" }
   es6.typed.int8-array { "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.typed.uint8-array { "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.typed.uint8-clamped-array { "electron":"0.36", "ie":"10", "node":"6.1" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -34,8 +34,6 @@ Using plugins:
   transform-destructuring { "electron":"0.36" }
   transform-block-scoping { "electron":"0.36" }
   transform-regenerator { "electron":"0.36" }
-  transform-member-expression-literals { "electron":"0.36" }
-  transform-property-literals { "electron":"0.36" }
   transform-modules-commonjs { "electron":"0.36" }
   proposal-dynamic-import { "electron":"0.36" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -50,8 +50,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "electron":"0.36", "ie":"10" }
-  transform-member-expression-literals { "electron":"0.36" }
-  transform-property-literals { "electron":"0.36" }
   transform-modules-commonjs { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-dynamic-import { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Ref - https://github.com/kangax/compat-table/pull/1605

The changes in the electron versions are because different electron versions are mapped to a single chrome version. For example, Chrome 66 -> [Electron 3, Electron 3.1]. The old script used the highest electron version, but we should use the lowest one.