### PR TITLE
Fix standalone tag when data-type is not set.

### DIFF
--- a/packages/babel-standalone/src/transformScriptTags.js
+++ b/packages/babel-standalone/src/transformScriptTags.js
@@ -53,7 +53,7 @@ function buildBabelOptions(script, filename) {
  */
 function run(transformFn, script) {
   const scriptEl = document.createElement("script");
-  if (typeof script.type !== "undefined") {
+  if (script.type) {
     scriptEl.setAttribute("type", script.type);
   }
   scriptEl.text = transformCode(transformFn, script);


### PR DESCRIPTION
Fixes #11621.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11621, fixes #11628
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | No
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I thought `getAttribute` returned `undefined` when the attribute was unset, but it actually returns null. 🤦‍♂️

I manually tested this patch with and without a `data-type` attribute. (It appears that the babel-standalone script tag has no tests?? I might add some later, but for now, I want to fix this bug right away.)