### PR TITLE
refactor: split locationParser into ParserErrors and error message

### DIFF
--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -1,23 +1,8 @@
 // @flow
 /* eslint sort-keys: "error" */
-import { getLineInfo, type Position } from "../util/location";
-import CommentsParser from "./comments";
-
-// This function is used to raise exceptions on parse errors. It
-// takes an offset integer (into the current `input`) to indicate
-// the location of the error, attaches the position to the end
-// of the error message, and then raises a `SyntaxError` with that
-// message.
-
-type ErrorContext = {
-  pos: number,
-  loc: Position,
-  missingPlugin?: Array<string>,
-  code?: string,
-};
 
 // The Errors key follows https://cs.chromium.org/chromium/src/v8/src/common/message-template.h unless it does not exist
-export const Errors = Object.freeze({
+export const ErrorMessages = Object.freeze({
   ArgumentsDisallowedInInitializer:
     "'arguments' is not allowed in class field initializer",
   AsyncFunctionInSingleStatementContext:
@@ -205,53 +190,3 @@ export const Errors = Object.freeze({
   ZeroDigitNumericSeparator:
     "Numeric separator can not be used after leading 0",
 });
-
-export default class LocationParser extends CommentsParser {
-  // Forward-declaration: defined in tokenizer/index.js
-  /*::
-  +isLookahead: boolean;
-  */
-
-  getLocationForPosition(pos: number): Position {
-    let loc;
-    if (pos === this.state.start) loc = this.state.startLoc;
-    else if (pos === this.state.lastTokStart) loc = this.state.lastTokStartLoc;
-    else if (pos === this.state.end) loc = this.state.endLoc;
-    else if (pos === this.state.lastTokEnd) loc = this.state.lastTokEndLoc;
-    else loc = getLineInfo(this.input, pos);
-
-    return loc;
-  }
-
-  raise(pos: number, errorTemplate: string, ...params: any): Error | empty {
-    return this.raiseWithData(pos, undefined, errorTemplate, ...params);
-  }
-
-  raiseWithData(
-    pos: number,
-    data?: {
-      missingPlugin?: Array<string>,
-      code?: string,
-    },
-    errorTemplate: string,
-    ...params: any
-  ): Error | empty {
-    const loc = this.getLocationForPosition(pos);
-    const message =
-      errorTemplate.replace(/%(\d+)/g, (_, i: number) => params[i]) +
-      ` (${loc.line}:${loc.column})`;
-    return this._raise(Object.assign(({ loc, pos }: Object), data), message);
-  }
-
-  _raise(errorContext: ErrorContext, message: string): Error | empty {
-    // $FlowIgnore
-    const err: SyntaxError & ErrorContext = new SyntaxError(message);
-    Object.assign(err, errorContext);
-    if (this.options.errorRecovery) {
-      if (!this.isLookahead) this.state.errors.push(err);
-      return err;
-    } else {
-      throw err;
-    }
-  }
-}

--- a/packages/babel-parser/src/parser/error.js
+++ b/packages/babel-parser/src/parser/error.js
@@ -1,0 +1,69 @@
+// @flow
+/* eslint sort-keys: "error" */
+import { getLineInfo, type Position } from "../util/location";
+import CommentsParser from "./comments";
+
+// This function is used to raise exceptions on parse errors. It
+// takes an offset integer (into the current `input`) to indicate
+// the location of the error, attaches the position to the end
+// of the error message, and then raises a `SyntaxError` with that
+// message.
+
+type ErrorContext = {
+  pos: number,
+  loc: Position,
+  missingPlugin?: Array<string>,
+  code?: string,
+};
+
+export { ErrorMessages as Errors } from "./error-message.js";
+
+export default class ParserError extends CommentsParser {
+  // Forward-declaration: defined in tokenizer/index.js
+  /*::
+  +isLookahead: boolean;
+  */
+
+  getLocationForPosition(pos: number): Position {
+    let loc;
+    if (pos === this.state.start) loc = this.state.startLoc;
+    else if (pos === this.state.lastTokStart) loc = this.state.lastTokStartLoc;
+    else if (pos === this.state.end) loc = this.state.endLoc;
+    else if (pos === this.state.lastTokEnd) loc = this.state.lastTokEndLoc;
+    else loc = getLineInfo(this.input, pos);
+
+    return loc;
+  }
+
+  raise(pos: number, errorTemplate: string, ...params: any): Error | empty {
+    return this.raiseWithData(pos, undefined, errorTemplate, ...params);
+  }
+
+  raiseWithData(
+    pos: number,
+    data?: {
+      missingPlugin?: Array<string>,
+      code?: string,
+    },
+    errorTemplate: string,
+    ...params: any
+  ): Error | empty {
+    const loc = this.getLocationForPosition(pos);
+    const message =
+      errorTemplate.replace(/%(\d+)/g, (_, i: number) => params[i]) +
+      ` (${loc.line}:${loc.column})`;
+    return this._raise(Object.assign(({ loc, pos }: Object), data), message);
+  }
+
+  _raise(errorContext: ErrorContext, message: string): Error | empty {
+    // $FlowIgnore
+    const err: SyntaxError & ErrorContext = new SyntaxError(message);
+    Object.assign(err, errorContext);
+    if (this.options.errorRecovery) {
+      if (!this.isLookahead) this.state.errors.push(err);
+      return err;
+    } else {
+      throw err;
+    }
+  }
+}

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -48,7 +48,7 @@ import {
   PARAM,
   functionFlags,
 } from "../util/production-parameter";
-import { Errors } from "./location";
+import { Errors } from "./error";
 
 export default class ExpressionParser extends LValParser {
   // Forward-declaration: defined in statement.js

--- a/packages/babel-parser/src/parser/lval.js
+++ b/packages/babel-parser/src/parser/lval.js
@@ -22,7 +22,7 @@ import {
 import { NodeUtils } from "./node";
 import { type BindingTypes, BIND_NONE } from "../util/scopeflags";
 import { ExpressionErrors } from "./util";
-import { Errors } from "./location";
+import { Errors } from "./error";
 
 const unwrapParenthesizedExpression = (node: Node) => {
   return node.type === "ParenthesizedExpression"

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -3,7 +3,7 @@
 import * as N from "../types";
 import { types as tt, type TokenType } from "../tokenizer/types";
 import ExpressionParser from "./expression";
-import { Errors } from "./location";
+import { Errors } from "./error";
 import {
   isIdentifierChar,
   isIdentifierStart,

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -7,7 +7,7 @@ import type { Node } from "../types";
 import { lineBreak } from "../util/whitespace";
 import { isIdentifierChar } from "../util/identifier";
 import * as charCodes from "charcodes";
-import { Errors } from "./location";
+import { Errors } from "./error";
 
 type TryParse<Node, Error, Thrown, Aborted, FailState> = {
   node: Node,

--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -6,7 +6,7 @@ import type { ExpressionErrors } from "../parser/util";
 import * as N from "../types";
 import type { Position } from "../util/location";
 import { type BindingTypes, BIND_NONE } from "../util/scopeflags";
-import { Errors } from "../parser/location";
+import { Errors } from "../parser/error";
 
 function isSimpleProperty(node: N.Node): boolean {
   return (

--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -22,7 +22,7 @@ import {
   SCOPE_OTHER,
 } from "../util/scopeflags";
 import type { ExpressionErrors } from "../parser/util";
-import { Errors } from "../parser/location";
+import { Errors } from "../parser/error";
 
 const reservedTypes = new Set([
   "_",

--- a/packages/babel-parser/src/plugins/jsx/index.js
+++ b/packages/babel-parser/src/plugins/jsx/index.js
@@ -11,7 +11,7 @@ import * as N from "../../types";
 import { isIdentifierChar, isIdentifierStart } from "../../util/identifier";
 import type { Position } from "../../util/location";
 import { isNewLine } from "../../util/whitespace";
-import { Errors } from "../../parser/location";
+import { Errors } from "../../parser/error";
 
 const HEX_NUMBER = /^[\da-fA-F]+$/;
 const DECIMAL_NUMBER = /^\d+$/;

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -27,7 +27,7 @@ import TypeScriptScopeHandler from "./scope";
 import * as charCodes from "charcodes";
 import type { ExpressionErrors } from "../../parser/util";
 import { PARAM } from "../../util/production-parameter";
-import { Errors } from "../../parser/location";
+import { Errors } from "../../parser/error";
 
 type TsModifier =
   | "readonly"

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -9,7 +9,7 @@ import * as charCodes from "charcodes";
 import { isIdentifierStart, isIdentifierChar } from "../util/identifier";
 import { types as tt, keywords as keywordTypes, type TokenType } from "./types";
 import { type TokContext, types as ct } from "./context";
-import LocationParser, { Errors } from "../parser/location";
+import ParserErrors, { Errors } from "../parser/error";
 import { SourceLocation } from "../util/location";
 import {
   lineBreak,
@@ -110,7 +110,7 @@ export class Token {
 
 // ## Tokenizer
 
-export default class Tokenizer extends LocationParser {
+export default class Tokenizer extends ParserErrors {
   // Forward-declarations
   // parser/util.js
   /*::

--- a/packages/babel-parser/src/util/class-scope.js
+++ b/packages/babel-parser/src/util/class-scope.js
@@ -5,7 +5,7 @@ import {
   CLASS_ELEMENT_FLAG_STATIC,
   type ClassElementTypes,
 } from "./scopeflags";
-import { Errors } from "../parser/location";
+import { Errors } from "../parser/error";
 
 export class ClassScope {
   // A list of private named declared in the current class

--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -16,7 +16,7 @@ import {
   type BindingTypes,
 } from "./scopeflags";
 import * as N from "../types";
-import { Errors } from "../parser/location";
+import { Errors } from "../parser/error";
 
 // Start an AST node, attaching a start offset.
 export class Scope {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Rename `packages/babel-parser/src/parser/location.js` into `error.js` and extract error message templates into a dedicated file.