### PR TITLE
fix: ensure (a?.b)() has proper this

### DIFF
--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/parenthesized-member-call/exec.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/parenthesized-member-call/exec.js
@@ -5,7 +5,7 @@ const foo = {
     count++;
     return {
       b() {
-        return "b" in this;
+        return "b" in this && !("a" in this);
       }
     }
   },

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/parenthesized-member-call/exec.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/parenthesized-member-call/exec.js
@@ -1,0 +1,25 @@
+let count = 0;
+
+const foo = {
+  get a() {
+    count++;
+    return {
+      b() {
+        return "b" in this;
+      }
+    }
+  },
+  b() {
+    return "b" in this && "a" in this;
+  }
+}
+
+expect((foo?.b)()).toBe(true);
+expect((foo?.b)?.()).toBe(true);
+expect(() => (undefined?.b)()).toThrow();
+
+expect((foo?.a.b)()).toBe(true);
+expect(count).toBe(1);
+
+expect((foo?.a.b)?.()).toBe(true);
+expect(count).toBe(2);

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/parenthesized-member-call/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/parenthesized-member-call/input.js
@@ -1,0 +1,7 @@
+(foo?.bar)();
+
+(foo?.bar)?.();
+
+(foo?.bar.baz)();
+
+(foo?.bar.baz)?.();

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/parenthesized-member-call/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/parenthesized-member-call/output.js
@@ -1,0 +1,6 @@
+var _foo, _foo2, _foo2$bar, _foo3, _foo3$bar, _foo4, _foo4$bar$baz, _foo4$bar;
+
+((_foo = foo) === null || _foo === void 0 ? void 0 : _foo.bar.bind(_foo))();
+(_foo2 = foo) === null || _foo2 === void 0 ? void 0 : (_foo2$bar = _foo2.bar) === null || _foo2$bar === void 0 ? void 0 : _foo2$bar.call(_foo2);
+((_foo3 = foo) === null || _foo3 === void 0 ? void 0 : (_foo3$bar = _foo3.bar).baz.bind(_foo3$bar))();
+(_foo4 = foo) === null || _foo4 === void 0 ? void 0 : (_foo4$bar$baz = (_foo4$bar = _foo4.bar).baz) === null || _foo4$bar$baz === void 0 ? void 0 : _foo4$bar$baz.call(_foo4$bar);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10802, closes #11327 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
It has been out there for quite a while and the fix seems more tricky than previously proposed in #11327 and #10802.

Unrelated: Can we introduce a granular `loose`-like `assumeNoAccessor` options in all the transformer plugins? Because I feel that the accessor-related memoizing code could bloat the code size. This option should also help `rest-spread` and `destructuring` transforms.