### PR TITLE
Typescript: always strip declare from class fields

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -93,6 +93,7 @@ export default declare(
         if (node.optional) node.optional = null;
         if (node.typeAnnotation) node.typeAnnotation = null;
         if (node.definite) node.definite = null;
+        if (node.declare) node.declare = null;
       },
       method({ node }) {
         if (node.accessibility) node.accessibility = null;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/declare/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/declare/input.ts
@@ -1,3 +1,4 @@
 class A {
   declare x;
+  @foo declare y: string;
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/declare/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/declare/options.json
@@ -1,3 +1,6 @@
 {
-  "plugins": [["transform-typescript", { "allowDeclareFields": true }]]
+  "plugins": [
+    ["transform-typescript", { "allowDeclareFields": true }],
+    ["syntax-decorators", { "legacy": true }]
+  ]
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/declare/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/declare/output.js
@@ -1,1 +1,4 @@
-class A {}
+class A {
+  @foo
+  y;
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/decorated-declare-properties/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/decorated-declare-properties/input.ts
@@ -1,0 +1,3 @@
+class Foo {
+  @decorator declare bar: string;
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/decorated-declare-properties/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/decorated-declare-properties/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["transform-typescript", { "allowDeclareFields": true }],
+    ["proposal-decorators", { "legacy": true }],
+    ["proposal-class-properties"]
+  ]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/decorated-declare-properties/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/decorated-declare-properties/output.js
@@ -1,0 +1,21 @@
+var _class, _descriptor, _temp;
+
+function _initializerDefineProperty(target, property, descriptor, context) { if (!descriptor) return; Object.defineProperty(target, property, { enumerable: descriptor.enumerable, configurable: descriptor.configurable, writable: descriptor.writable, value: descriptor.initializer ? descriptor.initializer.call(context) : void 0 }); }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object.keys(descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object.defineProperty(target, property, desc); desc = null; } return desc; }
+
+function _initializerWarningHelper(descriptor, context) { throw new Error('Decorating class property failed. Please ensure that ' + 'proposal-class-properties is enabled and runs after the decorators transform.'); }
+
+let Foo = (_class = (_temp = class Foo {
+  constructor() {
+    _initializerDefineProperty(this, "bar", _descriptor, this);
+  }
+
+}, _temp), (_descriptor = _applyDecoratedDescriptor(_class.prototype, "bar", [decorator], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: null
+})), _class);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Normally, a class field annotated with `declare` would be stripped because `declare` indicates this is type-only information. The exception is when a decorator is also applied to the property, e.g.

```ts
class Foo {
  @bar declare x: string;
}
```

In this case, the property should be preserved so that the decorator can do its thing. Currently `babel-plugin-transform-typescript` is correctly not stripping the property, but it is *also* not stripping the `declare`.

This PR fixes this by always removing `declare` if still found if the path has not been removed.

This matches the behavior of the TypeScript compiler: https://www.typescriptlang.org/play/?experimentalDecorators=true#code/MYGwhgzhAEBiD29oG8CwAoa0ACATApsPAE5gAuJ0BoYx+0AZogFzQRnECWAdgOYDcGLNXB1oAI1qt2XPoPQBfIA

I've pushed a failing test first to demonstrate the issue and then pushed the fix.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11747"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jamescdavis/babel.git/6a820990ba92b7598c0282314a9832b4cc9e0bd4.svg" /></a>