### PR TITLE
Disallow duplicated AST nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ packages/babel-standalone/babel.min.js
 /eslint/*/node_modules
 /eslint/*/LICENSE
 !/packages/babel-eslint-plugin/LICENSE
+/.vscode

--- a/packages/babel-helper-builder-react-jsx-experimental/src/index.js
+++ b/packages/babel-helper-builder-react-jsx-experimental/src/index.js
@@ -457,7 +457,7 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
     }
 
     return makeTrace(
-      state.fileNameIdentifier,
+      t.cloneNode(state.fileNameIdentifier),
       location.start.line,
       location.start.column,
     );

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.js
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.js
@@ -137,7 +137,7 @@ export function buildDecoratedClass(ref, path, elements, file) {
   let replacement = template.expression.ast`
     ${addDecorateHelper(file)}(
       ${classDecorators || t.nullLiteral()},
-      function (${initializeId}, ${superClass ? superId : null}) {
+      function (${initializeId}, ${superClass ? t.cloneNode(superId) : null}) {
         ${node}
         return { F: ${t.cloneNode(node.id)}, d: ${definitions} };
       },
@@ -158,7 +158,7 @@ export function buildDecoratedClass(ref, path, elements, file) {
   }
 
   return {
-    instanceNodes: [template.statement.ast`${initializeId}(this)`],
+    instanceNodes: [template.statement.ast`${t.cloneNode(initializeId)}(this)`],
     wrapClass(path) {
       path.replaceWith(replacement);
       return path.get(classPathDesc);

--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -1,3 +1,4 @@
+import { types as t } from "@babel/core";
 import nameFunction from "@babel/helper-function-name";
 import splitExportDeclaration from "@babel/helper-split-export-declaration";
 import {
@@ -129,7 +130,7 @@ export function createClassFeaturePlugin({
           nameFunction(path);
           ref = path.scope.generateUidIdentifier("class");
         } else {
-          ref = path.node.id;
+          ref = t.cloneNode(path.node.id);
         }
 
         // NODE: These three functions don't support decorators yet,

--- a/packages/babel-helper-create-class-features-plugin/src/misc.js
+++ b/packages/babel-helper-create-class-features-plugin/src/misc.js
@@ -72,8 +72,14 @@ export function injectInitialization(path, constructor, nodes, renamer) {
   if (isDerived) {
     const bareSupers = [];
     constructor.traverse(findBareSupers, bareSupers);
+    let isFirst = true;
     for (const bareSuper of bareSupers) {
-      bareSuper.insertAfter(nodes);
+      if (isFirst) {
+        bareSuper.insertAfter(nodes);
+        isFirst = false;
+      } else {
+        bareSuper.insertAfter(nodes.map(n => t.cloneNode(n)));
+      }
     }
   } else {
     constructor.get("body").unshiftContainer("body", nodes);

--- a/packages/babel-helper-member-expression-to-functions/src/index.js
+++ b/packages/babel-helper-member-expression-to-functions/src/index.js
@@ -235,8 +235,12 @@ const handle = {
             t.binaryExpression(
               "===",
               baseNeedsMemoised
-                ? t.assignmentExpression("=", baseRef, startingNode)
-                : baseRef,
+                ? t.assignmentExpression(
+                    "=",
+                    t.cloneNode(baseRef),
+                    t.cloneNode(startingNode),
+                  )
+                : t.cloneNode(baseRef),
               t.nullLiteral(),
             ),
             t.binaryExpression(
@@ -263,7 +267,7 @@ const handle = {
               false,
               true,
             ),
-            [context, ...endParent.arguments],
+            [t.cloneNode(context), ...endParent.arguments],
             false,
           ),
         );

--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.js
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.js
@@ -337,7 +337,9 @@ const rewriteReferencesVisitor = {
       path
         .get("left")
         .replaceWith(
-          t.variableDeclaration("let", [t.variableDeclarator(newLoopId)]),
+          t.variableDeclaration("let", [
+            t.variableDeclarator(t.cloneNode(newLoopId)),
+          ]),
         );
       scope.registerDeclaration(path.get("left"));
     }

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -146,6 +146,7 @@ function run(task) {
   function getOpts(self) {
     const newOpts = merge(
       {
+        ast: true,
         cwd: path.dirname(self.loc),
         filename: self.loc,
         filenameRelative: self.filename,

--- a/packages/babel-plugin-proposal-async-generator-functions/src/for-await.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/src/for-await.js
@@ -61,7 +61,7 @@ export default function (path, { getAsyncIterator }) {
     ITERATOR_KEY: scope.generateUidIdentifier("iterator"),
     GET_ITERATOR: getAsyncIterator,
     OBJECT: node.right,
-    STEP_VALUE: stepValue,
+    STEP_VALUE: t.cloneNode(stepValue),
     STEP_KEY: stepKey,
   });
 

--- a/packages/babel-plugin-proposal-decorators/src/transformer-legacy.js
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-legacy.js
@@ -160,7 +160,7 @@ function applyTargetDecorators(path, state, decoratedProps) {
       acc = acc.concat([
         t.assignmentExpression(
           "=",
-          descriptor,
+          t.cloneNode(descriptor),
           t.callExpression(state.addHelper("applyDecoratedDescriptor"), [
             t.cloneNode(target),
             t.cloneNode(property),

--- a/packages/babel-plugin-proposal-function-bind/src/index.js
+++ b/packages/babel-plugin-proposal-function-bind/src/index.js
@@ -7,7 +7,7 @@ export default declare(api => {
 
   function getTempId(scope) {
     let id = scope.path.getData("functionBind");
-    if (id) return id;
+    if (id) return t.cloneNode(id);
 
     id = scope.generateDeclaredUidIdentifier("context");
     return scope.path.setData("functionBind", id);
@@ -35,7 +35,7 @@ export default declare(api => {
         bind.callee.object,
       );
     }
-    return tempId;
+    return t.cloneNode(tempId);
   }
 
   return {

--- a/packages/babel-plugin-proposal-partial-application/src/index.js
+++ b/packages/babel-plugin-proposal-partial-application/src/index.js
@@ -97,7 +97,7 @@ export default declare(api => {
               "=",
               t.cloneNode(functionLVal),
               t.memberExpression(
-                receiverLVal,
+                t.cloneNode(receiverLVal),
                 node.callee.property,
                 false,
                 false,
@@ -105,19 +105,19 @@ export default declare(api => {
             ),
             ...argsInitializers,
             t.functionExpression(
-              node.callee.property,
+              t.cloneNode(node.callee.property),
               placeholdersParams,
               t.blockStatement(
                 [
                   t.returnStatement(
                     t.callExpression(
                       t.memberExpression(
-                        functionLVal,
+                        t.cloneNode(functionLVal),
                         t.identifier("call"),
                         false,
                         false,
                       ),
-                      [receiverLVal, ...args],
+                      [t.cloneNode(receiverLVal), ...args],
                     ),
                   ),
                 ],
@@ -132,10 +132,14 @@ export default declare(api => {
             t.assignmentExpression("=", t.cloneNode(functionLVal), node.callee),
             ...argsInitializers,
             t.functionExpression(
-              node.callee,
+              t.cloneNode(node.callee),
               placeholdersParams,
               t.blockStatement(
-                [t.returnStatement(t.callExpression(functionLVal, args))],
+                [
+                  t.returnStatement(
+                    t.callExpression(t.cloneNode(functionLVal), args),
+                  ),
+                ],
                 [],
               ),
               false,

--- a/packages/babel-plugin-proposal-pipeline-operator/src/buildOptimizedSequenceExpression.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/buildOptimizedSequenceExpression.js
@@ -30,7 +30,7 @@ const buildOptimizedSequenceExpression = ({ assign, call, path }) => {
 
     call.callee = evalSequence;
 
-    path.scope.push({ id: placeholderNode });
+    path.scope.push({ id: t.cloneNode(placeholderNode) });
 
     return t.sequenceExpression([assign, call]);
   }
@@ -40,7 +40,7 @@ const buildOptimizedSequenceExpression = ({ assign, call, path }) => {
     return t.sequenceExpression([pipelineLeft, calledExpression.body]);
   }
 
-  path.scope.push({ id: placeholderNode });
+  path.scope.push({ id: t.cloneNode(placeholderNode) });
 
   if (param) {
     path.get("right").scope.rename(param.name, placeholderNode.name);

--- a/packages/babel-plugin-proposal-pipeline-operator/src/smartVisitor.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/smartVisitor.js
@@ -2,7 +2,7 @@ import { types as t } from "@babel/core";
 
 const updateTopicReferenceVisitor = {
   PipelinePrimaryTopicReference(path) {
-    path.replaceWith(this.topicId);
+    path.replaceWith(t.cloneNode(this.topicId));
   },
   PipelineTopicExpression(path) {
     path.skip();

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -33,7 +33,7 @@ export default declare((api, opts) => {
             const decl = node.declarations[i];
             const assign = t.assignmentExpression(
               "=",
-              decl.id,
+              t.cloneNode(decl.id),
               decl.init || scope.buildUndefinedNode(),
             );
             assign._ignoreBlockScopingTDZ = true;

--- a/packages/babel-plugin-transform-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-modules-amd/src/index.js
@@ -71,8 +71,8 @@ export default declare((api, options) => {
             new Promise((${resolveId}, ${rejectId}) =>
               ${requireId}(
                 [${getImportSource(t, path.node)}],
-                imported => ${resolveId}(${result}),
-                ${rejectId}
+                imported => ${t.cloneNode(resolveId)}(${result}),
+                ${t.cloneNode(rejectId)}
               )
             )`,
         );
