### PR TITLE
rescan gt/lt token after TsAsExpression is parsed

### DIFF
--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -2135,6 +2135,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         (code === charCodes.greaterThan || code === charCodes.lessThan)
       ) {
         return this.finishOp(tt.relational, 1);
+      } else if (this.state.inType && code === charCodes.questionMark) {
+        // allow double nullable types in Flow: ??string
+        return this.finishOp(tt.question, 1);
       } else if (isIteratorStart(code, next)) {
         this.state.isIterator = true;
         return super.readWord();

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1884,6 +1884,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           node.typeAnnotation = this.tsNextThenParseType();
         }
         this.finishNode(node, "TSAsExpression");
+        // rescan `<`, `>` because they were scanned when this.state.inType was true
+        this.reScan_lt_gt();
         return this.parseExprOp(
           node,
           leftStartPos,
@@ -2635,6 +2637,17 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return this.finishOp(tt.relational, 1);
       } else {
         return super.getTokenFromCode(code);
+      }
+    }
+
+    // used after we have finished parsing types
+    reScan_lt_gt() {
+      if (this.match(tt.relational)) {
+        const code = this.input.charCodeAt(this.state.start);
+        if (code === charCodes.lessThan || code === charCodes.greaterThan) {
+          this.state.pos -= 1;
+          this.readToken_lt_gt(code);
+        }
       }
     }
 

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2628,7 +2628,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     // ensure that inside types, we bypass the jsx parser plugin
     getTokenFromCode(code: number): void {
-      if (this.state.inType && (code === 62 || code === 60)) {
+      if (
+        this.state.inType &&
+        (code === charCodes.greaterThan || code === charCodes.lessThan)
+      ) {
         return this.finishOp(tt.relational, 1);
       } else {
         return super.getTokenFromCode(code);

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -693,7 +693,7 @@ export default class Tokenizer extends ParserErrors {
     // '?'
     const next = this.input.charCodeAt(this.state.pos + 1);
     const next2 = this.input.charCodeAt(this.state.pos + 2);
-    if (next === charCodes.questionMark && !this.state.inType) {
+    if (next === charCodes.questionMark) {
       if (next2 === charCodes.equalsTo) {
         // '??='
         this.finishOp(tt.assign, 3);

--- a/packages/babel-parser/test/fixtures/typescript/cast/as/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/cast/as/input.ts
@@ -1,4 +1,6 @@
 x as T;
 x < y as boolean; // (x < y) as boolean;
+x as boolean <= y; // (x as boolean) <= y;
 x === 1 as number; // x === (1 as number);
 x as any as T;
+x as boolean ?? y; // (x as boolean) ?? y;

--- a/packages/babel-parser/test/fixtures/typescript/cast/as/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/cast/as/output.json
@@ -1,9 +1,9 @@
 {
   "type": "File",
-  "start":0,"end":106,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":14}},
+  "start":0,"end":192,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":42}},
   "program": {
     "type": "Program",
-    "start":0,"end":106,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":14}},
+    "start":0,"end":192,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":42}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
@@ -70,27 +70,23 @@
           "type": "BinaryExpression",
           "start":49,"end":66,"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":17}},
           "left": {
-            "type": "Identifier",
-            "start":49,"end":50,"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":1},"identifierName":"x"},
-            "name": "x"
-          },
-          "operator": "===",
-          "right": {
             "type": "TSAsExpression",
-            "start":55,"end":66,"loc":{"start":{"line":3,"column":6},"end":{"line":3,"column":17}},
+            "start":49,"end":61,"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":12}},
             "expression": {
-              "type": "NumericLiteral",
-              "start":55,"end":56,"loc":{"start":{"line":3,"column":6},"end":{"line":3,"column":7}},
-              "extra": {
-                "rawValue": 1,
-                "raw": "1"
-              },
-              "value": 1
+              "type": "Identifier",
+              "start":49,"end":50,"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":1},"identifierName":"x"},
+              "name": "x"
             },
             "typeAnnotation": {
-              "type": "TSNumberKeyword",
-              "start":60,"end":66,"loc":{"start":{"line":3,"column":11},"end":{"line":3,"column":17}}
+              "type": "TSBooleanKeyword",
+              "start":54,"end":61,"loc":{"start":{"line":3,"column":5},"end":{"line":3,"column":12}}
             }
+          },
+          "operator": "<=",
+          "right": {
+            "type": "Identifier",
+            "start":65,"end":66,"loc":{"start":{"line":3,"column":16},"end":{"line":3,"column":17},"identifierName":"y"},
+            "name": "y"
           }
         },
         "leadingComments": [
@@ -103,36 +99,81 @@
         "trailingComments": [
           {
             "type": "CommentLine",
-            "value": " x === (1 as number);",
+            "value": " (x as boolean) <= y;",
             "start":68,"end":91,"loc":{"start":{"line":3,"column":19},"end":{"line":3,"column":42}}
           }
         ]
       },
       {
         "type": "ExpressionStatement",
-        "start":92,"end":106,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":14}},
+        "start":92,"end":110,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":18}},
+        "expression": {
+          "type": "BinaryExpression",
+          "start":92,"end":109,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":17}},
+          "left": {
+            "type": "Identifier",
+            "start":92,"end":93,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":1},"identifierName":"x"},
+            "name": "x"
+          },
+          "operator": "===",
+          "right": {
+            "type": "TSAsExpression",
+            "start":98,"end":109,"loc":{"start":{"line":4,"column":6},"end":{"line":4,"column":17}},
+            "expression": {
+              "type": "NumericLiteral",
+              "start":98,"end":99,"loc":{"start":{"line":4,"column":6},"end":{"line":4,"column":7}},
+              "extra": {
+                "rawValue": 1,
+                "raw": "1"
+              },
+              "value": 1
+            },
+            "typeAnnotation": {
+              "type": "TSNumberKeyword",
+              "start":103,"end":109,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":17}}
+            }
+          }
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " (x as boolean) <= y;",
+            "start":68,"end":91,"loc":{"start":{"line":3,"column":19},"end":{"line":3,"column":42}}
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentLine",
+            "value": " x === (1 as number);",
+            "start":111,"end":134,"loc":{"start":{"line":4,"column":19},"end":{"line":4,"column":42}}
+          }
+        ]
+      },
+      {
+        "type": "ExpressionStatement",
+        "start":135,"end":149,"loc":{"start":{"line":5,"column":0},"end":{"line":5,"column":14}},
         "expression": {
           "type": "TSAsExpression",
-          "start":92,"end":105,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":13}},
+          "start":135,"end":148,"loc":{"start":{"line":5,"column":0},"end":{"line":5,"column":13}},
           "expression": {
             "type": "TSAsExpression",
-            "start":92,"end":100,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":8}},
+            "start":135,"end":143,"loc":{"start":{"line":5,"column":0},"end":{"line":5,"column":8}},
             "expression": {
               "type": "Identifier",
-              "start":92,"end":93,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":1},"identifierName":"x"},
+              "start":135,"end":136,"loc":{"start":{"line":5,"column":0},"end":{"line":5,"column":1},"identifierName":"x"},
               "name": "x"
             },
             "typeAnnotation": {
               "type": "TSAnyKeyword",
-              "start":97,"end":100,"loc":{"start":{"line":4,"column":5},"end":{"line":4,"column":8}}
+              "start":140,"end":143,"loc":{"start":{"line":5,"column":5},"end":{"line":5,"column":8}}
             }
           },
           "typeAnnotation": {
             "type": "TSTypeReference",
-            "start":104,"end":105,"loc":{"start":{"line":4,"column":12},"end":{"line":4,"column":13}},
+            "start":147,"end":148,"loc":{"start":{"line":5,"column":12},"end":{"line":5,"column":13}},
             "typeName": {
               "type": "Identifier",
-              "start":104,"end":105,"loc":{"start":{"line":4,"column":12},"end":{"line":4,"column":13},"identifierName":"T"},
+              "start":147,"end":148,"loc":{"start":{"line":5,"column":12},"end":{"line":5,"column":13},"identifierName":"T"},
               "name": "T"
             }
           }
@@ -141,7 +182,41 @@
           {
             "type": "CommentLine",
             "value": " x === (1 as number);",
-            "start":68,"end":91,"loc":{"start":{"line":3,"column":19},"end":{"line":3,"column":42}}
+            "start":111,"end":134,"loc":{"start":{"line":4,"column":19},"end":{"line":4,"column":42}}
+          }
+        ]
+      },
+      {
+        "type": "ExpressionStatement",
+        "start":150,"end":168,"loc":{"start":{"line":6,"column":0},"end":{"line":6,"column":18}},
+        "expression": {
+          "type": "LogicalExpression",
+          "start":150,"end":167,"loc":{"start":{"line":6,"column":0},"end":{"line":6,"column":17}},
+          "left": {
+            "type": "TSAsExpression",
+            "start":150,"end":162,"loc":{"start":{"line":6,"column":0},"end":{"line":6,"column":12}},
+            "expression": {
+              "type": "Identifier",
+              "start":150,"end":151,"loc":{"start":{"line":6,"column":0},"end":{"line":6,"column":1},"identifierName":"x"},
+              "name": "x"
+            },
+            "typeAnnotation": {
+              "type": "TSBooleanKeyword",
+              "start":155,"end":162,"loc":{"start":{"line":6,"column":5},"end":{"line":6,"column":12}}
+            }
+          },
+          "operator": "??",
+          "right": {
+            "type": "Identifier",
+            "start":166,"end":167,"loc":{"start":{"line":6,"column":16},"end":{"line":6,"column":17},"identifierName":"y"},
+            "name": "y"
+          }
+        },
+        "trailingComments": [
+          {
+            "type": "CommentLine",
+            "value": " (x as boolean) ?? y;",
+            "start":169,"end":192,"loc":{"start":{"line":6,"column":19},"end":{"line":6,"column":42}}
           }
         ]
       }
