### PR TITLE
Make error message prefixes more descriptive

### DIFF
--- a/packages/babel-core/src/config/full.ts
+++ b/packages/babel-core/src/config/full.ts
@@ -220,7 +220,9 @@ function enhanceError<T extends Function>(context: ConfigContext, fn: T): T {
       // There are a few case where thrown errors will try to annotate themselves multiple times, so
       // to keep things simple we just bail out if re-wrapping the message.
       if (!/^\[BABEL\]/.test(e.message)) {
-        e.message = `[BABEL] ${context.filename || "unknown"}: ${e.message}`;
+        e.message = `[BABEL] ${context.filename ?? "unknown file"}: ${
+          e.message
+        }`;
       }
 
       throw e;

--- a/packages/babel-core/src/transformation/index.ts
+++ b/packages/babel-core/src/transformation/index.ts
@@ -46,7 +46,7 @@ export function* run(
   try {
     yield* transformFile(file, config.passes);
   } catch (e) {
-    e.message = `${opts.filename ?? "unknown"}: ${e.message}`;
+    e.message = `${opts.filename ?? "unknown file"}: ${e.message}`;
     if (!e.code) {
       e.code = "BABEL_TRANSFORM_ERROR";
     }
@@ -59,7 +59,7 @@ export function* run(
       ({ outputCode, outputMap } = generateCode(config.passes, file));
     }
   } catch (e) {
-    e.message = `${opts.filename ?? "unknown"}: ${e.message}`;
+    e.message = `${opts.filename ?? "unknown file"}: ${e.message}`;
     if (!e.code) {
       e.code = "BABEL_GENERATE_ERROR";
     }

--- a/packages/babel-core/test/__snapshots__/option-manager.js.snap
+++ b/packages/babel-core/test/__snapshots__/option-manager.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is following a preset 1`] = `
-"[BABEL] unknown: Unknown option: .useSpread. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
+"[BABEL] unknown file: Unknown option: .useSpread. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
 - Maybe you meant to use
 \\"presets\\": [
   [\\"./fixtures/option-manager/babel-preset-bar\\", {
@@ -12,7 +12,7 @@ To be a valid preset, its name and options should be wrapped in a pair of bracke
 `;
 
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a plugin 1`] = `
-"[BABEL] unknown: .useSpread is not a valid Plugin property
+"[BABEL] unknown file: .useSpread is not a valid Plugin property
 - Maybe you meant to use
 \\"plugins\\": [
   [\\"./fixtures/option-manager/babel-plugin-foo\\", {
@@ -23,7 +23,7 @@ To be a valid plugin, its name and options should be wrapped in a pair of bracke
 `;
 
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a preset 1`] = `
-"[BABEL] unknown: Unknown option: .useBuiltIns. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
+"[BABEL] unknown file: Unknown option: .useBuiltIns. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
 - Maybe you meant to use
 \\"presets\\": [
   [\\"./fixtures/option-manager/babel-preset-bar\\", {

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -947,7 +947,9 @@ describe("api", function () {
             },
           ],
         }),
-      ).toThrowErrorMatchingInlineSnapshot(`"unknown: Unknown helper fooBar"`);
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"unknown file: Unknown helper fooBar"`,
+      );
     });
   });
 });

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -123,7 +123,7 @@ describe("asynchronicity", () => {
         process.chdir("plugin");
 
         expect(() => babel.transformSync("")).toThrow(
-          `[BABEL] unknown: You appear to be using an async plugin/preset, but Babel` +
+          `[BABEL] unknown file: You appear to be using an async plugin/preset, but Babel` +
             ` has been called synchronously`,
         );
       });
@@ -144,7 +144,7 @@ describe("asynchronicity", () => {
         expect(() =>
           babel.transformSync(""),
         ).toThrowErrorMatchingInlineSnapshot(
-          `"unknown: You appear to be using an plugin with an async .pre, which your current version` +
+          `"unknown file: You appear to be using an plugin with an async .pre, which your current version` +
             ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
             ` @babel/core version."`,
         );
@@ -156,7 +156,7 @@ describe("asynchronicity", () => {
         await expect(
           babel.transformAsync(""),
         ).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"unknown: You appear to be using an plugin with an async .pre, which your current version` +
+          `"unknown file: You appear to be using an plugin with an async .pre, which your current version` +
             ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
             ` @babel/core version."`,
         );
@@ -170,7 +170,7 @@ describe("asynchronicity", () => {
         expect(() =>
           babel.transformSync(""),
         ).toThrowErrorMatchingInlineSnapshot(
-          `"unknown: You appear to be using an plugin with an async .post, which your current version` +
+          `"unknown file: You appear to be using an plugin with an async .post, which your current version` +
             ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
             ` @babel/core version."`,
         );
@@ -182,7 +182,7 @@ describe("asynchronicity", () => {
         await expect(
           babel.transformAsync(""),
         ).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"unknown: You appear to be using an plugin with an async .post, which your current version` +
+          `"unknown file: You appear to be using an plugin with an async .post, which your current version` +
             ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
             ` @babel/core version."`,
         );
@@ -194,7 +194,7 @@ describe("asynchronicity", () => {
         process.chdir("plugin-inherits");
 
         expect(() => babel.transformSync("")).toThrow(
-          `[BABEL] unknown: You appear to be using an async plugin/preset, but Babel has been` +
+          `[BABEL] unknown file: You appear to be using an async plugin/preset, but Babel has been` +
             ` called synchronously`,
         );
       });
@@ -234,7 +234,7 @@ describe("asynchronicity", () => {
         process.chdir("preset");
 
         expect(() => babel.transformSync("")).toThrow(
-          `[BABEL] unknown: You appear to be using an async plugin/preset, ` +
+          `[BABEL] unknown file: You appear to be using an async plugin/preset, ` +
             `but Babel has been called synchronously`,
         );
       });
@@ -253,7 +253,7 @@ describe("asynchronicity", () => {
         process.chdir("preset-plugin-promise");
 
         expect(() => babel.transformSync("")).toThrow(
-          `[BABEL] unknown: You appear to be using a promise as a plugin, which your` +
+          `[BABEL] unknown file: You appear to be using a promise as a plugin, which your` +
             ` current version of Babel does not support. If you're using a published` +
             ` plugin, you may need to upgrade your @babel/core version. As an` +
             ` alternative, you can prefix the promise with "await".`,
@@ -264,7 +264,7 @@ describe("asynchronicity", () => {
         process.chdir("preset-plugin-promise");
 
         await expect(babel.transformAsync("")).rejects.toThrow(
-          `[BABEL] unknown: You appear to be using a promise as a plugin, which your` +
+          `[BABEL] unknown file: You appear to be using a promise as a plugin, which your` +
             ` current version of Babel does not support. If you're using a published` +
             ` plugin, you may need to upgrade your @babel/core version. As an` +
             ` alternative, you can prefix the promise with "await".`,

--- a/packages/babel-core/test/errors-stacks.js
+++ b/packages/babel-core/test/errors-stacks.js
@@ -207,7 +207,7 @@ describe("@babel/core errors", function () {
         root: fixture("use-exclude-in-preset"),
       });
     }).toMatchInlineSnapshot(`
-      "Error: [BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,
+      "Error: [BABEL] unknown file: Preset /* your preset */ requires a filename to be set when babel is called directly,
       \`\`\`
       babel.transformSync(code, { filename: 'file.ts', presets: [/* your preset */] });
       \`\`\`

--- a/packages/babel-core/test/fixtures/plugins/build-code-frame-error/exec.js
+++ b/packages/babel-core/test/fixtures/plugins/build-code-frame-error/exec.js
@@ -15,4 +15,4 @@ expect(() => {
     // hard to assert on ANSI escape codes
     highlightCode: false,
   });
-}).toThrow(/^unknown: someMsg\s+> 1 \| function f\(\) {}/);
+}).toThrow(/^unknown file: someMsg\s+> 1 \| function f\(\) {}/);


### PR DESCRIPTION
~Sorry for the drive-by contribution. Didn't want to forget about it. I'll look at possible CI failures later.~ Updated tests

I noticed when testing errors for babel macro with `babel-plugin-tester` that the error messages would be prefixed with `unknown:`. It wasn't clear to me whether this was an issue on my side with custom errors or babel-plugin-tester. 

Turns out this is expected if the code does not come from an actual file. Hopefully this is less confusing for future users if we prefix it with "unknown file" instead of "unknown". It's not obvious to me that "unknown" refers to a file in the error context.

It might even make more sense to not prefix the filename and instead append the filename e.g.

```
Some error message from plugin X
  in /path/to/file/that/is/transformed.js
```

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | found none using keywords `unknown error`
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Probably
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11612"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

