### PR TITLE
Add note about VS Code breakpoints to contrib.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,6 +274,8 @@ A common approach to debugging JavaScript code is to walk through the code using
 For illustration purposes, we are going to assume that we need to get a better understanding of [`Generator.generate()`](https://github.com/babel/babel/blob/b5246994b57f06af871be6a63dcc4c6fd41d94d6/packages/babel-generator/src/index.js#L32), which is responsible for generating code for a given AST.
 To get a better understanding of what is actually going on for this particular piece of code, we are going to make use of breakpoints.
 
+> Note that VSCode breakpoints will not work properly. The native `debugger` statement must be used.
+
 ```diff
 generate() {
 + debugger; // breakpoint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,14 +274,14 @@ A common approach to debugging JavaScript code is to walk through the code using
 For illustration purposes, we are going to assume that we need to get a better understanding of [`Generator.generate()`](https://github.com/babel/babel/blob/b5246994b57f06af871be6a63dcc4c6fd41d94d6/packages/babel-generator/src/index.js#L32), which is responsible for generating code for a given AST.
 To get a better understanding of what is actually going on for this particular piece of code, we are going to make use of breakpoints.
 
-> Note that VSCode breakpoints will not work properly. The native `debugger` statement must be used.
-
 ```diff
 generate() {
 + debugger; // breakpoint
   return super.generate(this.ast);
 }
 ```
+
+> Note that VSCode breakpoints will not work properly. The native `debugger` statement must be used.
 
 To include the changes, we have to make sure to build Babel:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,7 +281,7 @@ generate() {
 }
 ```
 
-> Note that VSCode breakpoints will not work properly. The native `debugger` statement must be used.
+> Note that VS Code IDE based breakpoints will not work properly. The native `debugger` statement must be used.
 
 To include the changes, we have to make sure to build Babel:
 


### PR DESCRIPTION
For an unknown reason, VSCode app based breakpoints do not trigger when developing babel. The `debugger` statement does work.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9045
| Patch: Bug Fix?          | Docs
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11746"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ianjennings/babel.git/e8c26220f358d37536ebacff11b10e6e97d61c60.svg" /></a>

