### PR TITLE
[regression] Don't validate file.comments in `@babel/types`

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -281,8 +281,10 @@ defineType("File", {
     },
     comments: {
       validate: !process.env.BABEL_TYPES_8_BREAKING
-        ? Object.assign(() => {}, { each: { type: "Comment" } })
-        : assertEach(assertNodeType("Comment")),
+        ? Object.assign(() => {}, {
+            each: { oneOfNodeTypes: ["CommentBlock", "CommentLine"] },
+          })
+        : assertEach(assertNodeType("CommentBlock", "CommentLine")),
       optional: true,
     },
     tokens: {

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -280,7 +280,9 @@ defineType("File", {
       validate: assertNodeType("Program"),
     },
     comments: {
-      validate: assertEach(assertNodeType("Comment")),
+      validate: !process.env.BABEL_TYPES_8_BREAKING
+        ? Object.assign(() => {}, { each: { type: "Comment" } })
+        : assertEach(assertNodeType("Comment")),
       optional: true,
     },
     tokens: {

--- a/packages/babel-types/test/regressions.js
+++ b/packages/babel-types/test/regressions.js
@@ -1,7 +1,7 @@
 import * as t from "../lib";
 
 describe("regressions", () => {
-  it("jest .toMatchInlineSnapshot usef 'Line' for comments", () => {
+  it("jest .toMatchInlineSnapshot used 'Line' for comments", () => {
     expect(() => {
       t.file(t.program([]), [{ type: "Line" }]);
     }).not.toThrow();

--- a/packages/babel-types/test/regressions.js
+++ b/packages/babel-types/test/regressions.js
@@ -1,0 +1,9 @@
+import * as t from "../lib";
+
+describe("regressions", () => {
+  it("jest .toMatchInlineSnapshot usef 'Line' for comments", () => {
+    expect(() => {
+      t.file(t.program([]), [{ type: "Line" }]);
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/pull/11687#discussion_r446474079, https://github.com/facebook/jest/issues/10208
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In https://github.com/babel/babel/pull/11687 we introduced a new valid check, but it breaks Jest. Let's defer it to Babel 8.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11752"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/0e34189559c4b38bfdd336c021fbea4bf7f6143c.svg" /></a>

