### PR TITLE
chore: do not push version commit on lerna version

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -26,15 +26,12 @@
         "# We ignore every JSON file, except for native-modules, built-ins and plugins defined in babel-preset-env/data.",
         "@(!(native-modules|built-ins|plugins|package)).json"
       ]
+    },
+    "version": {
+      "push": false
     }
   },
-  "packages": [
-    "codemods/*",
-    "eslint/*",
-    "packages/*"
-  ],
+  "packages": ["codemods/*", "eslint/*", "packages/*"],
   "npmClient": "yarn",
-  "npmClientArgs": [
-    "--pure-lockfile"
-  ]
+  "npmClientArgs": ["--pure-lockfile"]
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Per https://github.com/lerna/lerna/tree/master/commands/version#--no-push, if `push: false` is specified, lerna will not push the version commit and the tags to the remote. So when we are publishing from local, we don't have to switch the tracking branch to `origin` as we did before.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11936"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/e959ba0619c7fe68937f7a94cdb86cd48dcd214a.svg" /></a>