@@ -84,7 +84,7 @@ export default declare((api, options) => {
             if (requireId) {
               injectWrapper(
                 path,
-                buildAnonymousWrapper({ REQUIRE: requireId }),
+                buildAnonymousWrapper({ REQUIRE: t.cloneNode(requireId) }),
               );
             }
             return;
@@ -94,7 +94,7 @@ export default declare((api, options) => {
           const importNames = [];
           if (requireId) {
             amdArgs.push(t.stringLiteral("require"));
-            importNames.push(requireId);
+            importNames.push(t.cloneNode(requireId));
           }
 
           let moduleName = getModuleName(this.file.opts, options);

--- a/packages/babel-plugin-transform-parameters/src/params.js
+++ b/packages/babel-plugin-transform-parameters/src/params.js
@@ -229,6 +229,6 @@ function buildScopeIIFE(shadowedParams, body) {
   }
 
   return t.returnStatement(
-    t.callExpression(t.arrowFunctionExpression(params, body), params),
+    t.callExpression(t.arrowFunctionExpression(args, body), params),
   );
 }

--- a/packages/babel-plugin-transform-parameters/src/params.js
+++ b/packages/babel-plugin-transform-parameters/src/params.js
@@ -229,6 +229,6 @@ function buildScopeIIFE(shadowedParams, body) {
   }
 
   return t.returnStatement(
-    t.callExpression(t.arrowFunctionExpression(args, body), params),
+    t.callExpression(t.arrowFunctionExpression(params, body), args),
   );
 }

--- a/packages/babel-plugin-transform-react-jsx-source/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-source/src/index.js
@@ -82,7 +82,7 @@ export default declare(api => {
       }
 
       const trace = makeTrace(
-        state.fileNameIdentifier,
+        t.cloneNode(state.fileNameIdentifier),
         location.start.line,
         location.start.column,
       );

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -301,7 +301,11 @@ export default declare((api, options, dirname) => {
               context2 = t.cloneNode(object);
             } else {
               context1 = path.scope.generateDeclaredUidIdentifier("context");
-              context2 = t.assignmentExpression("=", context1, object);
+              context2 = t.assignmentExpression(
+                "=",
+                t.cloneNode(context1),
+                object,
+              );
             }
             node.callee = t.memberExpression(
               t.callExpression(

--- a/packages/babel-plugin-transform-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-template-literals/src/index.js
@@ -87,9 +87,9 @@ export default declare((api, options) => {
         const lazyLoad = template.ast`
           function ${templateObject}() {
             const data = ${t.callExpression(helperId, callExpressionInput)};
-            ${templateObject} = function() { return data };
+            ${t.cloneNode(templateObject)} = function() { return data };
             return data;
-          } 
+          }
         `;
 
         scope.path.unshiftContainer("body", lazyLoad);

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -134,7 +134,9 @@ export default declare(
               );
             }
 
-            return template.statement.ast`this.${id} = ${id}`;
+            return template.statement.ast`this.${t.cloneNode(
+              id,
+            )} = ${t.cloneNode(id)}`;
           });
 
           injectInitialization(classPath, path, assigns);

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -134,9 +134,8 @@ export default declare(
               );
             }
 
-            return template.statement.ast`this.${t.cloneNode(
-              id,
-            )} = ${t.cloneNode(id)}`;
+            return template.statement.ast`
+              this.${t.cloneNode(id)} = ${t.cloneNode(id)}`;
           });
 
           injectInitialization(classPath, path, assigns);

--- a/packages/babel-plugin-transform-typescript/src/namespace.js
+++ b/packages/babel-plugin-transform-typescript/src/namespace.js
@@ -157,8 +157,10 @@ function handleNested(path, t, node, parentExport) {
 
   if (parentExport) {
     fallthroughValue = template.expression.ast`
-      ${parentExport}.${realName} || (
-        ${parentExport}.${realName} = ${fallthroughValue}
+      ${parentExport}.${t.cloneNode(realName)} || (
+        ${t.cloneNode(parentExport)}.${t.cloneNode(
+      realName,
+    )} = ${fallthroughValue}
       )
     `;
   }
@@ -166,6 +168,6 @@ function handleNested(path, t, node, parentExport) {
   return template.statement.ast`
     (function (${t.identifier(name)}) {
       ${namespaceTopLevel}
-    })(${realName} || (${realName} = ${fallthroughValue}));
+    })(${realName} || (${t.cloneNode(realName)} = ${fallthroughValue}));
   `;
 }

--- a/packages/babel-plugin-transform-typescript/src/namespace.js
+++ b/packages/babel-plugin-transform-typescript/src/namespace.js
@@ -156,12 +156,10 @@ function handleNested(path, t, node, parentExport) {
   let fallthroughValue = t.objectExpression([]);
 
   if (parentExport) {
+    const memberExpr = t.memberExpression(parentExport, realName);
     fallthroughValue = template.expression.ast`
-      ${parentExport}.${t.cloneNode(realName)} || (
-        ${t.cloneNode(parentExport)}.${t.cloneNode(
-      realName,
-    )} = ${fallthroughValue}
-      )
+      ${t.cloneNode(memberExpr)} ||
+        (${t.cloneNode(memberExpr)} = ${fallthroughValue})
     `;
   }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11506 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As a follow-up to #7149, this PR enables duplicated node checks against all testcases and then fixes all duplicate AST errors.

I didn't add a regression test of #11506 because it is covered in [this test case](https://github.com/babel/babel/blob/v7.10.4/packages/babel-plugin-proposal-decorators/test/fixtures/element-descriptors/original-own-field/exec.js). I realized that the duplicated node checks are not effective when I am investigating #11506, which should have been captured by our test runner.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11807"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/1e796b349b07e5cf28c4bd81eecdf030484bb314.svg" /></a>

