### PR TITLE
fixed the names of the rules

### DIFF
--- a/eslint/babel-eslint-plugin/README.md
+++ b/eslint/babel-eslint-plugin/README.md
@@ -26,11 +26,11 @@ original ones as well!).
 ```json
 {
   "rules": {
-    "babel/new-cap": "error",
-    "babel/no-invalid-this": "error",
-    "babel/no-unused-expressions": "error",
-    "babel/object-curly-spacing": "error",
-    "babel/semi": "error"
+    "@babel/new-cap": "error",
+    "@babel/no-invalid-this": "error",
+    "@babel/no-unused-expressions": "error",
+    "@babel/object-curly-spacing": "error",
+    "@babel/semi": "error"
   }
 }
 ```
@@ -41,8 +41,8 @@ Each rule corresponds to a core `eslint` rule and has the same options.
 
 🛠: means it's autofixable with `--fix`.
 
-- `babel/new-cap`: handles decorators (`@Decorator`)
-- `babel/no-invalid-this`: handles class fields and private class methods (`class A { a = this.b; }`)
-- `babel/no-unused-expressions`: handles `do` expressions
-- `babel/object-curly-spacing`: handles `export * as x from "mod";` (🛠)
-- `babel/semi`: Handles class properties (🛠)
+- `@babel/new-cap`: handles decorators (`@Decorator`)
+- `@babel/no-invalid-this`: handles class fields and private class methods (`class A { a = this.b; }`)
+- `@babel/no-unused-expressions`: handles `do` expressions
+- `@babel/object-curly-spacing`: handles `export * as x from "mod";` (🛠)
+- `@babel/semi`: Handles class properties (🛠)


### PR DESCRIPTION
Fixed the names of the rules. Names of the rules without prefix "@" - don't working

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11933"><img src="https://gitpod.io/api/apps/github/pbs/github.com/AleksRap/babel.git/1d82a745cf13284971341546c6967fd522a7f0d9.svg" /></a>

