### PR TITLE
Fix comments for smartPipeline topic-forbidding contexts

### DIFF
--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -659,9 +659,7 @@ export default class StatementParser extends ExpressionParser {
 
       clause.body =
         // For the smartPipelines plugin: Disable topic references from outer
-        // contexts within the function body. They are permitted in function
-        // default-parameter expressions, which are part of the outer context,
-        // outside of the function body.
+        // contexts within the catch clause's body.
         this.withTopicForbiddingContext(() =>
           // Parse the catch clause's body.
           this.parseBlock(false, false),
@@ -718,9 +716,9 @@ export default class StatementParser extends ExpressionParser {
 
     node.body =
       // For the smartPipelines plugin:
-      // Disable topic references from outer contexts within the function body.
+      // Disable topic references from outer contexts within the with statement's body.
       // They are permitted in function default-parameter expressions, which are
-      // part of the outer context, outside of the function body.
+      // part of the outer context, outside of the with statement's body.
       this.withTopicForbiddingContext(() =>
         // Parse the statement body.
         this.parseStatement("with"),
@@ -1074,8 +1072,8 @@ export default class StatementParser extends ExpressionParser {
     this.parseFunctionParams(node);
 
     // For the smartPipelines plugin: Disable topic references from outer
-    // contexts within the function body. They are permitted in test
-    // expressions, outside of the function body.
+    // contexts within the function body. They are permitted in function
+    // default-parameter expressions, outside of the function body.
     this.withTopicForbiddingContext(() => {
       // Parse the function body.
       this.parseFunctionBodyAndFinish(
@@ -1197,8 +1195,7 @@ export default class StatementParser extends ExpressionParser {
     this.expect(tt.braceL);
 
     // For the smartPipelines plugin: Disable topic references from outer
-    // contexts within the class body. They are permitted in test expressions,
-    // outside of the class body.
+    // contexts within the class body.
     this.withTopicForbiddingContext(() => {
       while (!this.match(tt.braceR)) {
         if (this.eat(tt.semi)) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | no
| Patch: Bug Fix?          | just comment strings
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | no
| Documentation PR Link    | no
| Any Dependency Changes?  | no
| License                  | MIT

I think these comments were probably hastily copied and pasted between different statement types without updating the comments to be specific to that statement type. I updated the comments to reflect what's actually the case to the best of my ability.
