### PR TITLE
Downgrade rollup to 1.27.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prettier": "^1.19.1",
     "pump": "^3.0.0",
     "rimraf": "^2.6.3",
-    "rollup": "^1.32.1",
+    "rollup": "1.27.9",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-builtins": "^2.1.2",

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -196,5 +196,13 @@
 }`);
       });
     });
+
+    describe("regressions", () => {
+      it("#11534 - supports quantifiers in unicode regexps", () => {
+        expect(() =>
+          Babel.transform("/a*/u", { presets: ["es2015"] }),
+        ).not.toThrow();
+      });
+    });
   },
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9188,10 +9188,10 @@ rollup-pluginutils@^2.3.1, rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.6.0,
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.32.1:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
+rollup@1.27.9:
+  version "1.27.9"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.27.9.tgz#742f1234c1fa935f35149a433807da675b10f9a6"
+  integrity sha512-8AfW4cJTPZfG6EXWwT/ujL4owUsDI1Xl8J1t+hvK4wDX81F5I4IbwP9gvGbHzxnV19fnU4rRABZQwZSX9J402Q==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/11534
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is a partial revert of #11233. Due to a bug in rollup's tree-shaking logic, `@babel/standalone` didn't contain some necessary code. (https://github.com/babel/babel/issues/11534#issuecomment-625742700)

We cannot upgrade to Rollup 2 yet because it requires Node.js 10.