### PR TITLE
Ensure `import()` is not transpiled in `babel-core` published source

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -69,7 +69,14 @@ function buildBabel(exclude, sourcesGlob = defaultSourcesGlob) {
     .pipe(errorsLogger())
     .pipe(newer({ dest: base, map: swapSrcWithLib }))
     .pipe(compilationLogger())
-    .pipe(babel())
+    .pipe(
+      babel({
+        caller: {
+          // We have wrapped packages/babel-core/src/config/files/configuration.js with feature detection
+          supportsDynamicImport: true,
+        },
+      })
+    )
     .pipe(
       // Passing 'file.relative' because newer() above uses a relative
       // path and this keeps it consistent.

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -1,6 +1,8 @@
+import cp from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import util from "util";
 import escapeRegExp from "lodash/escapeRegExp";
 import * as babel from "../lib";
 
@@ -51,6 +53,31 @@ function loadOptionsAsync(opts) {
   return babel.loadOptionsAsync({ cwd: __dirname, ...opts });
 }
 
+async function loadOptionsAsyncInSpawedProcess({ filename, cwd }) {
+  // !!!! hack is coming !!!!
+  // remove this section when https://github.com/facebook/jest/issues/9430 is resolved
+  // We don't check process.versions.node here, it will fail if node does not support esm
+  // please publish Babel on a modernized node :)
+  const { stdout, stderr } = await util.promisify(cp.execFile)(
+    require.resolve("./fixtures/babel-load-options-async.mjs"),
+    // pass `cwd` as params as `process.cwd()` will normalize `cwd` on macOS
+    [filename, cwd],
+    {
+      cwd,
+      env: process.env,
+    },
+  );
+  if (stderr) {
+    throw new Error(
+      "error is thrown in babel-load-options-async.mjs: stdout\n" +
+        stdout +
+        "\nstderr:\n" +
+        stderr,
+    );
+  }
+  return JSON.parse(stdout);
+}
+
 function pairs(items) {
   const pairs = [];
   for (let i = 0; i < items.length - 1; i++) {
@@ -61,11 +88,10 @@ function pairs(items) {
   return pairs;
 }
 
-async function getTemp(name) {
+async function getTemp(name, fixtureFolder = "config-files-templates") {
   const cwd = await pfs.mkdtemp(os.tmpdir() + path.sep + name);
   const tmp = name => path.join(cwd, name);
-  const config = name =>
-    pfs.copyFile(fixture("config-files-templates", name), tmp(name));
+  const config = name => pfs.copyFile(fixture(fixtureFolder, name), tmp(name));
   return { cwd, tmp, config };
 }
 
@@ -1034,20 +1060,20 @@ describe("buildConfigChain", function () {
         );
       });
 
-      test.each([
-        "babel.config.json",
-        "babel.config.js",
-        "babel.config.cjs",
-        "babel.config.mjs",
-      ])("should load %s asynchronously", async name => {
+      test.each(
+        [
+          "babel.config.json",
+          "babel.config.js",
+          "babel.config.cjs",
+          // We can't transpile import() while publishing, and it isn't supported
+          // by jest.
+          process.env.IS_PUBLISH ? "" : "babel.config.mjs",
+        ].filter(Boolean),
+      )("should load %s asynchronously", async name => {
         const { cwd, tmp, config } = await getTemp(
           `babel-test-load-config-async-${name}`,
         );
         const filename = tmp("src.js");
-
-        // We can't transpile import() while publishing, and it isn't supported
-        // by jest.
-        if (process.env.IS_PUBLISH && name === "babel.config.mjs") return;
 
         await config(name);
 
@@ -1087,6 +1113,29 @@ describe("buildConfigChain", function () {
           loadOptionsAsync({ filename: tmp("src.js"), cwd }),
         ).rejects.toThrow(/Multiple configuration files found/);
       });
+
+      if (process.env.IS_PUBLISH) {
+        test.each(["babel.config.mjs", ".babelrc.mjs"])(
+          "should load %s asynchronously",
+          async name => {
+            const { cwd, tmp, config } = await getTemp(
+              `babel-test-load-config-async-prepublish-${name}`,
+              "config-files-templates-prepublish",
+            );
+            const filename = tmp("src.js");
+            await config(name);
+            expect(
+              await loadOptionsAsyncInSpawedProcess({ filename, cwd }),
+            ).toEqual({
+              ...getDefaults(),
+              filename,
+              cwd,
+              root: cwd,
+              comments: true,
+            });
+          },
+        );
+      }
     });
 
     describe("relative", () => {
@@ -1126,21 +1175,21 @@ describe("buildConfigChain", function () {
         );
       });
 
-      test.each([
-        "package.json",
-        ".babelrc",
-        ".babelrc.js",
-        ".babelrc.cjs",
-        ".babelrc.mjs",
-      ])("should load %s asynchronously", async name => {
+      test.each(
+        [
+          "package.json",
+          ".babelrc",
+          ".babelrc.js",
+          ".babelrc.cjs",
+          // We can't transpile import() while publishing, and it isn't supported
+          // by jest.
+          process.env.IS_PUBLISH ? "" : "babel.config.mjs",
+        ].filter(Boolean),
+      )("should load %s asynchronously", async name => {
         const { cwd, tmp, config } = await getTemp(
           `babel-test-load-config-${name}`,
         );
         const filename = tmp("src.js");
-
-        // We can't transpile import() while publishing, and it isn't supported
-        // by jest.
-        if (process.env.IS_PUBLISH && name === ".babelrc.mjs") return;
 
         await config(name);
 

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -55,7 +55,7 @@ function loadOptionsAsync(opts) {
 
 async function loadOptionsAsyncInSpawedProcess({ filename, cwd }) {
   // !!!! hack is coming !!!!
-  // remove this section when https://github.com/facebook/jest/issues/9430 is resolved
+  // todo(Babel 8): remove this section when https://github.com/facebook/jest/issues/9430 is resolved
   // We don't check process.versions.node here, it will fail if node does not support esm
   // please publish Babel on a modernized node :)
   const { stdout, stderr } = await util.promisify(cp.execFile)(

--- a/packages/babel-core/test/fixtures/babel-load-options-async.mjs
+++ b/packages/babel-core/test/fixtures/babel-load-options-async.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+// Usage:
+// babel-load-options-async.js [filename]
+import babel from "@babel/core";
+
+const [, , filename, cwd] = process.argv;
+
+(async () => {
+  process.stdout.write(
+    JSON.stringify(await babel.loadOptionsAsync({ filename, cwd }))
+  );
+})();

--- a/packages/babel-core/test/fixtures/config/config-files-templates-prepublish/.babelrc.mjs
+++ b/packages/babel-core/test/fixtures/config/config-files-templates-prepublish/.babelrc.mjs
@@ -1,0 +1,3 @@
+export default {
+  comments: true,
+};

--- a/packages/babel-core/test/fixtures/config/config-files-templates-prepublish/babel.config.mjs
+++ b/packages/babel-core/test/fixtures/config/config-files-templates-prepublish/babel.config.mjs
@@ -1,0 +1,3 @@
+export default {
+  comments: true,
+};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11958
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
#11879 introduced a regression: Since `@babel/core` is compiled with `gulp-babel`, which does not declare support of dynamic import, `import()` is transpiled in the published source: https://unpkg.com/browse/@babel/core@7.11.0/lib/config/files/import.js

This PR adds the extra caller data and also a hacky prepublish test to ensure that `.mjs` loading works in the published builds.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11974"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/15c25e9f37d74bbe5c56d1e811ef985af584e39e.svg" /></a>

