### PR TITLE
Run prepublish build after versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,8 +244,8 @@ ifneq ("$(I_AM_USING_VERDACCIO)", "I_AM_SURE")
 	echo "You probably don't know what you are doing"
 	exit 1
 endif
-	$(MAKE) prepublish-build
 	$(YARN) lerna version $(VERSION) --exclude-dependents --force-publish=$(FORCE_PUBLISH)  --no-push --yes --tag-version-prefix="version-e2e-test-"
+	$(MAKE) prepublish-build
 	$(YARN) lerna publish from-git --registry http://localhost:4873 --yes --tag-version-prefix="version-e2e-test-"
 	$(MAKE) clean
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "make build",
     "fix": "make fix",
     "lint": "make lint",
-    "test": "make test"
+    "test": "make test",
+    "version": "yarn --immutable-cache && git add yarn.lock"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.4",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | After `make new-version` is run, `make publish` will fail because committed changes of `yarn.lock`.
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR reorders workflows in publish-test to align with our actual workflow. I added a `"version"` lifecycle event: So when we run `lerna version`, it will invoke the `version` lifecycle event after package.json is updated but before it is committed: See also https://github.com/lerna/lerna/tree/master/commands/version#lifecycle-scripts 

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12028"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/6305cf45154d8bdfda1b1378cdb9b133da153a33.svg" /></a>

