### PR TITLE
Forward deopt node path

### DIFF
--- a/packages/babel-core/test/evaluation.js
+++ b/packages/babel-core/test/evaluation.js
@@ -21,25 +21,6 @@ describe("evaluation", function () {
     });
   }
 
-  function addDeoptTest(code, type, expectedType) {
-    it(type + " deopt: " + code, function () {
-      const visitor = {};
-
-      visitor[type] = function (path) {
-        const evaluate = path.evaluate();
-        expect(evaluate.confident).toBeFalsy();
-        expect(evaluate.deopt.type).toEqual(expectedType);
-      };
-
-      traverse(
-        parse(code, {
-          plugins: ["*"],
-        }),
-        visitor,
-      );
-    });
-  }
-
   addTest("void 0", "UnaryExpression", undefined);
   addTest("!true", "UnaryExpression", false);
   addTest("+'2'", "UnaryExpression", 2);
@@ -112,8 +93,4 @@ describe("evaluation", function () {
     ab: 200,
     z: [1, 2, 3],
   });
-
-  addDeoptTest("({a:{b}})", "ObjectExpression", "Identifier");
-  addDeoptTest("({[a + 'b']: 1})", "ObjectExpression", "Identifier");
-  addDeoptTest("[{a}]", "ArrayExpression", "Identifier");
 });

--- a/packages/babel-core/test/evaluation.js
+++ b/packages/babel-core/test/evaluation.js
@@ -21,6 +21,25 @@ describe("evaluation", function () {
     });
   }
 
+  function addDeoptTest(code, type, expectedType) {
+    it(type + " deopt: " + code, function () {
+      const visitor = {};
+
+      visitor[type] = function (path) {
+        const evaluate = path.evaluate();
+        expect(evaluate.confident).toBeFalsy();
+        expect(evaluate.deopt.type).toEqual(expectedType);
+      };
+
+      traverse(
+        parse(code, {
+          plugins: ["*"],
+        }),
+        visitor,
+      );
+    });
+  }
+
   addTest("void 0", "UnaryExpression", undefined);
   addTest("!true", "UnaryExpression", false);
   addTest("+'2'", "UnaryExpression", 2);
@@ -93,4 +112,8 @@ describe("evaluation", function () {
     ab: 200,
     z: [1, 2, 3],
   });
+
+  addDeoptTest("({a:{b}})", "ObjectExpression", "Identifier");
+  addDeoptTest("({[a + 'b']: 1})", "ObjectExpression", "Identifier");
+  addDeoptTest("[{a}]", "ArrayExpression", "Identifier");
 });

--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -219,7 +219,7 @@ function _evaluate(path, state) {
       if (elemValue.confident) {
         arr.push(elemValue.value);
       } else {
-        return deopt(elem, state);
+        return deopt(elemValue.deopt, state);
       }
     }
     return arr;
@@ -237,7 +237,7 @@ function _evaluate(path, state) {
       if (prop.node.computed) {
         key = key.evaluate();
         if (!key.confident) {
-          return deopt(keyPath, state);
+          return deopt(key.deopt, state);
         }
         key = key.value;
       } else if (key.isIdentifier()) {
@@ -248,7 +248,7 @@ function _evaluate(path, state) {
       const valuePath = prop.get("value");
       let value = valuePath.evaluate();
       if (!value.confident) {
-        return deopt(valuePath, state);
+        return deopt(value.deopt, state);
       }
       value = value.value;
       obj[key] = value;

--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -407,19 +407,24 @@ function evaluateQuasis(path, quasis: Array<Object>, state, raw = false) {
 /**
  * Walk the input `node` and statically evaluate it.
  *
- * Returns an object in the form `{ confident, value }`. `confident` indicates
- * whether or not we had to drop out of evaluating the expression because of
- * hitting an unknown node that we couldn't confidently find the value of.
+ * Returns an object in the form `{ confident, value, deopt }`. `confident`
+ * indicates whether or not we had to drop out of evaluating the expression
+ * because of hitting an unknown node that we couldn't confidently find the
+ * value of, in which case `deopt` is the path of said node.
  *
  * Example:
  *
  *   t.evaluate(parse("5 + 5")) // { confident: true, value: 10 }
  *   t.evaluate(parse("!true")) // { confident: true, value: false }
- *   t.evaluate(parse("foo + foo")) // { confident: false, value: undefined }
+ *   t.evaluate(parse("foo + foo")) // { confident: false, value: undefined, deopt: NodePath }
  *
  */
 
-export function evaluate(): { confident: boolean, value: any } {
+export function evaluate(): {
+  confident: boolean,
+  value: any,
+  deopt?: NodePath,
+} {
   const state = {
     confident: true,
     deoptPath: null,

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -13,6 +13,25 @@ function getPath(code) {
   return path;
 }
 
+function addDeoptTest(code, type, expectedType) {
+  it(type + " deopt: " + code, function () {
+    const visitor = {};
+
+    visitor[type] = function (path) {
+      const evaluate = path.evaluate();
+      expect(evaluate.confident).toBeFalsy();
+      expect(evaluate.deopt.type).toEqual(expectedType);
+    };
+
+    traverse(
+      parse(code, {
+        plugins: ["*"],
+      }),
+      visitor,
+    );
+  });
+}
+
 describe("evaluation", function () {
   describe("evaluateTruthy", function () {
     it("it should work with null", function () {
@@ -228,4 +247,8 @@ describe("evaluation", function () {
     expect(result.deopt).toBeNull();
     expect(result.value).toEqual(["foo", "bar"]);
   });
+
+  addDeoptTest("({a:{b}})", "ObjectExpression", "Identifier");
+  addDeoptTest("({[a + 'b']: 1})", "ObjectExpression", "Identifier");
+  addDeoptTest("[{a}]", "ArrayExpression", "Identifier");
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Currently, when evaluating array values, object keys, and object properties, if a deopt is found, the location is discarded and the location in the array or the object will be used. I suggest this information is kept. It will make it easier to understand the cause of the deopt.

```javascript
{
  a: { // <- deopt currently points to this object
    b // <- I suggest pointing to this identifier
  }
}
```


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11832"><img src="https://gitpod.io/api/apps/github/pbs/github.com/johanholmerin/babel.git/c3065e8a16a82363bdc32f579e25f33938a17cce.svg" /></a>

