### PR TITLE
docs: Fix simple typo, preprelease -> pre-release

### DIFF
--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -139,7 +139,7 @@ export default class File {
     if (typeof versionRange !== "string") return true;
 
     // semver.intersects() has some surprising behavior with comparing ranges
-    // with preprelease versions. We add '^' to ensure that we are always
+    // with pre-release versions. We add '^' to ensure that we are always
     // comparing ranges with ranges, which sidesteps this logic.
     // For example:
     //

--- a/packages/babel-plugin-transform-runtime/src/helpers.js
+++ b/packages/babel-plugin-transform-runtime/src/helpers.js
@@ -8,7 +8,7 @@ export function hasMinVersion(minVersion, runtimeVersion) {
   if (!runtimeVersion) return true;
 
   // semver.intersects() has some surprising behavior with comparing ranges
-  // with preprelease versions. We add '^' to ensure that we are always
+  // with pre-release versions. We add '^' to ensure that we are always
   // comparing ranges with ranges, which sidesteps this logic.
   // For example:
   //


### PR DESCRIPTION
There is a small typo in packages/babel-core/src/transformation/file/file.js, packages/babel-plugin-transform-runtime/src/helpers.js.

Should read `pre-release` rather than `preprelease`.



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12102"><img src="https://gitpod.io/api/apps/github/pbs/github.com/timgates42/babel.git/54da5658cd3e56d887beae5ab599689f01d90532.svg" /></a>

