### PR TITLE
chore: pin browserslist version to 4.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@lerna/package": "patch:@lerna/package@npm:3.16.0#.yarn-patches/@lerna/package.patch",
     "@lerna/package-graph": "patch:@lerna/package-graph@npm:3.18.5#.yarn-patches/@lerna/package-graph.patch",
     "@lerna/pack-directory": "patch:@lerna/pack-directory@npm:3.16.4#.yarn-patches/@lerna/pack-directory.patch",
-    "browserslists": "npm:4.12.0",
+    "browserslist": "npm:4.12.0",
     "caniuse-lite": "npm:1.0.30001077"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@lerna/package": "patch:@lerna/package@npm:3.16.0#.yarn-patches/@lerna/package.patch",
     "@lerna/package-graph": "patch:@lerna/package-graph@npm:3.18.5#.yarn-patches/@lerna/package-graph.patch",
     "@lerna/pack-directory": "patch:@lerna/pack-directory@npm:3.16.4#.yarn-patches/@lerna/pack-directory.patch",
+    "browserslists": "npm:4.12.0",
     "caniuse-lite": "npm:1.0.30001077"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6095,7 +6095,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.12.0, browserslist@npm:^4.8.3":
+"browserslist@npm:4.12.0":
   version: 4.12.0
   resolution: "browserslist@npm:4.12.0"
   dependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Pin `browserslist` resolution to 4.12.0 so that it still includes Firefox 68 in `defaults` query, so it fixes current e2e test error.

I will update `browserslist` and other compat table deps in separate PRs.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12070"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/ffca069d6a7a979c799673ac309c14871607b614.svg" /></a>

