### PR TITLE
chore: use latest node on ci workflow when possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Use Node.js latest
         uses: actions/setup-node@v2-beta
+        with:
+          node-version: "*"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -38,6 +40,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Use Node.js latest
         uses: actions/setup-node@v2-beta
+        with:
+          node-version: "*"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -62,6 +66,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Use Node.js latest
         uses: actions/setup-node@v2-beta
+        with:
+          node-version: "*"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -96,7 +102,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Use Node.js latest
-        uses: actions/setup-node@v2-beta # Build Babel on latest node versions
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: "*" # Build Babel on latest node versions
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR partially reverts change implemented in #11952 where `node-version` is removed.

/cc @fisker 

Per `actions/setup-node` docs
> The node-version input is optional. If not supplied, node which is in your PATH will be used.

Currently, when `node-version` is not set, it refers to v12 LTS: https://github.com/JLHwung/babel/runs/1093487909#step:6:8

When `node-version` is set to `*`, it refers to v14: https://github.com/babel/babel/pull/12049/checks?check_run_id=1093534529#step:3:7

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12049"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/67dfeef6a1d62746bb49ec867057f4148e45b143.svg" /></a>

