### PR TITLE
chore: add git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# git-blame ignored revisions
+# To configure, run
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# Requires Git > 2.23
+# See https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
+
+# Use prettier (#600)
+5180ecdca48e486b4b0f347fcbd752f865df5e55

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,6 @@
 
 # Use prettier (#600)
 5180ecdca48e486b4b0f347fcbd752f865df5e55
+
+# Update prettier to v2 (#11579)
+41085248560b1403b8d0f99f108491e679531c6c


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Added `.git-blame-ignore-revs` so `git blame` can skip the formatting commits.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12063"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/1b4267501cd53f58debd67910289d0928394eac9.svg" /></a>

