### PR TITLE
Replace lodash 'escapeRegExp' with escape-string-regexp library

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -53,6 +53,7 @@
     "@babel/types": "workspace:^7.10.4",
     "convert-source-map": "^1.7.0",
     "debug": "^4.1.0",
+    "escape-string-regexp": "^4.0.0",
     "gensync": "^1.0.0-beta.1",
     "json5": "^2.1.2",
     "lodash": "^4.17.13",

--- a/packages/babel-core/src/config/pattern-to-regex.js
+++ b/packages/babel-core/src/config/pattern-to-regex.js
@@ -1,6 +1,6 @@
 // @flow
 import path from "path";
-import escapeRegExp from "lodash/escapeRegExp";
+import escapeRegExp from "escape-string-regexp";
 
 const sep = `\\${path.sep}`;
 const endSep = `(?:${sep}|$)`;

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -20,6 +20,7 @@
     "@babel/helper-fixtures": "workspace:^7.10.4",
     "@babel/polyfill": "workspace:^7.10.4",
     "babel-check-duplicated-nodes": "^1.0.0",
+    "escape-string-regexp": "^4.0.0",
     "jest": "^25.1.0",
     "jest-diff": "^25.1.0",
     "lodash": "^4.17.13",

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -6,7 +6,7 @@ import sourceMap from "source-map";
 import { codeFrameColumns } from "@babel/code-frame";
 import defaults from "lodash/defaults";
 import includes from "lodash/includes";
-import escapeRegExp from "lodash/escapeRegExp";
+import escapeRegExp from "escape-string-regexp";
 import * as helpers from "./helpers";
 import extend from "lodash/extend";
 import merge from "lodash/merge";

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -17,6 +17,7 @@
     "./lib/node.js": "./lib/browser.js"
   },
   "dependencies": {
+    "escape-string-regexp": "^4.0.0",
     "find-cache-dir": "^3.2.0",
     "lodash": "^4.17.13",
     "pirates": "^4.0.0",

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -1,7 +1,7 @@
 import deepClone from "lodash/cloneDeep";
 import sourceMapSupport from "source-map-support";
 import * as registerCache from "./cache";
-import escapeRegExp from "lodash/escapeRegExp";
+import escapeRegExp from "escape-string-regexp";
 import * as babel from "@babel/core";
 import { OptionManager, DEFAULT_EXTENSIONS } from "@babel/core";
 import { addHook } from "pirates";

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,6 +172,7 @@ __metadata:
     "@babel/types": "workspace:^7.10.4"
     convert-source-map: ^1.7.0
     debug: ^4.1.0
+    escape-string-regexp: ^4.0.0
     gensync: ^1.0.0-beta.1
     json5: ^2.1.2
     lodash: ^4.17.13
@@ -963,6 +964,7 @@ __metadata:
     "@babel/helper-fixtures": "workspace:^7.10.4"
     "@babel/polyfill": "workspace:^7.10.4"
     babel-check-duplicated-nodes: ^1.0.0
+    escape-string-regexp: ^4.0.0
     jest: ^25.1.0
     jest-diff: ^25.1.0
     lodash: ^4.17.13
@@ -3355,6 +3357,7 @@ __metadata:
     "@babel/plugin-transform-modules-commonjs": "workspace:^7.10.4"
     browserify: 16.5.0
     default-require-extensions: ^2.0.0
+    escape-string-regexp: ^4.0.0
     find-cache-dir: ^3.2.0
     lodash: ^4.17.13
     pirates: ^4.0.0
@@ -8365,6 +8368,13 @@ __metadata:
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
   checksum: f9484b8b4c8827d816e0fd905c25ed4b561376a9c220e1430403ea84619bf680c76a883a48cff8b8e091daf55d6a497e37479f9787b9f15f3c421b6054289744
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "escape-string-regexp@npm:4.0.0"
+  checksum: c747be8d5ff7873127e3e0cffe7d2206a37208077fa9c30a3c1bb4f26bebd081c8c24d5fba7a99449f9d20670bea3dc5e1b6098b0f074b099bd38766271a272f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Any Dependency Changes?  | No
| License                  | MIT

From [previous discussion](https://github.com/babel/babel/pull/11789#discussion_r452863345) about removing `lodash` dependencies, it sounds like we can use the widely-used [escape-string-regexp](https://www.npmjs.com/package/escape-string-regexp) library to replace the functionality provided by `lodash/escapeRegExp`.

As noted in that discussion, this module requires Node 10 or greater, and that won't be guaranteed in `babel` until version 8, so this changeset is based against the `next-8-dev` branch.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11842"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jayaddison/babel.git/82745ffa3ccd2d034ddd63498344d3091634f7c7.svg" /></a>

