### PR TITLE
chore: fix typo in codebase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
           <<: *test262_workdir
       - store_artifacts: *artifact_test262_diff_tap
       - run:
-          name: Output comparision results and report to CircleCI
+          name: Output comparison results and report to CircleCI
           command: |
             mkdir -p ~/test-results/test262
             cat ~/diff.tap | $(npm bin)/tap-merge | $(npm bin)/tap-mocha-reporter xunit | tee ~/test-results/test262/results.xml

--- a/eslint/babel-eslint-plugin-development/src/utils/get-reference-origin.js
+++ b/eslint/babel-eslint-plugin-development/src/utils/get-reference-origin.js
@@ -21,7 +21,7 @@ type ReferenceOrigin =
 // Given a node and a context, returns a description of where its value comes
 // from.
 // It resolves imports, parameters of exported functions and property accesses.
-// See the ReferenceOrigin type for more informations.
+// See the ReferenceOrigin type for more information.
 export default function getReferenceOrigin(
   node,
   scope,

--- a/packages/babel-compat-data/scripts/build-corejs3-proposals.js
+++ b/packages/babel-compat-data/scripts/build-corejs3-proposals.js
@@ -25,10 +25,10 @@ const builtInDefinitionsPath = path.join(
 const builtInDefinitions = fs.readFileSync(builtInDefinitionsPath, "utf-8");
 
 for (const feature of finishedProposals) {
-  const standarizedName = feature.replace("esnext.", "es.");
-  if (!builtInDefinitions.includes(standarizedName)) {
+  const standardizedName = feature.replace("esnext.", "es.");
+  if (!builtInDefinitions.includes(standardizedName)) {
     console.log(
-      `${feature} is now standarized as ${standarizedName}, please add "${standarizedName}" to "${builtInDefinitionsPath}"`
+      `${feature} is now standarized as ${standardizedName}, please add "${standardizedName}" to "${builtInDefinitionsPath}"`
     );
   }
 }

--- a/packages/babel-core/src/config/files/import.js
+++ b/packages/babel-core/src/config/files/import.js
@@ -1,5 +1,5 @@
 // @flow
-// We keep this in a seprate file so that in older node versions, where
+// We keep this in a separate file so that in older node versions, where
 // import() isn't supported, we can try/catch around the require() call
 // when loading this file.
 

--- a/packages/babel-core/src/gensync-utils/async.js
+++ b/packages/babel-core/src/gensync-utils/async.js
@@ -10,7 +10,7 @@ const runGenerator = gensync(function* (item) {
   return yield* item;
 });
 
-// This Gensync returns true if the current execution contect is
+// This Gensync returns true if the current execution context is
 // asynchronous, otherwise it returns false.
 export const isAsync = gensync<[], boolean>({
   sync: () => false,

--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.js
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.js
@@ -12,7 +12,7 @@ export default function rewriteLiveReferences(
   const imported = new Map();
   const exported = new Map();
   const requeueInParent = path => {
-    // Manualy re-queue `exports.default =` expressions so that the ES3
+    // Manually re-queue `exports.default =` expressions so that the ES3
     // transform has an opportunity to convert them. Ideally this would
     // happen automatically from the replaceWith above. See #4140 for
     // more info.

--- a/packages/babel-helper-split-export-declaration/src/index.js
+++ b/packages/babel-helper-split-export-declaration/src/index.js
@@ -2,7 +2,7 @@ import * as t from "@babel/types";
 
 export default function splitExportDeclaration(exportDeclaration) {
   if (!exportDeclaration.isExportDeclaration()) {
-    throw new Error("Only export declarations can be splitted.");
+    throw new Error("Only export declarations can be split.");
   }
 
   // build specifiers that point back to this export declaration

--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -1077,7 +1077,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
       /* The inexact flag should only be added on ObjectTypeAnnotations that
        * are not the body of an interface, declare interface, or declare class.
-       * Since spreads are only allowed in objec types, checking that is
+       * Since spreads are only allowed in object types, checking that is
        * sufficient here.
        */
       if (allowSpread) {
@@ -2698,7 +2698,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
         if (!arrow.error && arrowExpression) return arrowExpression;
 
-        // If we are here, both JSX and Flow parsing attemps failed.
+        // If we are here, both JSX and Flow parsing attempts failed.
         // Give the precedence to the JSX error, except if JSX had an
         // unrecoverable error while Flow didn't.
         // If the error is recoverable, we can only re-report it if there is

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -596,7 +596,7 @@ export default declare((api, opts) => {
           exp = t.callExpression(t.cloneNode(helper), [
             exp,
             // If we have static props, we need to insert an empty object
-            // becuase the odd arguments are copied with [[Get]], not
+            // because the odd arguments are copied with [[Get]], not
             // [[GetOwnProperty]]
             ...(hadProps ? [t.objectExpression([]), obj] : []),
           ]);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/exec.js
@@ -16,6 +16,6 @@ const obj = new Obj();
 expect(() => {
   obj.call();
 
-  // Asser that this throws, but that it's not
+  // Assert that this throws, but that it's not
   // Obj.p.test's error that is thrown
 }).toThrowError(TypeError)

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/input.js
@@ -16,6 +16,6 @@ const obj = new Obj();
 expect(() => {
   obj.call();
 
-  // Asser that this throws, but that it's not
+  // Assert that this throws, but that it's not
   // Obj.p.test's error that is thrown
 }).toThrowError(TypeError)

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/output.js
@@ -56,6 +56,6 @@ let Obj = /*#__PURE__*/function (_Base) {
 
 const obj = new Obj();
 expect(() => {
-  obj.call(); // Asser that this throws, but that it's not
+  obj.call(); // Assert that this throws, but that it's not
   // Obj.p.test's error that is thrown
 }).toThrowError(TypeError);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-setter-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-setter-defined-on-parent/exec.js
@@ -19,6 +19,6 @@ const obj = new Obj();
 expect(() => {
   obj.call();
 
-  // Asser that this throws, but that it's not
+  // Assert that this throws, but that it's not
   // a gobbledygook error that is thrown
 }).toThrowError(TypeError)

--- a/packages/babel-preset-env/CONTRIBUTING.md
+++ b/packages/babel-preset-env/CONTRIBUTING.md
@@ -51,13 +51,13 @@ const es = {
 }
 ```
 
-If you wan to transform a new built-in by `useBuiltIns: 'usage'`, add mapping to related `core-js` modules to [this file](https://github.com/babel/babel/blob/main/packages/babel-preset-env/polyfills/corejs2/built-in-definitions.js).
+If you want to transform a new built-in by `useBuiltIns: 'usage'`, add mapping to related `core-js` modules to [this file](https://github.com/babel/babel/blob/main/packages/babel-preset-env/polyfills/corejs2/built-in-definitions.js).
 
 ### Update data for `core-js@3` polyfilling
 
 Just update the version of [`core-js-compat`](https://github.com/zloirock/core-js/tree/main/packages/core-js-compat) in dependencies.
 
-If you wan to transform a new built-in by `useBuiltIns: 'usage'`, add mapping to related [`core-js`](https://github.com/zloirock/core-js/tree/main/packages/core-js/modules) modules to [this file](https://github.com/babel/babel/blob/main/packages/babel-preset-env/polyfills/corejs3/built-in-definitions.js).
+If you want to transform a new built-in by `useBuiltIns: 'usage'`, add mapping to related [`core-js`](https://github.com/zloirock/core-js/tree/main/packages/core-js/modules) modules to [this file](https://github.com/babel/babel/blob/main/packages/babel-preset-env/polyfills/corejs3/built-in-definitions.js).
 
 If you want to mark a new proposal as shipped, add it to [this list](https://github.com/babel/babel/blob/main/packages/babel-preset-env/polyfills/corejs3/shipped-proposals.js).
 

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -33,7 +33,7 @@ const validateTopLevelOptions = (options: Options) => {
 
 const allPluginsList = Object.keys(pluginsList);
 
-// NOTE: Since module plugins are handled seperatly compared to other plugins (via the "modules" option) it
+// NOTE: Since module plugins are handled separately compared to other plugins (via the "modules" option) it
 // should only be possible to exclude and not include module plugins, otherwise it's possible that preset-env
 // will add a module plugin twice.
 const modulePlugins = [

--- a/packages/babel-traverse/src/path/introspection.js
+++ b/packages/babel-traverse/src/path/introspection.js
@@ -402,7 +402,7 @@ export function _guessExecutionStatusRelativeToDifferentFunctions(
       return "unknown";
     }
 
-    // Prevent infinte loops in recursive functions
+    // Prevent infinite loops in recursive functions
     if (executionOrderCheckedNodes.has(path.node)) continue;
     executionOrderCheckedNodes.add(path.node);
 

--- a/packages/babel-types/src/builders/flow/createFlowUnionType.js
+++ b/packages/babel-types/src/builders/flow/createFlowUnionType.js
@@ -4,7 +4,7 @@ import removeTypeDuplicates from "../../modifications/flow/removeTypeDuplicates"
 
 /**
  * Takes an array of `types` and flattens them, removing duplicates and
- * returns a `UnionTypeAnnotation` node containg them.
+ * returns a `UnionTypeAnnotation` node containing them.
  */
 export default function createFlowUnionType(types: Array<Object>): Object {
   const flattened = removeTypeDuplicates(types);

--- a/packages/babel-types/src/builders/typescript/createTSUnionType.js
+++ b/packages/babel-types/src/builders/typescript/createTSUnionType.js
@@ -3,7 +3,7 @@ import removeTypeDuplicates from "../../modifications/typescript/removeTypeDupli
 
 /**
  * Takes an array of `types` and flattens them, removing duplicates and
- * returns a `UnionTypeAnnotation` node containg them.
+ * returns a `UnionTypeAnnotation` node containing them.
  */
 export default function createTSUnionType(
   typeAnnotations: Array<Object>,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10653
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Fixes typo listed on https://fossies.org/linux/www/babel-7.10.5.tar.gz/codespell.html

The typo of `CHANGELO-preset-env-v0-v1.md` is ignored because it is how the commit title is, the other typos are fixed.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11846"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/2f41146baa2383d8ee75d1bab6bafb386be813c7.svg" /></a>

