### PR TITLE
Fix reexporting init-less variable in systemjs

### DIFF
--- a/packages/babel-plugin-transform-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.js
@@ -506,9 +506,11 @@ export default declare((api, options) => {
             path,
             (id, name, hasInit) => {
               variableIds.push(id);
-              if (!hasInit) {
-                exportNames.push(name);
-                exportValues.push(scope.buildUndefinedNode());
+              if (!hasInit && name in exportMap) {
+                for (const exported of exportMap[name]) {
+                  exportNames.push(exported);
+                  exportValues.push(scope.buildUndefinedNode());
+                }
               }
             },
             null,

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-named-3/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-named-3/output.mjs
@@ -3,7 +3,7 @@ System.register([], function (_export, _context) {
 
   var foo;
 
-  _export("foo", void 0);
+  _export("bar", void 0);
 
   return {
     setters: [],

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-named-4/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-named-4/output.mjs
@@ -3,7 +3,7 @@ System.register([], function (_export, _context) {
 
   var foo;
 
-  _export("foo", void 0);
+  _export("default", void 0);
 
   return {
     setters: [],

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-named-5/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-named-5/output.mjs
@@ -4,7 +4,7 @@ System.register([], function (_export, _context) {
   var foo, bar;
 
   _export({
-    foo: void 0,
+    default: void 0,
     bar: void 0
   });
 

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/output.mjs
@@ -7,10 +7,7 @@ System.register(["./evens"], function (_export, _context) {
     return _export("p", p = isEven(n) ? n + 1 : n + 2);
   }
 
-  _export({
-    nextOdd: nextOdd,
-    a: void 0
-  });
+  _export("nextOdd", nextOdd);
 
   return {
     setters: [function (_evens) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/pull/12091#discussion_r493030159
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Updated test fixtures
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR checks exportMap when hoisting variables so we don't accidentally push unexported variables to `_export` call. We also push `exported` instead of the `local` variable so it respects cases like
```js
var foo
export { foo as bar }
```

/cc @guybedford 

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12110"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/0fe715e9db637dbb0474add594475f65cd073983.svg" /></a>

