### PR TITLE
fix: ensure `[…map.keys]` can be correctly transformed in loose mode

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -518,7 +518,7 @@ class BlockScoping {
     // remap loop heads with colliding variables
     if (this.loop) {
       // nb: clone outsideRefs keys since the map is modified within the loop
-      for (const name of [...outsideRefs.keys()]) {
+      for (const name of Array.from(outsideRefs.keys())) {
         const id = outsideRefs.get(name);
 
         if (

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -210,6 +210,13 @@
           }),
         ).not.toThrow();
       });
+      it("#11897 - [...map.keys()] in Babel source should be transformed correctly", () => {
+        expect(() =>
+          Babel.transform("for (let el of []) { s => el }", {
+            plugins: ["transform-block-scoping"],
+          }),
+        ).not.toThrow();
+      });
     });
   },
 );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11897 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes a regression introduced in #11798. It is indeed an interesting bug: Babel does not transform `[...map.keys()]` correctly in the loose mode and thus it caused semantic change for `@babel/standalone`.

```js
[...outsideRef.keys()]
```
is transformed to
```
[].concat(outsideRef.keys())
```
which is an `MapIterator[]` instead of `string[]`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11901"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/8e48572bd41554f9c7123928349c9a0a2b68f233.svg" /></a>

