### PR TITLE
chore: check version lazily in babel-eslint-parser

### DIFF
--- a/eslint/babel-eslint-parser/src/index.js
+++ b/eslint/babel-eslint-parser/src/index.js
@@ -1,6 +1,6 @@
 import semver from "semver";
 import {
-  version as CURRENT_BABEL_VERSION,
+  version as babelCoreVersion,
   parseSync as babelParse,
 } from "@babel/core";
 import packageJson from "../package.json";
@@ -12,17 +12,19 @@ import convert from "./convert";
 import analyzeScope from "./analyze-scope";
 import visitorKeys from "./visitor-keys";
 
-const SUPPORTED_BABEL_VERSION_RANGE =
-  packageJson.peerDependencies["@babel/core"];
-const IS_RUNNING_SUPPORTED_VERSION = semver.satisfies(
-  CURRENT_BABEL_VERSION,
-  SUPPORTED_BABEL_VERSION_RANGE,
-);
+let isRunningSupportedVersion;
 
 function baseParse(code, options) {
-  if (!IS_RUNNING_SUPPORTED_VERSION) {
+  if (typeof isRunningSupportedVersion !== "boolean") {
+    isRunningSupportedVersion = semver.satisfies(
+      babelCoreVersion,
+      packageJson.peerDependencies["@babel/core"],
+    );
+  }
+
+  if (!isRunningSupportedVersion) {
     throw new Error(
-      `babel-eslint@${packageJson.version} does not support @babel/core@${CURRENT_BABEL_VERSION}. Please downgrade to babel-eslint@^10 or upgrade to @babel/core@${SUPPORTED_BABEL_VERSION_RANGE}`,
+      `@babel/eslint-parser@${packageJson.version} does not support @babel/core@${babelCoreVersion}. Please upgrade to @babel/core@${packageJson.peerDependencies["@babel/core"]}`,
     );
   }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Small internal change to run the supported version calculation lazily (the first time it's called), rather than during startup. Not a huge win, but it's something 😄 