### PR TITLE
Use `repository.directory` field in `package.json` files

### DIFF
--- a/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
+++ b/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-codemod-object-assign-to-object-spread",
   "version": "7.7.4",
   "description": "Transforms Object.assign into object spread syntax",
-  "repository": "https://github.com/babel/babel/tree/master/codemods/babel-plugin-codemod-object-assign-to-object-spread",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "codemods/babel-plugin-codemod-object-assign-to-object-spread"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/codemods/babel-plugin-codemod-optional-catch-binding/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-codemod-optional-catch-binding",
   "version": "7.7.4",
   "description": "Remove unused catch bindings",
-  "repository": "https://github.com/babel/babel/tree/master/codemods/babel-plugin-codemod-remove-unused-catch-binding",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "codemods/babel-plugin-codemod-remove-unused-catch-binding"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/eslint/babel-eslint-config-internal/package.json
+++ b/eslint/babel-eslint-config-internal/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type" : "git",
     "url" : "https://github.com/babel/babel.git",
-    "directory": "packages/babel-eslint-config-internal"
+    "directory": "eslint/babel-eslint-config-internal"
   },
   "main": "index.js",
   "peerDependencies": {

--- a/eslint/babel-eslint-config-internal/package.json
+++ b/eslint/babel-eslint-config-internal/package.json
@@ -6,7 +6,11 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "private": true,
-  "repository": "https://github.com/babel/babel/tree/master/eslint/babel-eslint-config-internal",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-eslint-config-internal"
+  },
   "main": "index.js",
   "peerDependencies": {
     "babel-eslint": "^10.0.0 || ^11.0.0-0",

--- a/eslint/babel-eslint-plugin/package.json
+++ b/eslint/babel-eslint-plugin/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/babel/babel.git",
+    "url": "https://github.com/babel/babel.git",
     "directory": "eslint/babel-eslint-plugin"
   },
   "keywords": [

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-cli",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-cli"
+  },
   "keywords": [
     "6to5",
     "babel",

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-code-frame",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-code-frame"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/highlight": "^7.8.3"

--- a/packages/babel-compat-data/package.json
+++ b/packages/babel-compat-data/package.json
@@ -4,7 +4,11 @@
   "author": "The Babel Team (https://babeljs.io/team)",
   "license": "MIT",
   "description": "",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-compat-data",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-compat-data"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -9,7 +9,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-core",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-core"
+  },
   "keywords": [
     "6to5",
     "babel",

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-generator",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-generator"
+  },
   "main": "lib/index.js",
   "files": [
     "lib"

--- a/packages/babel-helper-annotate-as-pure/package.json
+++ b/packages/babel-helper-annotate-as-pure/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-annotate-as-pure",
   "version": "7.8.3",
   "description": "Helper function to annotate paths and nodes with #__PURE__ comment",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-annotate-as-pure",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-annotate-as-pure"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-bindify-decorators/package.json
+++ b/packages/babel-helper-bindify-decorators/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-bindify-decorators",
   "version": "7.8.3",
   "description": "Helper function to bindify decorators",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-bindify-decorators",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-bindify-decorators"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-builder-binary-assignment-operator-visitor",
   "version": "7.8.3",
   "description": "Helper function to build binary assignment operator visitors",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-builder-binary-assignment-operator-visitor"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-builder-react-jsx-experimental/package.json
+++ b/packages/babel-helper-builder-react-jsx-experimental/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-builder-react-jsx-experimental",
   "version": "7.9.5",
   "description": "Helper function to build react jsx",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx-experimental",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-builder-react-jsx-experimental"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-builder-react-jsx",
   "version": "7.9.0",
   "description": "Helper function to build react jsx",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-builder-react-jsx"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-call-delegate/package.json
+++ b/packages/babel-helper-call-delegate/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-call-delegate",
   "version": "7.8.7",
   "description": "Helper function to call delegate",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-call-delegate"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -4,7 +4,11 @@
   "author": "The Babel Team (https://babeljs.io/team)",
   "license": "MIT",
   "description": "Engine compat data used in @babel/preset-env",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-compilation-targets",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-compilation-targets"
+  },
   "main": "lib/index.js",
   "exports": {
     ".": "./lib/index.js"

--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -4,7 +4,11 @@
   "author": "The Babel Team (https://babeljs.io/team)",
   "license": "MIT",
   "description": "Compile class public and private fields, private methods and decorators to ES6",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-create-class-features-plugin",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-create-class-features-plugin"
+  },
   "main": "lib/index.js",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -6,7 +6,7 @@
   "description": "Compile ESNext Regular Expressions to ES5",
   "repository": {
     "type": "git",
-    "url": "https://github.com/babel/babel",
+    "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-helper-create-regexp-features-plugin"
   },
   "main": "lib/index.js",

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-define-map",
   "version": "7.8.3",
   "description": "Helper function to define a map",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-define-map",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-define-map"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-explode-assignable-expression",
   "version": "7.8.3",
   "description": "Helper function to explode an assignable expression",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-explode-assignable-expression"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-explode-class/package.json
