### PR TITLE
throw constant violations in loop body

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -409,11 +409,14 @@ class BlockScoping {
   }
 
   checkConstants() {
-    const scope = this.scope;
     const state = this.state;
 
-    for (const name of Object.keys(scope.bindings)) {
-      const binding = scope.bindings[name];
+    const blockScope = this.blockPath.scope;
+    const letRefs = this.letReferences;
+
+    for (const name of Object.keys(letRefs)) {
+      const ref = letRefs[name];
+      const binding = blockScope.getBinding(ref.name);
       if (binding.kind !== "const") continue;
 
       for (const violation of (binding.constantViolations: Array)) {
@@ -438,6 +441,44 @@ class BlockScoping {
         }
       }
     }
+
+    // for (const name of Object.keys(scope.bindings)) {
+    //   const binding = scope.bindings[name];
+    //   if (binding.kind !== "const") continue;
+    //   // if (this.scope.uid == 996)
+    //   //   console.log(scope)
+    //   // if (this.scope.uid == 996) {
+    //   //   console.log(binding);
+    //   // }
+
+    //   for (const violation of (binding.constantViolations: Array)) {
+    //     const readOnlyError = state.addHelper("readOnlyError");
+    //     const throwNode = t.callExpression(readOnlyError, [
+    //       t.stringLiteral(name),
+    //     ]);
+
+    //     if (this.scope.uid == 996) {
+    //         console.log(violation);
+    //       }
+    //     if (violation.isAssignmentExpression()) {
+    //       violation
+    //         .get("right")
+    //         .replaceWith(
+    //           t.sequenceExpression([throwNode, violation.get("right").node]),
+    //         );
+    //     } else if (violation.isUpdateExpression()) {
+    //       // if (this.scope.uid == 996) {
+    //       //   console.log("UpdateError");
+    //       // }
+    //       violation.replaceWith(
+    //         t.sequenceExpression([throwNode, violation.node]),
+    //       );
+    //     } else if (violation.isForXStatement()) {
+    //       violation.ensureBlock();
+    //       violation.node.body.body.unshift(t.expressionStatement(throwNode));
+    //     }
+    //   }
+    // }
   }
 
   updateScopeInfo(wrappedInClosure) {

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/assignment-in-for-loop/exec.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/assignment-in-for-loop/exec.js
@@ -1,0 +1,7 @@
+expect(function () {
+    const array = [1, 2, 3];
+    for (const element of array) {
+        const from = 50;
+        from--;
+    }
+}).toThrow('"from" is read-only');

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/assignment-in-for-loop/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/assignment-in-for-loop/input.js
@@ -1,0 +1,6 @@
+const array = [1, 2, 3];
+console.log("this file runs")
+for (const element of []) {
+  const from = 50;
+  from--;
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/assignment-in-for-loop/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/assignment-in-for-loop/output.js
@@ -1,0 +1,9 @@
+function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+
+var array = [1, 2, 3];
+console.log("this file runs");
+
+for (var element of []) {
+  var from = 50;
+  _readOnlyError("from"), from--;
+}


### PR DESCRIPTION

| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes [#11475 ](https://github.com/babel/babel/issues/11475)
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | No
| License                  | MIT

Fix the bug where changing the value of constant variable in a loop will not output a read-only error.

**Input**
```const array = [1, 2, 3];
for (const element of array) {
  const from = 50;
  from--;
}
```

**Output**
```function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }

var array = [1, 2, 3];
console.log("this file runs");

for (var element of []) {
  var from = 50;
  _readOnlyError("from"), from--;
}
```


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11745"><img src="https://gitpod.io/api/apps/github/pbs/github.com/MLH-Fellowship/babel.git/480a2720494dac15d42358aed6c58ed17af08c4c.svg" /></a>

