### PR TITLE
Account for ConfigItem being generated by another copy of Babel

### DIFF
--- a/packages/babel-core/src/config/item.js
+++ b/packages/babel-core/src/config/item.js
@@ -49,6 +49,8 @@ export function getItemDescriptor(item: mixed): UnloadedDescriptor | void {
 
 export type { ConfigItem };
 
+const CONFIG_ITEM_BRAND = Symbol.for("@babel/core@7 - ConfigItem");
+
 /**
  * A public representation of a plugin/preset that will _eventually_ be load.
  * Users can use this to interact with the results of a loaded Babel
@@ -67,7 +69,7 @@ class ConfigItem {
   /**
    * Used to detect ConfigItem instances from other Babel instances.
    */
-  [Symbol.for("@babel/core@7 - ConfigItem")] = true;
+  [CONFIG_ITEM_BRAND] = true;
 
   /**
    * The resolved value of the item itself.
@@ -110,8 +112,7 @@ class ConfigItem {
     this._descriptor = descriptor;
     Object.defineProperty(this, "_descriptor", { enumerable: false });
 
-    this._isConfigItem = true;
-    Object.defineProperty(this, "_isConfigItem", { enumerable: false });
+    Object.defineProperty(this, CONFIG_ITEM_BRAND, { enumerable: false });
 
     this.value = this._descriptor.value;
     this.options = this._descriptor.options;

--- a/packages/babel-core/src/config/item.js
+++ b/packages/babel-core/src/config/item.js
@@ -40,7 +40,7 @@ export function createConfigItem(
 }
 
 export function getItemDescriptor(item: mixed): UnloadedDescriptor | void {
-  if (item instanceof ConfigItem || item._isConfigItem === true) {
+  if (item && item[Symbol.for("@babel/core@7 - ConfigItem")] === true) {
     return item._descriptor;
   }
 

--- a/packages/babel-core/src/config/item.js
+++ b/packages/babel-core/src/config/item.js
@@ -67,7 +67,7 @@ class ConfigItem {
   /**
    * Used to detect ConfigItem instances from other Babel instances.
    */
-  _isConfigItem: true;
+  [Symbol.for("@babel/core@7 - ConfigItem")] = true;
 
   /**
    * The resolved value of the item itself.

--- a/packages/babel-core/src/config/item.js
+++ b/packages/babel-core/src/config/item.js
@@ -40,7 +40,7 @@ export function createConfigItem(
 }
 
 export function getItemDescriptor(item: mixed): UnloadedDescriptor | void {
-  if (item?.[Symbol.for("@babel/core@7 - ConfigItem")] === true) {
+  if (item?.[CONFIG_ITEM_BRAND]) {
     return item._descriptor;
   }
 

--- a/packages/babel-core/src/config/item.js
+++ b/packages/babel-core/src/config/item.js
@@ -40,7 +40,7 @@ export function createConfigItem(
 }
 
 export function getItemDescriptor(item: mixed): UnloadedDescriptor | void {
-  if (item && item[Symbol.for("@babel/core@7 - ConfigItem")] === true) {
+  if (item?.[Symbol.for("@babel/core@7 - ConfigItem")] === true) {
     return item._descriptor;
   }
 

--- a/packages/babel-core/src/config/item.js
+++ b/packages/babel-core/src/config/item.js
@@ -40,7 +40,7 @@ export function createConfigItem(
 }
 
 export function getItemDescriptor(item: mixed): UnloadedDescriptor | void {
-  if (item instanceof ConfigItem) {
+  if (item instanceof ConfigItem || item._isConfigItem === true) {
     return item._descriptor;
   }
 
@@ -63,6 +63,11 @@ class ConfigItem {
    * If you access this, you are a bad person.
    */
   _descriptor: UnloadedDescriptor;
+
+  /**
+   * Used to detect ConfigItem instances from other Babel instances.
+   */
+  _isConfigItem: true;
 
   /**
    * The resolved value of the item itself.
@@ -104,6 +109,9 @@ class ConfigItem {
     // pass the item through JSON.stringify, it doesn't show up.
     this._descriptor = descriptor;
     Object.defineProperty(this, "_descriptor", { enumerable: false });
+
+    this._isConfigItem = true;
+    Object.defineProperty(this, "_isConfigItem", { enumerable: false });
 
     this.value = this._descriptor.value;
     this.options = this._descriptor.options;

--- a/packages/babel-core/src/config/item.js
+++ b/packages/babel-core/src/config/item.js
@@ -1,5 +1,7 @@
 // @flow
 
+/*:: declare var invariant; */
+
 import type { PluginTarget, PluginOptions } from "./validation/options";
 
 import path from "path";
@@ -40,7 +42,8 @@ export function createConfigItem(
 }
 
 export function getItemDescriptor(item: mixed): UnloadedDescriptor | void {
-  if (item?.[CONFIG_ITEM_BRAND]) {
+  if ((item: any)?.[CONFIG_ITEM_BRAND]) {
+    /*:: invariant(item instanceof ConfigItem) */
     return item._descriptor;
   }
 
@@ -70,6 +73,7 @@ class ConfigItem {
   /**
    * Used to detect ConfigItem instances from other Babel instances.
    */
+  // $FlowIgnore
   [CONFIG_ITEM_BRAND] = true;
 
   /**

--- a/packages/babel-core/src/config/item.js
+++ b/packages/babel-core/src/config/item.js
@@ -66,6 +66,7 @@ class ConfigItem {
    */
   _descriptor: UnloadedDescriptor;
 
+  // TODO(Babel 8): Check if this symbol needs to be updated
   /**
    * Used to detect ConfigItem instances from other Babel instances.
    */


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | developit/microbundle#657
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR Link    | N/A
| Any Dependency Changes?  | no
| License                  | MIT

This fixes `ConfigItem` unboxing when `core.createConfigItem()` is used to generate a ConfigItem that is then passed to a different copy of Babel. This is common in cases where npm fails to dedupe modules, or when differing versions of Babel are in-use.

```
// good - uses the version of babel that is doing the transforming:
module.exports = function preset(api) {
  api.createConfigItem(...)
}
// bad - uses whatever version this module installed:
import api from '@babel/core';
module.exports = babelLoader.custom({
  options() {
    api.createConfigItem(..)
  }
});
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11734"><img src="https://gitpod.io/api/apps/github/pbs/github.com/developit/babel.git/a00bf9e3bb5a6e2baf3b4509edf9a32ac6f40452.svg" /></a>

