### PR TITLE
refactor: replace caniuse-db by mdn-browser-compat-data

### DIFF
--- a/packages/babel-compat-data/data/native-modules.json
+++ b/packages/babel-compat-data/data/native-modules.json
@@ -1,15 +1,16 @@
 {
   "es6.module": {
+    "chrome": "61",
+    "and_chr": "61",
     "edge": "16",
     "firefox": "60",
-    "chrome": "61",
-    "safari": "10.1",
-    "opera": "48",
-    "ios_saf": "10.3",
-    "android": "61",
-    "op_mob": "48",
-    "and_chr": "61",
     "and_ff": "60",
-    "samsung": "8.2"
+    "node": "13.2.0",
+    "opera": "48",
+    "op_mob": "48",
+    "safari": "10.1",
+    "ios_saf": "10.3",
+    "samsung": "8.2",
+    "android": "61"
   }
 }

--- a/packages/babel-compat-data/package.json
+++ b/packages/babel-compat-data/package.json
@@ -21,7 +21,7 @@
     "./plugin-bugfixes": "./data/plugin-bugfixes.json"
   },
   "scripts": {
-    "build-data": "./scripts/download-compat-table.sh; node ./scripts/build-data.js; node ./scripts/build-modules-support.js; node ./scripts/build-bugfixes-targets.js"
+    "build-data": "./scripts/download-compat-table.sh && node ./scripts/build-data.js && node ./scripts/build-modules-support.js && node ./scripts/build-bugfixes-targets.js"
   },
   "keywords": [
     "babel",
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@babel/helper-compilation-targets": "^7.10.4",
-    "caniuse-db": "1.0.30001035",
+    "mdn-browser-compat-data": "1.0.31",
     "electron-to-chromium": "1.3.377",
     "lodash": "^4.17.19"
   }

--- a/packages/babel-compat-data/scripts/build-modules-support.js
+++ b/packages/babel-compat-data/scripts/build-modules-support.js
@@ -1,40 +1,59 @@
 const path = require("path");
 const fs = require("fs");
 
-const moduleSupport = require("caniuse-db/features-json/es6-module.json");
+const compatData = require("mdn-browser-compat-data").javascript;
 
-const acceptedWithCaveats = new Set(["safari", "ios_saf"]);
-
+// Map mdn-browser-compat-data to browserslist browser names
 const browserNameMap = {
-  and_chr: "chrome",
-  and_ff: "firefox",
-  android: "chrome", // map to chrome here as Android WebView 61 is Chromium-based
-  op_mob: "opera",
+  chrome_android: "and_chr",
+  firefox_android: "and_ff",
+  safari_ios: "ios_saf",
+  nodejs: "node",
+  webview_android: "android",
+  opera_android: "op_mob",
+  samsunginternet_android: "samsung",
 };
-const { stats } = moduleSupport;
 
-const allowedBrowsers = {};
+const browserSupportMap = {
+  android: "chrome_android", // map to chrome here as Android WebView 61 is Chromium-based
+};
 
