### PR TITLE
fix: do not transform ClassPrivateMethods in estree

### DIFF
--- a/eslint/babel-eslint-parser/src/visitor-keys.js
+++ b/eslint/babel-eslint-parser/src/visitor-keys.js
@@ -1,19 +1,22 @@
 import { types as t } from "@babel/core";
 import { KEYS as ESLINT_VISITOR_KEYS } from "eslint-visitor-keys";
 
-/*eslint no-unused-vars: ["error", { "ignoreRestSiblings": true }]*/
-const { ExportAllDeclaration, ...BABEL_VISITOR_KEYS } = t.VISITOR_KEYS;
+// AST Types that are not presented in Babel AST
+export const newTypes = {
+  ChainExpression: ESLINT_VISITOR_KEYS.ChainExpression,
+  ImportExpression: ESLINT_VISITOR_KEYS.ImportExpression,
+  Literal: ESLINT_VISITOR_KEYS.Literal,
+  MethodDefinition: ["decorators"].concat(ESLINT_VISITOR_KEYS.MethodDefinition),
+  Property: ["decorators"].concat(ESLINT_VISITOR_KEYS.Property),
+};
 
-export default Object.assign(
-  {
-    ChainExpression: ESLINT_VISITOR_KEYS.ChainExpression,
-    ExportAllDeclaration: ESLINT_VISITOR_KEYS.ExportAllDeclaration,
-    ImportExpression: ESLINT_VISITOR_KEYS.ImportExpression,
-    Literal: ESLINT_VISITOR_KEYS.Literal,
-    MethodDefinition: ["decorators"].concat(
-      ESLINT_VISITOR_KEYS.MethodDefinition,
-    ),
-    Property: ["decorators"].concat(ESLINT_VISITOR_KEYS.Property),
-  },
-  BABEL_VISITOR_KEYS,
-);
+// AST Types that shares `"type"` property with Babel but have different shape
+export const conflictTypes = {
+  // todo: remove this when class features are supported
+  ClassPrivateMethod: ["decorators"].concat(
+    ESLINT_VISITOR_KEYS.MethodDefinition,
+  ),
+  ExportAllDeclaration: ESLINT_VISITOR_KEYS.ExportAllDeclaration,
+};
+
+export default Object.assign(newTypes, t.VISITOR_KEYS, conflictTypes);

--- a/eslint/babel-eslint-tests/test/integration/eslint/eslint.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/eslint.js
@@ -1767,6 +1767,7 @@ describe("verify", () => {
             }
           `,
           { "no-unused-vars": 1 },
+          ["3:6 'unused' is defined but never used. no-unused-vars"],
         );
       });
 
@@ -1778,6 +1779,19 @@ describe("verify", () => {
             }
           `,
           { "no-unused-vars": 1 },
+          ["3:14 'unused' is defined but never used. no-unused-vars"],
+        );
+      });
+
+      it("should work with no-unreachable", () => {
+        verifyAndAssertMessages(
+          `class C {
+  #a() {
+    return;
+  }
+  #b() {} // no-unreachable should not bail here
+}`,
+          { "no-unreachable": 1 },
         );
       });
     });

--- a/eslint/babel-eslint-tests/test/integration/eslint/eslint.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/eslint.js
@@ -1758,6 +1758,28 @@ describe("verify", () => {
           { "no-unused-vars": 1 },
         );
       });
+
+      it("should visit params", () => {
+        verifyAndAssertMessages(
+          `export class C {
+              constructor() { this.#d(); }
+              #d(unused) {};
+            }
+          `,
+          { "no-unused-vars": 1 },
+        );
+      });
+
+      it("should visit body", () => {
+        verifyAndAssertMessages(
+          `export class C {
+              constructor() { this.#d(); }
+              #d() { var unused; };
+            }
+          `,
+          { "no-unused-vars": 1 },
+        );
+      });
     });
   });
 

