### PR TITLE
chore: remove babel-register generated test artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ clean: test-clean
 	rm -rf packages/babel-polyfill/dist
 	rm -rf coverage
 	rm -rf packages/*/npm-debug*
+	rm -rf node_modules/.cache
 
 test-clean:
 	$(foreach source, $(SOURCES), \

--- a/packages/babel-register/test/fixtures/browserify/register.js
+++ b/packages/babel-register/test/fixtures/browserify/register.js
@@ -1,3 +1,4 @@
+process.env.BABEL_DISABLE_CACHE = "true";
 require("@babel/register").default({
-  ignore: false
+  ignore: false,
 });

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -7,6 +7,7 @@ let currentOptions;
 let sourceMapSupport = false;
 
 const registerFile = require.resolve("../lib/node");
+const testCacheFilename = path.join(__dirname, ".babel");
 const testFile = require.resolve("./fixtures/babelrc/es2015");
 const testFileContent = fs.readFileSync(testFile);
 const sourceMapTestFile = require.resolve("./fixtures/source-map/index");
@@ -41,10 +42,23 @@ const defaultOptions = {
   ignoreNodeModules: false,
 };
 
+function cleanCache() {
+  try {
+    fs.unlinkSync(testCacheFilename);
+  } catch (e) {
+    // It is convenient to always try to clear
+  }
+}
+
+function resetCache() {
+  process.env.BABEL_CACHE_PATH = null;
+}
+
 describe("@babel/register", function () {
   let babelRegister;
 
   function setupRegister(config = { babelrc: false }) {
+    process.env.BABEL_CACHE_PATH = testCacheFilename;
     config = {
       cwd: path.dirname(testFile),
       ...config,
@@ -60,6 +74,7 @@ describe("@babel/register", function () {
       delete require.cache[registerFile];
       babelRegister = null;
     }
+    cleanCache();
   }
 
   afterEach(() => {
@@ -68,6 +83,10 @@ describe("@babel/register", function () {
     currentOptions = null;
     sourceMapSupport = false;
     jest.resetModules();
+  });
+
+  afterAll(() => {
+    resetCache();
   });
 
   test("registers hook correctly", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Our Travis CI build is always packing a new n_m cache after tests: https://travis-ci.com/github/babel/babel/jobs/356503785#L1076
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR refines `babel-register` tests to ensure that they output to customized cache path and removed after test. I also add a general remove `node_modules/.cache` step to `make test-clean` as our last resort.

Hopefully Travis CI should not pack a new n_m cache after test is finished. (See https://travis-ci.com/github/babel/babel/jobs/356530518#L1082)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11776"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/f896c4f315696dacf9835e8e6b6189c68768be2a.svg" /></a>