### PR TITLE
fix(plugin-proposal-function-bind): fix invalid code emitted for `::super.foo`

### DIFF
--- a/packages/babel-plugin-proposal-function-bind/src/index.js
+++ b/packages/babel-plugin-proposal-function-bind/src/index.js
@@ -15,7 +15,10 @@ export default declare(api => {
 
   function getStaticContext(bind, scope) {
     const object = bind.object || bind.callee.object;
-    return scope.isStatic(object) && object;
+    return (
+      scope.isStatic(object) &&
+      (t.isSuper(object) ? t.thisExpression() : object)
+    );
   }
 
   function inferBindContext(bind, scope) {

--- a/packages/babel-plugin-proposal-function-bind/test/fixtures/function-bind/super/input.js
+++ b/packages/babel-plugin-proposal-function-bind/test/fixtures/function-bind/super/input.js
@@ -1,0 +1,5 @@
+class C {
+  foo() {
+    ::super.bar;
+  }
+}

--- a/packages/babel-plugin-proposal-function-bind/test/fixtures/function-bind/super/input.js
+++ b/packages/babel-plugin-proposal-function-bind/test/fixtures/function-bind/super/input.js
@@ -1,5 +1,6 @@
 class C {
   foo() {
     ::super.bar;
+    ::super.baz(123);
   }
 }

--- a/packages/babel-plugin-proposal-function-bind/test/fixtures/function-bind/super/output.js
+++ b/packages/babel-plugin-proposal-function-bind/test/fixtures/function-bind/super/output.js
@@ -1,5 +1,7 @@
 class C {
   foo() {
     super.bar.bind(this);
+    super.baz.call(this, 123);
   }
+
 }

--- a/packages/babel-plugin-proposal-function-bind/test/fixtures/function-bind/super/output.js
+++ b/packages/babel-plugin-proposal-function-bind/test/fixtures/function-bind/super/output.js
@@ -1,0 +1,5 @@
+class C {
+  foo() {
+    super.bar.bind(this);
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | none
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This PR fixes the handling of `super` in `plugin-proposal-function-bind`.
Current implementation emits invalid code when converting `::super.foo`.

**example**

Input

```js
class C {
  foo() {
    ::super.bar;
    ::super.baz(123);
  }
}
```

Current Output

```js
class C {
  foo() {
    super.bar.bind(super);
    super.baz.call(super, 123);
  }

}
```

New Output

```js
class C {
  foo() {
    super.bar.bind(this);
    super.baz.call(this, 123);
  }

}
```


