### PR TITLE
Update typescript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "rollup-plugin-terser": "^7.0.0",
     "test262-stream": "^1.3.0",
     "through2": "^2.0.0",
-    "typescript": "^3.6.3"
+    "typescript": "^3.9.7"
   },
   "workspaces": [
     "codemods/*",

--- a/packages/babel-types/scripts/generators/typescript.js
+++ b/packages/babel-types/scripts/generators/typescript.js
@@ -128,9 +128,8 @@ for (const typeName of t.TYPES) {
 
   lines.push(
     `export function is${typeName}(node: object | null | undefined, opts?: object | null): ${result};`,
-    // TypeScript 3.7: https://github.com/microsoft/TypeScript/pull/32695 will allow assert declarations
     // eslint-disable-next-line max-len
-    `// export function assert${typeName}(node: object | null | undefined, opts?: object | null): asserts ${
+    `export function assert${typeName}(node: object | null | undefined, opts?: object | null): asserts ${
       result === "boolean" ? "node" : result
     };`
   );
@@ -138,8 +137,7 @@ for (const typeName of t.TYPES) {
 
 lines.push(
   // assert/
-  // Commented out as this declaration requires TypeScript 3.7 (what do?)
-  `// export function assertNode(obj: any): asserts obj is Node`,
+  `export function assertNode(obj: any): asserts obj is Node`,
 
   // builders/
   // eslint-disable-next-line max-len
@@ -304,9 +302,8 @@ lines.push(
   // the MemberExpression implication is incidental, but it follows from the implementation
   // eslint-disable-next-line max-len
   `export function matchesPattern(node: Node | null | undefined, match: string | ReadonlyArray<string>, allowPartial?: boolean): node is MemberExpression`,
-  // TypeScript 3.7: ": asserts n is T"
   // eslint-disable-next-line max-len
-  `export function validate<T extends Node, K extends keyof T>(n: Node | null | undefined, key: K, value: T[K]): void`,
+  `export function validate<T extends Node, K extends keyof T>(n: Node | null | undefined, key: K, value: T[K]): asserts n is T`,
   `export function validate(n: Node, key: string, value: any): void;`
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4737,7 +4737,7 @@ __metadata:
     rollup-plugin-terser: ^7.0.0
     test262-stream: ^1.3.0
     through2: ^2.0.0
-    typescript: ^3.6.3
+    typescript: ^3.9.7
   dependenciesMeta:
     core-js:
       built: false
@@ -12893,7 +12893,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-typescript@^3.6.3:
+typescript@^3.9.7:
   version: 3.9.7
   resolution: "typescript@npm:3.9.7"
   bin:
@@ -12903,7 +12903,7 @@ typescript@^3.6.3:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^3.6.3#builtin<compat/typescript>":
+"typescript@patch:typescript@^3.9.7#builtin<compat/typescript>":
   version: 3.9.7
   resolution: "typescript@patch:typescript@npm%3A3.9.7#builtin<compat/typescript>::version=3.9.7&hash=5bf698"
   bin:


### PR DESCRIPTION
This is needed in the context of migration to typescript #11578 to allow using `import type` typescript syntax.

Also, updated generated types in `@babel/types` to have `assert` annotations.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | yes, updated typescript
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11580"><img src="https://gitpod.io/api/apps/github/pbs/github.com/zxbodya/babel.git/910c03c150ec8e1c400ccae3c904c070b45d4fa8.svg" /></a>

