### PR TITLE
TypeScript 4.0: Allow spread in the middle of tuples

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -651,12 +651,6 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         const restNode: N.TsRestType = this.startNode();
         this.next(); // skips ellipsis
         restNode.typeAnnotation = this.tsParseType();
-        if (
-          this.match(tt.comma) &&
-          this.lookaheadCharCode() !== charCodes.rightSquareBracket
-        ) {
-          this.raiseRestNotLast(this.state.start);
-        }
         return this.finishNode(restNode, "TSRestType");
       }
 

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -630,9 +630,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         /* skipFirstToken */ false,
       );
 
-      // Validate the elementTypes to ensure:
-      //   No mandatory elements may follow optional elements
-      //   If there's a rest element, it must be at the end of the tuple
+      // Validate the elementTypes to ensure that no mandatory elements
+      // follow optional elements
       let seenOptionalElement = false;
       node.elementTypes.forEach(elementNode => {
         if (elementNode.type === "TSOptionalType") {

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-invalid/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-invalid/input.ts
@@ -1,1 +1,0 @@
-let x: [...number[], string]

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-invalid/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-invalid/options.json
@@ -1,5 +1,0 @@
-{
-  "sourceType": "module",
-  "plugins": ["typescript"],
-  "throws": "Rest element must be last element (1:19)"
-}

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-not-last/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-not-last/input.ts
@@ -1,0 +1,1 @@
+let x: [...[number, string], string]

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-not-last/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-not-last/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["typescript"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-not-last/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-not-last/output.json
@@ -1,0 +1,62 @@
+{
+  "type": "File",
+  "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":36}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":36}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":36}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":4,"end":36,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":36}},
+            "id": {
+              "type": "Identifier",
+              "start":4,"end":36,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":36},"identifierName":"x"},
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":5,"end":36,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":36}},
+                "typeAnnotation": {
+                  "type": "TSTupleType",
+                  "start":7,"end":36,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":36}},
+                  "elementTypes": [
+                    {
+                      "type": "TSRestType",
+                      "start":8,"end":27,"loc":{"start":{"line":1,"column":8},"end":{"line":1,"column":27}},
+                      "typeAnnotation": {
+                        "type": "TSTupleType",
+                        "start":11,"end":27,"loc":{"start":{"line":1,"column":11},"end":{"line":1,"column":27}},
+                        "elementTypes": [
+                          {
+                            "type": "TSNumberKeyword",
+                            "start":12,"end":18,"loc":{"start":{"line":1,"column":12},"end":{"line":1,"column":18}}
+                          },
+                          {
+                            "type": "TSStringKeyword",
+                            "start":20,"end":26,"loc":{"start":{"line":1,"column":20},"end":{"line":1,"column":26}}
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "TSStringKeyword",
+                      "start":29,"end":35,"loc":{"start":{"line":1,"column":29},"end":{"line":1,"column":35}}
+                    }
+                  ]
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

https://devblogs.microsoft.com/typescript/announcing-typescript-4-0-beta/#variadic-tuple-types

Example:
```js
type Strings = [string, string];
type Numbers = [number, number];

// [string, string, number, number]
type StrStrNumNum = [...Strings, ...Numbers];
```

Note: currently the node is called `TSRestType` and not `TSSpreadType`. I _think_ we should rename it in the future.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11753"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/97c649a2d7c1fb3f3b3703a91ee07ce0a26a4e1c.svg" /></a>

