### PR TITLE
refactor: add recoverable error on accessorIsGenerator

### DIFF
--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -3,7 +3,7 @@
 
 // The Errors key follows https://cs.chromium.org/chromium/src/v8/src/common/message-template.h unless it does not exist
 export const ErrorMessages = Object.freeze({
-  AccessorIsGenerator: "A %0ter can not be a generator",
+  AccessorIsGenerator: "A %0ter cannot be a generator",
   ArgumentsDisallowedInInitializer:
     "'arguments' is not allowed in class field initializer",
   AsyncFunctionInSingleStatementContext:

--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -3,6 +3,7 @@
 
 // The Errors key follows https://cs.chromium.org/chromium/src/v8/src/common/message-template.h unless it does not exist
 export const ErrorMessages = Object.freeze({
+  AccessorIsGenerator: "A %0ter can not be a generator",
   ArgumentsDisallowedInInitializer:
     "'arguments' is not allowed in class field initializer",
   AsyncFunctionInSingleStatementContext:

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1757,8 +1757,11 @@ export default class ExpressionParser extends LValParser {
       // set PropertyName[?Yield, ?Await] ( PropertySetParameterList ) { FunctionBody[~Yield, ~Await] }
       if (keyName === "get" || keyName === "set") {
         isAccessor = true;
-        isGenerator = this.eat(tt.star); // tt.star is allowed in `maybeAsyncOrAccessorProp`, we will throw in `parseObjectMethod` later
         prop.kind = keyName;
+        if (this.match(tt.star)) {
+          this.raise(this.state.pos, Errors.AccessorIsGenerator, keyName);
+          this.next();
+        }
         this.parsePropertyName(prop, /* isPrivateNameAllowed */ false);
       }
     }
@@ -1813,8 +1816,7 @@ export default class ExpressionParser extends LValParser {
     isAccessor: boolean,
   ): ?N.ObjectMethod {
     if (isAccessor) {
-      // isAccessor implies isAsync: false, isPattern: false
-      if (isGenerator) this.unexpected();
+      // isAccessor implies isAsync: false, isPattern: false, isGenerator: false
       this.parseMethod(
         prop,
         /* isGenerator */ false,

--- a/packages/babel-parser/test/fixtures/es2015/object/invalid-accessor-generator/input.js
+++ b/packages/babel-parser/test/fixtures/es2015/object/invalid-accessor-generator/input.js
@@ -1,0 +1,4 @@
+({
+    get *iterator() { },
+    set *iterator(iter) { }
+})

--- a/packages/babel-parser/test/fixtures/es2015/object/invalid-accessor-generator/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/object/invalid-accessor-generator/output.json
@@ -1,0 +1,81 @@
+{
+  "type": "File",
+  "start":0,"end":58,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":2}},
+  "errors": [
+    "SyntaxError: A getter can not be a generator (2:9)",
+    "SyntaxError: A setter can not be a generator (3:9)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":58,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":2}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":58,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":2}},
+        "expression": {
+          "type": "ObjectExpression",
+          "start":1,"end":57,"loc":{"start":{"line":1,"column":1},"end":{"line":4,"column":1}},
+          "properties": [
+            {
+              "type": "ObjectMethod",
+              "start":7,"end":26,"loc":{"start":{"line":2,"column":4},"end":{"line":2,"column":23}},
+              "method": false,
+              "key": {
+                "type": "Identifier",
+                "start":12,"end":20,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":17},"identifierName":"iterator"},
+                "name": "iterator"
+              },
+              "computed": false,
+              "kind": "get",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":23,"end":26,"loc":{"start":{"line":2,"column":20},"end":{"line":2,"column":23}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ObjectMethod",
+              "start":32,"end":55,"loc":{"start":{"line":3,"column":4},"end":{"line":3,"column":27}},
+              "method": false,
+              "key": {
+                "type": "Identifier",
+                "start":37,"end":45,"loc":{"start":{"line":3,"column":9},"end":{"line":3,"column":17},"identifierName":"iterator"},
+                "name": "iterator"
+              },
+              "computed": false,
+              "kind": "set",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start":46,"end":50,"loc":{"start":{"line":3,"column":18},"end":{"line":3,"column":22},"identifierName":"iter"},
+                  "name": "iter"
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start":52,"end":55,"loc":{"start":{"line":3,"column":24},"end":{"line":3,"column":27}},
+                "body": [],
+                "directives": []
+              }
+            }
+          ],
+          "extra": {
+            "parenthesized": true,
+            "parenStart": 0
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2015/object/invalid-accessor-generator/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/object/invalid-accessor-generator/output.json
@@ -2,8 +2,8 @@
   "type": "File",
   "start":0,"end":58,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":2}},
   "errors": [
-    "SyntaxError: A getter can not be a generator (2:9)",
-    "SyntaxError: A setter can not be a generator (3:9)"
+    "SyntaxError: A getter cannot be a generator (2:9)",
+    "SyntaxError: A setter cannot be a generator (3:9)"
   ],
   "program": {
     "type": "Program",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Add a recoverable error when accessor is generator.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11921"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/f9e19f35fcfeb7167e5eea228cb52a2d3c54ca5e.svg" /></a>

