### PR TITLE
Prepare to publish `@babel/eslint-*` packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,11 +249,6 @@ endif
 	$(YARN) lerna publish from-git --registry http://localhost:4873 --yes --tag-version-prefix="version-e2e-test-"
 	$(MAKE) clean
 
-publish-eslint:
-	$(call set-json-field, ./eslint/$(PKG)/package.json, private, false)
-	cd eslint/$(PKG); yarn publish
-	$(call set-json-field, ./eslint/$(PKG)/package.json, private, true)
-
 bootstrap-only: lerna-bootstrap
 
 yarn-install: clean-all
@@ -311,11 +306,4 @@ define clean-source-all
 	rm -rf $(1)/*/node_modules
 	rm -rf $(1)/*/package-lock.json
 
-endef
-
-define set-json-field
-	$(NODE) -e "\
-		require('fs').writeFileSync('$1'.trim(), \
-			JSON.stringify({ ...require('$1'.trim()), $2: $3 }, null, 2) + '\\n' \
-		)"
 endef

--- a/eslint/babel-eslint-config-internal/package.json
+++ b/eslint/babel-eslint-config-internal/package.json
@@ -10,7 +10,12 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "eslint/babel-eslint-config-internal"
   },
-  "main": "index.js",
+  "main": "./index.js",
+  "type": "commonjs",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
   "peerDependencies": {
     "@babel/eslint-parser": "^7.10.4",
     "eslint-plugin-flowtype": "^3.0.0"

--- a/eslint/babel-eslint-config-internal/package.json
+++ b/eslint/babel-eslint-config-internal/package.json
@@ -2,7 +2,7 @@
   "name": "@babel/eslint-config-internal",
   "version": "7.10.4",
   "description": "The Babel Team's ESLint configuration. Since it's internal, it might not respect semver.",
-  "author": "Sebastian McKenzie <sebmck@gmail.com>",
+  "author": "The Babel Team (https://babeljs.io/team)",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "private": true,

--- a/eslint/babel-eslint-config-internal/package.json
+++ b/eslint/babel-eslint-config-internal/package.json
@@ -5,7 +5,6 @@
   "author": "The Babel Team (https://babeljs.io/team)",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/babel/babel.git",

--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -2,9 +2,8 @@
   "name": "@babel/eslint-parser",
   "version": "7.10.4",
   "description": "ESLint parser that allows for linting of experimental syntax transformed by Babel",
-  "author": "Sebastian McKenzie <sebmck@gmail.com>",
+  "author": "The Babel Team (https://babeljs.io/team)",
   "license": "MIT",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/babel/babel.git",
@@ -15,11 +14,11 @@
   },
   "homepage": "https://babeljs.io/",
   "engines": {
-    "node": ">=10.9"
+    "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
   },
   "main": "lib/index.js",
   "peerDependencies": {
-    "@babel/core": ">=7.10.4",
+    "@babel/core": ">=7.11.0",
     "eslint": ">=7.5.0"
   },
   "dependencies": {

--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -16,7 +16,12 @@
   "engines": {
     "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
   },
-  "main": "lib/index.js",
+  "main": "./lib/index.js",
+  "type": "commonjs",
+  "exports": {
+    ".": "./lib/index.js",
+    "./package.json": "./package.json"
+  },
   "peerDependencies": {
     "@babel/core": ">=7.11.0",
     "eslint": ">=7.5.0"

--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -23,7 +23,7 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "@babel/core": ">=7.11.0",
+    "@babel/core": ">=7.10.0",
     "eslint": ">=7.5.0"
   },
   "dependencies": {

--- a/eslint/babel-eslint-plugin-development-internal/package.json
+++ b/eslint/babel-eslint-plugin-development-internal/package.json
@@ -18,15 +18,12 @@
   "author": "Kai Cataldo <kai@kaicataldo.com>",
   "license": "MIT",
   "private": true,
-  "engines": {
-    "node": ">=10.9"
-  },
   "bugs": {
     "url": "https://github.com/babel/babel/issues"
   },
   "homepage": "https://github.com/babel/babel/tree/master/eslint/babel-eslint-plugin-development-internal",
   "peerDependencies": {
-    "@babel/eslint-parser": ">=7.10.4",
+    "@babel/eslint-parser": ">=7.11.0",
     "eslint": ">=7.5.0"
   },
   "devDependencies": {

--- a/eslint/babel-eslint-plugin-development/package.json
+++ b/eslint/babel-eslint-plugin-development/package.json
@@ -12,7 +12,12 @@
     "email": "nicolo.ribaudo@gmail.com",
     "url": "https://github.com/nicolo-ribaudo"
   },
-  "main": "lib/index.js",
+  "main": "./lib/index.js",
+  "type": "commonjs",
+  "exports": {
+    ".": "./lib/index.js",
+    "./package.json": "./package.json"
+  },
   "engines": {
     "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
   },

--- a/eslint/babel-eslint-plugin-development/package.json
+++ b/eslint/babel-eslint-plugin-development/package.json
@@ -2,7 +2,6 @@
   "name": "@babel/eslint-plugin-development",
   "version": "7.10.4",
   "description": "ESLint rules that enforce best practices in the development of Babel plugins.",
-  "private": true,
   "keywords": [
     "eslint",
     "eslintplugin",
@@ -15,7 +14,7 @@
   },
   "main": "lib/index.js",
   "engines": {
-    "node": ">=10.9"
+    "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/eslint/babel-eslint-plugin/package.json
+++ b/eslint/babel-eslint-plugin/package.json
@@ -17,16 +17,15 @@
   ],
   "author": "Jason Quense @monasticpanic",
   "license": "MIT",
-  "private": true,
   "engines": {
-    "node": ">=10.9"
+    "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
   },
   "bugs": {
     "url": "https://github.com/babel/babel/issues"
   },
   "homepage": "https://babeljs.io/",
   "peerDependencies": {
-    "@babel/eslint-parser": ">=7.10.4",
+    "@babel/eslint-parser": ">=7.11.0",
     "eslint": ">=7.5.0"
   },
   "dependencies": {

--- a/eslint/babel-eslint-plugin/package.json
+++ b/eslint/babel-eslint-plugin/package.json
@@ -2,7 +2,12 @@
   "name": "@babel/eslint-plugin",
   "version": "7.10.4",
   "description": "Companion rules for @babel/eslint-parser",
-  "main": "lib/index.js",
+  "main": "./lib/index.js",
+  "type": "commonjs",
+  "exports": {
+    ".": "./lib/index.js",
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/babel/babel.git",

--- a/lerna.json
+++ b/lerna.json
@@ -24,9 +24,7 @@
         "**/test/**",
         "codemods/**",
         "# We ignore every JSON file, except for native-modules, built-ins and plugins defined in babel-preset-env/data.",
-        "@(!(native-modules|built-ins|plugins|package)).json",
-        "# Until the ESLint packages version are aligned with Babel's, we ignore them",
-        "eslint/**"
+        "@(!(native-modules|built-ins|plugins|package)).json"
       ]
     }
   },

--- a/scripts/integration-tests/publish-local.sh
+++ b/scripts/integration-tests/publish-local.sh
@@ -11,13 +11,6 @@ source utils/local-registry.sh
 source utils/git.sh
 source utils/cleanup.sh
 
-function publishESLintPkg {
-  cd eslint/$1
-  yarn version --new-version $2 --no-git-tag-version
-  cd ../..
-  make -j publish-eslint PKG=$1
-}
-
 # Echo every command being executed
 set -x
 
@@ -42,10 +35,5 @@ VERSION=$(
 )
 
 I_AM_USING_VERDACCIO=I_AM_SURE VERSION="$VERSION" make publish-test
-
-publishESLintPkg babel-eslint-config-internal "$VERSION"
-publishESLintPkg babel-eslint-parser "$VERSION"
-publishESLintPkg babel-eslint-plugin "$VERSION"
-publishESLintPkg babel-eslint-plugin-development "$VERSION"
 
 cleanup


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed issue | Closes #10709, resolves https://github.com/babel/babel-eslint/issues/787
| Any Dependency Changes?  | Bump `node` requirements of `@babel/eslint-*` packages.
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR includes preparations need to publish `@babel/eslint-*` packages. It includes commits in #11857, I will rebase once that PR gets merged.

Some noticeable changes compared to #11857:

- Require `node` to be `^10.13.0 || ^12.13.0 || >=14.0.0`. It covers only supported node versions as of July 2020
- Disable submodule exports
- Require `babel` to be `>=7.11.0` since it is the Babel version that these packages are tested against

Note that `@babel/eslint-shared-fixtures` and `@babel/eslint-tests` are still private packages. I can not think of any use case of them and they looks to me more like a side-effect of sharing internal utils across different packages in a monorepo.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11894"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/b708c4369ce6c9c7e743ec2208ad22fb947140dd.svg" /></a>

