### PR TITLE
fix: ensure defaults are set in @babel/eslint-parser

### DIFF
--- a/eslint/babel-eslint-parser/src/configuration.js
+++ b/eslint/babel-eslint-parser/src/configuration.js
@@ -9,7 +9,19 @@ export function normalizeESLintConfig(options) {
     requireConfigFile: true,
   };
 
-  return Object.assign(defaultOptions, options);
+  // ESLint sets ecmaVersion: undefined when ecmaVersion is not set in the config.
+  // Prune to ensure that defaults are respected.
+  const prunedOptions = Object.entries(options).reduce(
+    (options, [key, value]) => {
+      if (value !== undefined) {
+        options[key] = value;
+      }
+      return options;
+    },
+    {},
+  );
+
+  return Object.assign(defaultOptions, prunedOptions);
 }
 
 export function normalizeBabelParseConfig(options) {

--- a/eslint/babel-eslint-parser/src/configuration.js
+++ b/eslint/babel-eslint-parser/src/configuration.js
@@ -1,27 +1,24 @@
 import { loadPartialConfig } from "@babel/core";
 
 export function normalizeESLintConfig(options) {
-  const defaultOptions = {
-    babelOptions: {},
-    ecmaVersion: 2020,
-    sourceType: "module",
-    allowImportExportEverywhere: false,
-    requireConfigFile: true,
+  const {
+    babelOptions = {},
+    // ESLint sets ecmaVersion: undefined when ecmaVersion is not set in the config.
+    ecmaVersion = 2020,
+    sourceType = "module",
+    allowImportExportEverywhere = false,
+    requireConfigFile = true,
+    ...otherOptions
+  } = options;
+
+  return {
+    babelOptions,
+    ecmaVersion,
+    sourceType,
+    allowImportExportEverywhere,
+    requireConfigFile,
+    ...otherOptions,
   };
-
-  // ESLint sets ecmaVersion: undefined when ecmaVersion is not set in the config.
-  // Prune to ensure that defaults are respected.
-  const prunedOptions = Object.entries(options).reduce(
-    (options, [key, value]) => {
-      if (value !== undefined) {
-        options[key] = value;
-      }
-      return options;
-    },
-    {},
-  );
-
-  return Object.assign(defaultOptions, prunedOptions);
 }
 
 export function normalizeBabelParseConfig(options) {

--- a/eslint/babel-eslint-tests/package.json
+++ b/eslint/babel-eslint-tests/package.json
@@ -4,7 +4,8 @@
   "description": "Tests for babel/eslint-* packages",
   "license": "MIT",
   "private": true,
-  "devDependencies": {
+  "dependencies": {
+    "@babel/eslint-parser": "^7.11.0",
     "dedent": "^0.7.0",
     "eslint": "^7.5.0",
     "eslint-plugin-import": "^2.22.0"

--- a/eslint/babel-eslint-tests/test/integration/eslint/config.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/config.js
@@ -1,0 +1,21 @@
+import eslint from "eslint";
+import * as parser from "@babel/eslint-parser";
+
+describe("ESLint config", () => {
+  it('should set ecmaVersion to latest and sourceType to "module" by default', () => {
+    const linter = new eslint.Linter();
+    linter.defineParser("@babel/eslint-parser", parser);
+    // ImportDeclarations result in a parser error if ecmaVersion < 2015 and sourceType != "module".
+    const messages = linter.verify('import { hello } from "greetings"', {
+      parser: "@babel/eslint-parser",
+      parserOptions: {
+        babelOptions: {
+          configFile: require.resolve(
+            "../../../../babel-eslint-shared-fixtures/config/babel.config.js",
+          ),
+        },
+      },
+    });
+    expect(messages.length).toEqual(0);
+  });
+});

--- a/eslint/babel-eslint-tests/test/integration/eslint/eslint.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/eslint.js
@@ -1,3 +1,5 @@
+import eslint from "eslint";
+import * as parser from "../../../../babel-eslint-parser";
 import verifyAndAssertMessages from "../../helpers/verifyAndAssertMessages";
 
 describe("verify", () => {
@@ -1913,5 +1915,25 @@ describe("verify", () => {
       `,
       { "no-unused-vars": 1, "no-undef": 1 },
     );
+  });
+});
+
+describe("ESLint config", () => {
+  it('should set ecmaVersion to latest and sourceType to "module" by default', () => {
+    const linter = new eslint.Linter();
+    linter.defineParser("@babel/eslint-parser", parser);
+
+    // ImportDeclarations result in a parser error if ecmaVersion < 2015 and sourceType != "module".
+    const messages = linter.verify('import { hello } from "greetings"', {
+      parser: "@babel/eslint-parser",
+      parserOptions: {
+        babelOptions: {
+          configFile: require.resolve(
+            "../../../../babel-eslint-shared-fixtures/config/babel.config.js",
+          ),
+        },
+      },
+    });
+    expect(messages.length).toEqual(0);
   });
 });

--- a/eslint/babel-eslint-tests/test/integration/eslint/verify.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/verify.js
@@ -1,5 +1,3 @@
-import eslint from "eslint";
-import * as parser from "../../../../babel-eslint-parser";
 import verifyAndAssertMessages from "../../helpers/verifyAndAssertMessages";
 
 describe("verify", () => {
@@ -1915,25 +1913,5 @@ describe("verify", () => {
       `,
       { "no-unused-vars": 1, "no-undef": 1 },
     );
-  });
-});
-
-describe("ESLint config", () => {
-  it('should set ecmaVersion to latest and sourceType to "module" by default', () => {
-    const linter = new eslint.Linter();
-    linter.defineParser("@babel/eslint-parser", parser);
-
-    // ImportDeclarations result in a parser error if ecmaVersion < 2015 and sourceType != "module".
-    const messages = linter.verify('import { hello } from "greetings"', {
-      parser: "@babel/eslint-parser",
-      parserOptions: {
-        babelOptions: {
-          configFile: require.resolve(
-            "../../../../babel-eslint-shared-fixtures/config/babel.config.js",
-          ),
-        },
-      },
-    });
-    expect(messages.length).toEqual(0);
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11902
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
ESLint sets `ecmaVersion: undefined` in the config options passed to custom parsers when the `ecmaVersion` isn't defined in the user's config. Since the key exists, it ends up overriding the default value :(

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11970"><img src="https://gitpod.io/api/apps/github/pbs/github.com/kaicataldo/babel.git/41df4ed1076a3b1b5393431fbb2d56ca0552fbaa.svg" /></a>

