### PR TITLE
Reduce dependency on lodash functions: includes, uniq, repeat, isinteger

### DIFF
--- a/packages/babel-cli/src/babel/options.js
+++ b/packages/babel-cli/src/babel/options.js
@@ -4,7 +4,6 @@ import fs from "fs";
 
 import commander from "commander";
 import { version } from "@babel/core";
-import uniq from "lodash/uniq";
 import glob from "glob";
 
 import pkg from "../../package.json";
@@ -195,7 +194,7 @@ export default function parseArgv(args: Array<string>): CmdOptions | null {
     return globbed.concat(files);
   }, []);
 
-  filenames = uniq(filenames);
+  filenames = Array.from(new Set(filenames));
 
   filenames.forEach(function (filename) {
     if (!fs.existsSync(filename)) {

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -2,7 +2,6 @@
 
 import readdirRecursive from "fs-readdir-recursive";
 import * as babel from "@babel/core";
-import includes from "lodash/includes";
 import path from "path";
 import fs from "fs";
 
@@ -47,7 +46,7 @@ export function isCompilableExtension(
 ): boolean {
   const exts = altExts || babel.DEFAULT_EXTENSIONS;
   const ext = path.extname(filename);
-  return includes(exts, ext);
+  return exts.includes(ext);
 }
 
 export function addSourceMappingUrl(code: string, loc: string): string {

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@babel/types": "^7.10.4",
     "jsesc": "^2.5.1",
-    "lodash": "^4.17.13",
     "source-map": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -1,4 +1,3 @@
-import isInteger from "lodash/isInteger";
 import Buffer from "./buffer";
 import * as n from "./node";
 import * as t from "@babel/types";
@@ -137,7 +136,7 @@ export default class Printer {
     // Integer tokens need special handling because they cannot have '.'s inserted
     // immediately after them.
     this._endsWithInteger =
-      isInteger(+str) &&
+      Number.isInteger(+str) &&
       !NON_DECIMAL_LITERAL.test(str) &&
       !SCIENTIFIC_NOTATION.test(str) &&
       !ZERO_DECIMAL_INTEGER.test(str) &&

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -1,5 +1,4 @@
 import isInteger from "lodash/isInteger";
-import repeat from "lodash/repeat";
 import Buffer from "./buffer";
 import * as n from "./node";
 import * as t from "@babel/types";
@@ -324,7 +323,7 @@ export default class Printer {
    */
 
   _getIndent(): string {
-    return repeat(this.format.indent.style, this._indent);
+    return this.format.indent.style.repeat(this._indent);
   }
 
   /**
@@ -616,7 +615,7 @@ export default class Printer {
         this._getIndent().length,
         this._buf.getCurrentColumn(),
       );
-      val = val.replace(/\n(?!$)/g, `\n${repeat(" ", indentSize)}`);
+      val = val.replace(/\n(?!$)/g, `\n${" ".repeat(indentSize)}`);
     }
 
     // Avoid creating //* comments

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -351,7 +351,12 @@ export default function (
   const suites = getFixtures(fixturesLoc);
 
   for (const testSuite of suites) {
-    if (suiteOpts.ignoreSuites.includes(testSuite.title)) continue;
+    if (
+      suiteOpts.ignoreSuites &&
+      suiteOpts.ignoreSuites.includes(testSuite.title)
+    ) {
+      continue;
+    }
 
     describe(name + "/" + testSuite.title, function () {
       jest.addMatchers({
@@ -360,8 +365,9 @@ export default function (
 
       for (const task of testSuite.tests) {
         if (
-          suiteOpts.ignoreTasks.includes(task.title) ||
-          suiteOpts.ignoreTasks.includes(testSuite.title + "/" + task.title)
+          suiteOpts.ignoreTasks &&
+          (suiteOpts.ignoreTasks.includes(task.title) ||
+            suiteOpts.ignoreTasks.includes(testSuite.title + "/" + task.title))
         ) {
           continue;
         }

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -351,12 +351,7 @@ export default function (
   const suites = getFixtures(fixturesLoc);
 
   for (const testSuite of suites) {
-    if (
-      suiteOpts.ignoreSuites &&
-      suiteOpts.ignoreSuites?.includes(testSuite.title)
-    ) {
-      continue;
-    }
+    if (suiteOpts.ignoreSuites?.includes(testSuite.title)) continue;
 
     describe(name + "/" + testSuite.title, function () {
       jest.addMatchers({
@@ -365,9 +360,8 @@ export default function (
 
       for (const task of testSuite.tests) {
         if (
-          suiteOpts.ignoreTasks &&
-          (suiteOpts.ignoreTasks.includes(task.title) ||
-            suiteOpts.ignoreTasks.includes(testSuite.title + "/" + task.title))
+          suiteOpts.ignoreTasks?.includes(task.title) ||
+          suiteOpts.ignoreTasks?.includes(testSuite.title + "/" + task.title)
         ) {
           continue;
         }

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -5,7 +5,6 @@ import getFixtures from "@babel/helper-fixtures";
 import sourceMap from "source-map";
 import { codeFrameColumns } from "@babel/code-frame";
 import defaults from "lodash/defaults";
-import includes from "lodash/includes";
 import escapeRegExp from "lodash/escapeRegExp";
 import * as helpers from "./helpers";
 import extend from "lodash/extend";
@@ -352,7 +351,7 @@ export default function (
   const suites = getFixtures(fixturesLoc);
 
   for (const testSuite of suites) {
-    if (includes(suiteOpts.ignoreSuites, testSuite.title)) continue;
+    if (suiteOpts.ignoreSuites.includes(testSuite.title)) continue;
 
     describe(name + "/" + testSuite.title, function () {
       jest.addMatchers({
@@ -361,8 +360,8 @@ export default function (
 
       for (const task of testSuite.tests) {
         if (
-          includes(suiteOpts.ignoreTasks, task.title) ||
-          includes(suiteOpts.ignoreTasks, testSuite.title + "/" + task.title)
+          suiteOpts.ignoreTasks.includes(task.title) ||
+          suiteOpts.ignoreTasks.includes(testSuite.title + "/" + task.title)
         ) {
           continue;
         }

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -353,7 +353,7 @@ export default function (
   for (const testSuite of suites) {
     if (
       suiteOpts.ignoreSuites &&
-      suiteOpts.ignoreSuites.includes(testSuite.title)
+      suiteOpts.ignoreSuites?.includes(testSuite.title)
     ) {
       continue;
     }

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -2,7 +2,6 @@ import { declare } from "@babel/helper-plugin-utils";
 import type NodePath from "@babel/traverse";
 import type Scope from "@babel/traverse";
 import { visitor as tdzVisitor } from "./tdz";
-import values from "lodash/values";
 import extend from "lodash/extend";
 import { traverse, template, types as t } from "@babel/core";
 
@@ -545,7 +544,7 @@ class BlockScoping {
     this.hoistVarDeclarations();
 
     // turn outsideLetReferences into an array
-    const args = values(outsideRefs).map(id => t.cloneNode(id));
+    const args = Object.values(outsideRefs).map(id => t.cloneNode(id));
     const params = args.map(id => t.cloneNode(id));
 
     const isSwitch = this.blockPath.isSwitchStatement();

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -2,6 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import type NodePath from "@babel/traverse";
 import type Scope from "@babel/traverse";
 import { visitor as tdzVisitor } from "./tdz";
+import values from "lodash/values";
 import extend from "lodash/extend";
 import { traverse, template, types as t } from "@babel/core";
 
@@ -544,7 +545,7 @@ class BlockScoping {
     this.hoistVarDeclarations();
 
     // turn outsideLetReferences into an array
-    const args = Object.values(outsideRefs).map(id => t.cloneNode(id));
+    const args = values(outsideRefs).map(id => t.cloneNode(id));
     const params = args.map(id => t.cloneNode(id));
 
     const isSwitch = this.blockPath.isSwitchStatement();

--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -1,6 +1,5 @@
 import TraversalContext from "./context";
 import * as visitors from "./visitors";
-import includes from "lodash/includes";
 import * as t from "@babel/types";
 import * as cache from "./cache";
 
@@ -90,7 +89,7 @@ traverse.hasType = function (
   blacklistTypes: Array<string>,
 ): boolean {
   // the node we're searching in is blacklisted
-  if (includes(blacklistTypes, tree.type)) return false;
+  if (blacklistTypes.includes(tree.type)) return false;
 
   // the type we're looking for is the same as the passed node
   if (tree.type === type) return true;

--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -89,7 +89,7 @@ traverse.hasType = function (
   blacklistTypes: Array<string>,
 ): boolean {
   // the node we're searching in is blacklisted
-  if (blacklistTypes.includes(tree.type)) return false;
+  if (blacklistTypes && blacklistTypes.includes(tree.type)) return false;
 
   // the type we're looking for is the same as the passed node
   if (tree.type === type) return true;

--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -89,7 +89,7 @@ traverse.hasType = function (
   blacklistTypes: Array<string>,
 ): boolean {
   // the node we're searching in is blacklisted
-  if (blacklistTypes && blacklistTypes.includes(tree.type)) return false;
+  if (blacklistTypes?.includes(tree.type)) return false;
 
   // the type we're looking for is the same as the passed node
   if (tree.type === type) return true;

--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -86,7 +86,7 @@ function hasBlacklistedType(path, state) {
 traverse.hasType = function (
   tree: Object,
   type: Object,
-  blacklistTypes: Array<string>,
+  blacklistTypes?: Array<string>,
 ): boolean {
   // the node we're searching in is blacklisted
   if (blacklistTypes?.includes(tree.type)) return false;

--- a/packages/babel-traverse/src/path/introspection.js
+++ b/packages/babel-traverse/src/path/introspection.js
@@ -1,7 +1,6 @@
 // This file contains methods responsible for introspecting the current path for certain values.
 
 import type NodePath from "./index";
-import includes from "lodash/includes";
 import * as t from "@babel/types";
 
 /**
@@ -149,7 +148,7 @@ export function isStatementOrBlock() {
   ) {
     return false;
   } else {
-    return includes(t.STATEMENT_OR_BLOCK_KEYS, this.key);
+    return t.STATEMENT_OR_BLOCK_KEYS.includes(this.key);
   }
 }
 

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -1,4 +1,3 @@
-import includes from "lodash/includes";
 import repeat from "lodash/repeat";
 import Renamer from "./lib/renamer";
 import type NodePath from "../path";
@@ -1038,8 +1037,8 @@ export default class Scope {
     if (this.hasOwnBinding(name)) return true;
     if (this.parentHasBinding(name, noGlobals)) return true;
     if (this.hasUid(name)) return true;
-    if (!noGlobals && includes(Scope.globals, name)) return true;
-    if (!noGlobals && includes(Scope.contextVariables, name)) return true;
+    if (!noGlobals && Scope.globals.includes(name)) return true;
+    if (!noGlobals && Scope.contextVariables.includes(name)) return true;
     return false;
   }
 

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -1,4 +1,3 @@
-import repeat from "lodash/repeat";
 import Renamer from "./lib/renamer";
 import type NodePath from "../path";
 import traverse from "../index";
@@ -501,7 +500,7 @@ export default class Scope {
   }
 
   dump() {
-    const sep = repeat("-", 60);
+    const sep = "-".repeat(60);
     console.log(sep);
     let scope = this;
     do {

--- a/packages/babel-types/src/utils/inherit.js
+++ b/packages/babel-types/src/utils/inherit.js
@@ -1,12 +1,12 @@
 // @flow
-import uniq from "lodash/uniq";
-
 export default function inherit(
   key: string,
   child: Object,
   parent: Object,
 ): void {
   if (child && parent) {
-    child[key] = uniq([].concat(child[key], parent[key]).filter(Boolean));
+    child[key] = Array.from(
+      new Set([].concat(child[key], parent[key]).filter(Boolean)),
+    );
   }
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Relates to #11789 
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Any Dependency Changes?  | No
| License                  | MIT

This change incorporates feedback from #11789 - in particular, the following `lodash` functions are replaced with JavaScript built-in functions:

- `lodash/includes` is replaced by `Array.prototype.includes`
- ~~`lodash/values` is replaced by `Object.values`~~ `Object.values` is fully-supported [from Node 7.x](https://node.green/#ES2017-features-Object-static-methods-Object-values)
- `lodash/uniq` is replaced by `Array.from(new Set(...))`
- `lodash.repeat` is replaced by `String.prototype.repeat`
- `lodash.isinteger` is replaced by `Number.isInteger`

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11790"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jayaddison/babel.git/ad95ab8c2f23cc47ab6c8e14181ad74e8834a936.svg" /></a>

