### PR TITLE
fix: disallow line break between async and property

### DIFF
--- a/packages/babel-generator/src/generators/methods.js
+++ b/packages/babel-generator/src/generators/methods.js
@@ -37,6 +37,8 @@ export function _methodHead(node: Object) {
   }
 
   if (node.async) {
+    // ensure `async` is in the same line with property name
+    this._catchUp("start", key.loc);
     this.word("async");
     this.space();
   }

--- a/packages/babel-generator/test/fixtures/regression/11870/input.js
+++ b/packages/babel-generator/test/fixtures/regression/11870/input.js
@@ -1,0 +1,4 @@
+class Test {
+  @TestDecorator
+  async decorateMe() {}
+}

--- a/packages/babel-generator/test/fixtures/regression/11870/options.json
+++ b/packages/babel-generator/test/fixtures/regression/11870/options.json
@@ -1,0 +1,4 @@
+{
+  "retainLines": true,
+  "plugins": [["decorators", { "decoratorsBeforeExport": true }]]
+}

--- a/packages/babel-generator/test/fixtures/regression/11870/output.js
+++ b/packages/babel-generator/test/fixtures/regression/11870/output.js
@@ -1,0 +1,3 @@
+class Test {
+  @TestDecorator
+  async decorateMe() {}}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11870 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11947"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/4da1ab7efd1ff31762396768dd8bd047cfdcf133.svg" /></a>

