### PR TITLE
Bump compat-table

### DIFF
--- a/packages/babel-compat-data/data/corejs2-built-ins.json
+++ b/packages/babel-compat-data/data/corejs2-built-ins.json
@@ -80,7 +80,7 @@
     "node": "11",
     "ios": "12",
     "samsung": "10",
-    "electron": "4"
+    "electron": "4.0"
   },
   "es6.array.for-each": {
     "chrome": "5",
@@ -248,7 +248,7 @@
     "ie": "9",
     "ios": "12",
     "samsung": "8",
-    "electron": "3"
+    "electron": "3.0"
   },
   "es6.array.species": {
     "chrome": "51",
@@ -710,7 +710,7 @@
     "node": "8.10",
     "ios": "9",
     "samsung": "8",
-    "electron": "3"
+    "electron": "3.0"
   },
   "es7.object.define-setter": {
     "chrome": "62",
@@ -721,7 +721,7 @@
     "node": "8.10",
     "ios": "9",
     "samsung": "8",
-    "electron": "3"
+    "electron": "3.0"
   },
   "es6.object.define-property": {
     "chrome": "5",
@@ -826,7 +826,7 @@
     "node": "8.10",
     "ios": "9",
     "samsung": "8",
-    "electron": "3"
+    "electron": "3.0"
   },
   "es7.object.lookup-setter": {
     "chrome": "62",
@@ -837,7 +837,7 @@
     "node": "8.10",
     "ios": "9",
     "samsung": "8",
-    "electron": "3"
+    "electron": "3.0"
   },
   "es6.object.prevent-extensions": {
     "chrome": "44",
@@ -971,7 +971,7 @@
     "node": "10",
     "ios": "11.3",
     "samsung": "8",
-    "electron": "3"
+    "electron": "3.0"
   },
   "es6.reflect.apply": {
     "chrome": "49",
@@ -1224,7 +1224,7 @@
     "node": "10",
     "ios": "12",
     "samsung": "8",
-    "electron": "3"
+    "electron": "3.0"
   },
   "es6.string.anchor": {
     "chrome": "5",
@@ -1528,7 +1528,7 @@
     "node": "10",
     "ios": "12",
     "samsung": "9",
-    "electron": "3"
+    "electron": "3.0"
   },
   "es7.string.trim-right": {
     "chrome": "66",
@@ -1539,7 +1539,7 @@
     "node": "10",
     "ios": "12",
     "samsung": "9",
-    "electron": "3"
+    "electron": "3.0"
   },
   "es6.typed.array-buffer": {
     "chrome": "51",

--- a/packages/babel-compat-data/data/native-modules.json
+++ b/packages/babel-compat-data/data/native-modules.json
@@ -12,6 +12,6 @@
     "ios_saf": "10.3",
     "samsung": "8.2",
     "android": "61",
-    "electron": "2.1"
+    "electron": "2.0"
   }
 }

--- a/packages/babel-compat-data/data/native-modules.json
+++ b/packages/babel-compat-data/data/native-modules.json
@@ -11,6 +11,7 @@
     "safari": "10.1",
     "ios_saf": "10.3",
     "samsung": "8.2",
-    "android": "61"
+    "android": "61",
+    "electron": "2.1"
   }
 }

--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -5,13 +5,13 @@
     "edge": "79",
     "node": "12",
     "samsung": "11",
