### PR TITLE
chore: refine yarn cache config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,12 @@ aliases:
   - &restore-node-modules-cache
     keys:
       - v1-yarn-deps-{{ checksum "yarn.lock" }}
+      - v1-yarn-deps-
 
   - &restore-yarn-cache
     keys:
-      - v1-yarn-cache
+      - v1-yarn-cache-{{ checksum "yarn.lock" }}
+      - v1-yarn-cache-
 
   - &save-node-modules-cache
     paths:
@@ -16,8 +18,8 @@ aliases:
 
   - &save-yarn-cache
     paths:
-      - ~/.yarn-cache
-    key: v1-yarn-cache
+      - "{{ .Environment.YARN_CACHE_FOLDER }}"
+    key: v1-yarn-cache-{{ checksum "yarn.lock" }}
 
   - &artifact_babel
     path: ~/babel/packages/babel-standalone/babel.js
@@ -61,6 +63,7 @@ jobs:
         # data for a JS file that's several megabytes large is bound to fail. Here,
         # we just run the babel-standalone test separately.
       - run: yarn jest "\-standalone/test"
+      - run: export YARN_CACHE_FOLDER=$(yarn cache dir)
       - store_artifacts: *artifact_babel
       - store_artifacts: *artifact_babel_min
       - save_cache: *save-node-modules-cache
@@ -119,13 +122,13 @@ jobs:
             cat ~/diff.tap | $(npm bin)/tap-merge | $(npm bin)/tap-mocha-reporter xunit | tee ~/test-results/test262/results.xml
           <<: *test262_workdir
       - store_test_results: *artifact_test262_xunit
-      - save_cache: *save-node-modules-cache
-      - save_cache: *save-yarn-cache
 
   publish-verdaccio:
     executor: node-executor
     steps:
       - checkout
+      - restore_cache: *restore-yarn-cache
+      - restore_cache: *restore-node-modules-cache
       - run: yarn install
       - run: ./scripts/integration-tests/publish-local.sh
       - persist_to_workspace:
@@ -216,4 +219,3 @@ workflows:
       - e2e-vue-cli:
           requires:
             - publish-verdaccio
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ aliases:
 
   - &restore-yarn-cache
     keys:
-      - v1-yarn-cache-{{ checksum "yarn.lock" }}
-      - v1-yarn-cache-
+      - v1-1-yarn-cache-{{ checksum "yarn.lock" }}
+      - v1-1-yarn-cache-
 
   - &save-node-modules-cache
     paths:
@@ -19,7 +19,7 @@ aliases:
   - &save-yarn-cache
     paths:
       - ~/.cache/yarn
-    key: v1-yarn-cache-{{ checksum "yarn.lock" }}
+    key: v1-1-yarn-cache-{{ checksum "yarn.lock" }}
 
   - &artifact_babel
     path: ~/babel/packages/babel-standalone/babel.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ aliases:
 
   - &save-yarn-cache
     paths:
-      - "{{ .Environment.YARN_CACHE_FOLDER }}"
+      - ~/.cache/yarn
     key: v1-yarn-cache-{{ checksum "yarn.lock" }}
 
   - &artifact_babel
@@ -63,7 +63,7 @@ jobs:
         # data for a JS file that's several megabytes large is bound to fail. Here,
         # we just run the babel-standalone test separately.
       - run: yarn jest "\-standalone/test"
-      - run: export YARN_CACHE_FOLDER=$(yarn cache dir)
+      - run: yarn cache dir
       - store_artifacts: *artifact_babel
       - store_artifacts: *artifact_babel_min
       - save_cache: *save-node-modules-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,6 @@ jobs:
         # data for a JS file that's several megabytes large is bound to fail. Here,
         # we just run the babel-standalone test separately.
       - run: yarn jest "\-standalone/test"
-      - run: yarn cache dir
       - store_artifacts: *artifact_babel
       - store_artifacts: *artifact_babel_min
       - save_cache: *save-node-modules-cache


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The Yarn Cache is not working properly because the cache directory of Yarn 1 is _not_ `~/.yarn-cache`, as we can see from this [job log](https://app.circleci.com/pipelines/github/babel/babel/3253/workflows/ef0651e9-e19b-4e0d-b9f5-e26e4de7029c/jobs/25141/parallel-runs/0/steps/0-102), the cache is only 32B.

Ideally we should run `yarn cache dir` and use this value as the paths that we should cache. However Circle-CI does not support template on cache paths.

Here is comparison of `yarn install` time between this PR and `main`.

| [main](https://app.circleci.com/pipelines/github/babel/babel/3253/workflows/ef0651e9-e19b-4e0d-b9f5-e26e4de7029c/jobs/25141/parallel-runs/0/steps/0-104) | [This PR](https://app.circleci.com/pipelines/github/babel/babel/3258/workflows/b4d98cd1-1b70-4bb8-8921-cf2ba12127d8/jobs/25178/parallel-runs/0/steps/0-104) |
| --- | --- |
| 39.76s | 6.03s |

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11782"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/7173491688423aee492e35ca8a13a7cc32794007.svg" /></a>

