### PR TITLE
[cjs] Skip duplicate reexported bindings in namespace reexports

### DIFF
--- a/packages/babel-helper-module-transforms/src/index.js
+++ b/packages/babel-helper-module-transforms/src/index.js
@@ -241,7 +241,13 @@ function buildNamespaceReexport(metadata, namespace, loose) {
           EXPORTS[key] = NAMESPACE[key];
         });
       `
-    : template.statement`
+    : // Also skip already assigned bindings if they are strictly equal
+      // to be somewhat more spec-compliant when a file has multiple
+      // namespace re-exports that would cause a binding to be exported
+      // multiple times. However, multiple bindings of the same name that
+      // export the same primitive value are silently skipped
+      // (the spec requires an "ambigous bindings" early error here).
+      template.statement`
         Object.keys(NAMESPACE).forEach(function(key) {
           if (key === "default" || key === "__esModule") return;
           VERIFY_NAME_LIST;

--- a/packages/babel-helper-module-transforms/src/index.js
+++ b/packages/babel-helper-module-transforms/src/index.js
@@ -236,6 +236,7 @@ function buildNamespaceReexport(metadata, namespace, loose) {
         Object.keys(NAMESPACE).forEach(function(key) {
           if (key === "default" || key === "__esModule") return;
           VERIFY_NAME_LIST;
+          if (key in EXPORTS && EXPORTS[key] === NAMESPACE[key]) return;
 
           EXPORTS[key] = NAMESPACE[key];
         });
@@ -244,6 +245,7 @@ function buildNamespaceReexport(metadata, namespace, loose) {
         Object.keys(NAMESPACE).forEach(function(key) {
           if (key === "default" || key === "__esModule") return;
           VERIFY_NAME_LIST;
+          if (key in EXPORTS && EXPORTS[key] === NAMESPACE[key]) return;
 
           Object.defineProperty(EXPORTS, key, {
             enumerable: true,

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from/output.js
@@ -6,6 +6,7 @@ define(["exports", "foo"], function (_exports, _foo) {
   });
   Object.keys(_foo).forEach(function (key) {
     if (key === "default" || key === "__esModule") return;
+    if (key in _exports && _exports[key] === _foo[key]) return;
     Object.defineProperty(_exports, key, {
       enumerable: true,
       get: function () {

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-from/output.js
@@ -4,6 +4,7 @@ define(["exports", "foo"], function (_exports, _foo) {
   _exports.__esModule = true;
   Object.keys(_foo).forEach(function (key) {
     if (key === "default" || key === "__esModule") return;
+    if (key in _exports && _exports[key] === _foo[key]) return;
     _exports[key] = _foo[key];
   });
 });

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-from/output.js
@@ -6,5 +6,6 @@ var _foo = require("foo");
 
 Object.keys(_foo).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === _foo[key]) return;
   exports[key] = _foo[key];
 });

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-all/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-all/output.js
@@ -11,6 +11,7 @@ var _react = babelHelpers.interopRequireWildcard(require("react"));
 Object.keys(_react).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
   if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
+  if (key in exports && exports[key] === _react[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from/output.js
@@ -8,6 +8,7 @@ var _foo = require("foo");
 
 Object.keys(_foo).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === _foo[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-all/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-all/output.js
@@ -8,6 +8,7 @@ var _foo = require("foo");
 
 Object.keys(_foo).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === _foo[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/reexport-all/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/reexport-all/output.js
@@ -8,6 +8,7 @@ var _foo = require("./foo");
 
 Object.keys(_foo).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === _foo[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-all/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-all/output.js
@@ -8,6 +8,7 @@ var _white = require("white");
 
 Object.keys(_white).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === _white[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {
@@ -20,6 +21,7 @@ var _black = require("black");
 
 Object.keys(_black).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === _black[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7165/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7165/output.js
@@ -10,6 +10,7 @@ var _bar = require("bar");
 
 Object.keys(_bar).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === _bar[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-all/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-all/output.js
@@ -27,6 +27,7 @@ var _mod = require("mod");
 Object.keys(_mod).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
   if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
+  if (key in exports && exports[key] === _mod[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-6/output.js
@@ -16,6 +16,7 @@
   _exports.__esModule = true;
   Object.keys(_foo).forEach(function (key) {
     if (key === "default" || key === "__esModule") return;
+    if (key in _exports && _exports[key] === _foo[key]) return;
     _exports[key] = _foo[key];
   });
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-6/output.js
@@ -18,6 +18,7 @@
   });
   Object.keys(_foo).forEach(function (key) {
     if (key === "default" || key === "__esModule") return;
+    if (key in _exports && _exports[key] === _foo[key]) return;
     Object.defineProperty(_exports, key, {
       enumerable: true,
       get: function () {

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules/output.js
@@ -16,6 +16,7 @@ var _mod = require("mod");
 
 _Object$keys(_mod).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === _mod[key]) return;
 
   _Object$defineProperty(exports, key, {
     enumerable: true,

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-loose/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-loose/output.js
@@ -23,6 +23,7 @@ var _mod = require("mod");
 _forEachInstanceProperty(_context = _Object$keys(_mod)).call(_context, function (key) {
   if (key === "default" || key === "__esModule") return;
   if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
+  if (key in exports && exports[key] === _mod[key]) return;
   exports[key] = _mod[key];
 });
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules/output.js
@@ -28,6 +28,7 @@ var _mod = require("mod");
 _forEachInstanceProperty(_context = _Object$keys(_mod)).call(_context, function (key) {
   if (key === "default" || key === "__esModule") return;
   if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
+  if (key in exports && exports[key] === _mod[key]) return;
 
   _Object$defineProperty(exports, key, {
     enumerable: true,

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/output.js
@@ -12,6 +12,7 @@ var _mod = require("mod");
 
 Object.keys(_mod).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === _mod[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11710
| Patch: Bug Fix?          | 👍 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes (I think)
| Documentation PR Link    | -
| Any Dependency Changes?  | 👎 
| License                  | MIT

Namespace reexports: skip already added reexports on the `exports` object if they are strictly equal (as suggested in https://github.com/babel/babel/issues/11710#issuecomment-647175235).

Questions:

1. Not sure if this change could cause other side effects?
	- Currently, loose mode wouldn't throw any errors on duplicate bindings (in non-loose `Object.defineProperty` does this automatically). However, the order of the objects should be the same (because both skip if already set).
2. I don't think there are any (integration) tests which aren't snapshot tests?




<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11739"><img src="https://gitpod.io/api/apps/github/pbs/github.com/mischnic/babel.git/87938edab4ad25e4f756b5d856423395acd03bdf.svg" /></a>

