### PR TITLE
fix: do not mutate newTypes

### DIFF
--- a/eslint/babel-eslint-parser/src/visitor-keys.js
+++ b/eslint/babel-eslint-parser/src/visitor-keys.js
@@ -19,4 +19,4 @@ export const conflictTypes = {
   ExportAllDeclaration: ESLINT_VISITOR_KEYS.ExportAllDeclaration,
 };
 
-export default Object.assign(newTypes, t.VISITOR_KEYS, conflictTypes);
+export default { ...newTypes, ...t.VISITOR_KEYS, ...conflictTypes };


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
#11973 introduced a bug that `newTypes` may be mutated in default exports. This is unwanted.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11978"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/c3ce0cff202f071a61af5cca287d6dfb2d340110.svg" /></a>

