### PR TITLE
Replace lodash 'extend' usage with Object.assign

### DIFF
--- a/packages/babel-helper-fixtures/src/index.js
+++ b/packages/babel-helper-fixtures/src/index.js
@@ -1,6 +1,5 @@
 import cloneDeep from "lodash/cloneDeep";
 import clone from "lodash/clone";
-import extend from "lodash/extend";
 import semver from "semver";
 import path from "path";
 import fs from "fs";
@@ -119,7 +118,7 @@ function pushTask(taskName, taskDir, suite, suiteName) {
   const taskOpts = cloneDeep(suite.options);
 
   const taskOptsLoc = tryResolve(taskDir + "/options");
-  if (taskOptsLoc) extend(taskOpts, require(taskOptsLoc));
+  if (taskOptsLoc) Object.assign(taskOpts, require(taskOptsLoc));
 
   const test = {
     optionsDir: taskOptsLoc ? path.dirname(taskOptsLoc) : null,

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -7,7 +7,6 @@ import { codeFrameColumns } from "@babel/code-frame";
 import defaults from "lodash/defaults";
 import escapeRegExp from "lodash/escapeRegExp";
 import * as helpers from "./helpers";
-import extend from "lodash/extend";
 import merge from "lodash/merge";
 import resolve from "resolve";
 import assert from "assert";
@@ -380,7 +379,7 @@ export default function (
               sourceMap: !!(task.sourceMappings || task.sourceMap),
             });
 
-            extend(task.options, taskOpts);
+            Object.assign(task.options, taskOpts);
 
             if (dynamicOpts) dynamicOpts(task.options, task);
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Any Dependency Changes?  | No
| License                  | MIT

Continues removal of lodash function dependencies identified per #11789.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11812"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jayaddison/babel.git/5ba169e4d23a7104dc7ed211ff9afe77b12082aa.svg" /></a>

