### PR TITLE
add test on ES2021 features

### DIFF
--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -61,7 +61,7 @@ describe("Babel and Espree", () => {
       loc: true,
       range: true,
       comment: true,
-      ecmaVersion: 2020,
+      ecmaVersion: 2021,
       sourceType: "module",
     });
     const babelAST = parseForESLint(code, {
@@ -295,6 +295,14 @@ describe("Babel and Espree", () => {
 
   it("nullish coalescing operator", () => {
     parseAndAssertSame("foo ?? bar");
+  });
+
+  it("logical assignment", () => {
+    parseAndAssertSame("foo ??= bar &&= qux ||= quux");
+  });
+
+  it("numeric separator", () => {
+    parseAndAssertSame("1_0.0_0e0_1");
   });
 
   // Espree doesn't support the pipeline operator yet

--- a/yarn.lock
+++ b/yarn.lock
@@ -4972,12 +4972,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^7.0.0, acorn@npm:^7.1.0, acorn@npm:^7.1.1, acorn@npm:^7.3.1":
-  version: 7.3.1
-  resolution: "acorn@npm:7.3.1"
+"acorn@npm:^7.0.0, acorn@npm:^7.1.0, acorn@npm:^7.1.1, acorn@npm:^7.4.0":
+  version: 7.4.0
+  resolution: "acorn@npm:7.4.0"
   bin:
     acorn: bin/acorn
-  checksum: 3fa70393843c3fd4af691f449563e983e064c5c3f655fd943f5f77fb767257623f8afc0a2454b0037aa0c4dd95374c75a9e0e6c54a5f497fc63e63449ad6327c
+  checksum: a25b12d9e803df49593e983f05abd8084be883df23f78a3ceb49bfb9c453fdc43d51b3ce268b6acd7694c34d9cde1707acb1cdcbc5303bde47bee43ffc131491
   languageName: node
   linkType: hard
 
@@ -8066,13 +8066,13 @@ __metadata:
   linkType: hard
 
 "espree@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "espree@npm:7.2.0"
+  version: 7.3.0
+  resolution: "espree@npm:7.3.0"
   dependencies:
-    acorn: ^7.3.1
+    acorn: ^7.4.0
     acorn-jsx: ^5.2.0
     eslint-visitor-keys: ^1.3.0
-  checksum: 51bdb836f47a360ea4fd1a28cf7df1974f2be93abd5cf707cfbedcb15fb6591d26f6dc345d3cb07c4b1df7c5435e50d4b2fdf2a0ed4d63175da8b2c83f06057b
+  checksum: dd2543c293e091532f3d6eda4a09ae49039ac65e69bc072aec952a5db6eb23eeee7617e99cde11414367104208c2dec13f709bbede0528d4f6854ce5cb734960
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Bumped `espree` to 7.3.0 and added ES2021 feature tests to `@babel/eslint-parser`. According to the test result, it seems that `@babel/eslint-parser` already supported ES2021, which is good.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12005"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/709741de5ad58e0356e4a7305d0612c11a0d004e.svg" /></a>