+++ b/packages/babel-helper-explode-class/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-explode-class",
   "version": "7.8.3",
   "description": "Helper function to explode class",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-class",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-explode-class"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -7,7 +7,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-fixtures",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-fixtures"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "lodash": "^4.17.13",

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-function-name",
   "version": "7.9.5",
   "description": "Helper function to change the property 'name' of every function",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-function-name",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-function-name"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-get-function-arity/package.json
+++ b/packages/babel-helper-get-function-arity/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-get-function-arity",
   "version": "7.8.3",
   "description": "Helper function to get function arity",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-get-function-arity"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-hoist-variables",
   "version": "7.8.3",
   "description": "Helper function to hoist variables",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-hoist-variables"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-member-expression-to-functions/package.json
+++ b/packages/babel-helper-member-expression-to-functions/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-member-expression-to-functions",
   "version": "7.10.0",
   "description": "Helper function to replace certain member expressions with function calls",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-member-expression-to-functions",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-member-expression-to-functions"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-module-imports"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/types": "^7.8.3"

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-module-transforms",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-module-transforms"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-module-imports": "^7.8.3",

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-optimise-call-expression",
   "version": "7.10.0",
   "description": "Helper function to optimise call expression",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-optimise-call-expression"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-plugin-test-runner/package.json
+++ b/packages/babel-helper-plugin-test-runner/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-plugin-test-runner",
   "version": "7.8.3",
   "description": "Helper function to support test runner",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-test-runner",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-plugin-test-runner"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-plugin-utils/package.json
+++ b/packages/babel-helper-plugin-utils/package.json
@@ -8,6 +8,10 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-utils",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-plugin-utils"
+  },
   "main": "lib/index.js"
 }

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-regex",
   "version": "7.8.3",
   "description": "Helper function to check for literal RegEx",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-regex",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-regex"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-remap-async-to-generator",
   "version": "7.8.3",
   "description": "Helper function to remap async functions to generators",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-remap-async-to-generator"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-replace-supers",
   "version": "7.10.0",
   "description": "Helper function to replace supers",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-replace-supers"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-simple-access",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-simple-access"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/template": "^7.8.3",

--- a/packages/babel-helper-split-export-declaration/package.json
+++ b/packages/babel-helper-split-export-declaration/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-split-export-declaration",
   "version": "7.8.3",
   "description": "",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-split-export-declaration",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-split-export-declaration"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-transform-fixture-test-runner",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-transform-fixture-test-runner"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/code-frame": "^7.8.3",

--- a/packages/babel-helper-validator-identifier/package.json
+++ b/packages/babel-helper-validator-identifier/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-validator-identifier",
   "version": "7.9.5",
   "description": "Validate identifier/keywords name",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-validator-identifier",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-validator-identifier"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/helper-wrap-function",
   "version": "7.8.3",
   "description": "Helper to wrap functions inside a function call.",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-wrap-function"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helpers",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helpers"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/template": "^7.10.0",

--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-highlight",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-highlight"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-validator-identifier": "^7.9.0",

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-node",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-node"
+  },
   "keywords": [
     "6to5",
     "babel",

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -16,7 +16,11 @@
     "ecmascript",
     "@babel/parser"
   ],
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-parser",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-parser"
+  },
   "main": "lib/index.js",
   "types": "typings/babel-parser.d.ts",
   "files": [

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-external-helpers",
   "version": "7.8.3",
   "description": "This plugin contains helper functions that’ll be placed at the top of the generated code",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-external-helpers",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-external-helpers"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-async-generator-functions/package.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-async-generator-functions",
   "version": "7.8.3",
   "description": "Turn async generator functions into ES2015 generators",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-async-generator-functions"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-class-properties",
   "version": "7.8.3",
   "description": "This plugin transforms static class properties as well as properties declared with the property initializer syntax",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-class-properties",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-class-properties"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -7,7 +7,11 @@
     "access": "public"
   },
   "description": "Compile class and object decorators to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-decorators",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-decorators"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel",

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-do-expressions",
   "version": "7.8.3",
   "description": "Compile do expressions to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-do-expressions",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-do-expressions"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-dynamic-import/package.json
