### PR TITLE
Enable PnP linker on CI build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           key: yarn-${{ hashFiles('yarn.lock') }}
       - name: Install
         run: |
-          make -j bootstrap-only
+          yarn install
       - name: Downgrade Jest for node <= 8
         if: matrix.node-version == '6' || matrix.node-version == '8'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check or update Yarn cache
         env:
           YARN_ENABLE_SCRIPTS: false # disable post-install scripts
-          YARN_NODE_LINKER: pnp # use pnp linker for better performance: it's meant to update yarn cache only
+          YARN_NODE_LINKER: pnp # use pnp linker for better linking performance: it's meant to update yarn cache only
         run: |
           yarn install --immutable --skip-builds
 
@@ -66,7 +66,7 @@ jobs:
     needs: prepare-yarn-cache
     runs-on: ubuntu-latest
     env:
-      YARN_NODE_LINKER: pnp
+      YARN_NODE_LINKER: pnp # use pnp linker for better linking performance and stricter checks
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -134,7 +134,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Use Node.js latest
+      - name: Use Node.js latest # Run yarn on latest node
         uses: actions/setup-node@v2-beta
         with:
           node-version: "*" # Build Babel on latest node LTS versions
@@ -147,7 +147,7 @@ jobs:
           key: yarn-${{ hashFiles('yarn.lock') }}
       - name: Install
         run: |
-          BABEL_ENV=test-legacy make -j bootstrap-only
+          make -j bootstrap-only
       - name: Downgrade Jest for node <= 8
         if: matrix.node-version == '6' || matrix.node-version == '8'
         run: |
@@ -161,13 +161,15 @@ jobs:
       - name: Generate runtime helpers
         run: |
           make build-plugin-transform-runtime-dist
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }} # Checkout node version for test executor
         uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node-version }}
       - name: Test on node.js ${{ matrix.node-version }}
         # Hack: --color has supports-color@5 returned true for GitHub CI
         # Remove once `chalk` is bumped to 4.0.
+
+        # Todo(Babel 8): Jest execution path is hardcoded because Yarn 2 does not support node 6
         run: |
           BABEL_ENV=test node ./node_modules/.bin/jest --ci --color
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
     name: Build Babel Artifacts
     needs: prepare-yarn-cache
     runs-on: ubuntu-latest
+    env:
+      YARN_NODE_LINKER: pnp
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -240,10 +240,9 @@ function buildRollup(packages, targetBrowsers) {
         input,
         external,
         onwarn(warning, warn) {
-          warn(warning);
-          // todo: remove this when we figure out how to deal with
-          // circular dependency
           if (warning.code !== "CIRCULAR_DEPENDENCY") {
+            warn(warning);
+            // https://github.com/babel/babel/pull/12011#discussion_r540434534
             throw new Error("Rollup aborted due to warnings above");
           }
         },

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -239,6 +239,14 @@ function buildRollup(packages, targetBrowsers) {
       const bundle = await rollup.rollup({
         input,
         external,
+        onwarn(warning, warn) {
+          warn(warning);
+          // todo: remove this when we figure out how to deal with
+          // circular dependency
+          if (warning.code !== "CIRCULAR_DEPENDENCY") {
+            throw new Error("Rollup aborted due to warnings above");
+          }
+        },
         plugins: [
           rollupBabelSource(),
           rollupReplace({
@@ -257,10 +265,6 @@ function buildRollup(packages, targetBrowsers) {
             extensions: [".mjs", ".cjs", ".ts", ".js", ".json"],
             browser: nodeResolveBrowser,
             preferBuiltins: true,
-            //todo: remove when semver and source-map are bumped to latest versions
-            dedupe(importee) {
-              return ["semver", "source-map"].includes(importee);
-            },
           }),
           rollupCommonJs({
             include: [

--- a/babel.config.js
+++ b/babel.config.js
@@ -49,7 +49,7 @@ module.exports = function (api) {
       ignoreLib = false;
       // rollup-commonjs will converts node_modules to ESM
       unambiguousSources.push(
-        "**/node_modules",
+        "/**/node_modules",
         "packages/babel-preset-env/data",
         "packages/babel-compat-data"
       );

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "jest": "^26.6.1",
     "lerna-changelog": "^0.5.0",
     "lint-staged": "^9.2.0",
+    "lodash": "^4.17.20",
     "mergeiterator": "^1.2.5",
     "prettier": "^2.0.5",
     "rollup": "^2.26.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4851,6 +4851,7 @@ __metadata:
     jest: ^26.6.1
     lerna-changelog: ^0.5.0
     lint-staged: ^9.2.0
+    lodash: ^4.17.20
     mergeiterator: ^1.2.5
     prettier: ^2.0.5
     rollup: ^2.26.5
@@ -9693,7 +9694,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19":
+"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20":
   version: 4.17.20
   resolution: "lodash@npm:4.17.20"
   checksum: c62101d2500c383b5f174a7e9e6fe8098149ddd6e9ccfa85f36d4789446195f5c4afd3cfba433026bcaf3da271256566b04a2bf2618e5a39f6e67f8c12030cb6


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR enables pnp build on GitHub CI. It provides better linking performance and more importantly stricter dependencies tracking. PnP mode incurs some cost (yarn unplug specific-libraries) on debugging node modules. But it's ideal for CI scenarios as it is rare that developers will ever debug on a CI machine.

I will mark it ready to preview when the Windows CI is green.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12011"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/02dc9389a5ba8a7abaea1d665299519190d0b7a1.svg" /></a>

