### PR TITLE
Replace lodash 'isPlainObject' usage with is-plain-object library

### DIFF
--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -17,7 +17,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@babel/helper-validator-identifier": "^7.10.4",
-    "is-plain-object": "^3.0.1",
+    "is-plain-object": "^4.0.0",
     "lodash": "^4.17.19",
     "to-fast-properties": "^2.0.0"
   },

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -17,6 +17,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@babel/helper-validator-identifier": "^7.10.4",
+    "is-plain-object": "^3.0.1",
     "lodash": "^4.17.19",
     "to-fast-properties": "^2.0.0"
   },

--- a/packages/babel-types/src/converters/valueToNode.js
+++ b/packages/babel-types/src/converters/valueToNode.js
@@ -1,5 +1,5 @@
 // @flow
-import isPlainObject from "lodash/isPlainObject";
+import isPlainObject from "is-plain-object";
 import isRegExp from "lodash/isRegExp";
 import isValidIdentifier from "../validators/isValidIdentifier";
 import {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Any Dependency Changes?  | Yes
| License                  | MIT

As per feedback in https://github.com/babel/babel/pull/11789#issuecomment-658982855, this is another instance of a `lodash` function that can be replaced by a standalone library.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11855"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jayaddison/babel.git/39bae07d0b5fc146bc5ccb8b256946a55c17f054.svg" /></a>

