### PR TITLE
chore: build babel-polyfill-dist on make watch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ build-no-bundle: clean clean-lib
 	BABEL_ENV=development $(YARN) gulp build-no-bundle
 	# Ensure that build artifacts for types are created during local
 	# development too.
-	$(MAKE) generate-type-helpers
-	$(MAKE) build-typings
+	# Babel-transform-fixture-test-runner requires minified polyfill for performance
+	$(MAKE) generate-type-helpers build-typings build-polyfill-dist
 
 build-no-bundle-ci: bootstrap-only
 	$(MAKE) build-no-bundle

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -39,7 +39,7 @@ function createContext() {
   // Initialize the test context with the polyfill, and then freeze the global to prevent implicit
   // global creation in tests, which could cause things to bleed between tests.
   runModuleInTestContext(
-    "@babel/polyfill/dist/polyfill.min",
+    "@babel/polyfill/dist/polyfill.min.js",
     __filename,
     context,
     moduleCache,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Running `make watch && yarn jest object-rest-spread` will throw
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As a follow-up to #11531 , this PR runs polyfill-dist task on `make watch`, because `transform-fixture-runner` requires the dist build.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11951"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/b4d7e7aa21d6087e1a6fb5a4601d157d8edf70f7.svg" /></a>

