### PR TITLE
improve node type definitions to avoid any's in generated types

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -281,10 +281,12 @@ defineType("File", {
     },
     comments: {
       validate: assertEach(assertNodeType("Comment")),
+      optional: true,
     },
     tokens: {
       // todo(ts): add Token type
       validate: assertEach(Object.assign(() => true, { type: "any" })),
+      optional: true,
     },
   },
 });

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -84,10 +84,13 @@ defineType("BinaryExpression", {
         const expression = assertNodeType("Expression");
         const inOp = assertNodeType("Expression", "PrivateName");
 
-        return function (node, key, val) {
+        const validator = function (node, key, val) {
           const validator = node.operator === "in" ? inOp : expression;
           validator(node, key, val);
         };
+        // todo(ts): can be discriminated union by `operator` property
+        validator.oneOfNodeTypes = ["Expression", "PrivateName"];
+        return validator;
       })(),
     },
     right: {
@@ -276,6 +279,13 @@ defineType("File", {
     program: {
       validate: assertNodeType("Program"),
     },
+    comments: {
+      validate: assertEach(assertNodeType("Comment")),
+    },
+    tokens: {
+      // todo(ts): add Token type
+      validate: assertEach(Object.assign(() => true, { type: "any" })),
+    },
   },
 });
 
