### PR TITLE
fix:require corejs3-shipped-proposals using similar proxy to other files

### DIFF
--- a/packages/babel-preset-env/data/corejs3-shipped.proposals.js
+++ b/packages/babel-preset-env/data/corejs3-shipped.proposals.js
@@ -1,0 +1,3 @@
+// TODO: Remove in Babel 8
+
+module.exports = require("@babel/compat-data/corejs3-shipped-proposals");

--- a/packages/babel-preset-env/data/corejs3-shipped.proposals.json.js
+++ b/packages/babel-preset-env/data/corejs3-shipped.proposals.json.js
@@ -1,0 +1,3 @@
+// TODO: Remove in Babel 8
+
+module.exports = require("@babel/compat-data/corejs3-shipped-proposals");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Various builds have gotten errors in the past like "Cannot find module '@babel/compat-data/[module]'" and these have been fixed by putting in proxy files to make sure they get required.  I'm now seeing this same error for "'@babel/compat-data/corejs3-shipped-proposals'" so I'm providing these files to apply the same fix.