### PR TITLE
Follow-up on initial TS4 catch param support

### DIFF
--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -174,6 +174,7 @@ export function CatchClause(node: Object) {
   if (node.param) {
     this.token("(");
     this.print(node.param, node);
+    this.print(node.param.typeAnnotation, node);
     this.token(")");
     this.space();
   }

--- a/packages/babel-generator/test/fixtures/typescript/catch-param-type/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/catch-param-type/input.js
@@ -1,0 +1,2 @@
+try {} catch (e: unknown) {}
+try {} catch (e: any) {}

--- a/packages/babel-generator/test/fixtures/typescript/catch-param-type/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/catch-param-type/output.js
@@ -1,0 +1,3 @@
+try {} catch (e: unknown) {}
+
+try {} catch (e: any) {}

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2666,7 +2666,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const type = this.tsTryParseTypeAnnotation();
 
       if (type) {
-        param.type = type;
+        param.typeAnnotation = type;
       }
 
       return param;

--- a/packages/babel-parser/test/fixtures/typescript/catch-clause/unknown/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/catch-clause/unknown/output.json
@@ -46,16 +46,17 @@
           "type": "CatchClause",
           "start":28,"end":50,"loc":{"start":{"line":2,"column":7},"end":{"line":2,"column":29}},
           "param": {
-            "type": {
+            "type": "Identifier",
+            "start":35,"end":37,"loc":{"start":{"line":2,"column":14},"end":{"line":2,"column":16},"identifierName":"ex"},
+            "name": "ex",
+            "typeAnnotation": {
               "type": "TSTypeAnnotation",
               "start":37,"end":46,"loc":{"start":{"line":2,"column":16},"end":{"line":2,"column":25}},
               "typeAnnotation": {
                 "type": "TSUnknownKeyword",
                 "start":39,"end":46,"loc":{"start":{"line":2,"column":18},"end":{"line":2,"column":25}}
               }
-            },
-            "start":35,"end":37,"loc":{"start":{"line":2,"column":14},"end":{"line":2,"column":16},"identifierName":"ex"},
-            "name": "ex"
+            }
           },
           "body": {
             "type": "BlockStatement",
@@ -79,16 +80,17 @@
           "type": "CatchClause",
           "start":58,"end":76,"loc":{"start":{"line":3,"column":7},"end":{"line":3,"column":25}},
           "param": {
-            "type": {
+            "type": "Identifier",
+            "start":65,"end":67,"loc":{"start":{"line":3,"column":14},"end":{"line":3,"column":16},"identifierName":"ex"},
+            "name": "ex",
+            "typeAnnotation": {
               "type": "TSTypeAnnotation",
               "start":67,"end":72,"loc":{"start":{"line":3,"column":16},"end":{"line":3,"column":21}},
               "typeAnnotation": {
                 "type": "TSAnyKeyword",
                 "start":69,"end":72,"loc":{"start":{"line":3,"column":18},"end":{"line":3,"column":21}}
               }
-            },
-            "start":65,"end":67,"loc":{"start":{"line":3,"column":14},"end":{"line":3,"column":16},"identifierName":"ex"},
-            "name": "ex"
+            }
           },
           "body": {
             "type": "BlockStatement",
@@ -119,7 +121,10 @@
           "type": "CatchClause",
           "start":133,"end":149,"loc":{"start":{"line":6,"column":7},"end":{"line":6,"column":23}},
           "param": {
-            "type": {
+            "type": "Identifier",
+            "start":140,"end":142,"loc":{"start":{"line":6,"column":14},"end":{"line":6,"column":16},"identifierName":"ex"},
+            "name": "ex",
+            "typeAnnotation": {
               "type": "TSTypeAnnotation",
               "start":142,"end":145,"loc":{"start":{"line":6,"column":16},"end":{"line":6,"column":19}},
               "typeAnnotation": {
@@ -131,9 +136,7 @@
                   "name": "A"
                 }
               }
-            },
-            "start":140,"end":142,"loc":{"start":{"line":6,"column":14},"end":{"line":6,"column":16},"identifierName":"ex"},
-            "name": "ex"
+            }
           },
           "body": {
             "type": "BlockStatement",
@@ -164,7 +167,10 @@
           "type": "CatchClause",
           "start":157,"end":177,"loc":{"start":{"line":7,"column":7},"end":{"line":7,"column":27}},
           "param": {
-            "type": {
+            "type": "Identifier",
+            "start":164,"end":166,"loc":{"start":{"line":7,"column":14},"end":{"line":7,"column":16},"identifierName":"ex"},
+            "name": "ex",
+            "typeAnnotation": {
               "type": "TSTypeAnnotation",
               "start":166,"end":173,"loc":{"start":{"line":7,"column":16},"end":{"line":7,"column":23}},
               "typeAnnotation": {
@@ -176,9 +182,7 @@
                   "name": "Error"
                 }
               }
-            },
-            "start":164,"end":166,"loc":{"start":{"line":7,"column":14},"end":{"line":7,"column":16},"identifierName":"ex"},
-            "name": "ex"
+            }
           },
           "body": {
             "type": "BlockStatement",
@@ -202,16 +206,17 @@
           "type": "CatchClause",
           "start":185,"end":206,"loc":{"start":{"line":8,"column":7},"end":{"line":8,"column":28}},
           "param": {
-            "type": {
+            "type": "Identifier",
+            "start":192,"end":194,"loc":{"start":{"line":8,"column":14},"end":{"line":8,"column":16},"identifierName":"ex"},
+            "name": "ex",
+            "typeAnnotation": {
               "type": "TSTypeAnnotation",
               "start":194,"end":202,"loc":{"start":{"line":8,"column":16},"end":{"line":8,"column":24}},
               "typeAnnotation": {
                 "type": "TSStringKeyword",
                 "start":196,"end":202,"loc":{"start":{"line":8,"column":18},"end":{"line":8,"column":24}}
               }
-            },
-            "start":192,"end":194,"loc":{"start":{"line":8,"column":14},"end":{"line":8,"column":16},"identifierName":"ex"},
-            "name": "ex"
+            }
           },
           "body": {
             "type": "BlockStatement",
@@ -235,7 +240,10 @@
           "type": "CatchClause",
           "start":214,"end":244,"loc":{"start":{"line":9,"column":7},"end":{"line":9,"column":37}},
           "param": {
-            "type": {
+            "type": "Identifier",
+            "start":221,"end":223,"loc":{"start":{"line":9,"column":14},"end":{"line":9,"column":16},"identifierName":"ex"},
+            "name": "ex",
+            "typeAnnotation": {
               "type": "TSTypeAnnotation",
               "start":223,"end":240,"loc":{"start":{"line":9,"column":16},"end":{"line":9,"column":33}},
               "typeAnnotation": {
@@ -252,9 +260,7 @@
                   }
                 ]
               }
-            },
-            "start":221,"end":223,"loc":{"start":{"line":9,"column":14},"end":{"line":9,"column":16},"identifierName":"ex"},
-            "name": "ex"
+            }
           },
           "body": {
             "type": "BlockStatement",

--- a/packages/babel-plugin-transform-typescript/test/fixtures/catch-clause/param-type/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/catch-clause/param-type/input.ts
@@ -1,0 +1,1 @@
+try {} catch (e: any) {}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/catch-clause/param-type/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/catch-clause/param-type/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["transform-typescript"],
+  "sourceType": "module"
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/catch-clause/param-type/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/catch-clause/param-type/output.mjs
@@ -1,0 +1,1 @@
+try {} catch (e) {}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The generator does not support catch param types
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes a bug in previous AST design #11755 where `type: string` is replaced by a `TypeAnnotation` AST Node. By doing so the transformer support is out of box.

This PR also adds generator support for catch param types.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11767"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/011458a444ad35efdd8609509a84c38a70d2204b.svg" /></a>