-    "electron": "6"
+    "electron": "6.0"
   },
   "proposal-private-methods": {
     "chrome": "84",
     "opera": "70",
     "edge": "84",
-    "electron": "10"
+    "electron": "10.0"
   },
   "proposal-numeric-separator": {
     "chrome": "75",
@@ -22,13 +22,13 @@
     "node": "12.5",
     "ios": "13",
     "samsung": "11",
-    "electron": "6"
+    "electron": "6.0"
   },
   "proposal-logical-assignment-operators": {
     "chrome": "85",
     "firefox": "79",
     "safari": "14",
-    "electron": "10"
+    "electron": "10.0"
   },
   "proposal-nullish-coalescing-operator": {
     "chrome": "80",
@@ -39,7 +39,7 @@
     "node": "14",
     "ios": "13.4",
     "samsung": "13",
-    "electron": "8"
+    "electron": "8.0"
   },
   "proposal-optional-chaining": {
     "chrome": "80",
@@ -50,7 +50,7 @@
     "node": "14",
     "ios": "13.4",
     "samsung": "13",
-    "electron": "8"
+    "electron": "8.0"
   },
   "proposal-json-strings": {
     "chrome": "66",
@@ -61,7 +61,7 @@
     "node": "10",
     "ios": "12",
     "samsung": "9",
-    "electron": "3"
+    "electron": "3.0"
   },
   "proposal-optional-catch-binding": {
     "chrome": "66",
@@ -72,7 +72,7 @@
     "node": "10",
     "ios": "11.3",
     "samsung": "9",
-    "electron": "3"
+    "electron": "3.0"
   },
   "transform-parameters": {
     "chrome": "49",
@@ -94,7 +94,7 @@
     "node": "10",
     "ios": "12",
     "samsung": "8",
-    "electron": "3"
+    "electron": "3.0"
   },
   "proposal-object-rest-spread": {
     "chrome": "60",
@@ -105,7 +105,7 @@
     "node": "8.3",
     "ios": "11.3",
     "samsung": "8",
-    "electron": "2"
+    "electron": "2.0"
   },
   "transform-dotall-regex": {
     "chrome": "62",
@@ -116,7 +116,7 @@
     "node": "8.10",
     "ios": "11.3",
     "samsung": "8",
-    "electron": "3"
+    "electron": "3.0"
   },
   "proposal-unicode-property-regex": {
     "chrome": "64",
@@ -127,7 +127,7 @@
     "node": "10",
     "ios": "11.3",
     "samsung": "9",
-    "electron": "3"
+    "electron": "3.0"
   },
   "transform-named-capturing-groups-regex": {
     "chrome": "64",
@@ -138,7 +138,7 @@
     "node": "10",
     "ios": "11.3",
     "samsung": "9",
-    "electron": "3"
+    "electron": "3.0"
   },
   "transform-async-to-generator": {
     "chrome": "55",

--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -1,7 +1,7 @@
 {
   "proposal-class-properties": {
     "chrome": "74",
-    "opera": "61",
+    "opera": "62",
     "edge": "79",
     "node": "12",
     "samsung": "11",
@@ -9,6 +9,7 @@
   },
   "proposal-private-methods": {
     "chrome": "84",
+    "opera": "70",
     "edge": "84",
     "electron": "10"
   },
@@ -37,6 +38,7 @@
     "safari": "13.1",
     "node": "14",
     "ios": "13.4",
+    "samsung": "13",
     "electron": "8"
   },
   "proposal-optional-chaining": {
@@ -47,6 +49,7 @@
     "safari": "13.1",
     "node": "14",
     "ios": "13.4",
+    "samsung": "13",
     "electron": "8"
   },
   "proposal-json-strings": {
@@ -424,10 +427,14 @@
   },
   "proposal-export-namespace-from": {
     "chrome": "72",
+    "and_chr": "72",
     "edge": "79",
-    "opera": "60",
     "firefox": "80",
     "node": "13.2",
-    "samsung": "11.0"
+    "opera": "60",
+    "op_mob": "51",
+    "samsung": "11.0",
+    "android": "72",
+    "electron": "5.0"
   }
 }

--- a/packages/babel-compat-data/package.json
+++ b/packages/babel-compat-data/package.json
@@ -30,8 +30,8 @@
   ],
   "devDependencies": {
     "@babel/helper-compilation-targets": "workspace:^7.10.4",
-    "electron-to-chromium": "1.3.513",
+    "electron-to-chromium": "1.3.570",
     "lodash": "^4.17.19",
-    "mdn-browser-compat-data": "1.0.31"
+    "mdn-browser-compat-data": "1.0.38"
   }
 }

--- a/packages/babel-compat-data/scripts/build-bugfixes-targets.js
+++ b/packages/babel-compat-data/scripts/build-bugfixes-targets.js
@@ -3,6 +3,7 @@
 // NOTE: This script must be run _after_ build-data.js
 
 const path = require("path");
+const { addElectronSupportFromChromium } = require("./chromium-to-electron");
 
 const {
   getLowestImplementedVersion,
@@ -38,6 +39,7 @@ for (const [plugin, { replaces, features }] of Object.entries(data)) {
       generatedTargets[plugin][env] = supportedWithBugfix;
     }
   }
