### PR TITLE
fix: do not eat get/set after async is parsed

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1754,7 +1754,7 @@ export default class ExpressionParser extends LValParser {
       }
       // get PropertyName[?Yield, ?Await] () { FunctionBody[~Yield, ~Await] }
       // set PropertyName[?Yield, ?Await] ( PropertySetParameterList ) { FunctionBody[~Yield, ~Await] }
-      if (prop.key.name === "get" || prop.key.name === "set") {
+      else if (prop.key.name === "get" || prop.key.name === "set") {
         isAccessor = true;
         isGenerator = this.eat(tt.star); // tt.star is allowed in `maybeAsyncOrAccessorProp`, we will throw in `parseObjectMethod` later
         prop.kind = prop.key.name;

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/async-shorthand-method/input.js
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/async-shorthand-method/input.js
@@ -1,0 +1,4 @@
+({
+  async get() {},
+  async set() {}
+})

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/async-shorthand-method/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/async-shorthand-method/output.json
@@ -1,0 +1,71 @@
+{
+  "type": "File",
+  "start":0,"end":40,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":2}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":40,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":2}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":40,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":2}},
+        "expression": {
+          "type": "ObjectExpression",
+          "start":1,"end":39,"loc":{"start":{"line":1,"column":1},"end":{"line":4,"column":1}},
+          "properties": [
+            {
+              "type": "ObjectMethod",
+              "start":5,"end":19,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":16}},
+              "method": true,
+              "key": {
+                "type": "Identifier",
+                "start":11,"end":14,"loc":{"start":{"line":2,"column":8},"end":{"line":2,"column":11},"identifierName":"get"},
+                "name": "get"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": true,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":17,"end":19,"loc":{"start":{"line":2,"column":14},"end":{"line":2,"column":16}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ObjectMethod",
+              "start":23,"end":37,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":16}},
+              "method": true,
+              "key": {
+                "type": "Identifier",
+                "start":29,"end":32,"loc":{"start":{"line":3,"column":8},"end":{"line":3,"column":11},"identifierName":"set"},
+                "name": "set"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": true,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":35,"end":37,"loc":{"start":{"line":3,"column":14},"end":{"line":3,"column":16}},
+                "body": [],
+                "directives": []
+              }
+            }
+          ],
+          "extra": {
+            "parenthesized": true,
+            "parenStart": 0
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11914 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Fixed a regression introduced in #11871. When `async` is consumed, we should not unintentionally eat `set`/`get` because async accessor is not a thing in the spec.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11916"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/5d6295988bfd32c2254d6c376259def082066a89.svg" /></a>

