### PR TITLE
fix: declare @babel/traverse as a dependency

### DIFF
--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -15,9 +15,7 @@
   "dependencies": {
     "@babel/helper-member-expression-to-functions": "^7.10.4",
     "@babel/helper-optimise-call-expression": "^7.10.4",
+    "@babel/traverse": "^7.10.4",
     "@babel/types": "^7.10.4"
-  },
-  "devDependencies": {
-    "@babel/traverse": "^7.10.4"
   }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/JLHwung/babel/commit/00b974298baa5663e8b51231da99fcd9f7b80879#r41492447
| Patch: Bug Fix?          | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This fix is extracted from https://github.com/babel/babel/pull/11962. It partially reverts #11937 since `@babel/traverse` is used in https://github.com/babel/babel/blob/028a051c2bb32a8886358d58e7a35dc90ffbf13a/packages/babel-helper-replace-supers/src/index.js#L3

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11985"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/69c934f303c924a165549eb92249008fce06b603.svg" /></a>

