### PR TITLE
update: hardcode @babel/eslint-parser min supported version check

### DIFF
--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -23,7 +23,7 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "@babel/core": ">=7.10.0",
+    "@babel/core": ">=7.11.0",
     "eslint": ">=7.5.0"
   },
   "dependencies": {

--- a/eslint/babel-eslint-parser/src/index.js
+++ b/eslint/babel-eslint-parser/src/index.js
@@ -15,7 +15,8 @@ import visitorKeys from "./visitor-keys";
 let isRunningMinSupportedCoreVersion = null;
 
 function baseParse(code, options) {
-  const minSupportedCoreVersion = ">=7.0.0";
+  // Ensure we're using a version of `@babel/core` that includes `parse()` and `tokTypes`.
+  const minSupportedCoreVersion = ">=7.2.0";
 
   if (typeof isRunningMinSupportedCoreVersion !== "boolean") {
     isRunningMinSupportedCoreVersion = semver.satisfies(
@@ -24,7 +25,6 @@ function baseParse(code, options) {
     );
   }
 
-  // Ensure we're using a version of `@babel/core` that includes the `parse()` API.
   if (!isRunningMinSupportedCoreVersion) {
     throw new Error(
       `@babel/eslint-parser@${packageJson.version} does not support @babel/core@${babelCoreVersion}. Please upgrade to @babel/core@${minSupportedCoreVersion}`,

--- a/eslint/babel-eslint-parser/src/index.js
+++ b/eslint/babel-eslint-parser/src/index.js
@@ -27,7 +27,7 @@ function baseParse(code, options) {
 
   if (!isRunningMinSupportedCoreVersion) {
     throw new Error(
-      `@babel/eslint-parser@${packageJson.version} does not support @babel/core@${babelCoreVersion}. Please upgrade to @babel/core@${minSupportedCoreVersion}`,
+      `@babel/eslint-parser@${packageJson.version} does not support @babel/core@${babelCoreVersion}. Please upgrade to @babel/core@${minSupportedCoreVersion}.`,
     );
   }
 

--- a/eslint/babel-eslint-parser/src/index.js
+++ b/eslint/babel-eslint-parser/src/index.js
@@ -12,19 +12,22 @@ import convert from "./convert";
 import analyzeScope from "./analyze-scope";
 import visitorKeys from "./visitor-keys";
 
-let isRunningSupportedVersion;
+let isRunningMinSupportedCoreVersion = null;
 
 function baseParse(code, options) {
-  if (typeof isRunningSupportedVersion !== "boolean") {
-    isRunningSupportedVersion = semver.satisfies(
+  const minSupportedCoreVersion = ">=7.0.0";
+
+  if (typeof isRunningMinSupportedCoreVersion !== "boolean") {
+    isRunningMinSupportedCoreVersion = semver.satisfies(
       babelCoreVersion,
-      packageJson.peerDependencies["@babel/core"],
+      minSupportedCoreVersion,
     );
   }
 
-  if (!isRunningSupportedVersion) {
+  // Ensure we're using a version of `@babel/core` that includes the `parse()` API.
+  if (!isRunningMinSupportedCoreVersion) {
     throw new Error(
-      `@babel/eslint-parser@${packageJson.version} does not support @babel/core@${babelCoreVersion}. Please upgrade to @babel/core@${packageJson.peerDependencies["@babel/core"]}`,
+      `@babel/eslint-parser@${packageJson.version} does not support @babel/core@${babelCoreVersion}. Please upgrade to @babel/core@${minSupportedCoreVersion}`,
     );
   }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The original intent of this was to ensure that we're using a version of `@babel/core` that has the `parse()` API. The current implementation leads to peer dependency changes causing breaking changes.

Ideally, we'd like users to use the same version of `@babel/core` and `@babel/eslint-parser` to ensure compatibility, but we can figure out if we want to do anything about that (logging a message, etc.) later.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11896"><img src="https://gitpod.io/api/apps/github/pbs/github.com/kaicataldo/babel.git/7d5e539ae84c479d2bd89cbcb8e971af57cef058.svg" /></a>