--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -287,6 +287,19 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       type: string,
       inClassScope: boolean = false,
     ): T {
+      if (type === "ClassPrivateMethod") {
+        // todo: supports ClassPrivateMethod
+        // see https://github.com/estree/estree/blob/master/experimental/class-features.md
+        return super.parseMethod(
+          node,
+          isGenerator,
+          isAsync,
+          isConstructor,
+          allowDirectSuper,
+          type,
+          inClassScope,
+        );
+      }
       let funcNode = this.startNode();
       funcNode.kind = node.kind; // provide kind, so super method correctly sets state
       funcNode = super.parseMethod(

--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -287,19 +287,6 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       type: string,
       inClassScope: boolean = false,
     ): T {
-      if (type === "ClassPrivateMethod") {
-        // todo: supports ClassPrivateMethod
-        // see https://github.com/estree/estree/blob/master/experimental/class-features.md
-        return super.parseMethod(
-          node,
-          isGenerator,
-          isAsync,
-          isConstructor,
-          allowDirectSuper,
-          type,
-          inClassScope,
-        );
-      }
       let funcNode = this.startNode();
       funcNode.kind = node.kind; // provide kind, so super method correctly sets state
       funcNode = super.parseMethod(

--- a/packages/babel-parser/test/fixtures/estree/class-private-method/basic/input.js
+++ b/packages/babel-parser/test/fixtures/estree/class-private-method/basic/input.js
@@ -1,0 +1,3 @@
+class A {
+  #foo(arg, ...others) {}
+}

--- a/packages/babel-parser/test/fixtures/estree/class-private-method/basic/options.json
+++ b/packages/babel-parser/test/fixtures/estree/class-private-method/basic/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["flow", "jsx", "estree", "classPrivateMethods"]
+}

--- a/packages/babel-parser/test/fixtures/estree/class-private-method/basic/output.json
+++ b/packages/babel-parser/test/fixtures/estree/class-private-method/basic/output.json
@@ -1,0 +1,68 @@
+{
+  "type": "File",
+  "start":0,"end":37,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":37,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":37,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"A"},
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":8,"end":37,"loc":{"start":{"line":1,"column":8},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassPrivateMethod",
+              "start":12,"end":35,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":25}},
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start":12,"end":16,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                "id": {
+                  "type": "Identifier",
+                  "start":13,"end":16,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"foo"},
+                  "name": "foo"
+                }
+              },
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "expression": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start":17,"end":20,"loc":{"start":{"line":2,"column":7},"end":{"line":2,"column":10},"identifierName":"arg"},
+                  "name": "arg"
+                },
+                {
+                  "type": "RestElement",
+                  "start":22,"end":31,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":21}},
+                  "argument": {
+                    "type": "Identifier",
+                    "start":25,"end":31,"loc":{"start":{"line":2,"column":15},"end":{"line":2,"column":21},"identifierName":"others"},
+                    "name": "others"
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start":33,"end":35,"loc":{"start":{"line":2,"column":23},"end":{"line":2,"column":25}},
+                "body": []
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/packages/babel-parser/test/fixtures/estree/class-private-method/basic/output.json
+++ b/packages/babel-parser/test/fixtures/estree/class-private-method/basic/output.json
@@ -34,30 +34,34 @@
                 }
               },
               "kind": "method",
-              "id": null,
-              "generator": false,
-              "async": false,
-              "expression": false,
-              "params": [
-                {
-                  "type": "Identifier",
-                  "start":17,"end":20,"loc":{"start":{"line":2,"column":7},"end":{"line":2,"column":10},"identifierName":"arg"},
-                  "name": "arg"
-                },
-                {
-                  "type": "RestElement",
-                  "start":22,"end":31,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":21}},
-                  "argument": {
+              "value": {
+                "type": "FunctionExpression",
+                "start":16,"end":35,"loc":{"start":{"line":2,"column":6},"end":{"line":2,"column":25}},
+                "id": null,
+                "generator": false,
+                "async": false,
+                "expression": false,
+                "params": [
+                  {
                     "type": "Identifier",
-                    "start":25,"end":31,"loc":{"start":{"line":2,"column":15},"end":{"line":2,"column":21},"identifierName":"others"},
-                    "name": "others"
+                    "start":17,"end":20,"loc":{"start":{"line":2,"column":7},"end":{"line":2,"column":10},"identifierName":"arg"},
+                    "name": "arg"
+                  },
+                  {
+                    "type": "RestElement",
+                    "start":22,"end":31,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":21}},
+                    "argument": {
+                      "type": "Identifier",
+                      "start":25,"end":31,"loc":{"start":{"line":2,"column":15},"end":{"line":2,"column":21},"identifierName":"others"},
+                      "name": "others"
+                    }
                   }
+                ],
+                "body": {
+                  "type": "BlockStatement",
+                  "start":33,"end":35,"loc":{"start":{"line":2,"column":23},"end":{"line":2,"column":25}},
+                  "body": []
                 }
-              ],
-              "body": {
-                "type": "BlockStatement",
-                "start":33,"end":35,"loc":{"start":{"line":2,"column":23},"end":{"line":2,"column":25}},
-                "body": []
               }
             }
           ]


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11972 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Use `MethodDefinition` as the visitorKeys of `ClassPrivateMethods`. This should be considered as a ad-hoc fixes before the class features support is landed.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11973"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/ce0451c056d6470bed9789247552e049817386f9.svg" /></a>

