### PR TITLE
fix(plugin-proposal-object-rest-spread): use computed memberExpression for literal keys

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -349,7 +349,7 @@ export default declare((api, opts) => {
             ref = t.memberExpression(
               ref,
               t.cloneNode(node.key),
-              t.isLiteral(node.key) || node.computed,
+              node.computed || t.isLiteral(node.key),
             );
           });
 

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -346,7 +346,11 @@ export default declare((api, opts) => {
           );
           refPropertyPath.forEach(prop => {
             const { node } = prop;
-            ref = t.memberExpression(ref, t.cloneNode(node.key), node.computed);
+            ref = t.memberExpression(
+              ref,
+              t.cloneNode(node.key),
+              t.isLiteral(node.key) || node.computed,
+            );
           });
 
           const objectPatternPath = path.findParent(path =>

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/nested-literal-property/input.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/nested-literal-property/input.js
@@ -1,0 +1,7 @@
+let useState = [{ some: 42 }, () => null];
+
+let {
+  0: { numeric,...rest1 },
+  '2': { str,...rest2 },
+  1: setState,
+} = useState;

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/nested-literal-property/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/nested-literal-property/output.js
@@ -1,0 +1,14 @@
+let useState = [{
+  some: 42
+}, () => null];
+let {
+  0: {
+    numeric
+  },
+  '2': {
+    str
+  },
+  1: setState
+} = useState,
+    rest1 = babelHelpers.objectWithoutProperties(useState[0], ["numeric"]),
+    rest2 = babelHelpers.objectWithoutProperties(useState['2'], ["str"]);


### PR DESCRIPTION
use computed memberExpression for literal keys

currently `plugin-proposal-object-rest-spread` fails to compile this:

```js
let {
  0: { firstName,...rest },
  1: setState,
} = useState();
```

which is a result of this optimization - [perf(gatsby/babel): Optimize hook destructuring](https://github.com/gatsbyjs/gatsby/pull/22619)

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | ☝️
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
