### PR TITLE
Add `numeric-separator` to `preset-env`

### DIFF
--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -1,15 +1,4 @@
 {
-  "proposal-numeric-separator": {
-    "chrome": "75",
-    "opera": "62",
-    "edge": "79",
-    "firefox": "70",
-    "safari": "13",
-    "node": "12.5",
-    "ios": "13",
-    "samsung": "11",
-    "electron": "6"
-  },
   "proposal-class-properties": {
     "chrome": "74",
     "opera": "61",
@@ -20,6 +9,17 @@
   },
   "proposal-private-methods": {
     "chrome": "84"
+  },
+  "proposal-numeric-separator": {
+    "chrome": "75",
+    "opera": "62",
+    "edge": "79",
+    "firefox": "70",
+    "safari": "13",
+    "node": "12.5",
+    "ios": "13",
+    "samsung": "11",
+    "electron": "6"
   },
   "proposal-nullish-coalescing-operator": {
     "chrome": "80",

--- a/packages/babel-compat-data/scripts/data/plugin-features.js
+++ b/packages/babel-compat-data/scripts/data/plugin-features.js
@@ -122,8 +122,11 @@ const es2020 = {
   "proposal-optional-chaining": "optional chaining operator (?.)",
 };
 
-const shippedProposal = {
+const es2021 = {
   "proposal-numeric-separator": "numeric separator",
+};
+
+const shippedProposal = {
   "proposal-class-properties": {
     features: [
       "static class fields",
@@ -139,6 +142,7 @@ const shippedProposal = {
 module.exports = Object.assign(
   {},
   shippedProposal,
+  es2021,
   es2020,
   es2019,
   es2015Parameter,

--- a/packages/babel-preset-env/data/shipped-proposals.js
+++ b/packages/babel-preset-env/data/shipped-proposals.js
@@ -4,7 +4,6 @@
 
 const proposalPlugins = new Set([
   "proposal-class-properties",
-  "proposal-numeric-separator",
   "proposal-private-methods"
 ]);
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"40" }
   proposal-nullish-coalescing-operator { "chrome":"40" }
   proposal-optional-chaining { "chrome":"40" }
   proposal-json-strings { "chrome":"40" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"70" }
   proposal-nullish-coalescing-operator { "chrome":"70" }
   proposal-optional-chaining { "chrome":"70" }
   syntax-json-strings { "chrome":"70" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "edge":"14" }
   proposal-nullish-coalescing-operator { "edge":"14" }
   proposal-optional-chaining { "edge":"14" }
   proposal-json-strings { "edge":"14" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "edge":"15" }
   proposal-nullish-coalescing-operator { "edge":"15" }
   proposal-optional-chaining { "edge":"15" }
   proposal-json-strings { "edge":"15" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "edge":"17" }
   proposal-nullish-coalescing-operator { "edge":"17" }
   proposal-optional-chaining { "edge":"17" }
   proposal-json-strings { "edge":"17" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "edge":"17" }
   proposal-nullish-coalescing-operator { "edge":"17" }
   proposal-optional-chaining { "edge":"17" }
   proposal-json-strings { "edge":"17" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "edge":"18" }
   proposal-nullish-coalescing-operator { "edge":"18" }
   proposal-optional-chaining { "edge":"18" }
   proposal-json-strings { "edge":"18" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "edge":"14" }
   proposal-nullish-coalescing-operator { "edge":"14" }
   proposal-optional-chaining { "edge":"14" }
   proposal-json-strings { "edge":"14" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "edge":"14" }
   proposal-nullish-coalescing-operator { "edge":"14" }
   proposal-optional-chaining { "edge":"14" }
   proposal-json-strings { "edge":"14" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "edge":"15" }
   proposal-nullish-coalescing-operator { "edge":"15" }
   proposal-optional-chaining { "edge":"15" }
   proposal-json-strings { "edge":"15" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "safari":"10" }
   proposal-nullish-coalescing-operator { "safari":"10" }
   proposal-optional-chaining { "safari":"10" }
   proposal-json-strings { "safari":"10" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "safari":"10" }
   proposal-nullish-coalescing-operator { "safari":"10" }
   proposal-optional-chaining { "safari":"10" }
   proposal-json-strings { "safari":"10" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "safari":"11" }
   proposal-nullish-coalescing-operator { "safari":"11" }
   proposal-optional-chaining { "safari":"11" }
   proposal-json-strings { "safari":"11" }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "safari":"9" }
   proposal-nullish-coalescing-operator { "safari":"9" }
   proposal-optional-chaining { "safari":"9" }
   proposal-json-strings { "safari":"9" }

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-numeric-separator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-numeric-separator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
   proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "ie":"11" }
   proposal-nullish-coalescing-operator { "ie":"11" }
   proposal-optional-chaining { "ie":"11" }
   proposal-json-strings { "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "android":"3" }
   proposal-nullish-coalescing-operator { "android":"3" }
   proposal-optional-chaining { "android":"3" }
   proposal-json-strings { "android":"3" }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -15,6 +15,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "edge":"18", "firefox":"68", "ios":"12.2", "samsung":"10.1" }
   proposal-nullish-coalescing-operator { "chrome":"79", "edge":"18", "firefox":"68", "ios":"12.2", "safari":"13", "samsung":"10.1" }
   proposal-optional-chaining { "chrome":"79", "edge":"18", "firefox":"68", "ios":"12.2", "safari":"13", "samsung":"10.1" }
   proposal-json-strings { "edge":"18" }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "edge":"18", "firefox":"68", "ie":"11", "ios":"12.2", "samsung":"10.1" }
   proposal-nullish-coalescing-operator { "chrome":"79", "edge":"18", "firefox":"68", "ie":"11", "ios":"12.2", "safari":"13", "samsung":"10.1" }
   proposal-optional-chaining { "chrome":"79", "edge":"18", "firefox":"68", "ie":"11", "ios":"12.2", "safari":"13", "samsung":"10.1" }
   proposal-json-strings { "edge":"18", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -15,6 +15,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "samsung":"10.1" }
   proposal-nullish-coalescing-operator { "ios":"13.3", "safari":"13", "samsung":"10.1" }
   proposal-optional-chaining { "ios":"13.3", "safari":"13", "samsung":"10.1" }
   syntax-json-strings { "android":"80", "chrome":"80", "edge":"80", "firefox":"75", "ios":"13.3", "opera":"67", "safari":"13", "samsung":"10.1" }

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "android":"4" }
   proposal-nullish-coalescing-operator { "android":"4" }
   proposal-optional-chaining { "android":"4" }
   proposal-json-strings { "android":"4" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -15,6 +15,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "electron":"0.36" }
   proposal-nullish-coalescing-operator { "electron":"0.36" }
   proposal-optional-chaining { "electron":"0.36" }
   proposal-json-strings { "electron":"0.36" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"55" }
   proposal-nullish-coalescing-operator { "chrome":"55" }
   proposal-optional-chaining { "chrome":"55" }
   proposal-json-strings { "chrome":"55" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "node":"6" }
   proposal-nullish-coalescing-operator { "node":"6" }
   proposal-optional-chaining { "node":"6" }
   proposal-json-strings { "node":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
@@ -6,6 +6,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
   proposal-class-properties { "chrome":"71" }
   proposal-private-methods { "chrome":"71" }
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
@@ -6,9 +6,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
   proposal-class-properties {}
   proposal-private-methods {}
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -13,6 +13,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-nullish-coalescing-operator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-optional-chaining { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -19,6 +19,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-nullish-coalescing-operator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-optional-chaining { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-json-strings { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6" }
   proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
   proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
   proposal-class-properties { "chrome":"71" }
   proposal-private-methods { "chrome":"71" }
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
@@ -6,9 +6,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
   proposal-class-properties {}
   proposal-private-methods {}
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "android":"4" }
   proposal-nullish-coalescing-operator { "android":"4" }
   proposal-optional-chaining { "android":"4" }
   proposal-json-strings { "android":"4" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
@@ -6,9 +6,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
   proposal-class-properties {}
   proposal-private-methods {}
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -15,6 +15,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "electron":"0.36" }
   proposal-nullish-coalescing-operator { "electron":"0.36" }
   proposal-optional-chaining { "electron":"0.36" }
   proposal-json-strings { "electron":"0.36" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
   proposal-class-properties { "chrome":"71" }
   proposal-private-methods { "chrome":"71" }
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
   proposal-class-properties { "chrome":"71" }
   proposal-private-methods { "chrome":"71" }
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
@@ -6,9 +6,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
   proposal-class-properties {}
   proposal-private-methods {}
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
@@ -6,9 +6,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
   proposal-class-properties {}
   proposal-private-methods {}
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"55" }
   proposal-nullish-coalescing-operator { "chrome":"55" }
   proposal-optional-chaining { "chrome":"55" }
   proposal-json-strings { "chrome":"55" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "node":"6" }
   proposal-nullish-coalescing-operator { "node":"6" }
   proposal-optional-chaining { "node":"6" }
   proposal-json-strings { "node":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
@@ -6,6 +6,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
   proposal-class-properties { "chrome":"71" }
   proposal-private-methods { "chrome":"71" }
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
   proposal-class-properties { "chrome":"71" }
   proposal-private-methods { "chrome":"71" }
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
   proposal-class-properties { "chrome":"71" }
   proposal-private-methods { "chrome":"71" }
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
@@ -6,9 +6,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
   proposal-class-properties {}
   proposal-private-methods {}
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
@@ -13,6 +13,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-nullish-coalescing-operator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-optional-chaining { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
   proposal-class-properties { "chrome":"71" }
   proposal-private-methods { "chrome":"71" }
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "samsung":"8.2" }
   proposal-class-properties { "samsung":"8.2" }
   proposal-private-methods { "samsung":"8.2" }
+  proposal-numeric-separator { "samsung":"8.2" }
   proposal-nullish-coalescing-operator { "samsung":"8.2" }
   proposal-optional-chaining { "samsung":"8.2" }
   proposal-json-strings { "samsung":"8.2" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
@@ -6,9 +6,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
   proposal-class-properties {}
   proposal-private-methods {}
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
   proposal-class-properties { "chrome":"71" }
   proposal-private-methods { "chrome":"71" }
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
@@ -6,9 +6,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
   proposal-class-properties {}
   proposal-private-methods {}
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -19,6 +19,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-nullish-coalescing-operator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-optional-chaining { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-json-strings { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
   proposal-class-properties { "chrome":"71" }
   proposal-private-methods { "chrome":"71" }
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
@@ -6,9 +6,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
   proposal-class-properties {}
   proposal-private-methods {}
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6" }
   proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
   proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "node":"6" }
   proposal-nullish-coalescing-operator { "node":"6" }
   proposal-optional-chaining { "node":"6" }
   proposal-json-strings { "node":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
@@ -6,9 +6,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
   proposal-class-properties {}
   proposal-private-methods {}
+  proposal-numeric-separator {}
   proposal-nullish-coalescing-operator {}
   proposal-optional-chaining {}
   proposal-json-strings {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
@@ -11,6 +11,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"55" }
   proposal-nullish-coalescing-operator { "chrome":"55" }
   proposal-optional-chaining { "chrome":"55" }
   proposal-json-strings { "chrome":"55" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6" }
   proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
   proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "firefox":"52", "node":"7.4" }
   proposal-nullish-coalescing-operator { "firefox":"52", "node":"7.4" }
   proposal-optional-chaining { "firefox":"52", "node":"7.4" }
   proposal-json-strings { "firefox":"52", "node":"7.4" }

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator { "chrome":"80" }
   proposal-class-properties { "chrome":"80" }
   proposal-private-methods { "chrome":"80" }
+  syntax-numeric-separator { "chrome":"80" }
   syntax-nullish-coalescing-operator { "chrome":"80" }
   syntax-optional-chaining { "chrome":"80" }
   syntax-json-strings { "chrome":"80" }

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
@@ -8,8 +8,8 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator { "chrome":"84" }
   syntax-class-properties { "chrome":"84" }
+  syntax-numeric-separator { "chrome":"84" }
   syntax-nullish-coalescing-operator { "chrome":"84" }
   syntax-optional-chaining { "chrome":"84" }
   syntax-json-strings { "chrome":"84" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
@@ -10,9 +10,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
@@ -10,9 +10,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"55" }
   proposal-nullish-coalescing-operator { "chrome":"55" }
   proposal-optional-chaining { "chrome":"55" }
   proposal-json-strings { "chrome":"55" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"71" }
   proposal-nullish-coalescing-operator { "chrome":"71" }
   proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
@@ -10,9 +10,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
@@ -10,9 +10,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"55" }
   proposal-nullish-coalescing-operator { "chrome":"55" }
   proposal-optional-chaining { "chrome":"55" }
   proposal-json-strings { "chrome":"55" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-numeric-separator { "safari":"10" }
   proposal-nullish-coalescing-operator { "safari":"10" }
   proposal-optional-chaining { "safari":"10" }
   proposal-json-strings { "safari":"10" }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`numeric-separator` was added to `preset-env` in #10971 but behind `shippedProposals` flag. This PR moves the proposal to `es2021` feature sets.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11865"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/e3b41da4506a1fb6a6325a5525e144eb244b6205.svg" /></a>

