### PR TITLE
chore: remove obsolete comment

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1265,8 +1265,6 @@ helpers.applyDecoratedDescriptor = helper("7.0.0-beta.0")`
         }
 
         if (desc.initializer === void 0){
-            // This is a hack to avoid this being processed by 'transform-runtime'.
-            // See issue #9.
             Object.defineProperty(target, property, desc);
             desc = null;
         }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This simply removes a comment that has become obsolete. The issue referenced in the comment is https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy/issues/9 and the comment was first introduced in https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy/commit/e0a167395dd19310684495b6da3d5526ec063ef7 (referenced in the issue). The "hack" has since [been reverted](https://github.com/babel/babel/pull/7646/files#diff-ba75bd4d116cc90ad8c8002e3010e821R1022) but the comment was not removed, thus causing confusion for anyone (at least me :smile:) looking at the code (and the referenced issue is not easy to find because it's actually in an obsolete repo where this code was moved from).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11953"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jamescdavis/babel.git/22a25418e113233e0014835f0e167a6887998dd9.svg" /></a>

