### PR TITLE
Added linting support for private class methods

### DIFF
--- a/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
@@ -8,7 +8,11 @@ export default ruleComposer.filterReports(noInvalidThisRule, problem => {
   let node = problem.node;
 
   while (node) {
-    if (node.type === "ClassProperty" || node.type === "ClassPrivateProperty") {
+    if (
+      node.type === "ClassPrivateMethod" ||
+      node.type === "ClassPrivateProperty" ||
+      node.type === "ClassProperty"
+    ) {
       inClassProperty = true;
       return;
     }

--- a/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
@@ -4,7 +4,7 @@ import eslint from "eslint";
 const noInvalidThisRule = new eslint.Linter().getRules().get("no-invalid-this");
 
 export default ruleComposer.filterReports(noInvalidThisRule, problem => {
-  let inClassElement = false;
+  let inClassMember = false;
   let node = problem.node;
 
   while (node) {
@@ -13,12 +13,12 @@ export default ruleComposer.filterReports(noInvalidThisRule, problem => {
       node.type === "ClassPrivateProperty" ||
       node.type === "ClassProperty"
     ) {
-      inClassElement = true;
+      inClassMember = true;
       return;
     }
 
     node = node.parent;
   }
 
-  return !inClassElement;
+  return !inClassMember;
 });

--- a/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
@@ -4,7 +4,7 @@ import eslint from "eslint";
 const noInvalidThisRule = new eslint.Linter().getRules().get("no-invalid-this");
 
 export default ruleComposer.filterReports(noInvalidThisRule, problem => {
-  let inClassProperty = false;
+  let inClassElement = false;
   let node = problem.node;
 
   while (node) {
@@ -13,12 +13,12 @@ export default ruleComposer.filterReports(noInvalidThisRule, problem => {
       node.type === "ClassPrivateProperty" ||
       node.type === "ClassProperty"
     ) {
-      inClassProperty = true;
+      inClassElement = true;
       return;
     }
 
     node = node.parent;
   }
 
-  return !inClassProperty;
+  return !inClassElement;
 });

--- a/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
@@ -107,6 +107,13 @@ const patterns = [
     valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
     invalid: [],
   },
+
+  {
+    code: "class A {#a() {return this.b;};};",
+    parserOptions: { ecmaVersion: 6 },
+    valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+    invalid: [],
+  },
 ];
 
 const ruleTester = new RuleTester();


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | No
| Any Dependency Changes?  | No
| License                  | MIT

The [ESLint plugin](https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin) claims its `@babel/no-invalid-this` rule handles private class methods correctly, however that doesn't seem to be the case.

Running

```bash
eslint -f pretty a.js
```

on

```js
class A {

    #a() {
        return this.b;
    }

}
```

with ESLint settings

```js
module.exports = {
    parser: "@babel/eslint-parser",
    plugins: ["@babel"],
    rules: { "@babel/no-invalid-this": 2 }
};
```

and Babel settings

```js
module.exports = {
    presets: [["@babel/env", {
        shippedProposals: true
    }]]
};
```

prints

```log
  a.js:4:10
  ×  4:10  Unexpected this.  @babel/no-invalid-this

  1 error
```

even though that `this` [is perfectly valid](https://github.com/tc39/proposal-private-methods).

This fixes the issue.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/11993"><img src="https://gitpod.io/api/apps/github/pbs/github.com/giovannicalo/babel.git/a136005c0dbb8ee3a98ac4481dc52cff88b22089.svg" /></a>

