### PR TITLE
Revert #12014

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -30,7 +30,7 @@
     "lodash": "^4.17.19",
     "make-dir": "^2.1.0",
     "slash": "^2.0.0",
-    "source-map": "^0.6.1"
+    "source-map": "^0.5.0"
   },
   "optionalDependencies": {
     "chokidar": "^2.1.8"

--- a/packages/babel-cli/test/fixtures/babel/filenames --out-file --source-maps/in-files/script.js
+++ b/packages/babel-cli/test/fixtures/babel/filenames --out-file --source-maps/in-files/script.js
@@ -1,1 +1,3 @@
 (() => 42)
+
+// some comments

--- a/packages/babel-cli/test/fixtures/babel/filenames --out-file --source-maps/out-files/script3.js
+++ b/packages/babel-cli/test/fixtures/babel/filenames --out-file --source-maps/out-files/script3.js
@@ -2,7 +2,7 @@
 
 (function () {
   return 42;
-});
+}); // some comments
 "use strict";
 
 arr.map(function (x) {

--- a/packages/babel-cli/test/fixtures/babel/filenames --out-file --source-maps/out-files/script3.js.map
+++ b/packages/babel-cli/test/fixtures/babel/filenames --out-file --source-maps/out-files/script3.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["script.js","script2.js"],"names":[],"mappings":";;AAAA,CAAC;AAAA,SAAM,EAAN;AAAA,CAAD;;;ACAA,GAAG,CAAC,GAAJ,CAAQ,UAAA,CAAC;AAAA,SAAI,CAAC,GAAG,UAAR;AAAA,CAAT","file":"script3.js","sourcesContent":["(() => 42)","arr.map(x => x * MULTIPLIER);"]}
+{"version":3,"sources":["script.js","script2.js"],"names":[],"mappings":";;AAAA,CAAC;AAAA,SAAM,EAAN;AAAA,CAAD,E,CAEA;;;ACFA,GAAG,CAAC,GAAJ,CAAQ,UAAA,CAAC;AAAA,SAAI,CAAC,GAAG,UAAR;AAAA,CAAT","file":"script3.js","sourcesContent":["(() => 42)\n\n// some comments","arr.map(x => x * MULTIPLIER);"]}

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -58,7 +58,7 @@
     "lodash": "^4.17.19",
     "resolve": "^1.3.2",
     "semver": "^5.4.1",
-    "source-map": "^0.6.1"
+    "source-map": "^0.5.0"
   },
   "devDependencies": {
     "@babel/helper-transform-fixture-test-runner": "workspace:^7.11.4"

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@babel/types": "workspace:^7.11.5",
     "jsesc": "^2.5.1",
-    "source-map": "^0.6.1"
+    "source-map": "^0.5.0"
   },
   "devDependencies": {
     "@babel/helper-fixtures": "workspace:^7.10.5",

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -25,6 +25,6 @@
     "lodash": "^4.17.19",
     "quick-lru": "5.1.0",
     "resolve": "^1.3.2",
-    "source-map": "^0.6.1"
+    "source-map": "^0.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,7 +45,7 @@ __metadata:
     make-dir: ^2.1.0
     rimraf: ^3.0.0
     slash: ^2.0.0
-    source-map: ^0.6.1
+    source-map: ^0.5.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
   dependenciesMeta:
@@ -145,7 +145,7 @@ __metadata:
     lodash: ^4.17.19
     resolve: ^1.3.2
     semver: ^5.4.1
-    source-map: ^0.6.1
+    source-map: ^0.5.0
   languageName: unknown
   linkType: soft
 
@@ -261,7 +261,7 @@ __metadata:
     "@babel/parser": "workspace:^7.11.5"
     "@babel/types": "workspace:^7.11.5"
     jsesc: ^2.5.1
-    source-map: ^0.6.1
+    source-map: ^0.5.0
   languageName: unknown
   linkType: soft
 
@@ -777,7 +777,7 @@ __metadata:
     lodash: ^4.17.19
     quick-lru: 5.1.0
     resolve: ^1.3.2
-    source-map: ^0.6.1
+    source-map: ^0.5.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12025 
| Patch: Bug Fix?          | Yes
| Any Dependency Changes?  | `source-map` is downgraded
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Revert #12014 where `source-map@0.6` includes https://github.com/mozilla/source-map/pull/265 that throws when there is JS comments in the input code. Before https://github.com/mozilla/source-map/issues/385 is resolved, we have to pin the `source-map` versions.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12027"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/f331935c8c565b14fa09a663d15049e9b421b2d0.svg" /></a>

