### PR TITLE
Replace lodash 'clone' usage with ES6 Spread initializer

### DIFF
--- a/packages/babel-helper-fixtures/src/index.js
+++ b/packages/babel-helper-fixtures/src/index.js
@@ -1,5 +1,4 @@
 import cloneDeep from "lodash/cloneDeep";
-import clone from "lodash/clone";
 import extend from "lodash/extend";
 import semver from "semver";
 import path from "path";
@@ -263,7 +262,7 @@ export default function get(entryLoc): Array<Suite> {
     if (shouldIgnore(suiteName)) continue;
 
     const suite = {
-      options: clone(rootOpts),
+      options: { ...rootOpts },
       tests: [],
       title: humanize(suiteName),
       filename: entryLoc + "/" + suiteName,

--- a/packages/babel-traverse/src/visitors.js
+++ b/packages/babel-traverse/src/visitors.js
@@ -1,6 +1,5 @@
 import * as virtualTypes from "./path/lib/virtual-types";
 import * as t from "@babel/types";
-import clone from "lodash/clone";
 
 /**
  * explode() will take a visitor object with all of the various shorthands
@@ -106,7 +105,7 @@ export function explode(visitor) {
       if (existing) {
         mergePair(existing, fns);
       } else {
-        visitor[alias] = clone(fns);
+        visitor[alias] = { ...fns };
       }
     }
   }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Any Dependency Changes?  | No
| License                  | MIT

Continues removal of lodash function dependencies identified per #11789.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11811"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jayaddison/babel.git/6da65ba5785d7ca508b7c451416acc6deec8df27.svg" /></a>

