### PR TITLE
Reduce dependency on lodash functions: values, extends

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -13,8 +13,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/helper-plugin-utils": "^7.10.4",
-    "lodash": "^4.17.13"
+    "@babel/helper-plugin-utils": "^7.10.4"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -338,6 +338,12 @@ const loopVisitor = {
   },
 };
 
+function extendMap(map, obj) {
+  for (const key of Object.keys(obj)) {
+    map.set(key, obj[key]);
+  }
+}
+
 class BlockScoping {
   constructor(
     loopPath?: NodePath,
@@ -700,10 +706,7 @@ class BlockScoping {
       const init = this.loop.left || this.loop.init;
       if (isBlockScoped(init)) {
         declarators.push(init);
-        const names = t.getBindingIdentifiers(init);
-        for (const name of Object.keys(names)) {
-          this.outsideLetReferences.set(name, names[name]);
-        }
+        extendMap(this.outsideLetReferences, t.getBindingIdentifiers(init));
       }
     }
 
@@ -752,9 +755,7 @@ class BlockScoping {
       // declaration, rather than (for example) mistakenly including the
       // parameters of a function declaration. Fixes #4880.
       const keys = t.getBindingIdentifiers(declar, false, true);
-      for (const key of Object.keys(keys)) {
-        this.letReferences.set(key, keys[key]);
-      }
+      extendMap(this.letReferences, keys);
       this.hasLetReferences = true;
     }
 

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -543,7 +543,7 @@ class BlockScoping {
     this.hoistVarDeclarations();
 
     // turn outsideLetReferences into an array
-    const args = [...outsideRefs.values()].map(node => t.cloneNode(node));
+    const args = Array.from(outsideRefs.values(), node => t.cloneNode(node));
     const params = args.map(id => t.cloneNode(id));
 
     const isSwitch = this.blockPath.isSwitchStatement();

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -193,7 +193,7 @@ const letReferenceBlockVisitor = traverse.visitors.merge([
 const letReferenceFunctionVisitor = traverse.visitors.merge([
   {
     ReferencedIdentifier(path, state) {
-      const ref = state.letReferences[path.node.name];
+      const ref = state.letReferences.get(path.node.name);
 
       // not a part of our scope
       if (!ref) return;
@@ -248,7 +248,7 @@ const continuationVisitor = {
     if (path.isAssignmentExpression() || path.isUpdateExpression()) {
       for (const name of Object.keys(path.getBindingIdentifiers())) {
         if (
-          state.outsideReferences[name] !==
+          state.outsideReferences.get(name) !==
           path.scope.getBindingIdentifier(name)
         ) {
           continue;
@@ -446,7 +446,7 @@ class BlockScoping {
     const letRefs = this.letReferences;
 
     for (const key of letRefs.keys()) {
-      const ref = letRefs[key];
+      const ref = letRefs.get(key);
       const binding = blockScope.getBinding(ref.name);
       if (!binding) continue;
       if (binding.kind === "let" || binding.kind === "const") {
@@ -477,7 +477,7 @@ class BlockScoping {
     for (const key of letRefs.keys()) {
       // just an Identifier node we collected in `getLetReferences`
       // this is the defining identifier of a declaration
-      const ref = letRefs[key];
+      const ref = letRefs.get(key);
 
       // todo: could skip this if the colliding binding is in another function
       if (scope.parentHasBinding(key) || scope.hasGlobal(key)) {

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -340,7 +340,7 @@ const loopVisitor = {
 
 function extendMap(map, obj) {
   for (const key of Object.keys(obj)) {
-    map.set(key, String(obj[key]));
+    map.set(String(key), obj[key]);
   }
 }
 

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -750,7 +750,7 @@ class BlockScoping {
       // declaration, rather than (for example) mistakenly including the
       // parameters of a function declaration. Fixes #4880.
       const keys = t.getBindingIdentifiers(declar, false, true);
-      for (const key of keys) {
+      for (const key of Object.keys(keys)) {
         this.letReferences.set(key, keys[key]);
       }
       this.hasLetReferences = true;

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -523,7 +523,8 @@ class BlockScoping {
 
     // remap loop heads with colliding variables
     if (this.loop) {
-      for (const name of outsideRefs.keys()) {
+      // nb: clone outsideRefs keys since the map is modified within the loop
+      for (const name of [...outsideRefs.keys()]) {
         const id = outsideRefs.get(name);
 
         if (

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -541,7 +541,7 @@ class BlockScoping {
     this.hoistVarDeclarations();
 
     // turn outsideLetReferences into an array
-    const args = outsideRefs.values().map(node => t.cloneNode(node));
+    const args = [...outsideRefs.values()].map(node => t.cloneNode(node));
     const params = args.map(id => t.cloneNode(id));
 
     const isSwitch = this.blockPath.isSwitchStatement();

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -340,9 +340,7 @@ const loopVisitor = {
 
 function extendMap(map, obj) {
   for (const key of Object.keys(obj)) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
-      map.set(key, obj[key]);
-    }
+    map.set(key, obj[key]);
   }
 }
 

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -340,7 +340,7 @@ const loopVisitor = {
 
 function extendMap(map, obj) {
   for (const key of Object.keys(obj)) {
-    map.set(key, String(obj[key]));
+    map.set(key, obj[key]);
   }
 }
 

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -338,12 +338,6 @@ const loopVisitor = {
   },
 };
 
-function extendMap(map, obj) {
-  for (const key of Object.keys(obj)) {
-    map.set(key, obj[key]);
-  }
-}
-
 class BlockScoping {
   constructor(
     loopPath?: NodePath,
@@ -707,7 +701,10 @@ class BlockScoping {
       const init = this.loop.left || this.loop.init;
       if (isBlockScoped(init)) {
         declarators.push(init);
-        extendMap(this.outsideLetReferences, t.getBindingIdentifiers(init));
+        const names = t.getBindingIdentifiers(init);
+        for (const name of Object.keys(names)) {
+          this.outsideLetReferences.set(name, names[name]);
+        }
       }
     }
 
@@ -756,7 +753,9 @@ class BlockScoping {
       // declaration, rather than (for example) mistakenly including the
       // parameters of a function declaration. Fixes #4880.
       const keys = t.getBindingIdentifiers(declar, false, true);
-      extendMap(this.letReferences, keys);
+      for (const key of Object.keys(keys)) {
+        this.letReferences.set(key, keys[key]);
+      }
       this.hasLetReferences = true;
     }
 

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -528,7 +528,7 @@ class BlockScoping {
 
           this.scope.rename(id.name);
 
-          outsideRefs.put(id.name, id);
+          outsideRefs.set(id.name, id);
         }
       }
     }

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -525,9 +525,11 @@ class BlockScoping {
           this.scope.parentHasBinding(id.name)
         ) {
           outsideRefs.delete(id.name);
+          this.letReferences.delete(id.name);
 
           this.scope.rename(id.name);
 
+          this.letReferences.set(id.name, id);
           outsideRefs.set(id.name, id);
         }
       }

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -340,7 +340,9 @@ const loopVisitor = {
 
 function extendMap(map, obj) {
   for (const key of Object.keys(obj)) {
-    map.set(key, obj[key]);
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      map.set(key, obj[key]);
+    }
   }
 }
 

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -2,7 +2,6 @@ import { declare } from "@babel/helper-plugin-utils";
 import type NodePath from "@babel/traverse";
 import type Scope from "@babel/traverse";
 import { visitor as tdzVisitor } from "./tdz";
-import values from "lodash/values";
 import extend from "lodash/extend";
 import { traverse, template, types as t } from "@babel/core";
 
@@ -545,7 +544,9 @@ class BlockScoping {
     this.hoistVarDeclarations();
 
     // turn outsideLetReferences into an array
-    const args = values(outsideRefs).map(id => t.cloneNode(id));
+    const args = Object.keys(outsideRefs).map(ref =>
+      t.cloneNode(outsideRefs[ref]),
+    );
     const params = args.map(id => t.cloneNode(id));
 
     const isSwitch = this.blockPath.isSwitchStatement();

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -340,7 +340,7 @@ const loopVisitor = {
 
 function extendMap(map, obj) {
   for (const key of Object.keys(obj)) {
-    map.set(String(key), obj[key]);
+    map.set(key, String(obj[key]));
   }
 }
 

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -340,7 +340,7 @@ const loopVisitor = {
 
 function extendMap(map, obj) {
   for (const key of Object.keys(obj)) {
-    map.set(key, obj[key]);
+    map.set(key, String(obj[key]));
   }
 }
 

--- a/packages/babel-plugin-transform-block-scoping/src/tdz.js
+++ b/packages/babel-plugin-transform-block-scoping/src/tdz.js
@@ -20,7 +20,7 @@ function buildTDZAssert(node, state) {
 }
 
 function isReference(node, scope, state) {
-  const declared = state.letReferences[node.name];
+  const declared = state.letReferences.get(node.name);
   if (!declared) return false;
 
   // declared node is different in this scope


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Any Dependency Changes?  | No
| License                  | MIT

As mentioned by @hzoo in https://github.com/babel/babel/pull/11790#issuecomment-654334560, we can remove the (only) use of `lodash.values` within the codebase with a slightly longer-form but logically-equivalent iteration over the target object properties followed by retrieval of each object value.

- `lodash/values` is replaced by `Object.keys` in combination with `map` and object property access-by-key
- `lodash/extend` is replaced by use of native JavaScript objecty property iteration

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11798"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jayaddison/babel.git/2b03b2ee92254bf90b836e465e5cc9da8e2685b2.svg" /></a>

