### PR TITLE
Fixup: ensure any prototype properties of cloned 'fns' object are retained

### DIFF
--- a/packages/babel-traverse/src/visitors.js
+++ b/packages/babel-traverse/src/visitors.js
@@ -105,7 +105,8 @@ export function explode(visitor) {
       if (existing) {
         mergePair(existing, fns);
       } else {
-        visitor[alias] = { ...fns };
+        visitor[alias] = Object.create(Object.getPrototypeOf(fns));
+        Object.assign(visitor[alias], fns);
       }
     }
   }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Any Dependency Changes?  | No
| License                  | MIT

This change is a fixup and continuation of changes applied in https://github.com/babel/babel/pull/11811 to remove usages of the `lodash/clone` function.

Ref: https://github.com/babel/babel/pull/11811#discussion_r452826637