### PR TITLE
Do not cache non-existent config files forever

### DIFF
--- a/packages/babel-core/src/config/files/utils.js
+++ b/packages/babel-core/src/config/files/utils.js
@@ -16,7 +16,6 @@ export function makeStaticFileCache<T>(
     const cached = cache.invalidate(() => fileMtime(filepath));
 
     if (cached === null) {
-      cache.forever();
       return null;
     }
 


### PR DESCRIPTION
We use `babelCore.loadPartialConfig` in Parcel and noticed that after creating a `.babelrc` in a directory where non previously existed, this config was not picked up without restarting the process. This was due to Babel caching the fact that the file did not exist indefinitely. This is not a safe assumption, as the user can create a config file without restarting the process. Always checking the mtime should do the trick.

Happy to add a test if someone can point me to a good place to do it. 😄 

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      |
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11906"><img src="https://gitpod.io/api/apps/github/pbs/github.com/devongovett/babel.git/62d71a7d6996c97dcad49ba0567f7420169dc7c0.svg" /></a>

