### PR TITLE
chore: use latest node in GitHub actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,16 +5,13 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [13.x]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/checkout@v2
+      - name: Use Node.js latest
+        uses: actions/setup-node@v2-beta
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "*"
       - name: Environment log
         id: env
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,13 +12,8 @@ jobs:
         uses: actions/setup-node@v2-beta
         with:
           node-version: "*"
-      - name: Environment log
-        id: env
-        run: |
-          yarn --version
       - name: Generate coverage report
         run: |
-          yarn --version
           make -j test-ci-coverage
       - name: Upload coverage report
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
- Updated `actions/checkout` to `v2`, which [improves](https://github.com/actions/checkout#whats-new) performance.
- Updated `actions/setup-node` to `v2-beta`
- Updated node.js to latest versions

Will mark it ready when CI is green.