### PR TITLE
fix: enforce ignore options for chokidar

### DIFF
--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -192,6 +192,7 @@ export default async function ({
     filenames.forEach(function (filenameOrDir: string): void {
       const watcher = chokidar.watch(filenameOrDir, {
         persistent: true,
+        ignored: babelOptions.ignore,
         ignoreInitial: true,
         awaitWriteFinish: {
           stabilityThreshold: 50,


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues? | Fixes #9565
| Patch: Bug Fix? | Yes
| Major: Breaking Change? | No
| Minor: New Feature? | No 
| Tests Added + Pass? | No
| Documentation PR Link |
| Any Dependency Changes? | No
| License                  | MIT

This PR adds the `ignore` option input from the cli to the [`ignored` field](https://github.com/MLH-Fellowship/babel.git) of the `chokidar` options, which uses the any match module. Babel `ignore` uses [MatchExpression](https://github.com/MLH-Fellowship/babel.git).

[This PR](https://github.com/babel/babel/pull/9559) offers a similar fix, but claims that `chokidar` `ignored` does not support regular expressions and was closed. The test harness does not appear to support tests for `chokidar`.