### PR TITLE
Add test for changing name of _typeof helper (for @babel/plugin-transform-typeof-symbol)

### DIFF
--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-declaration_typeof/input.mjs
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-declaration_typeof/input.mjs
@@ -1,0 +1,2 @@
+typeof Reflect === "object";
+function _typeof() { };

--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-declaration_typeof/options.json
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-declaration_typeof/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-typeof-symbol"]
+}

--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-declaration_typeof/output.mjs
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-declaration_typeof/output.mjs
@@ -1,0 +1,7 @@
+function _typeof2(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof2 = function (obj) { return typeof obj; }; } else { _typeof2 = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof2(obj); }
+
+(typeof Reflect === "undefined" ? "undefined" : _typeof2(Reflect)) === "object";
+
+function _typeof() {}
+
+;

--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-func_typeof/input.mjs
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-func_typeof/input.mjs
@@ -1,0 +1,2 @@
+typeof Reflect === "symbol";
+var a = function _typeof() { };

--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-func_typeof/options.json
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-func_typeof/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-typeof-symbol"]
+}

--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-func_typeof/output.mjs
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-func_typeof/output.mjs
@@ -1,0 +1,5 @@
+function _typeof2(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof2 = function (obj) { return typeof obj; }; } else { _typeof2 = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof2(obj); }
+
+(typeof Reflect === "undefined" ? "undefined" : _typeof2(Reflect)) === "symbol";
+
+var a = function _typeof() {};

--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-var_typeof/input.mjs
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-var_typeof/input.mjs
@@ -1,0 +1,2 @@
+typeof Reflect === "symbol";
+var _typeof = function a() { };

--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-var_typeof/options.json
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-var_typeof/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-typeof-symbol"]
+}

--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-var_typeof/output.mjs
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/function-expression-var_typeof/output.mjs
@@ -1,0 +1,5 @@
+function _typeof2(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof2 = function (obj) { return typeof obj; }; } else { _typeof2 = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof2(obj); }
+
+(typeof Reflect === "undefined" ? "undefined" : _typeof2(Reflect)) === "symbol";
+
+var _typeof = function a() {};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

## Summary

The name of the helper changes from _typeof to `_typeof2` .

* When the function name in the function declaration is is _typeof
* When the variable name of the function expression is _typeof
* When the function name of the function expression is _typeof

So I add  tests about it.

Bebel REPL ↓↓

![image](https://user-images.githubusercontent.com/11146767/85508129-6e176800-b62e-11ea-892b-08a66ff0f8d1.png)


## Test

```bash
#~/JavaScriptProjects/babel (add_test_about-transform-typeof-symbol)
$ TEST_ONLY=babel-plugin-transform-typeof-symbol make test
BABEL_ENV=test yarn --silent eslint scripts packages codemods eslint '*.js' --format=codeframe
scripts/lint-ts-typings.sh
BABEL_ENV=test ./scripts/test.sh
 PASS  packages/babel-plugin-transform-typeof-symbol/test/helper.spec.js
 PASS  packages/babel-plugin-transform-typeof-symbol/test/index.js

Test Suites: 2 passed, 2 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        4.024s
Ran all test suites matching /(packages|codemods|eslint)\/.*babel-plugin-transform-typeof-symbol.*\/test/i.
/Applications/Xcode.app/Contents/Developer/usr/bin/make test-clean
rm -rf  packages/*/test/tmp
rm -rf  packages/*/test-fixtures.json
rm -rf  codemods/*/test/tmp
rm -rf  codemods/*/test-fixtures.json
rm -rf  eslint/*/test/tmp
rm -rf  eslint/*/test-fixtures.json
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11743"><img src="https://gitpod.io/api/apps/github/pbs/github.com/yukihirop/babel.git/0565c099ec75e2f3b741adfbf7ef898f70e40f92.svg" /></a>

