### PR TITLE
chore: use repository HEAD when pulling third party repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
       - run:
           name: Setup Test Runner
           command: |
-            git clone --recurse-submodules https://github.com/babel/babel-test262-runner
+            git clone --depth=1 --recurse-submodules https://github.com/babel/babel-test262-runner
             cd babel-test262-runner
             npm ci
             npm i tap-mocha-reporter --save-dev

--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,8 @@ test-ci-coverage:
 bootstrap-flow:
 	rm -rf build/flow
 	mkdir -p build
-	git clone --branch=master --single-branch --shallow-since=2018-11-01 https://github.com/facebook/flow.git build/flow
-	cd build/flow && git checkout $(FLOW_COMMIT)
+	git clone --single-branch --shallow-since=2018-11-01 https://github.com/facebook/flow.git build/flow
+	cd build/flow && git checkout -q $(FLOW_COMMIT)
 
 test-flow:
 	$(NODE) scripts/parser-tests/flow
@@ -179,8 +179,8 @@ test-flow-update-allowlist:
 bootstrap-typescript:
 	rm -rf ./build/typescript
 	mkdir -p ./build
-	git clone --branch=master --single-branch --shallow-since=2019-09-01 https://github.com/microsoft/TypeScript.git ./build/typescript
-	cd build/typescript && git checkout $(TYPESCRIPT_COMMIT)
+	git clone --single-branch --shallow-since=2019-09-01 https://github.com/microsoft/TypeScript.git ./build/typescript
+	cd build/typescript && git checkout -q $(TYPESCRIPT_COMMIT)
 
 test-typescript:
 	$(NODE) scripts/parser-tests/typescript
@@ -194,8 +194,8 @@ test-typescript-update-allowlist:
 bootstrap-test262:
 	rm -rf build/test262
 	mkdir -p build
-	git clone --branch=master --single-branch --shallow-since=2019-12-01 https://github.com/tc39/test262.git build/test262
-	cd build/test262 && git checkout $(TEST262_COMMIT)
+	git clone --single-branch --shallow-since=2019-12-01 https://github.com/tc39/test262.git build/test262
+	cd build/test262 && git checkout -q $(TEST262_COMMIT)
 
 test-test262:
 	$(NODE) scripts/parser-tests/test262

--- a/packages/babel-compat-data/scripts/download-compat-table.sh
+++ b/packages/babel-compat-data/scripts/download-compat-table.sh
@@ -16,5 +16,5 @@ fi
 
 rm -rf build/compat-table
 mkdir -p build
-git clone --branch=gh-pages --single-branch --shallow-since=2020-04-01 https://github.com/kangax/compat-table.git build/compat-table
-cd build/compat-table && git checkout -qf $COMPAT_TABLE_COMMIT
+git clone --single-branch --shallow-since=2020-04-01 https://github.com/kangax/compat-table.git build/compat-table
+cd build/compat-table && git checkout -q $COMPAT_TABLE_COMMIT


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The `test262` is [planning](https://github.com/tc39/test262/issues/2699) to rename `master` into `main`. In this PR we removes the `--branch` option when cloning third-party repos. By doing so `git` will always clone the repository `HEAD`, which is the default branch HEAD as of GitHub repos -- so we are agnostic about upstream default branch name.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11837"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/683ab0dbb3966ebb288df307ca8dce5dd56018ee.svg" /></a>

