### PR TITLE
fix build config to work the same when running on windows

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,11 @@
 "use strict";
 
+const path = require("path");
+
+function normalize(src) {
+  return src.replace(/\//, path.sep);
+}
+
 module.exports = function (api) {
   const env = api.env();
 
@@ -93,7 +99,9 @@ module.exports = function (api) {
       "packages/*/test/fixtures",
       ignoreLib ? "packages/*/lib" : null,
       "packages/babel-standalone/babel.js",
-    ].filter(Boolean),
+    ]
+      .filter(Boolean)
+      .map(normalize),
     presets: [["@babel/env", envOpts]],
     plugins: [
       // TODO: Use @babel/preset-flow when
@@ -115,14 +123,14 @@ module.exports = function (api) {
         test: [
           "packages/babel-parser",
           "packages/babel-helper-validator-identifier",
-        ],
+        ].map(normalize),
         plugins: [
           "babel-plugin-transform-charcodes",
           ["@babel/transform-for-of", { assumeArray: true }],
         ],
       },
       {
-        test: ["./packages/babel-cli", "./packages/babel-core"],
+        test: ["./packages/babel-cli", "./packages/babel-core"].map(normalize),
         plugins: [
           // Explicitly use the lazy version of CommonJS modules.
           convertESM
@@ -131,11 +139,11 @@ module.exports = function (api) {
         ].filter(Boolean),
       },
       {
-        test: "./packages/babel-polyfill",
+        test: normalize("./packages/babel-polyfill"),
         presets: [["@babel/env", envOptsNoTargets]],
       },
       {
-        test: unambiguousSources,
+        test: unambiguousSources.map(normalize),
         sourceType: "unambiguous",
       },
       includeRegeneratorRuntime && {

--- a/scripts/rollup-plugin-babel-source.js
+++ b/scripts/rollup-plugin-babel-source.js
@@ -2,11 +2,16 @@ const path = require("path");
 const fs = require("fs");
 const dirname = path.join(__dirname, "..");
 
+const BABEL_SRC_REGEXP =
+  path.sep === "/"
+    ? /packages\/(babel-[^/]+)\/src\//
+    : /packages\\(babel-[^\\]+)\\src\\/;
+
 module.exports = function () {
   return {
     name: "babel-source",
     load(id) {
-      const matches = id.match(/packages\/(babel-[^/]+)\/src\//);
+      const matches = id.match(BABEL_SRC_REGEXP);
       if (matches) {
         // check if browser field exists for this file and replace
         const packageFolder = path.join(dirname, "packages", matches[1]);
@@ -16,18 +21,20 @@ module.exports = function () {
           packageJson["browser"] &&
           typeof packageJson["browser"] === "object"
         ) {
-          for (let nodeFile in packageJson["browser"]) {
+          for (const nodeFile in packageJson["browser"]) {
             const browserFile = packageJson["browser"][nodeFile].replace(
               /^(\.\/)?lib\//,
               "src/"
             );
-            nodeFile = nodeFile.replace(/^(\.\/)?lib\//, "src/");
-            if (id.endsWith(nodeFile)) {
+            const nodeFileSrc = path.normalize(
+              nodeFile.replace(/^(\.\/)?lib\//, "src/")
+            );
+            if (id.endsWith(nodeFileSrc)) {
               if (browserFile === false) {
                 return "";
               }
               return fs.readFileSync(
-                path.join(packageFolder, browserFile),
+                path.join(packageFolder, path.normalize(browserFile)),
                 "UTF-8"
               );
             }
@@ -74,10 +81,12 @@ module.exports = function () {
           ? packageJson["browser"]
           : packageJson["main"];
 
-      return path.join(
-        packageFolder,
-        // replace lib with src in the package.json entry
-        filename.replace(/^(\.\/)?lib\//, "src/")
+      return path.normalize(
+        path.join(
+          packageFolder,
+          // replace lib with src in the package.json entry
+          filename.replace(/^(\.\/)?lib\//, "src/")
+        )
       );
     },
   };


### PR DESCRIPTION
While debugging failing windows build for #11578 (https://travis-ci.com/github/babel/babel/jobs/345463718) found a problem bundling `babel-standalone`: it was failing when trying to bundle `./lib/config/files/index.js` instead of `./src/config/files/index-browser.ts` from `babel-core`

Fixes for it are in two places:
- `scripts/rollup-plugin-babel-source.js` - `load` there was not handling windows path separator correctly
- `babel.config.js` - filter fix in rollup config, some modules failed to compile because babel config overrides were not applied on windows for the same path separator issue.

However, I still do not understand - how current master version can build correctly on windows… It looks like there is some other place in rollup to use `browser` field, but then - why it would change after converting sources to typescript

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11688"><img src="https://gitpod.io/api/apps/github/pbs/github.com/zxbodya/babel.git/35c566f1f513304f20bcbfa1c2157adaa30b8fa9.svg" /></a>

