### PR TITLE
Revert "chore: pin windows node.js version (#11522)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,7 @@ matrix:
     - node_js: "13"
     # Move `windows` build to be the third since it is slow
     - os: windows
-      # Pin windows node.js version until https://github.com/nodejs/node/issues/33166 is resolved
-      node_js: "14.0"
+      node_js: "node"
       env:
         - JOB=test
         # https://travis-ci.community/t/build-doesnt-finish-after-completing-tests/288/9


### PR DESCRIPTION
This reverts commit 812f3750c8e5a9cb73da0a4c69bff383e7a68249.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The mysterious issue is fixed on Node.js 14.3, see https://github.com/nodejs/node/issues/33166#issuecomment-631313914

Good to merge if CI is green.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11730"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/bb0e9e5b77c7fb32965e45f1b10dee2e6b83dc43.svg" /></a>

