### PR TITLE
fix: apply terser plugin only on *.min.js

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -84,115 +84,104 @@ function buildBabel(exclude, sourcesGlob = defaultSourcesGlob) {
     .pipe(gulp.dest(base));
 }
 
-let babelVersion = require("./packages/babel-core/package.json").version;
+// If this build is part of a pull request, include the pull request number in
+// the version number.
+let versionSuffix = "";
+if (process.env.CIRCLE_PR_NUMBER) {
+  versionSuffix = "+pr." + process.env.CIRCLE_PR_NUMBER;
+}
+
+const babelVersion =
+  require("./packages/babel-core/package.json").version + versionSuffix;
 function buildRollup(packages) {
   const sourcemap = process.env.NODE_ENV === "production";
   return Promise.all(
-    packages.map(
-      ({ src, format, dest, name, filename, version = babelVersion }) => {
-        const extraPlugins = [];
-        let nodeResolveBrowser = false,
-          babelEnvName = "rollup";
-        switch (src) {
-          case "packages/babel-standalone":
-            nodeResolveBrowser = true;
-            babelEnvName = "standalone";
-            break;
-        }
-        // If this build is part of a pull request, include the pull request number in
-        // the version number.
-        if (process.env.CIRCLE_PR_NUMBER) {
-          const prVersion = "+pr." + process.env.CIRCLE_PR_NUMBER;
-          babelVersion += prVersion;
-          version += prVersion;
-        }
-        const input = getIndexFromPackage(src);
-        fancyLog(`Compiling '${chalk.cyan(input)}' with rollup ...`);
-        return rollup
-          .rollup({
-            input,
-            plugins: [
-              ...extraPlugins,
-              rollupBabelSource(),
-              rollupReplace({
-                "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
-                BABEL_VERSION: JSON.stringify(babelVersion),
-                VERSION: JSON.stringify(version),
-              }),
-              rollupBabel({
-                envName: babelEnvName,
-                babelrc: false,
-                babelHelpers: "bundled",
-                extends: "./babel.config.js",
-              }),
-              rollupNodeResolve({
-                browser: nodeResolveBrowser,
-                preferBuiltins: true,
-                //todo: remove when semver and source-map are bumped to latest versions
-                dedupe(importee) {
-                  return ["semver", "source-map"].includes(importee);
-                },
-              }),
-              rollupCommonJs({
-                include: [
-                  /node_modules/,
-                  "packages/babel-runtime/regenerator/**",
-                  "packages/babel-preset-env/data/*.js",
-                  // Rollup doesn't read export maps, so it loads the cjs fallback
-                  "packages/babel-compat-data/*.js",
-                ],
-              }),
-              rollupJson(),
-              rollupNodePolyfills({
-                sourceMap: sourcemap,
-                include: "**/*.js",
-              }),
-            ],
-          })
-          .then(bundle => {
-            const outputFile = path.resolve(src, dest, filename || "index.js");
-            return bundle
-              .write({
-                file: outputFile,
-                format,
-                name,
-                sourcemap: sourcemap,
-              })
-              .then(() => {
-                if (!process.env.IS_PUBLISH) {
-                  fancyLog(
-                    chalk.yellow(
-                      `Skipped minification of '${chalk.cyan(
-                        path.relative(path.join(__dirname, ".."), outputFile)
-                      )}' because not publishing`
-                    )
-                  );
-                  return undefined;
-                }
-                fancyLog(
-                  `Minifying '${chalk.cyan(
-                    path.relative(path.join(__dirname, ".."), outputFile)
-                  )}'...`
-                );
-
-                return bundle.write({
-                  file: outputFile.replace(/\.js$/, ".min.js"),
-                  format,
-                  name,
-                  sourcemap: sourcemap,
-                  plugins: [
-                    rollupTerser({
-                      // workaround https://bugs.webkit.org/show_bug.cgi?id=212725
-                      output: {
-                        ascii_only: true,
-                      },
-                    }),
-                  ],
-                });
-              });
-          });
+    packages.map(async ({ src, format, dest, name, filename, version }) => {
+      let nodeResolveBrowser = false,
+        babelEnvName = "rollup";
+      switch (src) {
+        case "packages/babel-standalone":
+          nodeResolveBrowser = true;
+          babelEnvName = "standalone";
+          break;
       }
-    )
+      const input = getIndexFromPackage(src);
+      fancyLog(`Compiling '${chalk.cyan(input)}' with rollup ...`);
+      const bundle = await rollup.rollup({
+        input,
+        plugins: [
+          rollupBabelSource(),
+          rollupReplace({
+            "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+            BABEL_VERSION: JSON.stringify(babelVersion),
+            VERSION: JSON.stringify(version),
+          }),
+          rollupBabel({
+            envName: babelEnvName,
+            babelrc: false,
+            babelHelpers: "bundled",
+            extends: "./babel.config.js",
+          }),
+          rollupNodeResolve({
+            browser: nodeResolveBrowser,
+            preferBuiltins: true,
+            //todo: remove when semver and source-map are bumped to latest versions
+            dedupe(importee) {
+              return ["semver", "source-map"].includes(importee);
+            },
+          }),
+          rollupCommonJs({
+            include: [
+              /node_modules/,
+              "packages/babel-runtime/regenerator/**",
+              "packages/babel-preset-env/data/*.js",
+              // Rollup doesn't read export maps, so it loads the cjs fallback
+              "packages/babel-compat-data/*.js",
+            ],
+          }),
+          rollupJson(),
+          rollupNodePolyfills({
+            sourceMap: sourcemap,
+            include: "**/*.js",
+          }),
+        ],
+      });
+
+      const outputFile = path.join(src, dest, filename || "index.js");
+      await bundle.write({
+        file: outputFile,
+        format,
+        name,
+        sourcemap: sourcemap,
+      });
+
+      if (!process.env.IS_PUBLISH) {
+        fancyLog(
+          chalk.yellow(
+            `Skipped minification of '${chalk.cyan(
+              outputFile
+            )}' because not publishing`
+          )
+        );
+        return undefined;
+      }
+      fancyLog(`Minifying '${chalk.cyan(outputFile)}'...`);
+
+      await bundle.write({
+        file: outputFile.replace(/\.js$/, ".min.js"),
+        format,
+        name,
+        sourcemap: sourcemap,
+        plugins: [
+          rollupTerser({
+            // workaround https://bugs.webkit.org/show_bug.cgi?id=212725
+            output: {
+              ascii_only: true,
+            },
+          }),
+        ],
+      });
+    })
   );
 }
 
@@ -201,7 +190,7 @@ const libBundles = [
     src: "packages/babel-parser",
     format: "cjs",
     dest: "lib",
-    version: require("./packages/babel-parser/package").version,
+    version: require("./packages/babel-parser/package").version + versionSuffix,
   },
 ];
 
