### PR TITLE
chore: add rejects assertion to fixture-test-runner

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -228,6 +228,7 @@ function run(task) {
         !expected.code &&
         outputCode &&
         !opts.throws &&
+        !opts.rejects &&
         fs.statSync(path.dirname(expected.loc)).isDirectory() &&
         !process.env.CI
       ) {
@@ -385,13 +386,22 @@ export default function (
             if (dynamicOpts) dynamicOpts(task.options, task);
 
             const throwMsg = task.options.throws;
+            const rejectMsg = task.options.rejects;
             if (throwMsg) {
               // internal api doesn't have this option but it's best not to pollute
               // the options object with useless options
               delete task.options.throws;
 
-              assert.throws(runTask, function (err) {
-                return throwMsg === true || err.message.indexOf(throwMsg) >= 0;
+              return assert.throws(runTask, function (err) {
+                assert.ok(err.message.indexOf(throwMsg) >= 0);
+                return true;
+              });
+            } else if (rejectMsg) {
+              delete task.options.rejects;
+
+              return assert.rejects(runTask, function (err) {
+                assert.ok(err.message.indexOf(rejectMsg) >= 0);
+                return true;
               });
             } else {
               if (task.exec.code) {

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -393,14 +393,14 @@ export default function (
               delete task.options.throws;
 
               return assert.throws(runTask, function (err) {
-                assert.ok(err.message.indexOf(throwMsg) >= 0);
+                assert.ok(err.message.includes(throwMsg));
                 return true;
               });
             } else if (rejectMsg) {
               delete task.options.rejects;
 
               return assert.rejects(runTask, function (err) {
-                assert.ok(err.message.indexOf(rejectMsg) >= 0);
+                assert.ok(err.message.includes(rejectMsg));
                 return true;
               });
             } else {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Minor: New Feature? | `"rejects": string` is supported
| Major: Breaking Change?  | `"throws": true` is no longer accepted in test fixture options
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR adds `rejects: string` supports to our fixture runner. When `rejects` is specified, it will check if an error is thrown asynchronously from the fixture tests. This feature is depended by #11141 due to the fact that we brings async config support to `@babel/core`.

Since `assert.rejects` is supported since node v10.0.0, this feature targets to Babel 8 only.

It also removes currently unused `"throws": boolean` support, to make it indeed a breaking change. 😄

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11740"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/6faada944f7deea44f53f8f7346e4c05e9f7f3dd.svg" /></a>