-Object.keys(stats).forEach(browser => {
-  const browserName = browserNameMap[browser] || browser;
-  const browserVersions = stats[browserName];
-  const allowedVersions = Object.keys(browserVersions)
-    .filter(value => {
-      // Edge 16/17 are marked as "y #6"
-      return acceptedWithCaveats.has(browserName)
-        ? browserVersions[value][0] === "a"
-        : browserVersions[value].startsWith("y");
-    })
-    .sort((a, b) => a - b);
-
-  if (allowedVersions[0] !== undefined) {
-    // Handle cases where caniuse specifies version as: "11.0-11.2"
-    allowedBrowsers[browser] = allowedVersions[0].split("-")[0];
+function browserVersion(browser, version_added) {
+  if (browser === "samsunginternet_android" && version_added === "8.0") {
+    return "8.2"; // samsung 8.0 is not defined in browserslist
   }
-});
+  // fixme: preset-env maps opera_android as opera, this is incorrect as they have different engine mappings
+  // see https://github.com/mdn/browser-compat-data/blob/master/browsers/opera_android.json
+  if (browser === "opera_android" && version_added === "45") {
+    return "48";
+  }
+  return version_added;
+}
+
+function process(source) {
+  const stats = source.__compat.support;
+  const allowedBrowsers = {};
+
+  Object.keys(stats).forEach(browser => {
+    const browserName = browserNameMap[browser] ?? browser;
+    let browserSupport = stats[browserSupportMap[browserName] ?? browser];
+    if (Array.isArray(browserSupport)) {
+      browserSupport = browserSupport[0]; // The first item is the most progressive support
+    }
+    if (browserSupport.version_added && !browserSupport.flags) {
+      allowedBrowsers[browserName] = browserVersion(
+        browser,
+        browserSupport.version_added
+      );
+    }
+  });
+
+  return allowedBrowsers;
+}
 
 const dataPath = path.join(__dirname, "../data/native-modules.json");
 const data = {
-  "es6.module": allowedBrowsers,
+  "es6.module": process(compatData.statements.export),
 };
 fs.writeFileSync(dataPath, `${JSON.stringify(data, null, 2)}\n`);
+exports.process = process;

--- a/packages/babel-helper-compilation-targets/test/__snapshots__/targets-parser.spec.js.snap
+++ b/packages/babel-helper-compilation-targets/test/__snapshots__/targets-parser.spec.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getTargets esmodules returns browser supporting modules and keyed browser overrides 1`] = `
+Object {
+  "android": "61.0.0",
+  "chrome": "61.0.0",
+  "edge": "16.0.0",
+  "firefox": "60.0.0",
+  "ie": "11.0.0",
+  "ios": "10.3.0",
+  "node": "13.2.0",
+  "opera": "48.0.0",
+  "safari": "10.1.0",
+  "samsung": "8.2.0",
+}
+`;
+
+exports[`getTargets esmodules returns browser supporting modules and keyed browser overrides, ignoring browsers field 1`] = `
+Object {
+  "android": "61.0.0",
+  "chrome": "61.0.0",
+  "edge": "16.0.0",
+  "firefox": "60.0.0",
+  "ie": "11.0.0",
+  "ios": "10.3.0",
+  "node": "13.2.0",
+  "opera": "48.0.0",
+  "safari": "10.1.0",
+  "samsung": "8.2.0",
+}
+`;
+
+exports[`getTargets esmodules returns browsers supporting modules 1`] = `
+Object {
+  "android": "61.0.0",
+  "chrome": "61.0.0",
+  "edge": "16.0.0",
+  "firefox": "60.0.0",
+  "ios": "10.3.0",
+  "node": "13.2.0",
+  "opera": "48.0.0",
+  "safari": "10.1.0",
+  "samsung": "8.2.0",
+}
+`;
+
+exports[`getTargets esmodules returns browsers supporting modules, ignoring browsers key 1`] = `
+Object {
+  "android": "61.0.0",
+  "chrome": "61.0.0",
+  "edge": "16.0.0",
+  "firefox": "60.0.0",
+  "ios": "10.3.0",
+  "node": "13.2.0",
+  "opera": "48.0.0",
+  "safari": "10.1.0",
+  "samsung": "8.2.0",
+}
+`;

--- a/packages/babel-helper-compilation-targets/test/targets-parser.spec.js
+++ b/packages/babel-helper-compilation-targets/test/targets-parser.spec.js
@@ -203,16 +203,7 @@ describe("getTargets", () => {
         getTargets({
           esmodules: true,
         }),
-      ).toEqual({
-        android: "61.0.0",
-        chrome: "61.0.0",
-        edge: "16.0.0",
-        firefox: "60.0.0",
-        ios: "10.3.0",
-        opera: "48.0.0",
-        safari: "10.1.0",
-        samsung: "8.2.0",
-      });
+      ).toMatchSnapshot();
     });
 
     it("returns browsers supporting modules, ignoring browsers key", () => {
@@ -221,16 +212,7 @@ describe("getTargets", () => {
           esmodules: true,
           browsers: "ie 8",
         }),
-      ).toEqual({
-        android: "61.0.0",
-        chrome: "61.0.0",
-        edge: "16.0.0",
-        firefox: "60.0.0",
-        ios: "10.3.0",
-        opera: "48.0.0",
-        safari: "10.1.0",
-        samsung: "8.2.0",
-      });
+      ).toMatchSnapshot();
     });
 
     it("returns browser supporting modules and keyed browser overrides", () => {
@@ -239,17 +221,7 @@ describe("getTargets", () => {
           esmodules: true,
           ie: 11,
         }),
-      ).toEqual({
-        android: "61.0.0",
-        chrome: "61.0.0",
-        safari: "10.1.0",
-        firefox: "60.0.0",
-        opera: "48.0.0",
-        ios: "10.3.0",
-        ie: "11.0.0",
-        edge: "16.0.0",
-        samsung: "8.2.0",
-      });
+      ).toMatchSnapshot();
     });
 
     it("returns browser supporting modules and keyed browser overrides, ignoring browsers field", () => {
@@ -259,17 +231,7 @@ describe("getTargets", () => {
           browsers: "ie 10",
           ie: 11,
         }),
-      ).toEqual({
-        android: "61.0.0",
-        chrome: "61.0.0",
-        safari: "10.1.0",
-        ios: "10.3.0",
-        ie: "11.0.0",
-        edge: "16.0.0",
-        firefox: "60.0.0",
-        opera: "48.0.0",
-        samsung: "8.2.0",
-      });
+      ).toMatchSnapshot();
     });
   });
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
@@ -7,6 +7,7 @@ Using targets:
   "edge": "16",
   "firefox": "60",
   "ios": "10.3",
+  "node": "13.2",
   "opera": "48",
   "safari": "10.1",
   "samsung": "8.2"
@@ -15,8 +16,8 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-optional-catch-binding { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   transform-parameters { "edge":"16" }
@@ -30,7 +31,7 @@ Using plugins:
   transform-function-name { "edge":"16" }
   transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
   transform-block-scoping { "ios":"10.3", "safari":"10.1" }
-  transform-modules-commonjs { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  transform-modules-commonjs { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
@@ -7,6 +7,7 @@ Using targets:
   "edge": "16",
   "firefox": "60",
   "ios": "10.3",
+  "node": "13.2",
   "opera": "48",
   "safari": "10.1",
   "samsung": "8.2"
@@ -15,8 +16,8 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-optional-catch-binding { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-async-generator-functions { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
@@ -25,13 +26,13 @@ Using plugins:
   proposal-unicode-property-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   transform-named-capturing-groups-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
-  bugfix/transform-async-arrows-in-class { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  bugfix/transform-edge-default-parameters { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  bugfix/transform-edge-function-name { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  bugfix/transform-safari-block-shadowing { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  bugfix/transform-safari-for-shadowing { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  bugfix/transform-tagged-template-caching { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-modules-commonjs { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  bugfix/transform-async-arrows-in-class { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  bugfix/transform-edge-default-parameters { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  bugfix/transform-edge-function-name { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  bugfix/transform-safari-block-shadowing { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  bugfix/transform-safari-for-shadowing { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  bugfix/transform-tagged-template-caching { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  transform-modules-commonjs { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -7,6 +7,7 @@ Using targets:
   "edge": "16",
   "firefox": "60",
   "ios": "10.3",
+  "node": "13.2",
   "opera": "48",
   "safari": "10.1",
   "samsung": "8.2"
@@ -15,8 +16,8 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-optional-catch-binding { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   transform-parameters { "edge":"16" }
@@ -30,9 +31,9 @@ Using plugins:
   transform-function-name { "edge":"16" }
   transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
   transform-block-scoping { "ios":"10.3", "safari":"10.1" }
-  syntax-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  syntax-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
 
 Using polyfills with `usage` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/input.mjs] Added following core-js polyfill:
-  web.dom.iterable { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  web.dom.iterable { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -7,6 +7,7 @@ Using targets:
   "edge": "16",
   "firefox": "60",
   "ios": "10.3",
+  "node": "13.2",
   "opera": "48",
   "safari": "10.1",
   "samsung": "8.2"
@@ -15,8 +16,8 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-optional-catch-binding { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   transform-parameters { "edge":"16" }
@@ -30,7 +31,7 @@ Using plugins:
   transform-function-name { "edge":"16" }
   transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
   transform-block-scoping { "ios":"10.3", "safari":"10.1" }
-  syntax-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  syntax-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
 
 Using polyfills with `usage` option:
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | `es6.modules` compat-data should include `node: 13.2`.
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR I have replaced `caniuse-db` by `mdn-browser-compat-data` when building the modules support in `@babel/compat-data`. The rationale here is

- `caniuse` [states](https://caniuse.com/#feat=mdn-javascript_statements_export) that the support data of `es6-modules` are from `mdn/browser-compat-data`
- I have submitted a PR for [`export * as ns` support](https://github.com/mdn/browser-compat-data/pull/6394), which enables us to include `export-namespace-from` in the `preset-env`.
- The `mdn-browser-compat-data` is easier to process than `caniuse-db` (no more `getLowestImplementedVersions`)
- `caniuse` does not have `nodejs` support data

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11838"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/842112b76dfb65afca4a1abda16e3261aa2d6472.svg" /></a>

