### PR TITLE
fix: add ImportExpression visitorKeys

### DIFF
--- a/eslint/babel-eslint-parser/src/convert/convertAST.js
+++ b/eslint/babel-eslint-parser/src/convert/convertAST.js
@@ -87,6 +87,7 @@ function convertNodes(ast, code) {
   try {
     // Monkey patch visitor keys in order to be able to traverse the estree nodes
     t.VISITOR_KEYS.ChainExpression = VISITOR_KEYS.ChainExpression;
+    t.VISITOR_KEYS.ImportExpression = VISITOR_KEYS.ImportExpression;
     t.VISITOR_KEYS.Property = VISITOR_KEYS.Property;
     t.VISITOR_KEYS.MethodDefinition = VISITOR_KEYS.MethodDefinition;
 
@@ -99,6 +100,7 @@ function convertNodes(ast, code) {
   } finally {
     // These can be safely deleted because they are not defined in the original visitor keys.
     delete t.VISITOR_KEYS.ChainExpression;
+    delete t.VISITOR_KEYS.ImportExpression;
     delete t.VISITOR_KEYS.MethodDefinition;
     delete t.VISITOR_KEYS.Property;
 

--- a/eslint/babel-eslint-parser/src/visitor-keys.js
+++ b/eslint/babel-eslint-parser/src/visitor-keys.js
@@ -8,6 +8,7 @@ export default Object.assign(
   {
     ChainExpression: ESLINT_VISITOR_KEYS.ChainExpression,
     ExportAllDeclaration: ESLINT_VISITOR_KEYS.ExportAllDeclaration,
+    ImportExpression: ESLINT_VISITOR_KEYS.ImportExpression,
     Literal: ESLINT_VISITOR_KEYS.Literal,
     MethodDefinition: ["decorators"].concat(
       ESLINT_VISITOR_KEYS.MethodDefinition,

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -569,7 +569,7 @@ describe("Babel and Espree", () => {
 
     it("Dynamic Import", () => {
       parseAndAssertSame(`
-        const a = import('a');
+        const a = import(moduleName);
       `);
     });
   });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10904
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As a follow-up to #10828, this PR adds `ImportExpression` to `VISITOR_KEYS`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11932"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/69c9f1ecec19d8dba71ccc04027ba3ab7eb57f01.svg" /></a>

