### PR TITLE
Push changelog to `main` instead of `master`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,22 +32,22 @@ jobs:
           changelog: ${{ steps.changelog.outputs.changelog }}
           token: ${{ secrets.BOT_TOKEN }}
 
-      - name: Check if releasing from master
-        id: is_master
+      - name: Check if releasing from main
+        id: is_main
         uses: babel/actions/ref-matches-branch@v2
         with:
-          name: master
+          name: main
 
       - name: Update CHANGELOG.md
-        if: steps.is_master.outputs.result == 1
+        if: steps.is_main.outputs.result == 1
         uses: babel/actions/update-changelog@v2
         with:
           changelog: ${{ steps.changelog.outputs.changelog }}
 
       - name: Commit CHANGELOG.md
-        if: steps.is_master.outputs.result == 1
+        if: steps.is_main.outputs.result == 1
         run: |
           git add CHANGELOG.md
           git -c user.name="Babel Bot" -c user.email="babel-bot@users.noreply.github.com" \
             commit -m "Add ${{ steps.tags.outputs.new }} to CHANGELOG.md [skip ci]" --no-verify --quiet
-          git push "https://babel-bot:${{ secrets.BOT_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" master
+          git push "https://babel-bot:${{ secrets.BOT_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" main


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I noticed that `CHANGELOG.md` doesn't contain 7.10.3 and 7.10.4.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11764"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/c16a9333bf146e4bf99aec136d722099e3c20788.svg" /></a>

