### PR TITLE
 Fix no-invalid-this for computed class field names

### DIFF
--- a/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
@@ -1,24 +1,70 @@
-import ruleComposer from "eslint-rule-composer";
 import eslint from "eslint";
+import ruleExtender from "../utils/rule-extender";
 
 const noInvalidThisRule = new eslint.Linter().getRules().get("no-invalid-this");
 
-export default ruleComposer.filterReports(noInvalidThisRule, problem => {
-  let inClassMember = false;
-  let node = problem.node;
+function isClassMember(node) {
+  return (
+    node.type === "ClassPrivateMethod" ||
+    node.type === "ClassPrivateProperty" ||
+    node.type === "ClassProperty"
+  );
+}
 
-  while (node) {
-    if (
-      node.type === "ClassPrivateMethod" ||
-      node.type === "ClassPrivateProperty" ||
-      node.type === "ClassProperty"
-    ) {
-      inClassMember = true;
-      return;
+export default ruleExtender(noInvalidThisRule, {
+  metaOverrides: {
+    docs: {
+      url:
+        "https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin",
+    },
+  },
+  createAdditionalVisitors(context) {
+    // The strict check in the original rule relies on ClassBody
+    // nodes being in strict mode. When the whole module isn't
+    // in strict mode, we need to do an extra check here.
+    if (context.parserOptions.sourceType === "script") {
+      return {
+        "ClassProperty[computed=true] ThisExpression"(node) {
+          let nodeToCheck = node;
+
+          while (nodeToCheck) {
+            // Is descendent of the key node.
+            if (nodeToCheck.parent && nodeToCheck.parent.key === nodeToCheck) {
+              context.report({
+                node,
+                messageId: "unexpectedThis",
+              });
+              break;
+            }
+
+            nodeToCheck = nodeToCheck.parent;
+          }
+        },
+      };
     }
 
-    node = node.parent;
-  }
+    return {};
+  },
+  reportOverrides(reportData) {
+    let node = reportData.node;
 
-  return !inClassMember;
+    while (node) {
+      if (
+        node.parent &&
+        isClassMember(node.parent) &&
+        node.parent.computed &&
+        node.parent.key === node
+      ) {
+        return true;
+      }
+
+      if (isClassMember(node)) {
+        return false;
+      }
+
+      node = node.parent;
+    }
+
+    return true;
+  },
 });

--- a/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
@@ -28,6 +28,10 @@ export default ruleExtender(noInvalidThisRule, {
           let nodeToCheck = node;
 
           while (nodeToCheck) {
+            if (nodeToCheck.type === "ClassProperty") {
+              break;
+            }
+
             // Is descendent of the key node.
             if (nodeToCheck.parent && nodeToCheck.parent.key === nodeToCheck) {
               context.report({

--- a/eslint/babel-eslint-plugin/src/utils/rule-extender.js
+++ b/eslint/babel-eslint-plugin/src/utils/rule-extender.js
@@ -1,11 +1,10 @@
 export default function ruleExtender(rule, options = {}) {
   if (!rule) {
-    console.error("No rule to extend found.");
+    throw new Error("No rule to extend found.");
   }
 
   if (!Object.keys(options).length) {
-    console.error("No extension options supplied. Rule remains unchanged.");
-    return rule;
+    throw new Error("No rule extension options supplied.");
   }
 
   const {
@@ -20,7 +19,7 @@ export default function ruleExtender(rule, options = {}) {
       fixable: metaOverrides.fixable || rule.meta.fixable || false,
       schema: metaOverrides.schema || rule.meta.schema || [],
       docs: { ...rule.meta.docs, ...metaOverrides.docs },
-      messages: { ...rule.meta.messages, ...metaOverrides.emssages },
+      messages: { ...rule.meta.messages, ...metaOverrides.messages },
     },
     create(context) {
       const duplicateVisitors = {};
@@ -31,7 +30,7 @@ export default function ruleExtender(rule, options = {}) {
             const overrideResult = reportOverrides(meta, modifiedContext);
 
             // Override return value is trinary:
-            //   - true: report with original meta (unchanged)
+            //   - true: report with original metadata (unchanged)
             //   - false: do not report
             //   - report metadata object: report with this metadata instead
             if (overrideResult === true) {

--- a/eslint/babel-eslint-plugin/src/utils/rule-extender.js
+++ b/eslint/babel-eslint-plugin/src/utils/rule-extender.js
@@ -1,0 +1,80 @@
+export default function ruleExtender(rule, options = {}) {
+  if (!rule) {
+    console.error("No rule to extend found.");
+  }
+
+  if (!Object.keys(options).length) {
+    console.error("No extension options supplied. Rule remains unchanged.");
+    return rule;
+  }
+
+  const {
+    metaOverrides = {},
+    createAdditionalVisitors = () => ({}),
+    reportOverrides = () => true,
+  } = options;
+
+  return {
+    meta: {
+      type: metaOverrides.type || rule.meta.type || undefined,
+      fixable: metaOverrides.fixable || rule.meta.fixable || false,
+      schema: metaOverrides.schema || rule.meta.schema || [],
+      docs: { ...rule.meta.docs, ...metaOverrides.docs },
+      messages: { ...rule.meta.messages, ...metaOverrides.emssages },
+    },
+    create(context) {
+      const duplicateVisitors = {};
+      const modifiedContext = Object.create(context, {
+        report: {
+          enumerable: true,
+          value: meta => {
+            const overrideResult = reportOverrides(meta, modifiedContext);
+
+            // Override return value is trinary:
+            //   - true: report with original meta (unchanged)
+            //   - false: do not report
+            //   - report metadata object: report with this metadata instead
+            if (overrideResult === true) {
+              return context.report(meta);
+            }
+
+            if (overrideResult === false) {
+              return;
+            }
+
+            if (
+              overrideResult &&
+              typeof overrideResult === "object" &&
+              !Array.isArray(overrideResult)
+            ) {
+              return context.report(overrideResult);
+            }
+
+            throw new Error(`ruleExtender.reportOverrides() return value must be one of the following:
+  - true: report with original meta (unchanged)
+  - false: do not report
+  - report metadata object: report with this metadata instead`);
+          },
+        },
+      });
+
+      return Object.entries(createAdditionalVisitors(modifiedContext)).reduce(
+        (visitors, [listener, visitor]) => {
+          if (visitors[listener]) {
+            if (duplicateVisitors[listener]) {
+              duplicateVisitors[listener].push(visitor);
+            } else {
+              duplicateVisitors[listener] = [visitors[listener], visitor];
+            }
+            visitors[listener] = node =>
+              duplicateVisitors[listener].forEach(visitor => visitor(node));
+          } else {
+            visitors[listener] = visitor;
+          }
+          return visitors;
+        },
+        rule.create(modifiedContext),
+      );
+    },
+  };
+}

--- a/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
@@ -3,10 +3,20 @@ import rule from "../../src/rules/no-invalid-this";
 import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
 
 /**
+ * A constant value for modules environment.
+ * This modifies pattern object to make modules.
+ * @param {Object} pattern - A pattern object to modify.
+ * @returns {void}
+ */
+function MODULE(pattern) {
+  pattern.parserOptions.sourceType = "module";
+}
+
+/**
  * A constant value for non strict mode environment.
  * @returns {void}
  */
-function NORMAL(pattern) {
+function SCRIPT(pattern) {
   pattern.parserOptions.sourceType = "script";
 }
 
@@ -27,19 +37,8 @@ function USE_STRICT(pattern) {
  * @returns {void}
  */
 function IMPLIED_STRICT(pattern) {
-  pattern.code = "/* implied strict mode */ " + pattern.code;
   pattern.parserOptions.ecmaFeatures = pattern.parserOptions.ecmaFeatures || {};
   pattern.parserOptions.ecmaFeatures.impliedStrict = true;
-}
-
-/**
- * A constant value for modules environment.
- * This modifies pattern object to make modules.
- * @param {Object} pattern - A pattern object to modify.
- * @returns {void}
- */
-function MODULES(pattern) {
-  pattern.code = "/* modules */ " + pattern.code;
 }
 
 /**
@@ -51,15 +50,15 @@ function MODULES(pattern) {
 function extractPatterns(patterns, type) {
   // Clone and apply the pattern environment.
   const patternsList = patterns.map(function (pattern) {
-    return pattern[type].map(function (applyCondition) {
+    return pattern[type].map(applyCondition => {
       const thisPattern = cloneDeep(pattern);
 
       applyCondition(thisPattern);
 
-      if (type === "valid") {
-        thisPattern.errors = [];
-      } else {
-        thisPattern.code += " /* should error */";
+      thisPattern.errors = [];
+
+      if (type === "invalid") {
+        thisPattern.errors.push({ messageId: "unexpectedThis" });
       }
 
       delete thisPattern.invalid;
@@ -78,40 +77,76 @@ function extractPatterns(patterns, type) {
 //------------------------------------------------------------------------------
 
 const patterns = [
-  // Class private fields
   {
-    code: "class A {a = this.b;};",
-    parserOptions: { ecmaVersion: 6 },
-    valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+    code: "class A { a = this.b; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
     invalid: [],
   },
-
   {
-    code: "class A {a = () => {return this.b;};};",
-    parserOptions: { ecmaVersion: 6 },
-    valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+    code: "class A { a = () => { return this.b; }; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
     invalid: [],
   },
-
-  // Class Private methods
   {
-    code: "class A {#a = this.b;};",
-    parserOptions: { ecmaVersion: 6 },
-    valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+    code: "class A { a = () => this.b; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
     invalid: [],
   },
-
   {
-    code: "class A {#a = () => {return this.b;};};",
-    parserOptions: { ecmaVersion: 6 },
-    valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+    code: "class A { [this] = b; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [],
+    invalid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
+  },
+  {
+    code: "class A { [this.a] = b; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [],
+    invalid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
+  },
+  {
+    code: "class A { [`${this.a}b`] = c; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [],
+    invalid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
+  },
+  {
+    code: "class A { [this.a] = () => { return b; }; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [],
+    invalid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
+  },
+  {
+    code: "class A { [this.a] = () => b; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [],
+    invalid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
+  },
+  {
+    code: "class A { #a = this.b; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
     invalid: [],
   },
-
   {
-    code: "class A {#a() {return this.b;};};",
-    parserOptions: { ecmaVersion: 6 },
-    valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+    code: "class A { #a() { return this.b; }; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
+    invalid: [],
+  },
+  {
+    code: "class A { #a = () => { return this.b; }; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
+    invalid: [],
+  },
+  {
+    code: "class A { #a = () => this.b; }",
+    parserOptions: { ecmaVersion: 2020 },
+    valid: [MODULE, SCRIPT, USE_STRICT, IMPLIED_STRICT],
     invalid: [],
   },
 ];

--- a/eslint/babel-eslint-plugin/test/utils/rule-extender.js
+++ b/eslint/babel-eslint-plugin/test/utils/rule-extender.js
@@ -483,7 +483,7 @@ describe("ruleExtender", () => {
         });
 
         new RuleTester().run("@babel/example-eslint-rule", extendedRule, {
-          valid: ["this", "fn.apply(this, 'arg')"],
+          valid: ["this", "this.a = b", "fn.apply(this, 'arg')"],
           invalid: [
             {
               code: "/* I'm not supposed to be here! */ this.a = b",

--- a/eslint/babel-eslint-plugin/test/utils/rule-extender.js
+++ b/eslint/babel-eslint-plugin/test/utils/rule-extender.js
@@ -1,0 +1,499 @@
+import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
+import ruleExtender from "../../src/utils/rule-extender";
+
+function createExampleRule() {
+  return {
+    meta: {
+      type: "example",
+      fixable: false,
+      schema: [
+        {
+          enum: ["option1", "option2", "option3"],
+        },
+      ],
+      docs: {
+        url: "eslint-rule-example.com",
+      },
+      messages: {
+        friendlySuggestion: "Here's a friendly suggestion!",
+      },
+    },
+    create(context) {
+      return {
+        ThisExpression(node) {
+          if (node.parent && node.parent.type === "MemberExpression") {
+            context.report({
+              node,
+              messageId: "friendlySuggestion",
+            });
+          }
+        },
+      };
+    },
+  };
+}
+
+describe("ruleExtender", () => {
+  let rule;
+
+  beforeEach(() => {
+    rule = createExampleRule();
+  });
+
+  it("should throw an error when no rule to extend is given", () => {
+    expect(() => ruleExtender()).toThrow(new Error("No rule to extend found."));
+  });
+
+  it("should throw an error when no options are given", () => {
+    expect(() => ruleExtender(rule)).toThrow(
+      new Error("No rule extension options supplied."),
+    );
+  });
+
+  describe("options", () => {
+    describe("metaOverrides", () => {
+      describe("meta.type", () => {
+        it("should override the original value when given", () => {
+          const type = "another example";
+          expect(
+            ruleExtender(rule, { metaOverrides: { type } }).meta.type,
+          ).toEqual(type);
+        });
+
+        it("should not override the original value when not given", () => {
+          expect(
+            ruleExtender(rule, { metaOverrides: { fixable: false } }).meta.type,
+          ).toEqual("example");
+        });
+
+        it("should set to undefined when not set in the original rule or overrides", () => {
+          delete rule.meta.type;
+          expect(
+            ruleExtender(rule, { metaOverrides: { fixable: false } }).meta.type,
+          ).toBeUndefined();
+        });
+      });
+
+      describe("meta.fixable", () => {
+        it("should override the original value when given", () => {
+          expect(
+            ruleExtender(rule, { metaOverrides: { fixable: true } }).meta
+              .fixable,
+          ).toEqual(true);
+        });
+
+        it("should not override the original value when not given", () => {
+          expect(
+            ruleExtender(rule, {
+              metaOverrides: { example: "another example" },
+            }).meta.fixable,
+          ).toEqual(rule.meta.fixable);
+        });
+
+        it("should default to false when not set in the original rule or in overrides", () => {
+          delete rule.meta.fixable;
+          expect(
+            ruleExtender(rule, {
+              metaOverrides: { example: "another example" },
+            }).meta.fixable,
+          ).toEqual(false);
+        });
+      });
+
+      describe("meta.schema", () => {
+        it("should override the original value when given", () => {
+          const schema = [
+            {
+              enum: ["option1", "option2", "option3"],
+            },
+            {
+              anyOf: [
+                {
+                  enum: ["option 4"],
+                },
+                {
+                  type: "object",
+                  properties: {
+                    whoaMoreOptions: {
+                      type: "boolean",
+                    },
+                  },
+                  additionalProperties: false,
+                },
+              ],
+            },
+          ];
+          expect(
+            ruleExtender(rule, { metaOverrides: { schema } }).meta.schema,
+          ).toStrictEqual(schema);
+        });
+
+        it("should not override the original value when not given", () => {
+          expect(
+            ruleExtender(rule, {
+              metaOverrides: { example: "another example" },
+            }).meta.schema,
+          ).toStrictEqual(rule.meta.schema);
+        });
+
+        it("should default to empty array when not set in the original rule or in overrides", () => {
+          delete rule.meta.schema;
+          expect(
+            ruleExtender(rule, {
+              metaOverrides: { example: "another example" },
+            }).meta.schema,
+          ).toStrictEqual([]);
+        });
+      });
+
+      describe("meta.docs", () => {
+        it("should merge the value with the original value when given", () => {
+          const docs = {
+            anotherUrl: "extended-eslint-rule-example.com",
+          };
+          const expectedValue = { ...rule.meta.docs, ...docs };
+
+          expect(
+            ruleExtender(rule, {
+              metaOverrides: {
+                docs,
+              },
+            }).meta.docs,
+          ).toStrictEqual(expectedValue);
+        });
+
+        it("should not alter the original value when not given", () => {
+          expect(
+            ruleExtender(rule, {
+              metaOverrides: { example: "another example" },
+            }).meta.docs,
+          ).toStrictEqual(rule.meta.docs);
+        });
+
+        it("should default to empty object when not set in the original rule or in overrides", () => {
+          delete rule.meta.docs;
+          expect(
+            ruleExtender(rule, {
+              metaOverrides: { example: "another example" },
+            }).meta.docs,
+          ).toStrictEqual({});
+        });
+      });
+
+      describe("meta.messages", () => {
+        it("should merge the value with the original value when given", () => {
+          const messages = {
+            anEvenFriendlierSuggestion:
+              "Here's an even FRIENDLIER suggestion! :D",
+          };
+          const expectedValue = { ...rule.meta.messages, ...messages };
+          expect(
+            ruleExtender(rule, {
+              metaOverrides: {
+                messages,
+              },
+            }).meta.messages,
+          ).toStrictEqual(expectedValue);
+        });
+
+        it("should not alter the original value when not given", () => {
+          expect(
+            ruleExtender(rule, {
+              metaOverrides: { example: "another example" },
+            }).meta.messages,
+          ).toStrictEqual(rule.meta.messages);
+        });
+
+        it("should default to empty object when not set in the original rule or in overrides", () => {
+          delete rule.meta.messages;
+          expect(
+            ruleExtender(rule, {
+              metaOverrides: { example: "another example" },
+            }).meta.messages,
+          ).toStrictEqual({});
+        });
+      });
+    });
+
+    // These tests can't be placed in an `it()` because RuleTester creates
+    // tests using Jest's `it()` and they shouldn't be nested.
+    describe("createAdditionalVisitors", () => {
+      describe("should add additional visitors to the rule", () => {
+        const extendedRule = ruleExtender(createExampleRule(), {
+          metaOverrides: {
+            messages: {
+              anAdditionalSuggestion: "One more thought!",
+            },
+          },
+          createAdditionalVisitors(context) {
+            return {
+              ArrowFunctionExpression(node) {
+                context.report({ node, messageId: "anAdditionalSuggestion" });
+              },
+            };
+          },
+        });
+
+        new RuleTester().run("@babel/example-eslint-rule", extendedRule, {
+          valid: ["this"],
+          invalid: [
+            {
+              code: "this.a = () => {}",
+              errors: [
+                { type: "ThisExpression", messageId: "friendlySuggestion" },
+                {
+                  type: "ArrowFunctionExpression",
+                  messageId: "anAdditionalSuggestion",
+                },
+              ],
+            },
+          ],
+        });
+      });
+
+      describe("should not overwrite any existings visitors with the same selector", () => {
+        const extendedRule = ruleExtender(createExampleRule(), {
+          metaOverrides: {
+            messages: {
+              anAdditionalSuggestion: "One more thought!",
+            },
+          },
+          createAdditionalVisitors(context) {
+            return {
+              ThisExpression(node) {
+                if (node.parent.type === "CallExpression") {
+                  context.report({ node, messageId: "anAdditionalSuggestion" });
+                }
+              },
+            };
+          },
+        });
+
+        new RuleTester().run("@babel/example-eslint-rule", extendedRule, {
+          valid: ["this"],
+          invalid: [
+            {
+              code: "this.a = b",
+              errors: [
+                { type: "ThisExpression", messageId: "friendlySuggestion" },
+              ],
+            },
+            {
+              code: "fn.apply(this, 'arg')",
+              errors: [
+                {
+                  type: "ThisExpression",
+                  messageId: "anAdditionalSuggestion",
+                },
+              ],
+            },
+          ],
+        });
+      });
+
+      describe("both existing and additional visitors should have access to the context object", () => {
+        const rule = createExampleRule();
+        rule.create = function (context) {
+          const sourceCode = context.getSourceCode();
+
+          return {
+            ThisExpression(node) {
+              if (node.parent && node.parent.type === "MemberExpression") {
+                const previousToken = sourceCode.getTokenBefore(node.parent, {
+                  includeComments: true,
+                });
+
+                if (
+                  previousToken &&
+                  previousToken.type === "Block" &&
+                  previousToken.value.trim() === "I'm not supposed to be here!"
+                ) {
+                  context.report({
+                    node,
+                    messageId: "friendlySuggestion",
+                  });
+                }
+              }
+            },
+          };
+        };
+
+        const extendedRule = ruleExtender(rule, {
+          metaOverrides: {
+            messages: {
+              anAdditionalSuggestion: "One more thought!",
+            },
+          },
+          createAdditionalVisitors(context) {
+            const sourceCode = context.getSourceCode();
+
+            return {
+              ThisExpression(node) {
+                if (node.parent.type === "CallExpression") {
+                  const previousToken = sourceCode.getTokenBefore(node.parent, {
+                    includeComments: true,
+                  });
+                  if (
+                    previousToken &&
+                    previousToken.type === "Block" &&
+                    previousToken.value.trim() ===
+                      "I'm not supposed to be here either!"
+                  ) {
+                    context.report({
+                      node,
+                      messageId: "anAdditionalSuggestion",
+                    });
+                  }
+                }
+              },
+            };
+          },
+        });
+
+        new RuleTester().run("@babel/example-eslint-rule", extendedRule, {
+          valid: ["this.a = b", "fn.apply(this, 'arg')"],
+          invalid: [
+            {
+              code: "/* I'm not supposed to be here! */ this.a = b",
+              errors: [
+                { type: "ThisExpression", messageId: "friendlySuggestion" },
+              ],
+            },
+            {
+              code:
+                "/* I'm not supposed to be here either! */ fn.apply(this, 'arg')",
+              errors: [
+                { type: "ThisExpression", messageId: "anAdditionalSuggestion" },
+              ],
+            },
+          ],
+        });
+      });
+    });
+
+    describe("reportOverrides", () => {
+      describe("should not report errors when the function returns false", () => {
+        const extendedRule = ruleExtender(createExampleRule(), {
+          reportOverrides(meta) {
+            return meta.node.type !== "ThisExpression";
+          },
+        });
+
+        new RuleTester().run("@babel/example-eslint-rule", extendedRule, {
+          valid: ["this", "this.a = b", "fn.apply(this, 'arg')"],
+          invalid: [],
+        });
+      });
+
+      describe("should report the original error when the function returns true", () => {
+        const extendedRule = ruleExtender(createExampleRule(), {
+          reportOverrides(meta) {
+            return meta.node.type === "ThisExpression";
+          },
+        });
+
+        new RuleTester().run("@babel/example-eslint-rule", extendedRule, {
+          valid: ["this", "fn.apply(this, 'arg')"],
+          invalid: [
+            {
+              code: "this.a = b",
+              errors: [
+                { type: "ThisExpression", messageId: "friendlySuggestion" },
+              ],
+            },
+          ],
+        });
+      });
+
+      describe("should report the original error when the function returns true", () => {
+        const extendedRule = ruleExtender(createExampleRule(), {
+          reportOverrides(meta) {
+            return meta.node.type === "ThisExpression";
+          },
+        });
+
+        new RuleTester().run("@babel/example-eslint-rule", extendedRule, {
+          valid: ["this", "fn.apply(this, 'arg')"],
+          invalid: [
+            {
+              code: "this.a = b",
+              errors: [
+                { type: "ThisExpression", messageId: "friendlySuggestion" },
+              ],
+            },
+          ],
+        });
+      });
+
+      describe("should report with alternative metadata if returned by the function", () => {
+        const extendedRule = ruleExtender(createExampleRule(), {
+          metaOverrides: {
+            messages: {
+              parentMessage: "I'm reporting something about the parent node.",
+            },
+          },
+          reportOverrides(meta) {
+            if (meta.node.type === "ThisExpression") {
+              meta.node = meta.node.parent;
+              meta.messageId = "parentMessage";
+              return meta;
+            }
+
+            return true;
+          },
+        });
+
+        new RuleTester().run("@babel/example-eslint-rule", extendedRule, {
+          valid: ["this", "fn.apply(this, 'arg')"],
+          invalid: [
+            {
+              code: "this.a = b",
+              errors: [
+                { type: "MemberExpression", messageId: "parentMessage" },
+              ],
+            },
+          ],
+        });
+      });
+
+      describe("should be able to access the context object", () => {
+        const extendedRule = ruleExtender(createExampleRule(), {
+          reportOverrides(meta, context) {
+            const sourceCode = context.getSourceCode();
+
+            if (meta.node.type === "ThisExpression") {
+              const previousToken = sourceCode.getTokenBefore(
+                meta.node.parent,
+                {
+                  includeComments: true,
+                },
+              );
+
+              if (
+                previousToken &&
+                previousToken.type === "Block" &&
+                previousToken.value.trim() === "I'm not supposed to be here!"
+              ) {
+                return true;
+              }
+            }
+
+            return false;
+          },
+        });
+
+        new RuleTester().run("@babel/example-eslint-rule", extendedRule, {
+          valid: ["this", "fn.apply(this, 'arg')"],
+          invalid: [
+            {
+              code: "/* I'm not supposed to be here! */ this.a = b",
+              errors: [
+                { type: "ThisExpression", messageId: "friendlySuggestion" },
+              ],
+            },
+          ],
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | refs https://github.com/babel/babel/pull/11993#discussion_r475031230
| Patch: Bug Fix?          | 👍🏼 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
 Following up on https://github.com/babel/babel/pull/11993#discussion_r475031230, this updates the `no-invalid-this` rule to handle this case. I came across some limitations of the current release of `eslint-rule-composer` in the process and thought it would be useful for us to have our own internal utility for extending existing rules. That way we can add whatever features we need to make our lives easier.

@JLHwung Did I get all the cases for the code snippet in question?

Marking this as a draft because I'm too tired to double check everything tonight. Will look it over with fresh eyes and mark it ready for review soon. Will also follow up with converting the other rules to the new util in a future PR.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12020"><img src="https://gitpod.io/api/apps/github/pbs/github.com/kaicataldo/babel.git/dc824812ae4d420563d5da905b6941dffbff9ea4.svg" /></a>