@@ -457,13 +467,19 @@ defineType("Identifier", {
   fields: {
     ...patternLikeCommon,
     name: {
-      validate: chain(assertValueType("string"), function (node, key, val) {
-        if (!process.env.BABEL_TYPES_8_BREAKING) return;
+      validate: chain(
+        assertValueType("string"),
+        Object.assign(
+          function (node, key, val) {
+            if (!process.env.BABEL_TYPES_8_BREAKING) return;
 
-        if (!isValidIdentifier(val, false)) {
-          throw new TypeError(`"${val}" is not a valid identifier name`);
-        }
-      }),
+            if (!isValidIdentifier(val, false)) {
+              throw new TypeError(`"${val}" is not a valid identifier name`);
+            }
+          },
+          { type: "string" },
+        ),
+      ),
     },
     optional: {
       validate: assertValueType("boolean"),
@@ -583,14 +599,20 @@ defineType("RegExpLiteral", {
       validate: assertValueType("string"),
     },
     flags: {
-      validate: chain(assertValueType("string"), function (node, key, val) {
-        if (!process.env.BABEL_TYPES_8_BREAKING) return;
+      validate: chain(
+        assertValueType("string"),
+        Object.assign(
+          function (node, key, val) {
+            if (!process.env.BABEL_TYPES_8_BREAKING) return;
 
-        const invalid = /[^gimsuy]/.exec(val);
-        if (invalid) {
-          throw new TypeError(`"${invalid[0]}" is not a valid RegExp flag`);
-        }
-      }),
+            const invalid = /[^gimsuy]/.exec(val);
+            if (invalid) {
+              throw new TypeError(`"${invalid[0]}" is not a valid RegExp flag`);
+            }
+          },
+          { type: "string" },
+        ),
+      ),
       default: "",
     },
   },
@@ -626,10 +648,13 @@ defineType("MemberExpression", {
         const normal = assertNodeType("Identifier", "PrivateName");
         const computed = assertNodeType("Expression");
 
-        return function (node, key, val) {
+        const validator = function (node, key, val) {
           const validator = node.computed ? computed : normal;
           validator(node, key, val);
         };
+        // todo(ts): can be discriminated union by `computed` property
+        validator.oneOfNodeTypes = ["Expression", "Identifier", "PrivateName"];
+        return validator;
       })(),
     },
     computed: {
@@ -719,10 +744,18 @@ defineType("ObjectMethod", {
         );
         const computed = assertNodeType("Expression");
 
-        return function (node, key, val) {
+        const validator = function (node, key, val) {
           const validator = node.computed ? computed : normal;
           validator(node, key, val);
         };
+        // todo(ts): can be discriminated union by `computed` property
+        validator.oneOfNodeTypes = [
+          "Expression",
+          "Identifier",
+          "StringLiteral",
+          "NumericLiteral",
+        ];
+        return validator;
       })(),
     },
     decorators: {
@@ -776,10 +809,18 @@ defineType("ObjectProperty", {
         );
         const computed = assertNodeType("Expression");
 
-        return function (node, key, val) {
+        const validator = function (node, key, val) {
           const validator = node.computed ? computed : normal;
           validator(node, key, val);
         };
+        // todo(ts): can be discriminated union by `computed` property
+        validator.oneOfNodeTypes = [
+          "Expression",
+          "Identifier",
+          "StringLiteral",
+          "NumericLiteral",
+        ];
+        return validator;
       })(),
     },
     value: {
@@ -790,15 +831,18 @@ defineType("ObjectProperty", {
     shorthand: {
       validate: chain(
         assertValueType("boolean"),
-        function (node, key, val) {
-          if (!process.env.BABEL_TYPES_8_BREAKING) return;
+        Object.assign(
+          function (node, key, val) {
+            if (!process.env.BABEL_TYPES_8_BREAKING) return;
 
-          if (val && node.computed) {
-            throw new TypeError(
-              "Property shorthand of ObjectProperty cannot be true if computed is true",
-            );
-          }
-        },
+            if (val && node.computed) {
+              throw new TypeError(
+                "Property shorthand of ObjectProperty cannot be true if computed is true",
+              );
+            }
+          },
+          { type: "boolean" },
+        ),
         function (node, key, val) {
           if (!process.env.BABEL_TYPES_8_BREAKING) return;
 
@@ -945,18 +989,26 @@ defineType("TryStatement", {
   aliases: ["Statement"],
   fields: {
     block: {
-      validate: chain(assertNodeType("BlockStatement"), function (node) {
-        if (!process.env.BABEL_TYPES_8_BREAKING) return;
+      validate: chain(
+        assertNodeType("BlockStatement"),
+        Object.assign(
+          function (node) {
+            if (!process.env.BABEL_TYPES_8_BREAKING) return;
 
-        // This validator isn't put at the top level because we can run it
-        // even if this node doesn't have a parent.
+            // This validator isn't put at the top level because we can run it
+            // even if this node doesn't have a parent.
 
-        if (!node.handler && !node.finalizer) {
-          throw new TypeError(
-            "TryStatement expects either a handler or finalizer, or both",
-          );
-        }
-      }),
+            if (!node.handler && !node.finalizer) {
+              throw new TypeError(
+                "TryStatement expects either a handler or finalizer, or both",
+              );
+            }
+          },
+          {
+            oneOfNodeTypes: ["BlockStatement"],
+          },
+        ),
+      ),
     },
     handler: {
       optional: true,

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -285,7 +285,7 @@ defineType("File", {
     },
     tokens: {
       // todo(ts): add Token type
-      validate: assertEach(Object.assign(() => true, { type: "any" })),
+      validate: assertEach(Object.assign(() => {}, { type: "any" })),
       optional: true,
     },
   },

--- a/packages/babel-types/src/definitions/experimental.js
+++ b/packages/babel-types/src/definitions/experimental.js
@@ -29,7 +29,6 @@ defineType("AwaitExpression", {
 defineType("BindExpression", {
   visitor: ["object", "callee"],
   aliases: ["Expression"],
-  // todo(ts): if this is breaking change - what node types should be here for old version?
   fields: !process.env.BABEL_TYPES_8_BREAKING
     ? {
         object: {

--- a/packages/babel-types/src/definitions/experimental.js
+++ b/packages/babel-types/src/definitions/experimental.js
@@ -32,12 +32,12 @@ defineType("BindExpression", {
   fields: !process.env.BABEL_TYPES_8_BREAKING
     ? {
         object: {
-          validate: Object.assign(() => true, {
+          validate: Object.assign(() => {}, {
             oneOfNodeTypes: ["Expression"],
           }),
         },
         callee: {
-          validate: Object.assign(() => true, {
+          validate: Object.assign(() => {}, {
             oneOfNodeTypes: ["Expression"],
           }),
         },

--- a/packages/babel-types/src/definitions/jsx.js
+++ b/packages/babel-types/src/definitions/jsx.js
@@ -65,6 +65,10 @@ defineType("JSXElement", {
         ),
       ),
     },
+    selfClosing: {
+      validate: assertValueType("boolean"),
+      optional: true,
+    },
   },
 });
 


### PR DESCRIPTION
Updates node type definitions in babel-types, to avoid `any` in generated types.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  #11474
| Patch: Bug Fix?          | yes(improve generate types)
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