@@ -156,8 +231,18 @@
     },
     {
       "type": "CommentLine",
-      "value": " x === (1 as number);",
+      "value": " (x as boolean) <= y;",
       "start":68,"end":91,"loc":{"start":{"line":3,"column":19},"end":{"line":3,"column":42}}
+    },
+    {
+      "type": "CommentLine",
+      "value": " x === (1 as number);",
+      "start":111,"end":134,"loc":{"start":{"line":4,"column":19},"end":{"line":4,"column":42}}
+    },
+    {
+      "type": "CommentLine",
+      "value": " (x as boolean) ?? y;",
+      "start":169,"end":192,"loc":{"start":{"line":6,"column":19},"end":{"line":6,"column":42}}
     }
   ]
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11446 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When parsing mixture of BinaryExpression and TsAsExpression, e.g.
```ts
a as boolean <= b
```
The `<=` is read when we are parsing TsType `boolean`, thus it is read as a single `<` (tt.relational) token instead of a compound of `<=`. Here we introduce a `reScan_lt_gt` method and re-scan `<`/`>` so `<=` can be correctly tokenized. Note that the TypeScript compiler adopted the same approach here:

https://github.com/microsoft/TypeScript/blob/624736418132374a6213bd4c66310017ee17d38a/src/compiler/parser.ts#L4329

This PR also fixes the following issue
```ts
a as boolean ?? b
```
because `??` is read as a pair of `?` questional instead of nullishCoalescing. Since it is used in Flow exclusively (#8115), I moved the code path to the flow plugin.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11912"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/169d6ce12ec68ad18409ff71f4d8296c47bb28ab.svg" /></a>

