### PR TITLE
Return a list of files that were read from loadPartialConfig

### DIFF
--- a/packages/babel-core/src/config/full.js
+++ b/packages/babel-core/src/config/full.js
@@ -63,7 +63,11 @@ export default gensync<[any], ResolvedConfig | null>(function* loadFullConfig(
   if (!result) {
     return null;
   }
-  const { options, context } = result;
+  const { options, context, isIgnored } = result;
+
+  if (isIgnored) {
+    return null;
+  }
 
   const optionDefaults = {};
   const passes: Array<Array<Plugin>> = [[]];

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -1222,6 +1222,63 @@ describe("buildConfigChain", function () {
           loadOptionsAsync({ filename, cwd: path.dirname(filename) }),
         ).rejects.toThrow(error);
       });
+
+      it("loadPartialConfig should return a list of files that were extended", () => {
+        const filename = fixture("config-files", "babelrc-extended", "src.js");
+
+        expect(
+          babel.loadPartialConfig({ filename, cwd: path.dirname(filename) }),
+        ).toEqual({
+          babelignore: fixture("config-files", ".babelignore"),
+          babelrc: fixture("config-files", "babelrc-extended", ".babelrc"),
+          config: undefined,
+          isIgnored: false,
+          options: {
+            ...getDefaults(),
+            filename: filename,
+            cwd: path.dirname(filename),
+            root: path.dirname(filename),
+            comments: true,
+          },
+          files: [
+            fixture("config-files", ".babelignore"),
+            fixture("config-files", "babelrc-extended", ".babelrc-extended"),
+            fixture("config-files", "babelrc-extended", ".babelrc"),
+          ],
+        });
+      });
+
+      it("loadPartialConfig should return null when ignored", () => {
+        const filename = fixture("config-files", "babelignore", "src.js");
+
+        expect(
+          babel.loadPartialConfig({ filename, cwd: path.dirname(filename) }),
+        ).toBeNull();
+      });
+
+      it("loadPartialConfig should return a list of files when ignored with showIgnoredFiles option", () => {
+        const filename = fixture("config-files", "babelignore", "src.js");
+
+        expect(
+          babel.loadPartialConfig({
+            filename,
+            cwd: path.dirname(filename),
+            showIgnoredFiles: true,
+          }),
+        ).toEqual({
+          babelignore: fixture("config-files", "babelignore", ".babelignore"),
+          babelrc: undefined,
+          config: undefined,
+          isIgnored: true,
+          options: {
+            ...getDefaults(),
+            filename: filename,
+            cwd: path.dirname(filename),
+            root: path.dirname(filename),
+          },
+          files: [fixture("config-files", "babelignore", ".babelignore")],
+        });
+      });
     });
 
     it("should throw when `test` presents but `filename` is not passed", () => {

--- a/packages/babel-core/test/fixtures/config/config-files/babelrc-extended/.babelrc
+++ b/packages/babel-core/test/fixtures/config/config-files/babelrc-extended/.babelrc
@@ -1,0 +1,3 @@
+{
+  "extends": "./.babelrc-extended"
+}

--- a/packages/babel-core/test/fixtures/config/config-files/babelrc-extended/.babelrc-extended
+++ b/packages/babel-core/test/fixtures/config/config-files/babelrc-extended/.babelrc-extended
@@ -1,0 +1,3 @@
+{
+  "comments": true
+}


### PR DESCRIPTION
This adds a `files` list to the return value of `babelCore.loadPartialConfig` which lists all files that were read in the process of loading the config. Some of these are currently returned in the `babelrc`, `babelignore`, and `configFile` fields, but other files such as those that were extended from another config are not returned, making it difficult for other tools that consume babel (e.g. Parcel, webpack) to properly watch these extended configs and invalidate caches. The `files` key should solve this as it includes all files that influenced the config, not just the top-level ones.

In addition, I've added a `showIgnoredFiles` option to `loadPartialConfig` which always returns a `PartialConfig` result even when the file is ignored, rather than returning `null`. This allows tools to properly invalidate caches when whatever config file that marked the compiled file as ignored changes. An `isIgnored` boolean is returned as part of the `PartialConfig` result to indicate that the file is ignored. Given that changing the `null` result to return a value would be a breaking change, this is behind an option. Open to better name suggestions though! 😉 

This is really important for us in Parcel so that we can get proper caching working with Babel. At the moment there's really no good way to do that without support from Babel itself, or reinventing all of its config loading. This should also help other tools like babel-loader - found a [todo comment](https://github.com/babel/babel-loader/blob/13a82386473986517a6e9dcfb1a7b75b47379d64/src/index.js#L209-L213) for it. 😄 

Totally open to alternative suggestions. Really made this to get the conversation started.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