+  addElectronSupportFromChromium(generatedTargets[plugin]);
 }
 
 for (const [replaced, features] of Object.entries(allReplacedFeatures)) {
@@ -57,6 +59,7 @@ for (const [replaced, features] of Object.entries(allReplacedFeatures)) {
       generatedTargets[replaced][env] = stillNotSupported;
     }
   }
+  addElectronSupportFromChromium(generatedTargets[replaced]);
 }
 
 for (const [filename, data] of [

--- a/packages/babel-compat-data/scripts/build-data.js
+++ b/packages/babel-compat-data/scripts/build-data.js
@@ -1,7 +1,8 @@
 "use strict";
 
 const path = require("path");
-
+const compatData = require("mdn-browser-compat-data").javascript;
+const { process } = require("./build-modules-support");
 const { generateData, environments, writeFile } = require("./utils-build-data");
 
 for (const target of ["plugin", "corejs2-built-in"]) {
@@ -11,16 +12,13 @@ for (const target of ["plugin", "corejs2-built-in"]) {
   );
   if (target === "plugin") {
     // add export-namespace-from from mdn-browser-compat-data
-    // todo: replace the hardcoded compat data to mdn-browser-compat-data
-    // after https://github.com/mdn/browser-compat-data/pull/6394 is published
-    newData["proposal-export-namespace-from"] = {
-      chrome: "72",
-      edge: "79",
-      opera: "60",
-      firefox: "80",
-      node: "13.2",
-      samsung: "11.0",
-    };
+    const exportNamespaceFromCompatData = process(
+      compatData.statements.export.namespace
+    );
+    // the node.js compat data is 12.0, the first node version ships `export *` behind a flag
+    // here we overwrite to 13.2 which is the first unflagged version
+    exportNamespaceFromCompatData.node = "13.2";
+    newData["proposal-export-namespace-from"] = exportNamespaceFromCompatData;
   }
   const dataPath = path.join(__dirname, `../data/${target}s.json`);
 

--- a/packages/babel-compat-data/scripts/build-modules-support.js
+++ b/packages/babel-compat-data/scripts/build-modules-support.js
@@ -2,6 +2,7 @@ const path = require("path");
 const fs = require("fs");
 
 const compatData = require("mdn-browser-compat-data").javascript;
+const { chromiumToElectron } = require("electron-to-chromium");
 
 // Map mdn-browser-compat-data to browserslist browser names
 const browserNameMap = {
@@ -47,6 +48,9 @@ function process(source) {
       );
     }
   });
+  if (allowedBrowsers.chrome) {
+    allowedBrowsers.electron = chromiumToElectron(allowedBrowsers.chrome);
+  }
 
   return allowedBrowsers;
 }

--- a/packages/babel-compat-data/scripts/build-modules-support.js
+++ b/packages/babel-compat-data/scripts/build-modules-support.js
@@ -2,7 +2,7 @@ const path = require("path");
 const fs = require("fs");
 
 const compatData = require("mdn-browser-compat-data").javascript;
-const { chromiumToElectron } = require("electron-to-chromium");
+const { addElectronSupportFromChromium } = require("./chromium-to-electron");
 
 // Map mdn-browser-compat-data to browserslist browser names
 const browserNameMap = {
@@ -48,9 +48,7 @@ function process(source) {
       );
     }
   });
-  if (allowedBrowsers.chrome) {
-    allowedBrowsers.electron = chromiumToElectron(allowedBrowsers.chrome);
-  }
+  addElectronSupportFromChromium(allowedBrowsers);
 
   return allowedBrowsers;
 }

--- a/packages/babel-compat-data/scripts/chromium-to-electron.js
+++ b/packages/babel-compat-data/scripts/chromium-to-electron.js
@@ -1,0 +1,32 @@
+const { versions } = require("electron-to-chromium");
+// todo: we should have imported `chromiumVersions` from `require("electron-to-chromium").chromiumVersions`,
+// however the data is inconsistent with `require("electron-to-chromium").versions`.
+// see https://github.com/Kilian/electron-to-chromium/pull/36
+const chromiumVersions = {};
+for (const electronVersion of Object.keys(versions)) {
+  chromiumVersions[versions[electronVersion]] =
+    chromiumVersions[versions[electronVersion]] || electronVersion;
+}
+const chromiumVersionList = Object.keys(chromiumVersions);
+
+function chromiumToElectron(version) {
+  if (chromiumVersions[version]) {
+    return chromiumVersions[version];
+  }
+  const supportedVersion = chromiumVersionList.concat(version);
+  supportedVersion.sort((a, b) => +a - +b);
+  const nextSupportedVersion =
+    supportedVersion[supportedVersion.indexOf(version) + 1];
+  return chromiumVersions[nextSupportedVersion];
+}
+
+function addElectronSupportFromChromium(supportData) {
+  if (supportData.chrome) {
+    const electronVersion = chromiumToElectron(supportData.chrome);
+    if (electronVersion) {
+      supportData.electron = electronVersion;
+    }
+  }
+}
+
+exports.addElectronSupportFromChromium = addElectronSupportFromChromium;

