### PR TITLE
fix: add new plugin names to missing plugin helpers

### DIFF
--- a/packages/babel-core/src/parser/util/missing-plugin-helper.js
+++ b/packages/babel-core/src/parser/util/missing-plugin-helper.js
@@ -133,6 +133,12 @@ const pluginNameMap = {
       url: "https://git.io/vAlRe",
     },
   },
+  moduleAttributes: {
+    syntax: {
+      name: "@babel/plugin-syntax-module-attributes",
+      url: "https://git.io/JfK3k",
+    },
+  },
   numericSeparator: {
     syntax: {
       name: "@babel/plugin-syntax-numeric-separator",
@@ -161,6 +167,16 @@ const pluginNameMap = {
     transform: {
       name: "@babel/plugin-proposal-pipeline-operator",
       url: "https://git.io/vb4SU",
+    },
+  },
+  privateIn: {
+    syntax: {
+      name: "@babel/plugin-syntax-private-property-in-object",
+      url: "https://git.io/JfK3q",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-private-property-in-object",
+      url: "https://git.io/JfK3O",
     },
   },
   recordAndTuple: {
@@ -235,6 +251,9 @@ const pluginNameMap = {
     },
   },
 };
+
+//todo: we don't have plugin-syntax-private-property-in-object
+pluginNameMap.privateIn.syntax = pluginNameMap.privateIn.transform;
 
 const getNameURLCombination = ({ name, url }) => `${name} (${url})`;
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
A small follow-up to both #11372 and #10962.