### PR TITLE
fix: add optional: false to chained optional call expression

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -660,8 +660,10 @@ export default class ExpressionParser extends LValParser {
       let node = this.startNodeAt(startPos, startLoc);
       node.callee = base;
 
+      if (state.optionalChainMember) {
+        node.optional = optional;
+      }
       if (optional) {
-        node.optional = true;
         node.arguments = this.parseCallExpressionArguments(tt.parenR, false);
       } else {
         node.arguments = this.parseCallExpressionArguments(

--- a/packages/babel-parser/test/fixtures/es2020/optional-chaining/optioanl-chain-expression/output.json
+++ b/packages/babel-parser/test/fixtures/es2020/optional-chaining/optioanl-chain-expression/output.json
@@ -39,6 +39,7 @@
             "computed": false,
             "optional": true
           },
+          "optional": false,
           "arguments": []
         }
       }

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/optional-chain-object/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/optional-chain-object/output.json
@@ -257,6 +257,7 @@
                             "computed": false,
                             "optional": false
                           },
+                          "optional": false,
                           "arguments": [
                             {
                               "type": "NumericLiteral",
@@ -303,6 +304,7 @@
                             "computed": false,
                             "optional": false
                           },
+                          "optional": false,
                           "arguments": []
                         }
                       ]

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/optional-chain-start-call/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/optional-chain-start-call/output.json
@@ -93,6 +93,7 @@
                         "computed": false,
                         "optional": true
                       },
+                      "optional": false,
                       "arguments": []
                     }
                   }

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/optional-chain-start-member-call/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/optional-chain-start-member-call/output.json
@@ -99,6 +99,7 @@
                         "computed": false,
                         "optional": false
                       },
+                      "optional": false,
                       "arguments": [
                         {
                           "type": "NumericLiteral",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `@babel/parser` does not align to AST spec on `a?.b()`
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Per [AST spec](https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#optionalcallexpression), `optional` is a required property of `OptionalCallExpression`.

This PR blocks #11815 

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11814"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/7acd2c09eb5665ceefc3e775a6b3f7654376d6f7.svg" /></a>

