### PR TITLE
Remove unthrown syntax error

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -106,8 +106,6 @@ const TSErrors = Object.freeze({
     "Argument in a type import must be a string literal",
   UnsupportedParameterPropertyKind:
     "A parameter property may not be declared using a binding pattern.",
-  UnsupportedSignatureParameterKind:
-    "Name in a signature must be an Identifier, ObjectPattern or ArrayPattern, instead got %0",
 });
 
 // Doesn't handle "void" or "null" because those are keywords, not identifiers.
@@ -444,23 +442,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     tsParseBindingListForSignature(): $ReadOnlyArray<
       N.Identifier | N.RestElement | N.ObjectPattern | N.ArrayPattern,
     > {
-      return this.parseBindingList(tt.parenR, charCodes.rightParenthesis).map(
-        pattern => {
-          if (
-            pattern.type !== "Identifier" &&
-            pattern.type !== "RestElement" &&
-            pattern.type !== "ObjectPattern" &&
-            pattern.type !== "ArrayPattern"
-          ) {
-            this.raise(
-              pattern.start,
-              TSErrors.UnsupportedSignatureParameterKind,
-              pattern.type,
-            );
-          }
-          return (pattern: any);
-        },
-      );
+      return this.parseBindingList(tt.parenR, charCodes.rightParenthesis);
     }
 
     tsParseTypeMemberSemicolon(): void {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When I'm working on #12103, I noticed that we have no tests for `TSErrors.UnsupportedSignatureParameterKind`. I looked it up but I couldn't find a case where this error is thrown.

If this is my misunderstanding, please close this PR.:smile:

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12104"><img src="https://gitpod.io/api/apps/github/pbs/github.com/sosukesuzuki/babel.git/9666a9f4255f8c511e2fed58e4ee91bf947a742c.svg" /></a>

