### PR TITLE
Use fastest-levenshtein instead of levenary

### DIFF
--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -23,8 +23,8 @@
   "dependencies": {
     "@babel/compat-data": "^7.10.4",
     "browserslist": "^4.12.0",
+    "fastest-levenshtein": "^1.0.10",
     "invariant": "^2.2.4",
-    "levenary": "^1.1.1",
     "semver": "^5.5.0"
   },
   "peerDependencies": {

--- a/packages/babel-helper-compilation-targets/src/index.js
+++ b/packages/babel-helper-compilation-targets/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import browserslist from "browserslist";
-import findSuggestion from "levenary";
+import { closest as findSuggestion } from "fastest-levenshtein";
 import invariant from "invariant";
 import browserModulesData from "@babel/compat-data/native-modules";
 

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -80,8 +80,8 @@
     "@babel/types": "^7.11.0",
     "browserslist": "^4.12.0",
     "core-js-compat": "^3.6.2",
+    "fastest-levenshtein": "^1.0.10",
     "invariant": "^2.2.2",
-    "levenary": "^1.1.1",
     "semver": "^5.5.0"
   },
   "peerDependencies": {

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -1,6 +1,6 @@
 // @flow
 import corejs3Polyfills from "core-js-compat/data";
-import findSuggestion from "levenary";
+import { closest as findSuggestion } from "fastest-levenshtein";
 import invariant from "invariant";
 import { coerce, SemVer } from "semver";
 import corejs2Polyfills from "@babel/compat-data/corejs2-built-ins";


### PR DESCRIPTION
`levenary` is incredibly slow. `fastest-levenshtein` should be used instead since it is much faster (up to 10x faster) and it has no dependencies - unlike `levenary`. 

### Benchmarks
                      50 words, length max=15 min=5 avr=8.4
         181,539 op/s » fastest-levenshtein
          55,712 op/s » levenary
                      20 sentences, length max=106 min=30 avr=64.4
          26,641 op/s » fastest-levenshtein
           3,356 op/s » levenary

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11911"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ka-weihe/babel.git/b1f9a8343ddc3cce2473e6f84a8120890a7e739c.svg" /></a>