--- a/packages/babel-compat-data/scripts/download-compat-table.sh
+++ b/packages/babel-compat-data/scripts/download-compat-table.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-COMPAT_TABLE_COMMIT=163aacb6f93e325231d578e31c03141cd9086dbb
+COMPAT_TABLE_COMMIT=e77292d3fc6f8d84c9a5a12b27e4636950fa1275
 GIT_HEAD=build/compat-table/.git/HEAD
 
 if [ -d "build/compat-table" ]; then

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,9 +92,9 @@ __metadata:
   resolution: "@babel/compat-data@workspace:packages/babel-compat-data"
   dependencies:
     "@babel/helper-compilation-targets": "workspace:^7.10.4"
-    electron-to-chromium: 1.3.513
+    electron-to-chromium: 1.3.570
     lodash: ^4.17.19
-    mdn-browser-compat-data: 1.0.31
+    mdn-browser-compat-data: 1.0.38
   languageName: unknown
   linkType: soft
 
@@ -7643,7 +7643,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:1.3.513, electron-to-chromium@npm:^1.3.413":
+"electron-to-chromium@npm:1.3.570":
+  version: 1.3.570
+  resolution: "electron-to-chromium@npm:1.3.570"
+  checksum: 23388b39692e2932e56033e7c0b5b5f70199e22c03335d97c811cad9b16f89e80c94abe55c6140aa12d0e19431abec764955395df9fdf3972918c6bccebc8e10
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.3.413":
   version: 1.3.513
   resolution: "electron-to-chromium@npm:1.3.513"
   checksum: f74b3b97095c669c86e879eb17b1877dc0a8948c87b92895d18e9d2df3f7b8ffdaed7b7a14c2c171838173ad5b28c1279788198868ce097418521ba0ed560c44
@@ -11615,12 +11622,12 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"mdn-browser-compat-data@npm:1.0.31":
-  version: 1.0.31
-  resolution: "mdn-browser-compat-data@npm:1.0.31"
+"mdn-browser-compat-data@npm:1.0.38":
+  version: 1.0.38
+  resolution: "mdn-browser-compat-data@npm:1.0.38"
   dependencies:
     extend: 3.0.2
-  checksum: 37257b8328e3410b824ed4cc89e827e3ee0d9321e68a1c0d35fe073eef22a8a49e3b577a125c9e2d42bb922f7a2ec1bc1bfdaddc412264d8801447e61d6120f9
+  checksum: 137bffed36b3d65fa2f58b7d7c58a238ff0a7de9d942517a280a04f817f06681354b62825c70966a2920d6efd666da86795942762d64c7b209eea7e543097a09
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7643,17 +7643,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:1.3.570":
+"electron-to-chromium@npm:1.3.570, electron-to-chromium@npm:^1.3.413":
   version: 1.3.570
   resolution: "electron-to-chromium@npm:1.3.570"
   checksum: 23388b39692e2932e56033e7c0b5b5f70199e22c03335d97c811cad9b16f89e80c94abe55c6140aa12d0e19431abec764955395df9fdf3972918c6bccebc8e10
-  languageName: node
-  linkType: hard
-
-"electron-to-chromium@npm:^1.3.413":
-  version: 1.3.513
-  resolution: "electron-to-chromium@npm:1.3.513"
-  checksum: f74b3b97095c669c86e879eb17b1877dc0a8948c87b92895d18e9d2df3f7b8ffdaed7b7a14c2c171838173ad5b28c1279788198868ce097418521ba0ed560c44
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Update compat table data source, also add `electron` support for module features
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR 
1) bumps compat-table data sources
2) removes hardcoded compat table for `export-namespace-from`
3) refactors how electron data is added to the compat-table.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12073"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/68249e160fe8a51a511559ea4512d6b0ba51e4a5.svg" /></a>

