### PR TITLE
babel-traverse: prefer clearer, reduced-bias option naming

### DIFF
--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -77,7 +77,7 @@ traverse.removeProperties = function (tree, opts) {
   return tree;
 };
 
-function hasBlacklistedType(path, state) {
+function hasDenylistedType(path, state) {
   if (path.node.type === state.type) {
     state.has = true;
     path.stop();
@@ -87,10 +87,10 @@ function hasBlacklistedType(path, state) {
 traverse.hasType = function (
   tree: Object,
   type: Object,
-  blacklistTypes: Array<string>,
+  denylistTypes: Array<string>,
 ): boolean {
-  // the node we're searching in is blacklisted
-  if (includes(blacklistTypes, tree.type)) return false;
+  // the node we're searching in is denylisted
+  if (includes(denylistTypes, tree.type)) return false;
 
   // the type we're looking for is the same as the passed node
   if (tree.type === type) return true;
@@ -104,8 +104,8 @@ traverse.hasType = function (
     tree,
     {
       noScope: true,
-      blacklist: blacklistTypes,
-      enter: hasBlacklistedType,
+      denylist: denylistTypes,
+      enter: hasDenylistedType,
     },
     null,
     state,

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -51,9 +51,9 @@ export function _call(fns?: Array<Function>): boolean {
   return false;
 }
 
-export function isBlacklisted(): boolean {
-  const blacklist = this.opts.blacklist;
-  return blacklist && blacklist.indexOf(this.node.type) > -1;
+export function isDenylisted(): boolean {
+  const denylist = this.opts.denylist;
+  return denylist && denylist.indexOf(this.node.type) > -1;
 }
 
 export function visit(): boolean {
@@ -61,7 +61,7 @@ export function visit(): boolean {
     return false;
   }
 
-  if (this.isBlacklisted()) {
+  if (this.isDenylisted()) {
     return false;
   }
 

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -52,9 +52,12 @@ export function _call(fns?: Array<Function>): boolean {
 }
 
 export function isDenylisted(): boolean {
-  const denylist = this.opts.denylist;
+  const denylist = this.opts.denylist ?? this.opts.blacklist;
   return denylist && denylist.indexOf(this.node.type) > -1;
 }
+
+// TODO: Remove in Babel 8
+export { isDenylisted as isBlacklisted };
 
 export function visit(): boolean {
   if (!this.node) {

--- a/packages/babel-traverse/src/visitors.js
+++ b/packages/babel-traverse/src/visitors.js
@@ -275,7 +275,13 @@ function shouldIgnoreKey(key) {
   if (key === "enter" || key === "exit" || key === "shouldSkip") return true;
 
   // ignore other options
-  if (key === "denylist" || key === "noScope" || key === "skipKeys") {
+  if (
+    key === "denylist" ||
+    key === "noScope" ||
+    key === "skipKeys" ||
+    // TODO: Remove in Babel 8
+    key === "blacklist"
+  ) {
     return true;
   }
 

--- a/packages/babel-traverse/src/visitors.js
+++ b/packages/babel-traverse/src/visitors.js
@@ -275,7 +275,7 @@ function shouldIgnoreKey(key) {
   if (key === "enter" || key === "exit" || key === "shouldSkip") return true;
 
   // ignore other options
-  if (key === "blacklist" || key === "noScope" || key === "skipKeys") {
+  if (key === "denylist" || key === "noScope" || key === "skipKeys") {
     return true;
   }
 

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -61,7 +61,7 @@ describe("traverse", function () {
     });
   });
 
-  it("traverse blacklistTypes", function () {
+  it("traverse denylistTypes", function () {
     const expected = [
       body[0],
       body[0].declarations[0],
@@ -75,7 +75,7 @@ describe("traverse", function () {
     const actual = [];
 
     traverse(program, {
-      blacklist: ["MemberExpression"],
+      denylist: ["MemberExpression"],
       enter: function (path) {
         actual.push(path.node);
       },


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | Yes
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR Link    | This babel-traverse option appears undocumented currently
| Any Dependency Changes?  | No
| License                  | MIT

This proposed change attempts to clarify the naming of a `babel-traverse` option (noticed during development of #11790) by using language that aims to be clearer for non-native English speakers and has reduced modern connotations of bias.

Since the option doesn't appear to be widely used ([ref](https://github.com/search?p=3&q=babel-traverse+blacklist+filename%3A%2A.js&type=Code)) and doesn't appear to be documented([ref](https://babeljs.io/docs/en/babel-traverse), [ref](https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md#babel-traverse)), this changeset doesn't attempt to maintain backwards compatibility, although a release note to indicate that it is a breaking change would be useful.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11791"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jayaddison/babel.git/9dc946d8924ee755c9a606ce5e8f3aec171cb852.svg" /></a>

