### PR TITLE
fix: don't elide jsx pragma import namespaces

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -169,6 +169,11 @@ export default declare(
             }
           }
 
+          let pragmaImportName = fileJsxPragma || jsxPragma;
+          if (pragmaImportName) {
+            [pragmaImportName] = pragmaImportName.split(".");
+          }
+
           // remove type imports
           for (let stmt of path.get("body")) {
             if (t.isImportDeclaration(stmt)) {

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -208,7 +208,7 @@ export default declare(
                     isImportTypeOnly({
                       binding,
                       programPath: path,
-                      jsxPragma: fileJsxPragma || jsxPragma,
+                      jsxPragma: pragmaImportName,
                     })
                   ) {
                     importsToRemove.push(binding.path);

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-namespace-no/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-namespace-no/input.ts
@@ -1,0 +1,4 @@
+/* @jsx jsx.htm */
+// Don't elide htm if a JSX element appears somewhere.
+import * as jsx from "fake-jsx-package";
+<div></div>;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-namespace-no/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-namespace-no/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-typescript", { "isTSX": true }]]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-namespace-no/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-namespace-no/output.mjs
@@ -1,0 +1,4 @@
+/* @jsx jsx.htm */
+// Don't elide htm if a JSX element appears somewhere.
+import * as jsx from "fake-jsx-package";
+<div></div>;


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | X
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

The logic to avoid removing pragma'd imports is less specific than its react counterpart and doesn't handle when files specify both `@jsx` and `@jsxFrag` very well. In particular this pattern is handled fine by the react transform but removed by TS

```js
/** @jsx _j.jsx **/
/** @jsxFrag _j.F **/

import * as _j from "astroturf/jsx";

<><div/></>
``` 
The above is required BTW, b/c  named imports don't work here for some reason: [repl link](https://babeljs.io/repl#?browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=PQKhAIAECsGcA9wH1rjMAUKCMEDEAnAQwHNkAzNETDASwFsAHAewIBdwBvcORI2ZNAA04POH4VwAX3DkCzeuABE_NvLYBXAuWC8lAbgwYAxswB2sDpQC84ABQZw4ADwA-ZwBNaAN2Du_ThgAlBhAA&debug=false&forceAllTransforms=false&shippedProposals=true&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact%2Ctypescript%2Cenv&prettier=false&targets=Node-12&version=7.9.6&externalPlugins=babel-plugin-for-await%400.0.21%2C%40babel%2Fplugin-syntax-async-generators%407.8.4%2C%40babel%2Fplugin-proposal-async-generator-functions%407.8.3), note that the fragment is incorrect

There should also be a separate plugin option for jsxFragmentPragma but i figured that was not necessary here
