### PR TITLE
fix: add optional: false to MemberExpression

### DIFF
--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -394,6 +394,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         delete node.arguments;
         // $FlowIgnore - callee isn't optional in the type definition
         delete node.callee;
+      } else if (node.type === "CallExpression") {
+        (node: N.Node).optional = false;
       }
 
       return node;
@@ -430,6 +432,16 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           }
 
           break;
+      }
+
+      return node;
+    }
+
+    parseSubscript(...args) {
+      const node = super.parseSubscript(...args);
+
+      if (node.type === "MemberExpression") {
+        node.optional = false;
       }
 
       return node;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes failing master: https://github.com/babel/babel/pull/11703/checks?check_run_id=763075625
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Acorn has shipped a new release including the optional chaining support. This PR does not add optional chaining but simply add a new property `optional: false` to `MemberExpression`, required by ESTree.

@kaicataldo Do we have an issue tracking the optional chaining support in `parser/estree`?