### PR TITLE
Add sourcemap markings for each line of a string

### DIFF
--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -119,8 +119,12 @@ export default class Buffer {
     this._buf.push(str);
     this._last = str[str.length - 1];
 
-    let last = 0;
+    // Search for newline chars. We search only for `\n`, since both `\r` and
+    // `\r\n` are normalized to `\n` during parse. We exclude `\u2028` and
+    // `\u2029` for performance reasons, they're so uncommon that it's probably
+    // ok. It's also unclear how other sourcemap utilities handle them...
     let i = str.indexOf("\n");
+    let last = 0;
 
     // If the string starts with a newline char, then adding a mark is redundant.
     // This catches both "no newlines" and "newline after several chars".

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -116,30 +116,41 @@ export default class Buffer {
     filename: ?string,
     force?: boolean,
   ): void {
-    // If there the line is ending, adding a new mapping marker is redundant
-    if (this._map && str[0] !== "\n") {
-      this._map.mark(
-        this._position.line,
-        this._position.column,
-        line,
-        column,
-        identifierName,
-        filename,
-        force,
-      );
-    }
-
     this._buf.push(str);
     this._last = str[str.length - 1];
 
+    let newline = true;
     for (let i = 0; i < str.length; i++) {
       if (str[i] === "\n") {
         this._position.line++;
         this._position.column = 0;
+        newline = true;
       } else {
+        if (newline) {
+          this._mark(line, column, identifierName, filename, force);
+          newline = false;
+        }
         this._position.column++;
       }
     }
+  }
+
+  _mark(
+    line: number,
+    column: number,
+    identifierName: ?string,
+    filename: ?string,
+    force?: boolean,
+  ): void {
+    this._map?.mark(
+      this._position.line,
+      this._position.column,
+      line,
+      column,
+      identifierName,
+      filename,
+      force,
+    );
   }
 
   removeTrailingNewline(): void {

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -119,21 +119,29 @@ export default class Buffer {
     this._buf.push(str);
     this._last = str[str.length - 1];
 
-    if (str[0] !== "\n") {
+    let last = 0;
+    let i = str.indexOf("\n");
+
+    // If the string starts with a newline char, then adding a mark is redundant.
+    // This catches both "no newlines" and "newline after several chars".
+    if (i !== 0) {
       this._mark(line, column, identifierName, filename, force);
     }
 
-    for (let i = 0; i < str.length; i++) {
-      if (str[i] === "\n") {
-        this._position.line++;
-        this._position.column = 0;
-        if (i + 1 < str.length) {
-          this._mark(++line, 0, identifierName, filename, force);
-        }
-      } else {
-        this._position.column++;
+    // Now, find each reamining newline char in the string.
+    while (i !== -1) {
+      this._position.line++;
+      this._position.column = 0;
+      last = i + 1;
+
+      // We mark the start of each line, which happens directly after this newline char
+      // unless this is the last char.
+      if (last < str.length) {
+        this._mark(++line, 0, identifierName, filename, force);
       }
+      i = str.indexOf("\n", last);
     }
+    this._position.column += str.length - last;
   }
 
   _mark(

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -119,17 +119,18 @@ export default class Buffer {
     this._buf.push(str);
     this._last = str[str.length - 1];
 
-    let newline = true;
+    if (str[0] !== "\n") {
+      this._mark(line, column, identifierName, filename, force);
+    }
+
     for (let i = 0; i < str.length; i++) {
       if (str[i] === "\n") {
         this._position.line++;
         this._position.column = 0;
-        newline = true;
-      } else {
-        if (newline) {
-          this._mark(line, column, identifierName, filename, force);
-          newline = false;
+        if (i + 1 < str.length) {
+          this._mark(++line, 0, identifierName, filename, force);
         }
+      } else {
         this._position.column++;
       }
     }

--- a/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/input.js
+++ b/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/input.js
@@ -1,2 +1,6 @@
 "before\
 after";
+
+"before\
+\
+after";

--- a/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/input.js
+++ b/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/input.js
@@ -1,0 +1,2 @@
+"before\
+after";

--- a/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/output.js
+++ b/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/output.js
@@ -1,2 +1,5 @@
 "before\
 after";
+"before\
+\
+after";

--- a/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/output.js
+++ b/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/output.js
@@ -1,0 +1,2 @@
+"before\
+after";

--- a/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/source-map.json
+++ b/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/source-map.json
@@ -1,0 +1,9 @@
+{
+  "mappings": "AAAA;AAAA",
+  "names": [],
+  "sources": ["fixtures/sourcemaps/string-literal-newline/input.js"],
+  "sourcesContent": [
+    "\"before\\\nafter\";"
+  ],
+  "version": 3
+}

--- a/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/source-map.json
+++ b/packages/babel-generator/test/fixtures/sourcemaps/string-literal-newline/source-map.json
@@ -1,9 +1,9 @@
 {
-  "mappings": "AAAA;AAAA",
+  "mappings": "AAAA;AACA,MADA;AAGA;AACA;AACA,MAFA",
   "names": [],
   "sources": ["fixtures/sourcemaps/string-literal-newline/input.js"],
   "sourcesContent": [
-    "\"before\\\nafter\";"
+    "\"before\\\nafter\";\n\n\"before\\\n\\\nafter\";"
   ],
   "version": 3
 }

--- a/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/input.js
+++ b/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/input.js
@@ -1,4 +1,27 @@
+// Newline
 `before
 after`;
+
+// Newline newline
+`before
+
+after`;
+
+// Newline LineContinuation
+`before
+\
+after`;
+
+// LineContinuation
 `before\
+after`;
+
+// LineContinuation newline
+`before\
+
+after`;
+
+// LineContinuation LineContinuation
+`before\
+\
 after`;

--- a/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/input.js
+++ b/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/input.js
@@ -1,0 +1,4 @@
+`before
+after`;
+`before\
+after`;

--- a/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/output.js
+++ b/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/output.js
@@ -1,0 +1,4 @@
+`before
+after`;
+`before\
+after`;

--- a/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/output.js
+++ b/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/output.js
@@ -1,4 +1,22 @@
+// Newline
 `before
-after`;
+after`; // Newline newline
+
+`before
+
+after`; // Newline LineContinuation
+
+`before
+\
+after`; // LineContinuation
+
 `before\
+after`; // LineContinuation newline
+
+`before\
+
+after`; // LineContinuation LineContinuation
+
+`before\
+\
 after`;

--- a/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/source-map.json
+++ b/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/source-map.json
@@ -1,9 +1,9 @@
 {
-  "mappings": "AAAC;AAAA,MAAD;AAEC;AAAA,MAAD",
+  "mappings": "AAAA;AACC;AACD,MADA,C,CAGA;;AACC;AACD;AACA,MAFA,C,CAIA;;AACC;AACD;AACA,MAFA,C,CAIA;;AACC;AACD,MADA,C,CAGA;;AACC;AACD;AACA,MAFA,C,CAIA;;AACC;AACD;AACA,MAFA",
   "names": [],
   "sources": ["fixtures/sourcemaps/template-literal-newline/input.js"],
   "sourcesContent": [
-    "`before\nafter`;\n`before\\\nafter`;"
+    "// Newline\n`before\nafter`;\n\n// Newline newline\n`before\n\nafter`;\n\n// Newline LineContinuation\n`before\n\\\nafter`;\n\n// LineContinuation\n`before\\\nafter`;\n\n// LineContinuation newline\n`before\\\n\nafter`;\n\n// LineContinuation LineContinuation\n`before\\\n\\\nafter`;"
   ],
   "version": 3
 }

--- a/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/source-map.json
+++ b/packages/babel-generator/test/fixtures/sourcemaps/template-literal-newline/source-map.json
@@ -1,0 +1,9 @@
+{
+  "mappings": "AAAC;AAAA,MAAD;AAEC;AAAA,MAAD",
+  "names": [],
+  "sources": ["fixtures/sourcemaps/template-literal-newline/input.js"],
+  "sourcesContent": [
+    "`before\nafter`;\n`before\\\nafter`;"
+  ],
+  "version": 3
+}

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -279,28 +279,7 @@ describe("generation", function () {
   });
 
   it("newline in template literal", () => {
-    const code = "`before\nafter`;";
-    const ast = parse(code, { filename: "inline" }).program;
-    const generated = generate(
-      ast,
-      {
-        filename: "inline",
-        sourceFileName: "inline",
-        sourceMaps: true,
-      },
-      code,
-    );
-
-    const consumer = new sourcemap.SourceMapConsumer(generated.map);
-    const loc = consumer.originalPositionFor({ line: 2, column: 1 });
-    expect(loc).toMatchObject({
-      column: 1,
-      line: 1,
-    });
-  });
-
-  it("newline in string literal", () => {
-    const code = "'before\\\nafter';";
+    const code = "`before\n\nafter`;";
     const ast = parse(code, { filename: "inline" }).program;
     const generated = generate(
       ast,
@@ -316,7 +295,28 @@ describe("generation", function () {
     const loc = consumer.originalPositionFor({ line: 2, column: 1 });
     expect(loc).toMatchObject({
       column: 0,
-      line: 1,
+      line: 2,
+    });
+  });
+
+  it("newline in string literal", () => {
+    const code = "'before\\\n\\\nafter';";
+    const ast = parse(code, { filename: "inline" }).program;
+    const generated = generate(
+      ast,
+      {
+        filename: "inline",
+        sourceFileName: "inline",
+        sourceMaps: true,
+      },
+      code,
+    );
+
+    const consumer = new sourcemap.SourceMapConsumer(generated.map);
+    const loc = consumer.originalPositionFor({ line: 2, column: 1 });
+    expect(loc).toMatchObject({
+      column: 0,
+      line: 2,
     });
   });
 

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -5,6 +5,7 @@ import * as t from "@babel/types";
 import fs from "fs";
 import path from "path";
 import fixtures from "@babel/helper-fixtures";
+import sourcemap from "source-map";
 
 describe("generation", function () {
   it("completeness", function () {
@@ -275,6 +276,48 @@ describe("generation", function () {
     );
 
     expect(generated.code).toBe("function foo2() {\n  bar2;\n}");
+  });
+
+  it("newline in template literal", () => {
+    const code = "`before\nafter`;";
+    const ast = parse(code, { filename: "inline" }).program;
+    const generated = generate(
+      ast,
+      {
+        filename: "inline",
+        sourceFileName: "inline",
+        sourceMaps: true,
+      },
+      code,
+    );
+
+    const consumer = new sourcemap.SourceMapConsumer(generated.map);
+    const loc = consumer.originalPositionFor({ line: 2, column: 1 });
+    expect(loc).toMatchObject({
+      column: 1,
+      line: 1,
+    });
+  });
+
+  it("newline in string literal", () => {
+    const code = "'before\\\nafter';";
+    const ast = parse(code, { filename: "inline" }).program;
+    const generated = generate(
+      ast,
+      {
+        filename: "inline",
+        sourceFileName: "inline",
+        sourceMaps: true,
+      },
+      code,
+    );
+
+    const consumer = new sourcemap.SourceMapConsumer(generated.map);
+    const loc = consumer.originalPositionFor({ line: 2, column: 1 });
+    expect(loc).toMatchObject({
+      column: 0,
+      line: 1,
+    });
   });
 
   it("lazy source map generation", function () {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12083
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Template literals and string literals can span multiple lines (string literals can through the `LineContinuation` grammar). Each of the lines should have at least one sourcemap marking, so that we can trace back to the source literal.

You can see a sample of the generated output:
- [template literals](https://justin.ridgewell.name/source-map-visualization/#base64,Ly8gTmV3bGluZQpgYmVmb3JlCmFmdGVyYDsgLy8gTmV3bGluZSBuZXdsaW5lCgpgYmVmb3JlCgphZnRlcmA7IC8vIE5ld2xpbmUgTGluZUNvbnRpbnVhdGlvbgoKYGJlZm9yZQpcCmFmdGVyYDsgLy8gTGluZUNvbnRpbnVhdGlvbgoKYGJlZm9yZVwKYWZ0ZXJgOyAvLyBMaW5lQ29udGludWF0aW9uIG5ld2xpbmUKCmBiZWZvcmVcCgphZnRlcmA7IC8vIExpbmVDb250aW51YXRpb24gTGluZUNvbnRpbnVhdGlvbgoKYGJlZm9yZVwKXAphZnRlcmA7,eyJtYXBwaW5ncyI6IkFBQUE7QUFDQztBQUNELE1BREEsQyxDQUdBOztBQUNDO0FBQ0Q7QUFDQSxNQUZBLEMsQ0FJQTs7QUFDQztBQUNEO0FBQ0EsTUFGQSxDLENBSUE7O0FBQ0M7QUFDRCxNQURBLEMsQ0FHQTs7QUFDQztBQUNEO0FBQ0EsTUFGQSxDLENBSUE7O0FBQ0M7QUFDRDtBQUNBLE1BRkEiLCJuYW1lcyI6W10sInNvdXJjZXMiOlsiZml4dHVyZXMvc291cmNlbWFwcy90ZW1wbGF0ZS1saXRlcmFsLW5ld2xpbmUvaW5wdXQuanMiXSwic291cmNlc0NvbnRlbnQiOlsiLy8gTmV3bGluZVxuYGJlZm9yZVxuYWZ0ZXJgO1xuXG4vLyBOZXdsaW5lIG5ld2xpbmVcbmBiZWZvcmVcblxuYWZ0ZXJgO1xuXG4vLyBOZXdsaW5lIExpbmVDb250aW51YXRpb25cbmBiZWZvcmVcblxcXG5hZnRlcmA7XG5cbi8vIExpbmVDb250aW51YXRpb25cbmBiZWZvcmVcXFxuYWZ0ZXJgO1xuXG4vLyBMaW5lQ29udGludWF0aW9uIG5ld2xpbmVcbmBiZWZvcmVcXFxuXG5hZnRlcmA7XG5cbi8vIExpbmVDb250aW51YXRpb24gTGluZUNvbnRpbnVhdGlvblxuYGJlZm9yZVxcXG5cXFxuYWZ0ZXJgOyJdLCJ2ZXJzaW9uIjozLCJmaWxlIjoiZXhhbXBsZS5qcyJ9,Ly8gTmV3bGluZQpgYmVmb3JlCmFmdGVyYDsKCi8vIE5ld2xpbmUgbmV3bGluZQpgYmVmb3JlCgphZnRlcmA7CgovLyBOZXdsaW5lIExpbmVDb250aW51YXRpb24KYGJlZm9yZQpcCmFmdGVyYDsKCi8vIExpbmVDb250aW51YXRpb24KYGJlZm9yZVwKYWZ0ZXJgOwoKLy8gTGluZUNvbnRpbnVhdGlvbiBuZXdsaW5lCmBiZWZvcmVcCgphZnRlcmA7CgovLyBMaW5lQ29udGludWF0aW9uIExpbmVDb250aW51YXRpb24KYGJlZm9yZVwKXAphZnRlcmA7)
- [string literals](https://justin.ridgewell.name/source-map-visualization/#base64,ImJlZm9yZVwKYWZ0ZXIiOwoiYmVmb3JlXApcCmFmdGVyIjs=,eyJtYXBwaW5ncyI6IkFBQUE7QUFDQSxNQURBO0FBR0E7QUFDQTtBQUNBLE1BRkEiLCJuYW1lcyI6W10sInNvdXJjZXMiOlsiZml4dHVyZXMvc291cmNlbWFwcy9zdHJpbmctbGl0ZXJhbC1uZXdsaW5lL2lucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbIlwiYmVmb3JlXFxcbmFmdGVyXCI7XG5cblwiYmVmb3JlXFxcblxcXG5hZnRlclwiOyJdLCJ2ZXJzaW9uIjozLCJmaWxlIjoiZXhhbXBsZS5qcyJ9,ImJlZm9yZVwKYWZ0ZXIiOwoKImJlZm9yZVwKXAphZnRlciI7)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12086"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jridgewell/babel.git/28d67857849fc5bd305a69b0ae3686c1b0512baf.svg" /></a>

