### PR TITLE
Move some @babel/traverse from deps to devDeps

### DIFF
--- a/packages/babel-helper-bindify-decorators/package.json
+++ b/packages/babel-helper-bindify-decorators/package.json
@@ -13,7 +13,9 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/traverse": "^7.10.4",
     "@babel/types": "^7.10.4"
+  },
+  "devDependencies": {
+    "@babel/traverse": "^7.10.4"
   }
 }

--- a/packages/babel-helper-call-delegate/package.json
+++ b/packages/babel-helper-call-delegate/package.json
@@ -14,7 +14,9 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-hoist-variables": "^7.10.4",
-    "@babel/traverse": "^7.10.4",
     "@babel/types": "^7.10.4"
+  },
+  "devDependencies": {
+    "@babel/traverse": "^7.10.4"
   }
 }

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -13,7 +13,9 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/traverse": "^7.10.4",
     "@babel/types": "^7.10.4"
+  },
+  "devDependencies": {
+    "@babel/traverse": "^7.10.4"
   }
 }

--- a/packages/babel-helper-explode-class/package.json
+++ b/packages/babel-helper-explode-class/package.json
@@ -14,7 +14,9 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-bindify-decorators": "^7.10.4",
-    "@babel/traverse": "^7.10.4",
     "@babel/types": "^7.10.4"
+  },
+  "devDependencies": {
+    "@babel/traverse": "^7.10.4"
   }
 }

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -16,7 +16,9 @@
     "@babel/helper-annotate-as-pure": "^7.10.4",
     "@babel/helper-wrap-function": "^7.10.4",
     "@babel/template": "^7.10.4",
-    "@babel/traverse": "^7.10.4",
     "@babel/types": "^7.10.4"
+  },
+  "devDependencies": {
+    "@babel/traverse": "^7.10.4"
   }
 }

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -15,7 +15,9 @@
   "dependencies": {
     "@babel/helper-member-expression-to-functions": "^7.10.4",
     "@babel/helper-optimise-call-expression": "^7.10.4",
-    "@babel/traverse": "^7.10.4",
     "@babel/types": "^7.10.4"
+  },
+  "devDependencies": {
+    "@babel/traverse": "^7.10.4"
   }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No issue
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Move some `@babel/traverse` which is used for only type import (like `import type { NodePath } from "@babel/traverse";`) from dependencies to devDependencies.

The dist won't be changed, but this PR fixes incorrect behavior of applications that refer `package.json` such as [Skypack](https://skypack.dev).


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11937"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Monchi/babel.git/dd8cf989dca0af54bea9f5a28d98b00d0406fe2c.svg" /></a>

