### PR TITLE
[babel-types] Add extra property to BaseNode type

### DIFF
--- a/packages/babel-types/scripts/generators/flow.js
+++ b/packages/babel-types/scripts/generators/flow.js
@@ -43,6 +43,7 @@ declare class ${NODE_PREFIX} {
   start: ?number;
   end: ?number;
   loc: ?${NODE_PREFIX}SourceLocation;
+  extra?: { [string]: mixed };
 }\n\n`;
 
 //

--- a/packages/babel-types/scripts/generators/typescript.js
+++ b/packages/babel-types/scripts/generators/typescript.js
@@ -45,7 +45,7 @@ interface BaseNode {
   end: number | null;
   loc: SourceLocation | null;
   type: Node["type"];
-  extra: Record<string, unknown>;
+  extra?: Record<string, unknown>;
 }
 
 export type Node = ${t.TYPES.sort().join(" | ")};\n\n`;

--- a/packages/babel-types/scripts/generators/typescript.js
+++ b/packages/babel-types/scripts/generators/typescript.js
@@ -45,6 +45,7 @@ interface BaseNode {
   end: number | null;
   loc: SourceLocation | null;
   type: Node["type"];
+  extra: Record<string, unknown>;
 }
 
 export type Node = ${t.TYPES.sort().join(" | ")};\n\n`;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | no issue filed
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  | :-1:
| Minor: New Feature?      | :-1:
| Tests Added + Pass?      | :-1:
| Documentation PR Link    | n/a
| Any Dependency Changes?  | :-1:
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Nodes sometimes have an "extra" property. It's documented in code, e.g. https://github.com/babel/babel/blob/286aaea/packages/babel-types/src/clone/cloneNode.js#L94-L98

This PR updates the type system to reflect this reality.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12136"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ryanrhee/babel.git/d1053c8ee56bce13239637ffdbe4eb50ca2ed167.svg" /></a>

