### PR TITLE
fix: eval?.() is indirect

### DIFF
--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -78,7 +78,11 @@ export default declare((api, options) => {
 
           let ref;
           let check;
-          if (loose && isCall && isSimpleMemberExpression(chain)) {
+          if (isCall && t.isIdentifier(chain, { name: "eval" })) {
+            check = ref = chain;
+            // `eval?.()` is an indirect eval call transformed to `(0,eval)()`
+            node[replaceKey] = t.sequenceExpression([t.numericLiteral(0), ref]);
+          } else if (loose && isCall && isSimpleMemberExpression(chain)) {
             // If we are using a loose transform (avoiding a Function#call) and we are at the call,
             // we can avoid a needless memoize. We only do this if the callee is a simple member
             // expression, to avoid multiple calls to nested call expressions.

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/optional-eval-call-loose/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/optional-eval-call-loose/input.js
@@ -1,0 +1,22 @@
+var foo;
+
+/* indirect eval calls */
+eval?.(foo);
+
+(eval)?.(foo);
+
+eval?.()();
+
+eval?.().foo;
+
+/* direct eval calls */
+
+eval()?.();
+
+eval()?.foo;
+
+/* plain function calls */
+
+foo.eval?.(foo);
+
+eval.foo?.(foo);

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/optional-eval-call-loose/options.json
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/optional-eval-call-loose/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["proposal-optional-chaining", { "loose": true }]]
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/optional-eval-call-loose/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/optional-eval-call-loose/output.js
@@ -1,0 +1,17 @@
+var _eval, _eval2;
+
+var foo;
+/* indirect eval calls */
+
+eval == null ? void 0 : (0, eval)(foo);
+eval == null ? void 0 : (0, eval)(foo);
+eval == null ? void 0 : (0, eval)()();
+eval == null ? void 0 : (0, eval)().foo;
+/* direct eval calls */
+
+(_eval = eval()) == null ? void 0 : _eval();
+(_eval2 = eval()) == null ? void 0 : _eval2.foo;
+/* plain function calls */
+
+foo.eval == null ? void 0 : foo.eval(foo);
+eval.foo == null ? void 0 : eval.foo(foo);

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/optional-eval-call/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/optional-eval-call/input.js
@@ -1,0 +1,22 @@
+var foo;
+
+/* indirect eval calls */
+eval?.(foo);
+
+(eval)?.(foo);
+
+eval?.()();
+
+eval?.().foo;
+
+/* direct eval calls */
+
+eval()?.();
+
+eval()?.foo;
+
+/* plain function calls */
+
+foo.eval?.(foo);
+
+eval.foo?.(foo);

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/optional-eval-call/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/optional-eval-call/output.js
@@ -1,0 +1,17 @@
+var _eval, _eval2, _foo$eval, _eval$foo;
+
+var foo;
+/* indirect eval calls */
+
+eval === null || eval === void 0 ? void 0 : (0, eval)(foo);
+eval === null || eval === void 0 ? void 0 : (0, eval)(foo);
+eval === null || eval === void 0 ? void 0 : (0, eval)()();
+eval === null || eval === void 0 ? void 0 : (0, eval)().foo;
+/* direct eval calls */
+
+(_eval = eval()) === null || _eval === void 0 ? void 0 : _eval();
+(_eval2 = eval()) === null || _eval2 === void 0 ? void 0 : _eval2.foo;
+/* plain function calls */
+
+(_foo$eval = foo.eval) === null || _foo$eval === void 0 ? void 0 : _foo$eval.call(foo, foo);
+(_eval$foo = eval.foo) === null || _eval$foo === void 0 ? void 0 : _eval$foo.call(eval, foo);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/proposals/issues/67#issuecomment-661272067
| Patch: Bug Fix?          | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Transform `eval?.()` as `(0,eval)()` when `eval` is not nullish.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11850"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/239928ffc25f0f1a11ea521a0a722a15ea225d76.svg" /></a>

