### PR TITLE
Throw a recoverable error for missing initializer in const declaration

### DIFF
--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1016,7 +1016,11 @@ export default class StatementParser extends ExpressionParser {
           // `const` with no initializer is allowed in TypeScript.
           // It could be a declaration like `const x: number;`.
           if (!isTypescript) {
-            this.unexpected();
+            this.raise(
+              this.state.lastTokEnd,
+              Errors.DeclarationMissingInitializer,
+              "Const declarations",
+            );
           }
         } else if (
           decl.id.type !== "Identifier" &&

--- a/packages/babel-parser/test/fixtures/core/uncategorised/536/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/536/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:7)"
-}

--- a/packages/babel-parser/test/fixtures/core/uncategorised/536/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/536/output.json
@@ -1,0 +1,33 @@
+{
+  "type": "File",
+  "start":0,"end":8,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":8}},
+  "errors": [
+    "SyntaxError: Const declarations require an initialization value (1:7)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":8,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":8}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":8,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":8}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7}},
+            "id": {
+              "type": "Identifier",
+              "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"a"},
+              "name": "a"
+            },
+            "init": null
+          }
+        ],
+        "kind": "const"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/esprima/es2015-for-of/unexpected-number/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-for-of/unexpected-number/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:14)"
+  "throws": "Unexpected token, expected \";\" (1:14)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0138/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0138/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:15)"
-}

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0138/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0138/output.json
@@ -1,0 +1,51 @@
+{
+  "type": "File",
+  "start":0,"end":16,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":16}},
+  "errors": [
+    "SyntaxError: Const declarations require an initialization value (1:15)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":16,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":16}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":16,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":16}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":6,"end":12,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":12}},
+            "id": {
+              "type": "Identifier",
+              "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"x"},
+              "name": "x"
+            },
+            "init": {
+              "type": "NumericLiteral",
+              "start":10,"end":12,"loc":{"start":{"line":1,"column":10},"end":{"line":1,"column":12}},
+              "extra": {
+                "rawValue": 12,
+                "raw": "12"
+              },
+              "value": 12
+            }
+          },
+          {
+            "type": "VariableDeclarator",
+            "start":14,"end":15,"loc":{"start":{"line":1,"column":14},"end":{"line":1,"column":15}},
+            "id": {
+              "type": "Identifier",
+              "start":14,"end":15,"loc":{"start":{"line":1,"column":14},"end":{"line":1,"column":15},"identifierName":"y"},
+              "name": "y"
+            },
+            "init": null
+          }
+        ],
+        "kind": "const"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0139/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0139/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:7)"
-}

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0139/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0139/output.json
@@ -1,0 +1,51 @@
+{
+  "type": "File",
+  "start":0,"end":16,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":16}},
+  "errors": [
+    "SyntaxError: Const declarations require an initialization value (1:7)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":16,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":16}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":16,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":16}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7}},
+            "id": {
+              "type": "Identifier",
+              "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"x"},
+              "name": "x"
+            },
+            "init": null
+          },
+          {
+            "type": "VariableDeclarator",
+            "start":9,"end":15,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":15}},
+            "id": {
+              "type": "Identifier",
+              "start":9,"end":10,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":10},"identifierName":"y"},
+              "name": "y"
+            },
+            "init": {
+              "type": "NumericLiteral",
+              "start":13,"end":15,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":15}},
+              "extra": {
+                "rawValue": 12,
+                "raw": "12"
+              },
+              "value": 12
+            }
+          }
+        ],
+        "kind": "const"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0140/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0140/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:7)"
-}

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0140/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0140/output.json
@@ -1,0 +1,33 @@
+{
+  "type": "File",
+  "start":0,"end":8,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":8}},
+  "errors": [
+    "SyntaxError: Const declarations require an initialization value (1:7)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":8,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":8}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":8,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":8}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7}},
+            "id": {
+              "type": "Identifier",
+              "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"x"},
+              "name": "x"
+            },
+            "init": null
+          }
+        ],
+        "kind": "const"
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

**Current behavior([REPL](https://babeljs.io/repl#?browsers=ie%20%3E%3D%2011&build=&builtIns=false&spec=false&loose=false&code_lz=MYewdgzgLgBAZiEBuIA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=script&lineWrap=false&presets=env&prettier=false&targets=&version=7.11.6&externalPlugins=)):**

Input code:

```js
const foo;
```

Syntax error thrown:

```
Unexpected token (1:9)
```

**Expected behavior(This PR):**

Input code:

```js
const foo;
```

Syntax error thrown(recoverable):

```
Const declarations require an initialization value (1:9)
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12120"><img src="https://gitpod.io/api/apps/github/pbs/github.com/sosukesuzuki/babel.git/1935ba1293e665166b3726dd93efff5b10f3dc71.svg" /></a>