+++ b/packages/babel-plugin-proposal-dynamic-import/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-dynamic-import",
   "version": "7.8.3",
   "description": "Transform import() expressions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-dynamic-import",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-dynamic-import"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-export-default-from/package.json
+++ b/packages/babel-plugin-proposal-export-default-from/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-export-default-from",
   "version": "7.8.3",
   "description": "Compile export default to ES2015",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-default-from",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-export-default-from"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-export-namespace-from/package.json
+++ b/packages/babel-plugin-proposal-export-namespace-from/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-export-namespace-from",
   "version": "7.8.3",
   "description": "Compile export namespace to ES2015",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-namespace-from",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-export-namespace-from"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-function-bind",
   "version": "7.8.3",
   "description": "Compile function bind operator to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-bind",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-function-bind"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-function-sent",
   "version": "7.8.3",
   "description": "Compile the function.sent meta property to valid ES2015 code",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-sent",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-function-sent"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-json-strings/package.json
+++ b/packages/babel-plugin-proposal-json-strings/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-json-strings",
   "version": "7.10.0",
   "description": "Escape U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR in JS strings",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-json-strings",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-json-strings"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-logical-assignment-operators",
   "version": "7.10.0",
   "description": "Transforms logical assignment operators into short-circuited assignments",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-logical-assignment-operators",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-logical-assignment-operators"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-nullish-coalescing-operator",
   "version": "7.8.3",
   "description": "Remove nullish coalescing operator",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-nullish-coalescing-operator",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-nullish-coalescing-operator"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-numeric-separator/package.json
+++ b/packages/babel-plugin-proposal-numeric-separator/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-numeric-separator",
   "version": "7.8.3",
   "description": "Remove numeric separators from Decimal, Binary, Hex and Octal literals",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-numeric-separator",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-numeric-separator"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-object-rest-spread/package.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-object-rest-spread",
   "version": "7.10.0",
   "description": "Compile object rest and spread to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-object-rest-spread"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-optional-catch-binding/package.json
+++ b/packages/babel-plugin-proposal-optional-catch-binding/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-optional-catch-binding",
   "version": "7.8.3",
   "description": "Compile optional catch bindings",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-optional-catch-binding"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-optional-chaining",
   "version": "7.10.0",
   "description": "Transform optional chaining operators into a series of nil checks",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-chaining",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-optional-chaining"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-partial-application/package.json
+++ b/packages/babel-plugin-proposal-partial-application/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-partial-application",
   "version": "7.8.3",
   "description": "Introduces a new ? token in an argument list which allows for partially applying an argument list to a call expression",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-partial-application",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-partial-application"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-pipeline-operator",
   "version": "7.8.3",
   "description": "Transform pipeline operator into call expressions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-pipeline-operator",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-pipeline-operator"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-private-methods/package.json
+++ b/packages/babel-plugin-proposal-private-methods/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-private-methods",
   "version": "7.8.3",
   "description": "This plugin transforms private class methods",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-private-methods",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-private-methods"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-private-property-in-object/package.json
