### PR TITLE
[gitpod] Run "make watch" in a second terminal

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,7 @@ tasks:
       Welcome to Gitpod!
 
       If you haven'\''t forked Babel yet and you want to prepare a PR, you can use
-      the Ctrl+P (or Cmd+P) shortcut, type `Fork` and press ENTER: Gitpod\ will
+      the Ctrl+P (or Cmd+P) shortcut, type `>Fork` and press ENTER: Gitpod\ will
       create the fork for you.
 
       <-- The other terminal is building Babel. It should automatically rebuild

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,6 +2,24 @@
 tasks:
   - init: make bootstrap
     command: make watch
+  - openMode: split-right
+    command: |-
+      clear && echo '
+      Welcome to Gitpod!
+
+      If you haven'\''t forked Babel yet and you want to prepare a PR, you can use
+      the Ctrl+P (or Cmd+P) shortcut, type `Fork` and press ENTER: Gitpod\ will
+      create the fork for you.
+
+      <-- The other terminal is building Babel. It should automatically rebuild
+          when you change a file, so you don'\''t need to worry about it.
+          If it'\''s still building, please wait until it'\''s finished!
+
+      If you want to run the tests, you can run `yarn jest` in this terminal,
+      or filter by package name (for example, `yarn jest babel-parser`).
+      '
+
+#' # <-- This is just because the gitpod theme has broken syntax highlighting
 
 github:
   # https://www.gitpod.io/docs/prebuilds/#configure-prebuilds

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,7 @@ tasks:
       Welcome to Gitpod!
 
       If you haven'\''t forked Babel yet and you want to prepare a PR, you can use
-      the Ctrl+P (or Cmd+P) shortcut, type `>Fork` and press ENTER: Gitpod\ will
+      the Ctrl+P (or ⌘P) shortcut, type `>Fork` and press ENTER: Gitpod\ will
       create the fork for you.
 
       <-- The other terminal is building Babel. It should automatically rebuild

--- a/Makefile
+++ b/Makefile
@@ -256,11 +256,12 @@ publish-eslint:
 bootstrap-only: lerna-bootstrap
 
 yarn-install: clean-all
-	yarn --ignore-engines
+	# Gitpod prebuilds have a slow network connection, so we need more time
+	yarn --ignore-engines --network-timeout 100000
 
 lerna-bootstrap: yarn-install
 # todo: remove `-- -- --ignore-engines` in Babel 8
-	$(YARN) lerna bootstrap -- -- --ignore-engines
+	$(YARN) lerna bootstrap -- -- --ignore-engines --network-timeout 100000
 
 bootstrap: bootstrap-only
 	$(MAKE) build


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The current Gitpod setup (it's working, try using the badge on README!) has a little usability problem: `make watch` takes over the terminal, and you have to know how to manually open a new one.

This PR opens a second terminal on startup on the right (so that you still see `make watch` on the left). I couldn't open an empty terminal, so I added a welcome message.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11718"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/d26ce7bba28ed62085751e57a23815cef06797aa.svg" /></a>

