### PR TITLE
removed type annotation in js file

### DIFF
--- a/packages/babel-helper-plugin-utils/src/index.js
+++ b/packages/babel-helper-plugin-utils/src/index.js
@@ -90,6 +90,6 @@ function throwVersionError(range, version) {
       code: "BABEL_VERSION_UNSUPPORTED",
       version,
       range,
-    }: any),
+    }),
   );
 }


### PR DESCRIPTION
Small Bug fix with .ts type annotation being used in .js file.