+++ b/packages/babel-plugin-proposal-private-property-in-object/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-private-property-in-object",
   "version": "7.10.0",
   "description": "This plugin transforms checks for a private property in an object",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-private-property-in-object",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-private-property-in-object"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-proposal-throw-expressions",
   "version": "7.8.3",
   "description": "Wraps Throw Expressions in an IIFE",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-throw-expressions",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-throw-expressions"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -19,7 +19,11 @@
     "unicode properties",
     "unicode"
   ],
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-unicode-property-regex",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-unicode-property-regex"
+  },
   "bugs": "https://github.com/babel/babel/issues",
   "dependencies": {
     "@babel/helper-create-regexp-features-plugin": "^7.8.8",

--- a/packages/babel-plugin-syntax-class-properties/package.json
+++ b/packages/babel-plugin-syntax-class-properties/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-class-properties",
   "version": "7.8.3",
   "description": "Allow parsing of class properties",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-class-properties"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-decorators",
   "version": "7.8.3",
   "description": "Allow parsing of decorators",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-decorators",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-decorators"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-do-expressions",
   "version": "7.8.3",
   "description": "Allow parsing of do expressions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-do-expressions",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-do-expressions"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-export-default-from/package.json
+++ b/packages/babel-plugin-syntax-export-default-from/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-export-default-from",
   "version": "7.8.3",
   "description": "Allow parsing of export default from",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-default-from",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-export-default-from"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-flow",
   "version": "7.8.3",
   "description": "Allow parsing of the flow syntax",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-flow",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-flow"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-function-bind",
   "version": "7.8.3",
   "description": "Allow parsing of function bind",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-bind",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-function-bind"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-function-sent",
   "version": "7.8.3",
   "description": "Allow parsing of the function.sent meta property",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-sent",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-function-sent"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-import-meta/package.json
+++ b/packages/babel-plugin-syntax-import-meta/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-import-meta",
   "version": "7.8.3",
   "description": "Allow parsing of import.meta",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-import-meta",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-import-meta"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-jsx",
   "version": "7.8.3",
   "description": "Allow parsing of jsx",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-jsx"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-syntax-logical-assignment-operators/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-logical-assignment-operators",
   "version": "7.8.3",
   "description": "Allow parsing of the logical assignment operators",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-logical-assignment-operators",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-logical-assignment-operators"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-module-attributes/package.json
+++ b/packages/babel-plugin-syntax-module-attributes/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-module-attributes",
   "version": "7.10.0",
   "description": "Allow parsing of the module attributes in the import statement",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-module-attributes",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-module-attributes"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-numeric-separator/package.json
+++ b/packages/babel-plugin-syntax-numeric-separator/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-numeric-separator",
   "version": "7.8.3",
   "description": "Allow parsing of Decimal, Binary, Hex and Octal literals that contain a Numeric Literal Separator",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-numeric-separator",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-numeric-separator"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-partial-application/package.json
+++ b/packages/babel-plugin-syntax-partial-application/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-partial-application",
   "version": "7.8.3",
   "description": "Allow parsing of partial application syntax",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-partial-application",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-partial-application"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-pipeline-operator/package.json
+++ b/packages/babel-plugin-syntax-pipeline-operator/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-pipeline-operator",
   "version": "7.8.3",
   "description": "Allow parsing of the pipeline operator",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-pipeline-operator",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-pipeline-operator"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-record-and-tuple/package.json
+++ b/packages/babel-plugin-syntax-record-and-tuple/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-record-and-tuple",
   "version": "7.9.0",
   "description": "Allow parsing of records and tuples.",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-record-and-tuple",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-record-and-tuple"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-throw-expressions/package.json
+++ b/packages/babel-plugin-syntax-throw-expressions/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-throw-expressions",
   "version": "7.8.3",
   "description": "Allow parsing of Throw Expressions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-throw-expressions",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-throw-expressions"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-top-level-await/package.json
+++ b/packages/babel-plugin-syntax-top-level-await/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-top-level-await",
   "version": "7.8.3",
   "description": "Allow parsing of top-level await in modules",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-top-level-await",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-top-level-await"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-syntax-typescript",
   "version": "7.8.3",
   "description": "Allow parsing of TypeScript syntax",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-typescript",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-typescript"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-arrow-functions",
   "version": "7.8.3",
   "description": "Compile ES2015 arrow functions to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-arrow-functions"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-async-to-generator",
   "version": "7.8.3",
   "description": "Turn async functions into ES2015 generators",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-async-to-generator"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-block-scoped-functions",
   "version": "7.8.3",
   "description": "Babel plugin to ensure function declarations at the block level are block scoped",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-block-scoped-functions"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-block-scoping",
   "version": "7.10.0",
   "description": "Compile ES2015 block scoping (const and let) to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-block-scoping"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-classes",
   "version": "7.9.5",
   "description": "Compile ES2015 classes to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-classes"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-computed-properties",
   "version": "7.8.3",
   "description": "Compile ES2015 computed properties to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-computed-properties"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-destructuring",
   "version": "7.10.0",
   "description": "Compile ES2015 destructuring to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-destructuring"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-dotall-regex/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/package.json
@@ -15,7 +15,11 @@
     "regular expressions",
     "dotall"
   ],
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-dotall-regex",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-dotall-regex"
+  },
   "bugs": "https://github.com/babel/babel/issues",
   "dependencies": {
     "@babel/helper-create-regexp-features-plugin": "^7.8.3",

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-duplicate-keys",
   "version": "7.8.3",
   "description": "Compile objects with duplicate keys to valid strict ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-duplicate-keys"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-exponentiation-operator",
   "version": "7.8.3",
   "description": "Compile exponentiation operator to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-exponentiation-operator",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-exponentiation-operator"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-flow-comments",
   "version": "7.10.0",
   "description": "Turn flow type annotations into comments",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-comments",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-flow-comments"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-flow-strip-types",
   "version": "7.9.0",
   "description": "Strip flow type annotations from your output code.",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-strip-types",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-flow-strip-types"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-for-of",
   "version": "7.10.0",
   "description": "Compile ES2015 for...of to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-for-of",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-for-of"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-function-name",
   "version": "7.8.3",
   "description": "Apply ES2015 function.name semantics to all functions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-function-name",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-function-name"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-instanceof",
   "version": "7.8.3",
   "description": "This plugin transforms all the ES2015 'instanceof' methods",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-instanceof",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-instanceof"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-jscript",
   "version": "7.8.3",
   "description": "Babel plugin to fix buggy JScript named function expressions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-jscript",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-jscript"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-literals",
   "version": "7.8.3",
   "description": "Compile ES2015 unicode string and number literals to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-literals",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-literals"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-member-expression-literals",
   "version": "7.8.3",
   "description": "Ensure that reserved words are quoted in property accesses",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-member-expression-literals"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-modules-amd",
   "version": "7.9.6",
   "description": "This plugin transforms ES2015 modules to AMD",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-modules-amd"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-modules-commonjs",
   "version": "7.9.6",
   "description": "This plugin transforms ES2015 modules to CommonJS",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-modules-commonjs"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-modules-systemjs",
   "version": "7.10.0",
   "description": "This plugin transforms ES2015 modules to SystemJS",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-modules-systemjs"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-modules-umd",
   "version": "7.9.0",
   "description": "This plugin transforms ES2015 modules to UMD",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-umd",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-modules-umd"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-new-target",
   "version": "7.8.3",
   "description": "Transforms new.target meta property",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-new-target"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-object-assign",
   "version": "7.8.3",
   "description": "Replace Object.assign with an inline helper",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-assign",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-object-assign"
+  },
   "author": "Jed Watson",
   "license": "MIT",
   "publishConfig": {

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-object-set-prototype-of-to-assign",
   "version": "7.8.3",
   "description": "Turn Object.setPrototypeOf to assignments",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-set-prototype-of-to-assign",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-object-set-prototype-of-to-assign"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-object-super",
   "version": "7.8.3",
   "description": "Compile ES2015 object super to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-object-super"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-parameters",
   "version": "7.9.5",
   "description": "Compile ES2015 default and rest parameters to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-parameters",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-parameters"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-property-literals",
   "version": "7.8.3",
   "description": "Ensure that reserved words are quoted in object property keys",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-literals",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-property-literals"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-property-mutators",
   "version": "7.8.3",
   "description": "Compile ES5 property mutator shorthand syntax to Object.defineProperty",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-mutators",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-property-mutators"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-proto-to-assign",
   "version": "7.8.3",
   "description": "Babel plugin for turning __proto__ into a shallow property clone",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-proto-to-assign",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-proto-to-assign"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-react-constant-elements",
   "version": "7.9.0",
   "description": "Treat React JSX elements as value types and hoist them to the highest scope",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-constant-elements",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-react-constant-elements"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-react-display-name",
   "version": "7.8.3",
   "description": "Add displayName to React.createClass calls",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-react-display-name"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-react-inline-elements",
   "version": "7.9.0",
   "description": "Turn JSX elements into exploded React objects",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-inline-elements",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-react-inline-elements"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-react-jsx-compat",
   "version": "7.8.3",
   "description": "Turn JSX into React Pre-0.12 function calls",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-compat",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-react-jsx-compat"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-react-jsx-development/package.json
+++ b/packages/babel-plugin-transform-react-jsx-development/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-react-jsx-development",
   "version": "7.9.0",
   "description": "Turn JSX into React function calls in development",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-development",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-react-jsx-development"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-react-jsx-self",
   "version": "7.9.0",
   "description": "Add a __self prop to all JSX Elements",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-self",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-react-jsx-self"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-react-jsx-source",
   "version": "7.10.0",
   "description": "Add a __source prop to all JSX Elements",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-react-jsx-source"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-react-jsx",
   "version": "7.9.4",
   "description": "Turn JSX into React function calls",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-react-jsx"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-react-pure-annotations/package.json
+++ b/packages/babel-plugin-transform-react-pure-annotations/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type" : "git",
     "url" : "https://github.com/babel/babel.git",
-    "directory": "packages/babel-plugin-transform-react-pure"
+    "directory": "packages/babel-plugin-transform-react-pure-annotations"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/babel-plugin-transform-react-pure-annotations/package.json
+++ b/packages/babel-plugin-transform-react-pure-annotations/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-react-pure-annotations",
   "version": "7.10.0",
   "description": "Mark top-level React method calls as pure for tree shaking",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-pure",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-react-pure"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -4,7 +4,11 @@
   "description": "Explode async and generator functions into a state machine.",
   "version": "7.8.7",
   "homepage": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-regenerator"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "regenerator-transform": "^0.14.2"

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-reserved-words",
   "version": "7.8.3",
   "description": "Ensure that no reserved words are used.",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-reserved-words",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-reserved-words"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-runtime",
   "version": "7.10.0",
   "description": "Externalise references to helpers and builtins, automatically polyfilling your code without polluting globals",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-runtime"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-shorthand-properties",
   "version": "7.8.3",
   "description": "Compile ES2015 shorthand properties to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-shorthand-properties",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-shorthand-properties"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-spread",
   "version": "7.10.0",
   "description": "Compile ES2015 spread to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-spread",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-spread"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-sticky-regex",
   "version": "7.8.3",
   "description": "Compile ES2015 sticky regex to an ES5 RegExp constructor",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-sticky-regex",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-sticky-regex"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-strict-mode",
   "version": "7.8.3",
   "description": "This plugin places a 'use strict'; directive at the top of all files to enable strict mode",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-strict-mode",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-strict-mode"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-template-literals",
   "version": "7.8.3",
   "description": "Compile ES2015 template literals to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-template-literals",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-template-literals"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-typeof-symbol",
   "version": "7.8.4",
   "description": "This transformer wraps all typeof expressions with a method that replicates native behaviour. (ie. returning “symbol” for symbols)",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typeof-symbol",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-typeof-symbol"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-typescript",
   "version": "7.10.0",
   "description": "Transform TypeScript into ES.next",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typescript",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-typescript"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-unicode-escapes/package.json
+++ b/packages/babel-plugin-transform-unicode-escapes/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-unicode-escapes",
   "version": "7.10.0",
   "description": "Compile ES2015 Unicode escapes to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-escapes",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-unicode-escapes"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/plugin-transform-unicode-regex",
   "version": "7.8.3",
   "description": "Compile ES2015 Unicode regex to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-transform-unicode-regex"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-polyfill/package.json
+++ b/packages/babel-polyfill/package.json
@@ -12,7 +12,11 @@
     "prepublishOnly": "cp dist/polyfill.min.js browser.js",
     "postpublish": "rm browser.js"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-polyfill",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-polyfill"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "core-js": "^2.6.5",

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-env",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-preset-env"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/compat-data": "^7.10.0",

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -3,7 +3,11 @@
   "version": "7.9.0",
   "description": "Babel preset for all Flow plugins.",
   "author": "James Kyle <me@thejameskyle.com>",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-flow",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-preset-flow"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-preset-react"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.8.3",

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -2,7 +2,11 @@
   "name": "@babel/preset-typescript",
   "version": "7.9.0",
   "description": "Babel preset for TypeScript.",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-typescript",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-preset-typescript"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -6,7 +6,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-register",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-register"
+  },
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "main": "lib/index.js",
   "browser": {

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -6,7 +6,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-runtime-corejs2",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-runtime-corejs2"
+  },
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "dependencies": {
     "core-js": "^2.6.5",

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -6,7 +6,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-runtime-corejs3",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-runtime-corejs3"
+  },
   "author": "Denis Pushkarev <zloirock@zloirock.ru>",
   "dependencies": {
     "core-js-pure": "^3.0.0",

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -123,5 +123,10 @@
   "bugs": {
     "url": "https://github.com/babel/babel/issues"
   },
-  "homepage": "https://github.com/babel/babel/tree/master/packages/babel-standalone"
+  "homepage": "https://github.com/babel/babel/tree/master/packages/babel-standalone",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-standalone"
+  }
 }

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-template",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-template"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/code-frame": "^7.8.3",

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-traverse",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-traverse"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/code-frame": "^7.8.3",

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -8,7 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-types",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/babel/babel.git",
+    "directory": "packages/babel-types"
+  },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "dependencies": {


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11619  
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Changed all packages.json's files, adding the new repository field for sub-packages.
