### PR TITLE
Instantiate presets before plugins

### DIFF
--- a/packages/babel-core/src/config/full.js
+++ b/packages/babel-core/src/config/full.js
@@ -24,6 +24,7 @@ import {
   validate,
   type CallerMetadata,
   checkNoUnwrappedItemOptionPairs,
+  type PluginItem,
 } from "./validation/options";
 import { validatePluginObject } from "./validation/plugins";
 import makeAPI from "./helpers/config-api";
@@ -70,58 +71,48 @@ export default gensync<[any], ResolvedConfig | null>(function* loadFullConfig(
   }
 
   const optionDefaults = {};
-  const passes: Array<Array<Plugin>> = [[]];
-  try {
-    const { plugins, presets } = options;
 
-    if (!plugins || !presets) {
-      throw new Error("Assertion failure - plugins and presets exist");
+  const { plugins, presets } = options;
+
+  if (!plugins || !presets) {
+    throw new Error("Assertion failure - plugins and presets exist");
+  }
+
+  const toDescriptor = (item: PluginItem) => {
+    const desc = getItemDescriptor(item);
+    if (!desc) {
+      throw new Error("Assertion failure - must be config item");
     }
 
-    const ignored = yield* (function* recurseDescriptors(config, pass) {
-      const plugins: Array<Plugin> = [];
-      for (let i = 0; i < config.plugins.length; i++) {
-        const descriptor = config.plugins[i];
-        if (descriptor.options !== false) {
-          try {
-            plugins.push(yield* loadPluginDescriptor(descriptor, context));
-          } catch (e) {
-            // print special message for `plugins: ["@babel/foo", { foo: "option" }]`
-            if (i > 0 && e.code === "BABEL_UNKNOWN_PLUGIN_PROPERTY") {
-              checkNoUnwrappedItemOptionPairs(
-                config.plugins[i - 1],
-                descriptor,
-                "plugin",
-                i,
-                e,
-              );
-            }
-            throw e;
-          }
-        }
-      }
+    return desc;
+  };
 
+  const presetsDescriptors = presets.map(toDescriptor);
+  const initialPluginsDescriptors = plugins.map(toDescriptor);
+  const pluginDescriptorsByPass: Array<Array<UnloadedDescriptor>> = [[]];
+  const passes: Array<Array<Plugin>> = [];
+
+  try {
+    const ignored = yield* (function* recursePresetDescriptors(
+      rawPresets: Array<UnloadedDescriptor>,
+      pluginDescriptorsPass: Array<UnloadedDescriptor>,
+    ) {
       const presets: Array<{|
         preset: ConfigChain | null,
-        pass: Array<Plugin>,
+        pass: Array<UnloadedDescriptor>,
       |}> = [];
-      for (let i = 0; i < config.presets.length; i++) {
-        const descriptor = config.presets[i];
+
+      for (let i = 0; i < rawPresets.length; i++) {
+        const descriptor = rawPresets[i];
         if (descriptor.options !== false) {
           try {
             presets.push({
               preset: yield* loadPresetDescriptor(descriptor, context),
-              pass: descriptor.ownPass ? [] : pass,
+              pass: descriptor.ownPass ? [] : pluginDescriptorsPass,
             });
           } catch (e) {
-            if (i > 0 && e.code === "BABEL_UNKNOWN_OPTION") {
-              checkNoUnwrappedItemOptionPairs(
-                config.presets[i - 1],
-                descriptor,
-                "preset",
-                i,
-                e,
-              );
+            if (e.code === "BABEL_UNKNOWN_OPTION") {
+              checkNoUnwrappedItemOptionPairs(rawPresets, i, "preset", e);
             }
             throw e;
           }
@@ -132,22 +123,18 @@ export default gensync<[any], ResolvedConfig | null>(function* loadFullConfig(
       if (presets.length > 0) {
         // The passes are created in the same order as the preset list, but are inserted before any
         // existing additional passes.
-        passes.splice(
+        pluginDescriptorsByPass.splice(
           1,
           0,
-          ...presets.map(o => o.pass).filter(p => p !== pass),
+          ...presets.map(o => o.pass).filter(p => p !== pluginDescriptorsPass),
         );
 
         for (const { preset, pass } of presets) {
           if (!preset) return true;
 
-          const ignored = yield* recurseDescriptors(
-            {
-              plugins: preset.plugins,
-              presets: preset.presets,
-            },
-            pass,
-          );
+          pass.unshift(...preset.plugins);
+
+          const ignored = yield* recursePresetDescriptors(preset.presets, pass);
           if (ignored) return true;
 
           preset.options.forEach(opts => {
@@ -155,34 +142,31 @@ export default gensync<[any], ResolvedConfig | null>(function* loadFullConfig(
           });
         }
       }
-
-      // resolve plugins
-      if (plugins.length > 0) {
-        pass.unshift(...plugins);
-      }
-    })(
-      {
-        plugins: plugins.map(item => {
-          const desc = getItemDescriptor(item);
-          if (!desc) {
-            throw new Error("Assertion failure - must be config item");
-          }
-
-          return desc;
-        }),
-        presets: presets.map(item => {
-          const desc = getItemDescriptor(item);
-          if (!desc) {
-            throw new Error("Assertion failure - must be config item");
-          }
-
-          return desc;
-        }),
-      },
-      passes[0],
-    );
+    })(presetsDescriptors, pluginDescriptorsByPass[0]);
 
     if (ignored) return null;
+
+    pluginDescriptorsByPass[0].unshift(...initialPluginsDescriptors);
+
+    for (const descs of pluginDescriptorsByPass) {
+      const pass = [];
+      passes.push(pass);
+
+      for (let i = 0; i < descs.length; i++) {
+        const descriptor: UnloadedDescriptor = descs[i];
+        if (descriptor.options !== false) {
+          try {
+            pass.push(yield* loadPluginDescriptor(descriptor, context));
+          } catch (e) {
+            if (e.code === "BABEL_UNKNOWN_PLUGIN_PROPERTY") {
+              // print special message for `plugins: ["@babel/foo", { foo: "option" }]`
+              checkNoUnwrappedItemOptionPairs(descs, i, "plugin", e);
+            }
+            throw e;
+          }
+        }
+      }
+    }
   } catch (e) {
     // There are a few case where thrown errors will try to annotate themselves multiple times, so
     // to keep things simple we just bail out if re-wrapping the message.

--- a/packages/babel-core/src/config/full.js
+++ b/packages/babel-core/src/config/full.js
@@ -192,10 +192,6 @@ export default gensync<[any], ResolvedConfig | null>(function* loadFullConfig(
     .map(plugins => ({ plugins }));
   opts.passPerPreset = opts.presets.length > 0;
 
-  if (context.filename?.includes("RuntimeErrorContaine")) {
-    console.log(initialPluginsDescriptors.map(p => p.key));
-  }
-
   return {
     options: opts,
     passes: passes,

--- a/packages/babel-core/src/config/full.js
+++ b/packages/babel-core/src/config/full.js
@@ -92,8 +92,9 @@ export default gensync<[any], ResolvedConfig | null>(function* loadFullConfig(
   const pluginDescriptorsByPass: Array<Array<UnloadedDescriptor>> = [[]];
   const passes: Array<Array<Plugin>> = [];
 
-  try {
-    const ignored = yield* (function* recursePresetDescriptors(
+  const ignored = yield* enhanceError(
+    context,
+    function* recursePresetDescriptors(
       rawPresets: Array<UnloadedDescriptor>,
       pluginDescriptorsPass: Array<UnloadedDescriptor>,
     ) {
@@ -142,10 +143,15 @@ export default gensync<[any], ResolvedConfig | null>(function* loadFullConfig(
           });
         }
       }
-    })(presetsDescriptors, pluginDescriptorsByPass[0]);
+    },
+  )(presetsDescriptors, pluginDescriptorsByPass[0]);
 
-    if (ignored) return null;
+  if (ignored) return null;
 
+  const opts: Object = optionDefaults;
+  mergeOptions(opts, options);
+
+  yield* enhanceError(context, function* loadPluginDescriptors() {
     pluginDescriptorsByPass[0].unshift(...initialPluginsDescriptors);
 
     for (const descs of pluginDescriptorsByPass) {
@@ -167,18 +173,7 @@ export default gensync<[any], ResolvedConfig | null>(function* loadFullConfig(
         }
       }
     }
-  } catch (e) {
-    // There are a few case where thrown errors will try to annotate themselves multiple times, so
-    // to keep things simple we just bail out if re-wrapping the message.
-    if (!/^\[BABEL\]/.test(e.message)) {
-      e.message = `[BABEL] ${context.filename || "unknown"}: ${e.message}`;
-    }
-
-    throw e;
-  }
-
-  const opts: Object = optionDefaults;
-  mergeOptions(opts, options);
+  })();
 
   opts.plugins = passes[0];
   opts.presets = passes
@@ -192,6 +187,22 @@ export default gensync<[any], ResolvedConfig | null>(function* loadFullConfig(
     passes: passes,
   };
 });
+
+function enhanceError<T: Function>(context, fn: T): T {
+  return (function* (arg1, arg2) {
+    try {
+      return yield* fn(arg1, arg2);
+    } catch (e) {
+      // There are a few case where thrown errors will try to annotate themselves multiple times, so
+      // to keep things simple we just bail out if re-wrapping the message.
+      if (!/^\[BABEL\]/.test(e.message)) {
+        e.message = `[BABEL] ${context.filename || "unknown"}: ${e.message}`;
+      }
+
+      throw e;
+    }
+  }: any);
+}
 
 /**
  * Load a generic plugin/preset from the given descriptor loaded from the config object.

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -454,12 +454,16 @@ function assertOverridesList(loc: OptionPath, value: mixed): OverridesList {
 }
 
 export function checkNoUnwrappedItemOptionPairs(
-  lastItem: UnloadedDescriptor,
-  thisItem: UnloadedDescriptor,
-  type: "plugin" | "preset",
+  items: Array<UnloadedDescriptor>,
   index: number,
+  type: "plugin" | "preset",
   e: Error,
 ): void {
+  if (index === 0) return;
+
+  const lastItem = items[index - 1];
+  const thisItem = items[index];
+
   if (
     lastItem.file &&
     lastItem.options === undefined &&

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -423,6 +423,8 @@ describe("api", function () {
         "argone;",
         "five;",
         "six;",
+        "twentyone;",
+        "twentytwo;",
         "three;",
         "four;",
         "nineteen;",

--- a/packages/babel-core/test/fixtures/config/complex-plugin-config/.babelrc
+++ b/packages/babel-core/test/fixtures/config/complex-plugin-config/.babelrc
@@ -14,6 +14,12 @@
       "./five",
       "./six",
     ],
+    presets: [{
+      plugins: [
+        "./twentyone",
+        "./twentytwo",
+      ]
+    }]
   }, {
     passPerPreset: true,
     presets: [{

--- a/packages/babel-core/test/fixtures/config/complex-plugin-config/twentyone.js
+++ b/packages/babel-core/test/fixtures/config/complex-plugin-config/twentyone.js
@@ -1,0 +1,1 @@
+module.exports = require("./plugin")("twentyone");

--- a/packages/babel-core/test/fixtures/config/complex-plugin-config/twentytwo.js
+++ b/packages/babel-core/test/fixtures/config/complex-plugin-config/twentytwo.js
@@ -1,0 +1,1 @@
+module.exports = require("./plugin")("twentytwo");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is only needed for https://github.com/babel/babel/pull/12151, but I'm sending them as two separate PR to make it easier to review them one by one (since the diffs overlap, but are conceptually separate).

The e2e failure makes me think that I got plugins ordering wrong, I'll check.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11689"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/eab3c06872851d5f34ca3f125525d2b64f4ab74f.svg" /></a>

