### PR TITLE
Fix incorrect module path when absoluteRuntime is specified

### DIFF
--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -35,6 +35,7 @@
     "@babel/plugin-transform-typeof-symbol": "^7.10.4",
     "@babel/preset-env": "^7.10.4",
     "@babel/runtime": "^7.10.5",
+    "@babel/runtime-corejs3": "^7.10.5",
     "@babel/template": "^7.10.4",
     "@babel/types": "^7.10.5"
   }

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -310,7 +310,7 @@ export default declare((api, options, dirname) => {
             node.callee = t.memberExpression(
               t.callExpression(
                 this.addDefaultImport(
-                  `${moduleName}/${corejsRoot}/instance/${InstanceProperties[propertyName].path}`,
+                  `${modulePath}/${corejsRoot}/instance/${InstanceProperties[propertyName].path}`,
                   `${propertyName}InstanceProperty`,
                 ),
                 [context2],
@@ -379,7 +379,7 @@ export default declare((api, options, dirname) => {
             path.replaceWith(
               t.callExpression(
                 this.addDefaultImport(
-                  `${moduleName}/core-js/get-iterator-method`,
+                  `${modulePath}/core-js/get-iterator-method`,
                   "getIteratorMethod",
                 ),
                 [object],
@@ -407,7 +407,7 @@ export default declare((api, options, dirname) => {
               path.replaceWith(
                 t.callExpression(
                   this.addDefaultImport(
-                    `${moduleName}/${corejsRoot}/instance/${InstanceProperties[propertyName].path}`,
+                    `${modulePath}/${corejsRoot}/instance/${InstanceProperties[propertyName].path}`,
                     `${propertyName}InstanceProperty`,
                   ),
                   [object],

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/input.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/input.js
@@ -1,0 +1,8 @@
+Array.map;
+function* makeIterator() {
+	yield 1;
+	yield 2;
+}
+for (const itItem of makeIterator()) {
+	console.log(itItem);
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/options.json
@@ -1,6 +1,7 @@
 {
   "presets": ["env"],
   "plugins": [
-    ["transform-runtime", { "absoluteRuntime": true, "corejs": { "version": 3, "proposals": true } }]
+    ["transform-runtime", { "absoluteRuntime": true, "corejs": { "version": 3, "proposals": true } }],
+    ["external-helpers", { "helperVersion": "7.100.0" }]
   ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/options.json
@@ -1,0 +1,6 @@
+{
+  "presets": ["env"],
+  "plugins": [
+    ["transform-runtime", { "absoluteRuntime": true, "corejs": { "version": 3, "proposals": true } }]
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/output.js
@@ -1,6 +1,6 @@
-var _regeneratorRuntime = require("<CWD>/node_modules/@babel/runtime-corejs3/regenerator");
+var _regeneratorRuntime = require("<CWD>/packages/babel-plugin-transform-runtime/node_modules/@babel/runtime-corejs3/regenerator");
 
-var _mapInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/instance/map");
+var _mapInstanceProperty = require("<CWD>/packages/babel-plugin-transform-runtime/node_modules/@babel/runtime-corejs3/core-js/instance/map");
 
 var _marked = /*#__PURE__*/_regeneratorRuntime.mark(makeIterator);
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/output.js
@@ -1,24 +1,6 @@
-var _getIterator = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/get-iterator");
-
-var _Array$isArray = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/array/is-array");
-
-var _getIteratorMethod = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/get-iterator-method");
-
-var _Symbol = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/symbol");
-
-var _Array$from = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/array/from");
-
-var _sliceInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/instance/slice");
-
 var _regeneratorRuntime = require("<CWD>/node_modules/@babel/runtime-corejs3/regenerator");
 
 var _mapInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/instance/map");
-
-function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof _Symbol === "undefined" || _getIteratorMethod(o) == null) { if (_Array$isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = _getIterator(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
-
-function _unsupportedIterableToArray(o, minLen) { var _context2; if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = _sliceInstanceProperty(_context2 = Object.prototype.toString.call(o)).call(_context2, 8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return _Array$from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
 var _marked = /*#__PURE__*/_regeneratorRuntime.mark(makeIterator);
 
@@ -44,7 +26,7 @@ function makeIterator() {
   }, _marked);
 }
 
-var _iterator = _createForOfIteratorHelper(makeIterator()),
+var _iterator = babelHelpers.createForOfIteratorHelper(makeIterator()),
     _step;
 
 try {

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/output.js
@@ -1,0 +1,59 @@
+var _getIterator = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/get-iterator");
+
+var _Array$isArray = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/array/is-array");
+
+var _getIteratorMethod = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/get-iterator-method");
+
+var _Symbol = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/symbol");
+
+var _Array$from = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/array/from");
+
+var _sliceInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/instance/slice");
+
+var _regeneratorRuntime = require("<CWD>/node_modules/@babel/runtime-corejs3/regenerator");
+
+var _mapInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/instance/map");
+
+function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof _Symbol === "undefined" || _getIteratorMethod(o) == null) { if (_Array$isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = _getIterator(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
+
+function _unsupportedIterableToArray(o, minLen) { var _context2; if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = _sliceInstanceProperty(_context2 = Object.prototype.toString.call(o)).call(_context2, 8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return _Array$from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+var _marked = /*#__PURE__*/_regeneratorRuntime.mark(makeIterator);
+
+_mapInstanceProperty(Array);
+
+function makeIterator() {
+  return _regeneratorRuntime.wrap(function makeIterator$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+          _context.next = 2;
+          return 1;
+
+        case 2:
+          _context.next = 4;
+          return 2;
+
+        case 4:
+        case "end":
+          return _context.stop();
+      }
+    }
+  }, _marked);
+}
+
+var _iterator = _createForOfIteratorHelper(makeIterator()),
+    _step;
+
+try {
+  for (_iterator.s(); !(_step = _iterator.n()).done;) {
+    var itItem = _step.value;
+    console.log(itItem);
+  }
+} catch (err) {
+  _iterator.e(err);
+} finally {
+  _iterator.f();
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/input.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/input.js
@@ -1,0 +1,8 @@
+Array.map;
+function* makeIterator() {
+	yield 1;
+	yield 2;
+}
+for (const itItem of makeIterator()) {
+	console.log(itItem);
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/options.json
@@ -1,6 +1,7 @@
 {
   "presets": ["env"],
   "plugins": [
-    ["transform-runtime", { "absoluteRuntime": true, "corejs": { "version": 3, "proposals": false } }]
+    ["transform-runtime", { "absoluteRuntime": true, "corejs": { "version": 3, "proposals": false } }],
+    ["external-helpers", { "helperVersion": "7.100.0" }]
   ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/options.json
@@ -1,0 +1,6 @@
+{
+  "presets": ["env"],
+  "plugins": [
+    ["transform-runtime", { "absoluteRuntime": true, "corejs": { "version": 3, "proposals": false } }]
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/output.js
@@ -1,24 +1,6 @@
-var _getIterator = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/get-iterator");
-
-var _Array$isArray = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/array/is-array");
-
-var _getIteratorMethod = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/get-iterator-method");
-
-var _Symbol = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/symbol");
-
-var _Array$from = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/array/from");
-
-var _sliceInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/instance/slice");
-
 var _regeneratorRuntime = require("<CWD>/node_modules/@babel/runtime-corejs3/regenerator");
 
 var _mapInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/instance/map");
-
-function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof _Symbol === "undefined" || _getIteratorMethod(o) == null) { if (_Array$isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = _getIterator(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
-
-function _unsupportedIterableToArray(o, minLen) { var _context2; if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = _sliceInstanceProperty(_context2 = Object.prototype.toString.call(o)).call(_context2, 8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return _Array$from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
 var _marked = /*#__PURE__*/_regeneratorRuntime.mark(makeIterator);
 
@@ -44,7 +26,7 @@ function makeIterator() {
   }, _marked);
 }
 
-var _iterator = _createForOfIteratorHelper(makeIterator()),
+var _iterator = babelHelpers.createForOfIteratorHelper(makeIterator()),
     _step;
 
 try {

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/output.js
@@ -1,6 +1,6 @@
-var _regeneratorRuntime = require("<CWD>/node_modules/@babel/runtime-corejs3/regenerator");
+var _regeneratorRuntime = require("<CWD>/packages/babel-plugin-transform-runtime/node_modules/@babel/runtime-corejs3/regenerator");
 
-var _mapInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/instance/map");
+var _mapInstanceProperty = require("<CWD>/packages/babel-plugin-transform-runtime/node_modules/@babel/runtime-corejs3/core-js-stable/instance/map");
 
 var _marked = /*#__PURE__*/_regeneratorRuntime.mark(makeIterator);
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/output.js
@@ -1,0 +1,59 @@
+var _getIterator = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/get-iterator");
+
+var _Array$isArray = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/array/is-array");
+
+var _getIteratorMethod = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/get-iterator-method");
+
+var _Symbol = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/symbol");
+
+var _Array$from = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/array/from");
+
+var _sliceInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/instance/slice");
+
+var _regeneratorRuntime = require("<CWD>/node_modules/@babel/runtime-corejs3/regenerator");
+
+var _mapInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/instance/map");
+
+function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof _Symbol === "undefined" || _getIteratorMethod(o) == null) { if (_Array$isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = _getIterator(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
+
+function _unsupportedIterableToArray(o, minLen) { var _context2; if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = _sliceInstanceProperty(_context2 = Object.prototype.toString.call(o)).call(_context2, 8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return _Array$from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+var _marked = /*#__PURE__*/_regeneratorRuntime.mark(makeIterator);
+
+_mapInstanceProperty(Array);
+
+function makeIterator() {
+  return _regeneratorRuntime.wrap(function makeIterator$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+          _context.next = 2;
+          return 1;
+
+        case 2:
+          _context.next = 4;
+          return 2;
+
+        case 4:
+        case "end":
+          return _context.stop();
+      }
+    }
+  }, _marked);
+}
+
+var _iterator = _createForOfIteratorHelper(makeIterator()),
+    _step;
+
+try {
+  for (_iterator.s(); !(_step = _iterator.n()).done;) {
+    var itItem = _step.value;
+    console.log(itItem);
+  }
+} catch (err) {
+  _iterator.e(err);
+} finally {
+  _iterator.f();
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11885 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Changed `moduleName` to `modulePath` in `packages/plugin-transform-runtime/src/index.js`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11893"><img src="https://gitpod.io/api/apps/github/pbs/github.com/sz-coder/babel.git/433c55d3752257816bd078b01f78246dd476a3d6.svg" /></a>

