### PR TITLE
[parser] Better error message for missing number exponent

### DIFF
--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -72,7 +72,7 @@ export const ErrorMessages = Object.freeze({
   InvalidLhsBinding: "Binding invalid left-hand side in %0",
   InvalidNumber: "Invalid number",
   InvalidOrMissingExponent:
-    "Invalid or Missing exponent after 'e' in floating-point number",
+    "Invalid or missing exponent after 'e' in floating-point number",
   InvalidOrUnexpectedToken: "Unexpected character '%0'",
   InvalidParenthesizedAssignment: "Invalid parenthesized assignment pattern",
   InvalidPrivateFieldResolution: "Private name #%0 is not defined",

--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -72,7 +72,7 @@ export const ErrorMessages = Object.freeze({
   InvalidLhsBinding: "Binding invalid left-hand side in %0",
   InvalidNumber: "Invalid number",
   InvalidOrMissingExponent:
-    "Invalid or missing exponent after 'e' in floating-point number",
+    "Floating-point numbers require a valid exponent after the 'e'",
   InvalidOrUnexpectedToken: "Unexpected character '%0'",
   InvalidParenthesizedAssignment: "Invalid parenthesized assignment pattern",
   InvalidPrivateFieldResolution: "Private name #%0 is not defined",

--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -71,6 +71,8 @@ export const ErrorMessages = Object.freeze({
   InvalidLhs: "Invalid left-hand side in %0",
   InvalidLhsBinding: "Binding invalid left-hand side in %0",
   InvalidNumber: "Invalid number",
+  InvalidOrMissingExponent:
+    "Invalid or Missing exponent after 'e' in floating-point number",
   InvalidOrUnexpectedToken: "Unexpected character '%0'",
   InvalidParenthesizedAssignment: "Invalid parenthesized assignment pattern",
   InvalidPrivateFieldResolution: "Private name #%0 is not defined",

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -1033,6 +1033,7 @@ export default class Tokenizer extends ParserErrors {
         ++this.state.pos;
         continue;
       }
+
       if (code >= charCodes.lowercaseA) {
         val = code - charCodes.lowercaseA + charCodes.lineFeed;
       } else if (code >= charCodes.uppercaseA) {

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -1033,7 +1033,6 @@ export default class Tokenizer extends ParserErrors {
         ++this.state.pos;
         continue;
       }
-
       if (code >= charCodes.lowercaseA) {
         val = code - charCodes.lowercaseA + charCodes.lineFeed;
       } else if (code >= charCodes.uppercaseA) {
@@ -1149,7 +1148,9 @@ export default class Tokenizer extends ParserErrors {
       if (next === charCodes.plusSign || next === charCodes.dash) {
         ++this.state.pos;
       }
-      if (this.readInt(10) === null) this.raise(start, Errors.InvalidNumber);
+      if (this.readInt(10) === null) {
+        this.raise(start, Errors.InvalidOrMissingExponent);
+      }
       isFloat = true;
       hasExponent = true;
       next = this.input.charCodeAt(this.state.pos);

--- a/packages/babel-parser/test/fixtures/core/uncategorised/349/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/349/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":2,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":2}},
   "errors": [
-    "SyntaxError: Invalid number (1:0)"
+    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/core/uncategorised/349/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/349/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":2,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":2}},
   "errors": [
-    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Floating-point numbers require a valid exponent after the 'e' (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/core/uncategorised/349/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/349/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":2,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":2}},
   "errors": [
-    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/core/uncategorised/350/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/350/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Floating-point numbers require a valid exponent after the 'e' (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/core/uncategorised/350/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/350/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/core/uncategorised/350/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/350/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid number (1:0)"
+    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/core/uncategorised/351/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/351/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Floating-point numbers require a valid exponent after the 'e' (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/core/uncategorised/351/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/351/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/core/uncategorised/351/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/351/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid number (1:0)"
+    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0004/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0004/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":2,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":2}},
   "errors": [
-    "SyntaxError: Invalid number (1:0)"
+    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0004/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0004/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":2,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":2}},
   "errors": [
-    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Floating-point numbers require a valid exponent after the 'e' (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0004/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0004/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":2,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":2}},
   "errors": [
-    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0005/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0005/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Floating-point numbers require a valid exponent after the 'e' (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0005/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0005/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0005/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0005/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid number (1:0)"
+    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0006/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0006/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Floating-point numbers require a valid exponent after the 'e' (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0006/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0006/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
+    "SyntaxError: Invalid or missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0006/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0006/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":3,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
   "errors": [
-    "SyntaxError: Invalid number (1:0)"
+    "SyntaxError: Invalid or Missing exponent after 'e' in floating-point number (1:0)"
   ],
   "program": {
     "type": "Program",


### PR DESCRIPTION
fix(babel-parser) better error message for missing number exponent

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12071
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12072"><img src="https://gitpod.io/api/apps/github/pbs/github.com/iamfotx/babel.git/4d5ef9369c8050474a2521e5bfd51837beda4d03.svg" /></a>

