### PR TITLE
fix:added check for forXstatement pattern

### DIFF
--- a/packages/babel-helper-member-expression-to-functions/src/index.js
+++ b/packages/babel-helper-member-expression-to-functions/src/index.js
@@ -329,7 +329,8 @@ const handle = {
       return;
     }
 
-    // for ( MEMBER of ARR) && for ( MEMBER in ARR)
+    // for (MEMBER of ARR)
+    // for (MEMBER in ARR)
     // { KEY: MEMBER } = OBJ -> { KEY: _destructureSet(MEMBER) } = OBJ
     // { KEY: MEMBER = _VALUE } = OBJ -> { KEY: _destructureSet(MEMBER) = _VALUE } = OBJ
     // {...MEMBER} -> {..._destructureSet(MEMBER)}

--- a/packages/babel-helper-member-expression-to-functions/src/index.js
+++ b/packages/babel-helper-member-expression-to-functions/src/index.js
@@ -337,7 +337,8 @@ const handle = {
     // [MEMBER = _VALUE] = ARR -> [_destructureSet(MEMBER) = _VALUE] = ARR
     // [...MEMBER] -> [..._destructureSet(MEMBER)]
     if (
-      parentPath.isForXStatement() ||
+      (parentPath.isForXStatement() &&
+        parentPath.parentPath.isAssignmentPattern({ left: node })) ||
       // { KEY: MEMBER } = OBJ
       (parentPath.isObjectProperty({ value: node }) &&
         parentPath.parentPath.isObjectPattern()) ||

--- a/packages/babel-helper-member-expression-to-functions/src/index.js
+++ b/packages/babel-helper-member-expression-to-functions/src/index.js
@@ -329,6 +329,7 @@ const handle = {
       return;
     }
 
+    // for ( MEMBER of ARR) && for ( MEMBER in ARR)
     // { KEY: MEMBER } = OBJ -> { KEY: _destructureSet(MEMBER) } = OBJ
     // { KEY: MEMBER = _VALUE } = OBJ -> { KEY: _destructureSet(MEMBER) = _VALUE } = OBJ
     // {...MEMBER} -> {..._destructureSet(MEMBER)}
@@ -337,6 +338,7 @@ const handle = {
     // [MEMBER = _VALUE] = ARR -> [_destructureSet(MEMBER) = _VALUE] = ARR
     // [...MEMBER] -> [..._destructureSet(MEMBER)]
     if (
+      // for ( MEMBER of ARR) && for ( MEMBER in ARR)
       parentPath.isForXStatement({ left: node }) ||
       // { KEY: MEMBER } = OBJ
       (parentPath.isObjectProperty({ value: node }) &&

--- a/packages/babel-helper-member-expression-to-functions/src/index.js
+++ b/packages/babel-helper-member-expression-to-functions/src/index.js
@@ -337,8 +337,7 @@ const handle = {
     // [MEMBER = _VALUE] = ARR -> [_destructureSet(MEMBER) = _VALUE] = ARR
     // [...MEMBER] -> [..._destructureSet(MEMBER)]
     if (
-      (parentPath.isForXStatement() &&
-        parentPath.parentPath.isAssignmentPattern({ left: node })) ||
+      parentPath.isForXStatement({ left: node }) ||
       // { KEY: MEMBER } = OBJ
       (parentPath.isObjectProperty({ value: node }) &&
         parentPath.parentPath.isObjectPattern()) ||

--- a/packages/babel-helper-member-expression-to-functions/src/index.js
+++ b/packages/babel-helper-member-expression-to-functions/src/index.js
@@ -339,7 +339,8 @@ const handle = {
     // [MEMBER = _VALUE] = ARR -> [_destructureSet(MEMBER) = _VALUE] = ARR
     // [...MEMBER] -> [..._destructureSet(MEMBER)]
     if (
-      // for ( MEMBER of ARR) && for ( MEMBER in ARR)
+      // for (MEMBER of ARR)
+      // for (MEMBER in ARR)
       parentPath.isForXStatement({ left: node }) ||
       // { KEY: MEMBER } = OBJ
       (parentPath.isObjectProperty({ value: node }) &&

--- a/packages/babel-helper-member-expression-to-functions/src/index.js
+++ b/packages/babel-helper-member-expression-to-functions/src/index.js
@@ -337,6 +337,7 @@ const handle = {
     // [MEMBER = _VALUE] = ARR -> [_destructureSet(MEMBER) = _VALUE] = ARR
     // [...MEMBER] -> [..._destructureSet(MEMBER)]
     if (
+      parentPath.isForXStatement() ||
       // { KEY: MEMBER } = OBJ
       (parentPath.isObjectProperty({ value: node }) &&
         parentPath.parentPath.isObjectPattern()) ||

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/1-helpermemberexpressionfunction/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/1-helpermemberexpressionfunction/input.js
@@ -4,3 +4,24 @@ class D {
     for (const el of this.#arr);
   }
 }
+
+class C {
+  #p;
+  m() {
+    for (this.#p of []);
+  }
+}
+
+class E {
+  #arr;
+  f() {
+    for (this.#arr of [1, 2]);
+  }
+}
+
+class F {
+  #ar;
+  g() {
+    for (this.#ar in [1,2,3]);
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/1-helpermemberexpressionfunction/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/1-helpermemberexpressionfunction/input.js
@@ -1,0 +1,6 @@
+class D {
+  #arr;
+  f() {
+    for (const el of this.#arr);
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/1-helpermemberexpressionfunction/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/1-helpermemberexpressionfunction/output.js
@@ -1,0 +1,24 @@
+var _arr = new WeakMap();
+
+var D = /*#__PURE__*/function () {
+  "use strict";
+
+  function D() {
+    babelHelpers.classCallCheck(this, D);
+
+    _arr.set(this, {
+      writable: true,
+      value: void 0
+    });
+  }
+
+  babelHelpers.createClass(D, [{
+    key: "f",
+    value: function f() {
+      for (var el of babelHelpers.classPrivateFieldGet(this, _arr)) {
+        ;
+      }
+    }
+  }]);
+  return D;
+}();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/1-helpermemberexpressionfunction/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/1-helpermemberexpressionfunction/output.js
@@ -22,3 +22,78 @@ var D = /*#__PURE__*/function () {
   }]);
   return D;
 }();
+
+var _p = new WeakMap();
+
+var C = /*#__PURE__*/function () {
+  "use strict";
+
+  function C() {
+    babelHelpers.classCallCheck(this, C);
+
+    _p.set(this, {
+      writable: true,
+      value: void 0
+    });
+  }
+
+  babelHelpers.createClass(C, [{
+    key: "m",
+    value: function m() {
+      for (babelHelpers.classPrivateFieldDestructureSet(this, _p).value of []) {
+        ;
+      }
+    }
+  }]);
+  return C;
+}();
+
+var _arr2 = new WeakMap();
+
+var E = /*#__PURE__*/function () {
+  "use strict";
+
+  function E() {
+    babelHelpers.classCallCheck(this, E);
+
+    _arr2.set(this, {
+      writable: true,
+      value: void 0
+    });
+  }
+
+  babelHelpers.createClass(E, [{
+    key: "f",
+    value: function f() {
+      for (babelHelpers.classPrivateFieldDestructureSet(this, _arr2).value of [1, 2]) {
+        ;
+      }
+    }
+  }]);
+  return E;
+}();
+
+var _ar = new WeakMap();
+
+var F = /*#__PURE__*/function () {
+  "use strict";
+
+  function F() {
+    babelHelpers.classCallCheck(this, F);
+
+    _ar.set(this, {
+      writable: true,
+      value: void 0
+    });
+  }
+
+  babelHelpers.createClass(F, [{
+    key: "g",
+    value: function g() {
+      for (babelHelpers.classPrivateFieldDestructureSet(this, _ar).value in [1, 2, 3]) {
+        ;
+      }
+    }
+  }]);
+  return F;
+}();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #11272
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Issue Ref: [Private Name in the left ForOfStatement is not transformed, #11272 ](https://github.com/babel/babel/issues/11272)

The problem was that the private label `#a` runs before the `for-of` transform, and that has been fixed by adding a pattern check at the start of the `if` statement. Test cases included the original one from #11272 and the following:

**Input**
```
class Rainbow {
  tColors = ['Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Indigo', 'Violet'];
  #color;

  PrintColors() {
    for (this.#color of this.tColors) {
      console.log(this.#color)
    }
  }
}
```

**Output**
```
var _color = new WeakMap();

var Rainbow = /*#__PURE__*/function () {
  "use strict";

  function Rainbow() {
    babelHelpers.classCallCheck(this, Rainbow);
    babelHelpers.defineProperty(this, "tColors", ['Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Indigo', 'Violet']);

    _color.set(this, {
      writable: true,
      value: void 0
    });
  }

  babelHelpers.createClass(Rainbow, [{
    key: "PrintColors",
    value: function PrintColors() {
      for (babelHelpers.classPrivateFieldDestructureSet(this, _color).value of this.tColors) {
        console.log(babelHelpers.classPrivateFieldGet(this, _color));
      }
    }
  }]);
  return Rainbow;
}();
```