### PR TITLE
Fix moduleAttributesVersion errors with stage-0 preset in babel standalone

### DIFF
--- a/packages/babel-plugin-syntax-module-attributes/src/index.js
+++ b/packages/babel-plugin-syntax-module-attributes/src/index.js
@@ -3,11 +3,11 @@ import { declare } from "@babel/helper-plugin-utils";
 export default declare((api, { version }) => {
   api.assertVersion(7);
 
-  if (typeof version !== "string" || version !== "apr-2020") {
+  if (typeof version !== "string" || version !== "may-2020") {
     throw new Error(
       "The 'moduleAttributes' plugin requires a 'version' option," +
         " representing the last proposal update. Currently, the" +
-        " only supported value is 'apr-2020'.",
+        " only supported value is 'may-2020'.",
     );
   }
 

--- a/packages/babel-standalone/examples/example.htm
+++ b/packages/babel-standalone/examples/example.htm
@@ -1,38 +1,49 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8" />
-  <title>babel-standalone example</title>
-</head>
-<body>
-  Input:
-  <textarea id="input" style="width: 100%" rows="10">
+  <head>
+    <meta charset="utf-8" />
+    <title>babel-standalone example</title>
+  </head>
+  <body>
+    Input:
+    <textarea id="input" style="width: 100%" rows="10">
 const getMessage = () => 'Hello World';
 const someDiv = <div>{getMessage()}</div>;
-</textarea>
+</textarea
+    >
 
-  Transformed code using Babel <strong id="version"></strong>:
-  <pre id="output">Loading...</pre>
+    Transformed code using Babel <strong id="version"></strong>:
+    <pre id="output">Loading...</pre>
 
-  <script src="../babel.js"></script>
-  <script>
-    console.log('Babel =', Babel);
-    document.getElementById('version').innerHTML = Babel.version;
-    var inputEl = document.getElementById('input');
-    var outputEl = document.getElementById('output');
+    <script src="../babel.js"></script>
+    <script>
+      console.log("Babel =", Babel);
+      document.getElementById("version").innerHTML = Babel.version;
+      var inputEl = document.getElementById("input");
+      var outputEl = document.getElementById("output");
 
-    function transform() {
-      try {
-        outputEl.innerHTML = Babel.transform(inputEl.value, {
-          presets: ['es2015', 'react', 'stage-0']
-        }).code;
-      } catch (ex) {
-        outputEl.innerHTML = 'ERROR: ' + ex.message;
+      function transform() {
+        try {
+          outputEl.innerHTML = Babel.transform(inputEl.value, {
+            presets: [
+              "es2015",
+              "react",
+              [
+                "stage-0",
+                {
+                  decoratorsBeforeExport: false,
+                  moduleAttributesVersion: "may-2020",
+                },
+              ],
+            ],
+          }).code;
+        } catch (ex) {
+          outputEl.innerHTML = "ERROR: " + ex.message;
+        }
       }
-    }
 
-    inputEl.addEventListener('keyup', transform, false);
-    transform();
-  </script>
-</body>
+      inputEl.addEventListener("keyup", transform, false);
+      transform();
+    </script>
+  </body>
 </html>

--- a/packages/babel-standalone/examples/example.htm
+++ b/packages/babel-standalone/examples/example.htm
@@ -32,7 +32,6 @@ const someDiv = <div>{getMessage()}</div>;
                 "stage-0",
                 {
                   decoratorsBeforeExport: false,
-                  moduleAttributesVersion: "may-2020",
                 },
               ],
             ],

--- a/packages/babel-standalone/src/preset-stage-0.js
+++ b/packages/babel-standalone/src/preset-stage-0.js
@@ -9,6 +9,7 @@ export default (_: any, opts: Object = {}) => {
     decoratorsLegacy = false,
     decoratorsBeforeExport,
     pipelineProposal = "minimal",
+    moduleAttributesVersion = "may-2020",
   } = opts;
 
   return {
@@ -21,6 +22,7 @@ export default (_: any, opts: Object = {}) => {
           decoratorsLegacy,
           decoratorsBeforeExport,
           pipelineProposal,
+          moduleAttributesVersion,
         },
       ],
     ],

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -203,6 +203,13 @@
           Babel.transform("/a*/u", { presets: ["es2015"] }),
         ).not.toThrow();
       });
+      it("#11628 - supports stage-0 passing moduleAttributesVersion to stage-1", () => {
+        expect(() =>
+          Babel.transform("const getMessage = () => 'Hello World'", {
+            presets: [["stage-0", { decoratorsBeforeExport: false }]],
+          }),
+        ).not.toThrow();
+      });
     });
   },
 );


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11628
| Patch: Bug Fix?          | ✅ 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT


Changes:

* Expose `moduleAttributesVersion` config option on the `stage-0` preset for babel standalone
* Forward that `moduleAttributesVersion` onto the config for `stage-1` preset
* Fix version mismatch in the `module-attributes` plugin and `plugin-utils` file (one was expecting `version: 'apr-2020'` and the other was expecting `version: 'may-2020'`, I **assumed** that may is the correct version here) See: https://github.com/babel/babel/blob/master/packages/babel-parser/src/plugin-utils.js#L95-L101
* Updated config in the `example.htm` file for testing the changes locally

Testing steps:

* `make prepublish-build-standalone`
* `npx serve ./packages/babel-standalone`
* Visit localhost and navigate to `examples/example.htm`
* Verify that babel **doesn't** hit an error when transforming the code from the textarea
