### PR TITLE
Fixed refs to decorated class from itself methods

### DIFF
--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-inner-refs/exec.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-inner-refs/exec.mjs
@@ -1,0 +1,42 @@
+let Child
+
+function dec(cls) {
+  Child = class extends cls {}
+  return Child
+}
+
+function dec2(cls) {
+  return class extends cls {}
+}
+
+@dec
+@dec2
+class Parent {
+  constructor() {
+    this.prop = Parent
+  }
+
+  static static() {
+    return Parent
+  }
+
+  method() {
+    return Parent
+  }
+
+  #priv() {
+    return Parent
+  }
+
+  public() {
+    return this.#priv()
+  }
+}
+
+expect(Parent.static()).toBe(Child)
+
+const p = new Parent()
+
+expect(p.prop).toBe(Child)
+expect(p.method()).toBe(Child)
+expect(p.public()).toBe(Child)

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-inner-refs/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-inner-refs/options.json
@@ -1,0 +1,8 @@
+{
+  "presets": ["env"],
+  "plugins": [
+    ["proposal-decorators", { "legacy": true }],
+    ["proposal-private-methods", { "loose": true }],
+    ["proposal-class-properties", { "loose": true }]
+  ]
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-decl-to-expression/class-decorators/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-decl-to-expression/class-decorators/output.mjs
@@ -1,7 +1,7 @@
-var _class, _class2;
+var _decoratedB, _class, _decoratedA, _class2;
 
-let A = dec(_class2 = class A {}) || _class2;
+let A = _decoratedA = dec(_class2 = class A {}) || _class2;
 
 export { A as default };
 
-let B = dec(_class = class B {}) || _class;
+let B = _decoratedB = dec(_class = class B {}) || _class;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated/output.mjs
@@ -1,5 +1,5 @@
-var _class;
+var _decoratedFoo, _class;
 
 import { observer } from 'mobx-react';
 
-let Foo = observer(_class = class Foo {}) || _class;
+let Foo = _decoratedFoo = observer(_class = class Foo {}) || _class;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/parameter-decorators/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/parameter-decorators/output.mjs
@@ -1,7 +1,7 @@
-var _dec, _class;
+var _dec, _decoratedCoreModule, _class;
 
 import { NgModule, Optional, SkipSelf } from '@angular/core';
-export let CoreModule = (_dec = NgModule({}), _dec(_class = class CoreModule {
+export let CoreModule = (_dec = NgModule({}), _decoratedCoreModule = _dec(_class = class CoreModule {
   constructor(_parentModule) {
     var _parentModule2 = Optional()(SkipSelf()(_parentModule));
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11131 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Problem described in #11131
Solved by inserting in all methods (including #private ones and constructor) `let ClassName = _someGeneratedVariable`, where `_someGeneratedVariable` hold "final" class, after all decorators applied.