### PR TITLE
refactor: add @babel/helper-validator-option

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -106,7 +106,10 @@ module.exports = function (api) {
     plugins: [
       // TODO: Use @babel/preset-flow when
       // https://github.com/babel/babel/issues/7233 is fixed
-      "@babel/plugin-transform-flow-strip-types",
+      [
+        "@babel/plugin-transform-flow-strip-types",
+        { allowDeclareFields: true },
+      ],
       [
         "@babel/proposal-object-rest-spread",
         { useBuiltIns: true, loose: true },

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -22,9 +22,8 @@
   ],
   "dependencies": {
     "@babel/compat-data": "workspace:^7.10.4",
+    "@babel/helper-validator-option": "workspace:^7.11.4",
     "browserslist": "^4.12.0",
-    "invariant": "^2.2.4",
-    "levenary": "^1.1.1",
     "semver": "^5.5.0"
   },
   "peerDependencies": {

--- a/packages/babel-helper-compilation-targets/src/index.js
+++ b/packages/babel-helper-compilation-targets/src/index.js
@@ -1,8 +1,7 @@
 // @flow
 
 import browserslist from "browserslist";
-import findSuggestion from "levenary";
-import invariant from "invariant";
+import { findSuggestion } from "@babel/helper-validator-option";
 import browserModulesData from "@babel/compat-data/native-modules";
 
 import {
@@ -10,6 +9,7 @@ import {
   semverMin,
   isUnreleasedVersion,
   getLowestUnreleased,
+  v,
 } from "./utils";
 import { browserNameMap } from "./targets";
 import { TargetNames } from "./options";
@@ -41,13 +41,12 @@ function objectToBrowserslist(object: Targets): Array<string> {
 
 function validateTargetNames(targets: InputTargets): Targets {
   const validTargets = Object.keys(TargetNames);
-  for (const target in targets) {
-    if (!TargetNames[target]) {
-      throw new Error(
-        `Invalid Option: '${target}' is not a valid target
+  for (const target of Object.keys(targets)) {
+    v.invariant(
+      !!TargetNames[target],
+      `'${target}' is not a valid target
         Maybe you meant to use '${findSuggestion(target, validTargets)}'?`,
-      );
-    }
+    );
   }
 
   // $FlowIgnore
@@ -59,9 +58,9 @@ export function isBrowsersQueryValid(browsers: Browsers | Targets): boolean {
 }
 
 function validateBrowsers(browsers: Browsers | void) {
-  invariant(
-    typeof browsers === "undefined" || isBrowsersQueryValid(browsers),
-    `Invalid Option: '${String(browsers)}' is not a valid browserslist query`,
+  v.invariant(
+    browsers === undefined || isBrowsersQueryValid(browsers),
+    `'${String(browsers)}' is not a valid browserslist query`,
   );
 
   return browsers;
@@ -133,7 +132,9 @@ function semverifyTarget(target, value) {
     return semverify(value);
   } catch (error) {
     throw new Error(
-      `Invalid Option: '${value}' is not a valid value for 'targets.${target}'.`,
+      v.formatMessage(
+        `'${value}' is not a valid value for 'targets.${target}'.`,
+      ),
     );
   }
 }

--- a/packages/babel-helper-compilation-targets/src/index.js
+++ b/packages/babel-helper-compilation-targets/src/index.js
@@ -9,10 +9,11 @@ import {
   semverMin,
   isUnreleasedVersion,
   getLowestUnreleased,
-  v,
 } from "./utils";
+import { OptionValidator } from "@babel/helper-validator-option";
 import { browserNameMap } from "./targets";
 import { TargetNames } from "./options";
+import { name as packageName } from "../package.json";
 import type { Targets, InputTargets, Browsers, TargetsTuple } from "./types";
 
 export type { Targets, InputTargets };
@@ -22,6 +23,7 @@ export { getInclusionReasons } from "./debug";
 export { default as filterItems, isRequired } from "./filter-items";
 export { unreleasedLabels } from "./targets";
 
+const v = new OptionValidator(packageName);
 const browserslistDefaults = browserslist.defaults;
 
 const validBrowserslistTargets = [

--- a/packages/babel-helper-compilation-targets/src/index.js
+++ b/packages/babel-helper-compilation-targets/src/index.js
@@ -47,7 +47,7 @@ function validateTargetNames(targets: Targets): TargetsTuple {
     if (!(target in TargetNames)) {
       throw new Error(
         v.formatMessage(`'${target}' is not a valid target
-        Maybe you meant to use '${findSuggestion(target, validTargets)}'?`),
+- Did you mean '${findSuggestion(target, validTargets)}'?`),
       );
     }
   }

--- a/packages/babel-helper-compilation-targets/src/types.js
+++ b/packages/babel-helper-compilation-targets/src/types.js
@@ -18,6 +18,10 @@ export type Targets = {
   [target: Target]: string,
 };
 
+export type TargetsTuple = {|
+  [target: Target]: string,
+|};
+
 export type Browsers = string | Array<string>;
 
 export type InputTargets = {

--- a/packages/babel-helper-compilation-targets/src/utils.js
+++ b/packages/babel-helper-compilation-targets/src/utils.js
@@ -1,12 +1,12 @@
 // @flow
-
-import invariant from "invariant";
 import semver from "semver";
-
+import { OptionValidator } from "@babel/helper-validator-option";
 import { unreleasedLabels } from "./targets";
 import type { Target, Targets } from "./types";
 
 const versionRegExp = /^(\d+|\d+.\d+)$/;
+
+export const v = new OptionValidator("@babel/helper-compilation-targets");
 
 export function semverMin(first: ?string, second: string): string {
   return first && semver.lt(first, second) ? first : second;
@@ -19,7 +19,7 @@ export function semverify(version: number | string): string {
     return version;
   }
 
-  invariant(
+  v.invariant(
     typeof version === "number" ||
       (typeof version === "string" && versionRegExp.test(version)),
     `'${version}' is not a valid version`,

--- a/packages/babel-helper-compilation-targets/src/utils.js
+++ b/packages/babel-helper-compilation-targets/src/utils.js
@@ -1,12 +1,13 @@
 // @flow
 import semver from "semver";
 import { OptionValidator } from "@babel/helper-validator-option";
+import { name as packageName } from "../package.json";
 import { unreleasedLabels } from "./targets";
 import type { Target, Targets } from "./types";
 
 const versionRegExp = /^(\d+|\d+.\d+)$/;
 
-export const v = new OptionValidator("@babel/helper-compilation-targets");
+const v = new OptionValidator(packageName);
 
 export function semverMin(first: ?string, second: string): string {
   return first && semver.lt(first, second) ? first : second;

--- a/packages/babel-helper-compilation-targets/test/__snapshots__/targets-parser.spec.js.snap
+++ b/packages/babel-helper-compilation-targets/test/__snapshots__/targets-parser.spec.js.snap
@@ -57,3 +57,5 @@ Object {
   "samsung": "8.2.0",
 }
 `;
+
+exports[`getTargets exception throws when version is not a semver 1`] = `"@babel/helper-compilation-targets: 'seventy-two' is not a valid value for 'targets.chrome'."`;

--- a/packages/babel-helper-compilation-targets/test/targets-parser.spec.js
+++ b/packages/babel-helper-compilation-targets/test/targets-parser.spec.js
@@ -260,4 +260,12 @@ describe("getTargets", () => {
       });
     });
   });
+
+  describe("exception", () => {
+    it("throws when version is not a semver", () => {
+      expect(() =>
+        getTargets({ chrome: "seventy-two" }),
+      ).toThrowErrorMatchingSnapshot();
+    });
+  });
 });

--- a/packages/babel-helper-validator-option/.npmignore
+++ b/packages/babel-helper-validator-option/.npmignore
@@ -1,0 +1,3 @@
+src
+test
+*.log

--- a/packages/babel-helper-validator-option/README.md
+++ b/packages/babel-helper-validator-option/README.md
@@ -1,0 +1,19 @@
+# @babel/helper-validator-option
+
+> Validate identifier/keywords name
+
+See our website [@babel/helper-validator-option](https://babeljs.io/docs/en/next/babel-helper-validator-option.html) for more information.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @babel/helper-validator-option
+```
+
+or using yarn:
+
+```sh
+yarn add @babel/helper-validator-option --dev
+```

--- a/packages/babel-helper-validator-option/README.md
+++ b/packages/babel-helper-validator-option/README.md
@@ -1,6 +1,6 @@
 # @babel/helper-validator-option
 
-> Validate identifier/keywords name
+> Validate plugin/preset options
 
 See our website [@babel/helper-validator-option](https://babeljs.io/docs/en/next/babel-helper-validator-option.html) for more information.
 

--- a/packages/babel-helper-validator-option/package.json
+++ b/packages/babel-helper-validator-option/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@babel/helper-validator-option",
+  "version": "7.11.4",
+  "description": "Validate plugin/preset options",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-validator-option"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./lib/index.js",
+  "exports": "./lib/index.js"
+}

--- a/packages/babel-helper-validator-option/src/find-suggestion.js
+++ b/packages/babel-helper-validator-option/src/find-suggestion.js
@@ -1,0 +1,38 @@
+// @flow
+
+const { min, max } = Math;
+
+// a minimal leven distance implementation
+// balanced maintenability with code size
+// It is not blazingly fast but should be okay for Babel user case
+// where it will be run for at most tens of time on strings
+// that have less than 20 ASCII characters
+
+// https://en.wikipedia.org/wiki/Levenshtein_distance
+function leven_d(s1: string, s2: string) {
+  return function leven(len1: number, len2: number): number {
+    return len1 * len2
+      ? min(
+          leven(len1 - 1, len2),
+          leven(len1, len2 - 1),
+          leven(len1 - 1, len2 - 1) - ((s1[len1] === s2[len2]: any): number),
+        ) + 1
+      : max(len1, len2);
+  };
+}
+
+/**
+ * Given a string `str` and an array of candidates `arr`,
+ * return the first of elements in candidates that has minimal
+ * Levenshtein distance with `str`.
+ * @export
+ * @param {string} str
+ * @param {string[]} arr
+ * @returns {string}
+ */
+export function findSuggestion(str: string, arr: string[]): string {
+  const distances = arr.map<number>(el =>
+    leven_d(el, str)(el.length, str.length),
+  );
+  return arr[distances.indexOf(min(...distances))];
+}

--- a/packages/babel-helper-validator-option/src/find-suggestion.js
+++ b/packages/babel-helper-validator-option/src/find-suggestion.js
@@ -1,6 +1,6 @@
 // @flow
 
-const { min, max } = Math;
+const { min } = Math;
 
 // a minimal leven distance implementation
 // balanced maintenability with code size
@@ -8,17 +8,31 @@ const { min, max } = Math;
 // where it will be run for at most tens of time on strings
 // that have less than 20 ASCII characters
 
-// https://en.wikipedia.org/wiki/Levenshtein_distance
-function leven_d(s1: string, s2: string) {
-  return function leven(len1: number, len2: number): number {
-    return len1 * len2
-      ? min(
-          leven(len1 - 1, len2),
-          leven(len1, len2 - 1),
-          leven(len1 - 1, len2 - 1) - ((s1[len1] === s2[len2]: any): number),
-        ) + 1
-      : max(len1, len2);
-  };
+// https://rosettacode.org/wiki/Levenshtein_distance#ES5
+function levenshtein(a, b) {
+  let t = [],
+    u = [],
+    i,
+    j;
+  const m = a.length,
+    n = b.length;
+  if (!m) {
+    return n;
+  }
+  if (!n) {
+    return m;
+  }
+  for (j = 0; j <= n; j++) {
+    t[j] = j;
+  }
+  for (i = 1; i <= m; i++) {
+    for (u = [i], j = 1; j <= n; j++) {
+      u[j] =
+        a[i - 1] === b[j - 1] ? t[j - 1] : min(t[j - 1], t[j], u[j - 1]) + 1;
+    }
+    t = u;
+  }
+  return u[n];
 }
 
 /**
@@ -31,8 +45,6 @@ function leven_d(s1: string, s2: string) {
  * @returns {string}
  */
 export function findSuggestion(str: string, arr: string[]): string {
-  const distances = arr.map<number>(el =>
-    leven_d(el, str)(el.length, str.length),
-  );
+  const distances = arr.map<number>(el => levenshtein(el, str));
   return arr[distances.indexOf(min(...distances))];
 }

--- a/packages/babel-helper-validator-option/src/index.js
+++ b/packages/babel-helper-validator-option/src/index.js
@@ -1,0 +1,2 @@
+export { OptionValidator } from "./validator";
+export { findSuggestion } from "./find-suggestion";

--- a/packages/babel-helper-validator-option/src/validator.js
+++ b/packages/babel-helper-validator-option/src/validator.js
@@ -22,7 +22,7 @@ export class OptionValidator {
       if (!validOptionNames.includes(option)) {
         throw new Error(
           `${this.descriptor}: '${option}' is not a valid top-level option.
-- Maybe you meant to use '${findSuggestion(option, validOptionNames)}'?`,
+- Maybe you are meant to use '${findSuggestion(option, validOptionNames)}'?`,
         );
       }
     }

--- a/packages/babel-helper-validator-option/src/validator.js
+++ b/packages/babel-helper-validator-option/src/validator.js
@@ -32,9 +32,9 @@ export class OptionValidator {
   // until we have to support `validateNumberOption`.
   validateBooleanOption(
     name: string,
-    value?: string,
-    defaultValue?: string,
-  ): string | void {
+    value?: boolean,
+    defaultValue?: boolean,
+  ): boolean | void {
     if (value === undefined) {
       value = defaultValue;
     } else {

--- a/packages/babel-helper-validator-option/src/validator.js
+++ b/packages/babel-helper-validator-option/src/validator.js
@@ -1,0 +1,86 @@
+// @flow
+import { findSuggestion } from "./find-suggestion.js";
+
+export class OptionValidator {
+  declare descriptor: string;
+  constructor(descriptor: string) {
+    this.descriptor = descriptor;
+  }
+
+  /**
+   * Validate if the given `options` follow the name of keys defined in the `TopLevelOptionShape`
+   *
+   * @param {Object} options
+   * @param {Object} TopLevelOptionShape
+   *   An object with all the valid key names that `options` should be allowed to have
+   *   The property values of `TopLevelOptionShape` can be arbitrary
+   * @memberof OptionValidator
+   */
+  validateTopLevelOptions(options: Object, TopLevelOptionShape: Object): void {
+    const validOptionNames = Object.keys(TopLevelOptionShape);
+    for (const option of Object.keys(options)) {
+      this.validateOneOf(option, validOptionNames, (option, suggestion) => {
+        return `'${option}' is not a valid top-level option.
+- Maybe you meant to use '${suggestion}'?`;
+      });
+    }
+  }
+
+  validateOneOf(
+    value: string,
+    candidates: string[],
+    errorFormatter: (value: string, suggestion: string) => string,
+  ): void {
+    this.invariant(
+      candidates.includes(value),
+      errorFormatter(value, findSuggestion(value, candidates)),
+    );
+  }
+
+  // note: we do not consider rewrite them to high order functions
+  // until we have to support `validateNumberOption`.
+  validateBooleanOption(
+    name: string,
+    value?: string,
+    defaultValue?: string,
+  ): string | void {
+    if (value === undefined) {
+      value = defaultValue;
+    } else {
+      this.invariant(
+        typeof value === "boolean",
+        `'${name}' option must be a boolean.`,
+      );
+    }
+    return value;
+  }
+
+  validateStringOption(
+    name: string,
+    value?: string,
+    defaultValue?: string,
+  ): string | void {
+    if (value === undefined) {
+      value = defaultValue;
+    } else {
+      this.invariant(
+        typeof value === "string",
+        `'${name}' option must be a string.`,
+      );
+    }
+    return value;
+  }
+  /**
+   * A helper interface copied from the `invariant` npm package.
+   * It throws given `message` when `condition` is not met
+   *
+   * @param {boolean} condition
+   * @param {string} message
+   * @memberof OptionValidator
+   */
+  invariant(condition: boolean, message: string): void {
+    if (!condition) {
+      throw new Error(`${this.descriptor}: ${message}`);
+    }
+  }
+}

--- a/packages/babel-helper-validator-option/src/validator.js
+++ b/packages/babel-helper-validator-option/src/validator.js
@@ -21,8 +21,8 @@ export class OptionValidator {
     for (const option of Object.keys(options)) {
       if (!validOptionNames.includes(option)) {
         throw new Error(
-          `${this.descriptor}: '${option}' is not a valid top-level option.
-- Maybe you are meant to use '${findSuggestion(option, validOptionNames)}'?`,
+          this.formatMessage(`'${option}' is not a valid top-level option.
+- Maybe you are meant to use '${findSuggestion(option, validOptionNames)}'?`),
         );
       }
     }
@@ -71,7 +71,11 @@ export class OptionValidator {
    */
   invariant(condition: boolean, message: string): void {
     if (!condition) {
-      throw new Error(`${this.descriptor}: ${message}`);
+      throw new Error(this.formatMessage(message));
     }
+  }
+
+  formatMessage(message: string): string {
+    return `${this.descriptor}: ${message}`;
   }
 }

--- a/packages/babel-helper-validator-option/src/validator.js
+++ b/packages/babel-helper-validator-option/src/validator.js
@@ -22,7 +22,7 @@ export class OptionValidator {
       if (!validOptionNames.includes(option)) {
         throw new Error(
           this.formatMessage(`'${option}' is not a valid top-level option.
-- Maybe you are meant to use '${findSuggestion(option, validOptionNames)}'?`),
+- Did you mean '${findSuggestion(option, validOptionNames)}'?`),
         );
       }
     }

--- a/packages/babel-helper-validator-option/src/validator.js
+++ b/packages/babel-helper-validator-option/src/validator.js
@@ -19,22 +19,13 @@ export class OptionValidator {
   validateTopLevelOptions(options: Object, TopLevelOptionShape: Object): void {
     const validOptionNames = Object.keys(TopLevelOptionShape);
     for (const option of Object.keys(options)) {
-      this.validateOneOf(option, validOptionNames, (option, suggestion) => {
-        return `'${option}' is not a valid top-level option.
-- Maybe you meant to use '${suggestion}'?`;
-      });
+      if (!validOptionNames.includes(option)) {
+        throw new Error(
+          `${this.descriptor}: '${option}' is not a valid top-level option.
+- Maybe you meant to use '${findSuggestion(option, validOptionNames)}'?`,
+        );
+      }
     }
-  }
-
-  validateOneOf(
-    value: string,
-    candidates: string[],
-    errorFormatter: (value: string, suggestion: string) => string,
-  ): void {
-    this.invariant(
-      candidates.includes(value),
-      errorFormatter(value, findSuggestion(value, candidates)),
-    );
   }
 
   // note: we do not consider rewrite them to high order functions

--- a/packages/babel-helper-validator-option/test/find-suggestion.spec.js
+++ b/packages/babel-helper-validator-option/test/find-suggestion.spec.js
@@ -1,0 +1,10 @@
+import { findSuggestion } from "..";
+
+describe("findSuggestion", function () {
+  test.each([
+    ["cat", ["cow", "dog", "pig"], "cow"],
+    ["uglifyjs", [], undefined],
+  ])("findSuggestion(%p, %p) returns %p", (str, arr, expected) => {
+    expect(findSuggestion(str, arr)).toBe(expected);
+  });
+});

--- a/packages/babel-helper-validator-option/test/validator.spec.js
+++ b/packages/babel-helper-validator-option/test/validator.spec.js
@@ -19,7 +19,11 @@ describe("OptionValidator", () => {
       expect(() =>
         v.validateTopLevelOptions(
           { hasOwnProperty: "foo" },
-          { foo: "foo" },
+          {
+            foo: "foo",
+            bar: "bar",
+            aLongPropertyKeyToSeeLevenPerformance: "a",
+          },
           "test",
         ),
       ).toThrow();

--- a/packages/babel-helper-validator-option/test/validator.spec.js
+++ b/packages/babel-helper-validator-option/test/validator.spec.js
@@ -1,0 +1,77 @@
+import { OptionValidator } from "..";
+
+describe("OptionValidator", () => {
+  describe("validateTopLevelOptions", () => {
+    let v;
+    beforeAll(() => {
+      v = new OptionValidator("test-descriptor");
+    });
+    it("should throw when option key is not found", () => {
+      expect(() =>
+        v.validateTopLevelOptions(
+          { unknown: "options" },
+          { foo: "foo" },
+          "test",
+        ),
+      ).toThrow();
+    });
+    it("should throw when option key is an own property but not found", () => {
+      expect(() =>
+        v.validateTopLevelOptions(
+          { hasOwnProperty: "foo" },
+          { foo: "foo" },
+          "test",
+        ),
+      ).toThrow();
+    });
+  });
+  describe("validateBooleanOption", () => {
+    let v;
+    beforeAll(() => {
+      v = new OptionValidator("test-descriptor");
+    });
+    it("`undefined` option returns false", () => {
+      expect(v.validateBooleanOption("test", undefined, false)).toBe(false);
+    });
+
+    it("`false` option returns false", () => {
+      expect(v.validateBooleanOption("test", false, false)).toBe(false);
+    });
+
+    it("`true` option returns true", () => {
+      expect(v.validateBooleanOption("test", true, false)).toBe(true);
+    });
+
+    it("array option is invalid", () => {
+      expect(() => {
+        v.validateBooleanOption("test", [], false);
+      }).toThrow();
+    });
+  });
+
+  describe("validateStringOption", () => {
+    let v;
+    beforeAll(() => {
+      v = new OptionValidator("test-descriptor");
+    });
+    it("`undefined` option default", () => {
+      expect(v.validateStringOption("test", undefined, "default")).toBe(
+        "default",
+      );
+    });
+
+    it("`value` option returns value", () => {
+      expect(v.validateStringOption("test", "value", "default")).toBe("value");
+    });
+
+    it("no default returns undefined", () => {
+      expect(v.validateStringOption("test", undefined)).toBe(undefined);
+    });
+
+    it("array option is invalid", () => {
+      expect(() => {
+        v.validateStringOption("test", [], "default");
+      }).toThrow();
+    });
+  });
+});

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -19,6 +19,7 @@
     "@babel/helper-compilation-targets": "workspace:^7.10.4",
     "@babel/helper-module-imports": "workspace:^7.10.4",
     "@babel/helper-plugin-utils": "workspace:^7.10.4",
+    "@babel/helper-validator-option": "workspace:^7.11.4",
     "@babel/plugin-proposal-async-generator-functions": "workspace:^7.10.4",
     "@babel/plugin-proposal-class-properties": "workspace:^7.10.4",
     "@babel/plugin-proposal-dynamic-import": "workspace:^7.10.4",
@@ -80,8 +81,6 @@
     "@babel/types": "workspace:^7.11.5",
     "browserslist": "^4.12.0",
     "core-js-compat": "^3.6.2",
-    "invariant": "^2.2.2",
-    "levenary": "^1.1.1",
     "semver": "^5.5.0"
   },
   "peerDependencies": {

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -7,6 +7,7 @@ import moduleTransformations from "./module-transformations";
 import { TopLevelOptions, ModulesOption, UseBuiltInsOption } from "./options";
 import { OptionValidator } from "@babel/helper-validator-option";
 import { defaultWebIncludes } from "./polyfills/corejs2/get-platform-specific-default";
+import { name as packageName } from "../package.json";
 
 import type {
   BuiltInsOption,
@@ -17,7 +18,7 @@ import type {
   PluginListOption,
 } from "./types";
 
-const v = new OptionValidator("@babel/preset-env");
+const v = new OptionValidator(packageName);
 
 const allPluginsList = Object.keys(pluginsList);
 

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -1,12 +1,11 @@
 // @flow
 import corejs3Polyfills from "core-js-compat/data";
-import findSuggestion from "levenary";
-import invariant from "invariant";
 import { coerce, SemVer } from "semver";
 import corejs2Polyfills from "@babel/compat-data/corejs2-built-ins";
 import { plugins as pluginsList } from "./plugins-compat-data";
 import moduleTransformations from "./module-transformations";
 import { TopLevelOptions, ModulesOption, UseBuiltInsOption } from "./options";
+import { OptionValidator } from "@babel/helper-validator-option";
 import { defaultWebIncludes } from "./polyfills/corejs2/get-platform-specific-default";
 
 import type {
@@ -18,18 +17,7 @@ import type {
   PluginListOption,
 } from "./types";
 
-const validateTopLevelOptions = (options: Options) => {
-  const validOptions = Object.keys(TopLevelOptions);
-
-  for (const option in options) {
-    if (!TopLevelOptions[option]) {
-      throw new Error(
-        `Invalid Option: ${option} is not a valid top-level option.
-        Maybe you meant to use '${findSuggestion(option, validOptions)}'?`,
-      );
-    }
-  }
-};
+const v = new OptionValidator("@babel/preset-env");
 
 const allPluginsList = Object.keys(pluginsList);
 
@@ -89,9 +77,9 @@ const expandIncludesAndExcludes = (
     (p, i) => selectedPlugins[i].length === 0,
   );
 
-  invariant(
+  v.invariant(
     invalidRegExpList.length === 0,
-    `Invalid Option: The plugins/built-ins '${invalidRegExpList.join(
+    `The plugins/built-ins '${invalidRegExpList.join(
       ", ",
     )}' passed to the '${type}' option are not
     valid. Please check data/[plugin-features|built-in-features].js in babel-preset-env`,
@@ -109,9 +97,9 @@ export const checkDuplicateIncludeExcludes = (
 ) => {
   const duplicates = include.filter(opt => exclude.indexOf(opt) >= 0);
 
-  invariant(
+  v.invariant(
     duplicates.length === 0,
-    `Invalid Option: The plugins/built-ins '${duplicates.join(
+    `The plugins/built-ins '${duplicates.join(
       ", ",
     )}' were found in both the "include" and
     "exclude" options.`,
@@ -126,61 +114,12 @@ const normalizeTargets = targets => {
   return { ...targets };
 };
 
-export const validateConfigPathOption = (
-  configPath: string = process.cwd(),
-) => {
-  invariant(
-    typeof configPath === "string",
-    `Invalid Option: The configPath option '${configPath}' is invalid, only strings are allowed.`,
-  );
-  return configPath;
-};
-
-export const validateBoolOption = (
-  name: string,
-  value?: boolean,
-  defaultValue: boolean,
-) => {
-  if (typeof value === "undefined") {
-    value = defaultValue;
-  }
-
-  if (typeof value !== "boolean") {
-    throw new Error(`Preset env: '${name}' option must be a boolean.`);
-  }
-
-  return value;
-};
-
-export const validateStringOption = (
-  name: string,
-  value?: string,
-  defaultValue?: string,
-) => {
-  if (typeof value === "undefined") {
-    value = defaultValue;
-  } else if (typeof value !== "string") {
-    throw new Error(`Preset env: '${name}' option must be a string.`);
-  }
-
-  return value;
-};
-
-export const validateIgnoreBrowserslistConfig = (
-  ignoreBrowserslistConfig: boolean,
-) =>
-  validateBoolOption(
-    TopLevelOptions.ignoreBrowserslistConfig,
-    ignoreBrowserslistConfig,
-    false,
-  );
-
 export const validateModulesOption = (
   modulesOpt: ModuleOption = ModulesOption.auto,
 ) => {
-  invariant(
+  v.invariant(
     ModulesOption[modulesOpt.toString()] || modulesOpt === ModulesOption.false,
-    `Invalid Option: The 'modules' option must be one of \n` +
+    `The 'modules' option must be one of \n` +
       ` - 'false' to indicate no module processing\n` +
       ` - a specific module type: 'commonjs', 'amd', 'umd', 'systemjs'` +
       ` - 'auto' (default) which will automatically select 'false' if the current\n` +
@@ -193,10 +132,10 @@ export const validateModulesOption = (
 export const validateUseBuiltInsOption = (
   builtInsOpt: BuiltInsOption = false,
 ) => {
-  invariant(
+  v.invariant(
     UseBuiltInsOption[builtInsOpt.toString()] ||
       builtInsOpt === UseBuiltInsOption.false,
-    `Invalid Option: The 'useBuiltIns' option must be either
+    `The 'useBuiltIns' option must be either
     'false' (default) to indicate no polyfill,
     '"entry"' to indicate replacing the entry polyfill, or
     '"usage"' to import only used polyfills per file`,
@@ -258,7 +197,7 @@ export function normalizeCoreJSOption(
 }
 
 export default function normalizeOptions(opts: Options) {
-  validateTopLevelOptions(opts);
+  v.validateTopLevelOptions(opts, TopLevelOptions);
 
   const useBuiltIns = validateUseBuiltInsOption(opts.useBuiltIns);
 
@@ -278,38 +217,42 @@ export default function normalizeOptions(opts: Options) {
 
   checkDuplicateIncludeExcludes(include, exclude);
 
-  const shippedProposals = validateBoolOption(
-    TopLevelOptions.shippedProposals,
-    opts.shippedProposals,
-    false,
-  );
-
   return {
-    bugfixes: validateBoolOption(
+    bugfixes: v.validateBooleanOption(
       TopLevelOptions.bugfixes,
       opts.bugfixes,
       false,
     ),
-    configPath: validateConfigPathOption(opts.configPath),
+    configPath: v.validateStringOption(
+      TopLevelOptions.configPath,
+      opts.configPath,
+      process.cwd(),
+    ),
     corejs,
-    debug: validateBoolOption(TopLevelOptions.debug, opts.debug, false),
+    debug: v.validateBooleanOption(TopLevelOptions.debug, opts.debug, false),
     include,
     exclude,
-    forceAllTransforms: validateBoolOption(
+    forceAllTransforms: v.validateBooleanOption(
       TopLevelOptions.forceAllTransforms,
       opts.forceAllTransforms,
       false,
     ),
-    ignoreBrowserslistConfig: validateIgnoreBrowserslistConfig(
+    ignoreBrowserslistConfig: v.validateBooleanOption(
+      TopLevelOptions.ignoreBrowserslistConfig,
       opts.ignoreBrowserslistConfig,
+      false,
     ),
-    loose: validateBoolOption(TopLevelOptions.loose, opts.loose, false),
+    loose: v.validateBooleanOption(TopLevelOptions.loose, opts.loose, false),
     modules: validateModulesOption(opts.modules),
-    shippedProposals,
-    spec: validateBoolOption(TopLevelOptions.spec, opts.spec, false),
+    shippedProposals: v.validateBooleanOption(
+      TopLevelOptions.shippedProposals,
+      opts.shippedProposals,
+      false,
+    ),
+    spec: v.validateBooleanOption(TopLevelOptions.spec, opts.spec, false),
     targets: normalizeTargets(opts.targets),
     useBuiltIns: useBuiltIns,
-    browserslistEnv: validateStringOption(
+    browserslistEnv: v.validateStringOption(
       TopLevelOptions.browserslistEnv,
       opts.browserslistEnv,
     ),

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -4,8 +4,6 @@ const normalizeOptions = require("../lib/normalize-options.js");
 
 const {
   checkDuplicateIncludeExcludes,
-  validateBoolOption,
-  validateStringOption,
   validateModulesOption,
   validateUseBuiltInsOption,
   normalizePluginName,
@@ -169,48 +167,6 @@ describe("normalize-options", () => {
       });
       expect(normalized.include).toEqual(["es.reflect.set-prototype-of"]);
       expect(normalized.exclude).toEqual(["es.reflect.set"]);
-    });
-  });
-
-  describe("validateBoolOption", () => {
-    it("`undefined` option returns false", () => {
-      expect(validateBoolOption("test", undefined, false)).toBe(false);
-    });
-
-    it("`false` option returns false", () => {
-      expect(validateBoolOption("test", false, false)).toBe(false);
-    });
-
-    it("`true` option returns true", () => {
-      expect(validateBoolOption("test", true, false)).toBe(true);
-    });
-
-    it("array option is invalid", () => {
-      expect(() => {
-        validateBoolOption("test", [], false);
-      }).toThrow();
-    });
-  });
-
-  describe("validateStringOption", () => {
-    it("`undefined` option default", () => {
-      expect(validateStringOption("test", undefined, "default")).toBe(
-        "default",
-      );
-    });
-
-    it("`value` option returns value", () => {
-      expect(validateStringOption("test", "value", "default")).toBe("value");
-    });
-
-    it("no default returns undefined", () => {
-      expect(validateStringOption("test", undefined)).toBe(undefined);
-    });
-
-    it("array option is invalid", () => {
-      expect(() => {
-        validateStringOption("test", [], "default");
-      }).toThrow();
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,9 +358,8 @@ __metadata:
     "@babel/compat-data": "workspace:^7.10.4"
     "@babel/core": "workspace:^7.10.4"
     "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
+    "@babel/helper-validator-option": "workspace:^7.11.4"
     browserslist: ^4.12.0
-    invariant: ^2.2.4
-    levenary: ^1.1.1
     semver: ^5.5.0
   peerDependencies:
     "@babel/core": ^7.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -794,6 +794,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@babel/helper-validator-option@workspace:^7.11.4, @babel/helper-validator-option@workspace:packages/babel-helper-validator-option":
+  version: 0.0.0-use.local
+  resolution: "@babel/helper-validator-option@workspace:packages/babel-helper-validator-option"
+  languageName: unknown
+  linkType: soft
+
 "@babel/helper-wrap-function@npm:^7.10.4":
   version: 7.10.4
   resolution: "@babel/helper-wrap-function@npm:7.10.4"
@@ -2957,6 +2963,7 @@ __metadata:
     "@babel/helper-module-imports": "workspace:^7.10.4"
     "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
     "@babel/helper-plugin-utils": "workspace:^7.10.4"
+    "@babel/helper-validator-option": "workspace:^7.11.4"
     "@babel/plugin-proposal-async-generator-functions": "workspace:^7.10.4"
     "@babel/plugin-proposal-class-properties": "workspace:^7.10.4"
     "@babel/plugin-proposal-dynamic-import": "workspace:^7.10.4"
@@ -3018,8 +3025,6 @@ __metadata:
     "@babel/types": "workspace:^7.11.5"
     browserslist: ^4.12.0
     core-js-compat: ^3.6.2
-    invariant: ^2.2.2
-    levenary: ^1.1.1
     semver: ^5.5.0
   peerDependencies:
     "@babel/core": ^7.0.0-0


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | A new package `@babel/helper-validator-option` is drafted to replace both `invariant` and `levenary`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is meant to resolve​ https://github.com/babel/babel/pull/10927#discussion_r446206185 and https://github.com/tanhauhau/levenary/pull/7#issuecomment-679236360.

#10927 will be rebased on this PR to apply similar option checks for all other `@babel/presets` and related `@babel/plugins`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12006"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/82a0546a5251f106b3e0bf6aefe00e9642c04001.svg" /></a>