@@ -212,7 +201,7 @@ const standaloneBundle = [
     name: "Babel",
     filename: "babel.js",
     dest: "",
-    version: require("./packages/babel-core/package").version,
+    version: babelVersion,
   },
 ];
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -101,6 +101,7 @@ function buildRollup(packages) {
             if (minify) {
               extraPlugins.push(
                 rollupTerser({
+                  include: /^.+\.min\.js$/,
                   // workaround https://bugs.webkit.org/show_bug.cgi?id=212725
                   output: {
                     ascii_only: true,

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -87,7 +87,6 @@ function buildBabel(exclude, sourcesGlob = defaultSourcesGlob) {
 let babelVersion = require("./packages/babel-core/package.json").version;
 function buildRollup(packages) {
   const sourcemap = process.env.NODE_ENV === "production";
-  const minify = !!process.env.IS_PUBLISH;
   return Promise.all(
     packages.map(
       ({ src, format, dest, name, filename, version = babelVersion }) => {
@@ -98,17 +97,6 @@ function buildRollup(packages) {
           case "packages/babel-standalone":
             nodeResolveBrowser = true;
             babelEnvName = "standalone";
-            if (minify) {
-              extraPlugins.push(
-                rollupTerser({
-                  include: /^.+\.min\.js$/,
-                  // workaround https://bugs.webkit.org/show_bug.cgi?id=212725
-                  output: {
-                    ascii_only: true,
-                  },
-                })
-              );
-            }
             break;
         }
         // If this build is part of a pull request, include the pull request number in
@@ -192,6 +180,14 @@ function buildRollup(packages) {
                   format,
                   name,
                   sourcemap: sourcemap,
+                  plugins: [
+                    rollupTerser({
+                      // workaround https://bugs.webkit.org/show_bug.cgi?id=212725
+                      output: {
+                        ascii_only: true,
+                      },
+                    }),
+                  ],
                 });
               });
           });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12095 
| Patch: Bug Fix?          | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes a regression introduced in https://github.com/babel/babel/pull/12010/files#diff-878989239e07228f7903fde98f450ed9L105

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12099"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/d9a77d30aa8a9b6dfcc3133120db73accdc820b7.svg" /></a>

