### PR TITLE
[ts] Add support for the "intrinsic" keyword

### DIFF
--- a/packages/babel-generator/src/generators/typescript.js
+++ b/packages/babel-generator/src/generators/typescript.js
@@ -162,6 +162,9 @@ export function TSNullKeyword() {
 export function TSNeverKeyword() {
   this.word("never");
 }
+export function TSIntrinsicKeyword() {
+  this.word("intrinsic");
+}
 
 export function TSThisType() {
   this.word("this");

--- a/packages/babel-generator/test/fixtures/typescript/types-keywords/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-keywords/input.js
@@ -9,3 +9,4 @@ let st: string;
 let sy: symbol;
 let u: undefined;
 let v: void;
+type Foo = intrinsic;

--- a/packages/babel-generator/test/fixtures/typescript/types-keywords/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-keywords/output.js
@@ -9,3 +9,4 @@ let st: string;
 let sy: symbol;
 let u: undefined;
 let v: void;
+type Foo = intrinsic;

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -113,6 +113,7 @@ const TSErrors = Object.freeze({
 });
 
 // Doesn't handle "void" or "null" because those are keywords, not identifiers.
+// It also doesn't handle "intrinsic", since usually it's not a keyword.
 function keywordTypeFromName(
   value: string,
 ): N.TsKeywordTypeType | typeof undefined {
@@ -1242,7 +1243,18 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       this.checkLVal(node.id, BIND_TS_TYPE, undefined, "typescript type alias");
 
       node.typeParameters = this.tsTryParseTypeParameters();
-      node.typeAnnotation = this.tsExpectThenParseType(tt.eq);
+      node.typeAnnotation = this.tsInType(() => {
+        this.expect(tt.eq);
+
+        if (this.isContextual("intrinsic")) {
+          const node: N.TsKeywordType = this.startNode();
+          this.next();
+          return this.finishNode(node, "TSIntrinsicKeyword");
+        }
+
+        return this.tsParseType();
+      });
+
       this.semicolon();
       return this.finishNode(node, "TSTypeAliasDeclaration");
     }

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1246,7 +1246,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       node.typeAnnotation = this.tsInType(() => {
         this.expect(tt.eq);
 
-        if (this.isContextual("intrinsic")) {
+        if (
+          this.isContextual("intrinsic") &&
+          this.lookahead().type !== tt.dot
+        ) {
           const node: N.TsKeywordType = this.startNode();
           this.next();
           return this.finishNode(node, "TSIntrinsicKeyword");

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1215,7 +1215,8 @@ export type TsKeywordTypeType =
   | "TSVoidKeyword"
   | "TSUndefinedKeyword"
   | "TSNullKeyword"
-  | "TSNeverKeyword";
+  | "TSNeverKeyword"
+  | "TSIntrinsicKeyword";
 export type TsKeywordType = TsTypeBase & {
   type: TsKeywordTypeType,
 };

--- a/packages/babel-parser/test/fixtures/typescript/types/intrinsic-identifier/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/intrinsic-identifier/input.ts
@@ -2,4 +2,5 @@ type intrinsic = 2;
 function foo(x: intrinsic): intrinsic {
   var a: intrinsic = 2;
   type X = 1 | intrinsic;
+  type Foo = intrinsic.bar;
 }

--- a/packages/babel-parser/test/fixtures/typescript/types/intrinsic-identifier/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/intrinsic-identifier/input.ts
@@ -1,0 +1,5 @@
+type intrinsic = 2;
+function foo(x: intrinsic): intrinsic {
+  var a: intrinsic = 2;
+  type X = 1 | intrinsic;
+}

--- a/packages/babel-parser/test/fixtures/typescript/types/intrinsic-identifier/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/intrinsic-identifier/output.json
@@ -1,9 +1,9 @@
 {
   "type": "File",
-  "start":0,"end":111,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+  "start":0,"end":139,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
   "program": {
     "type": "Program",
-    "start":0,"end":111,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+    "start":0,"end":139,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
@@ -31,7 +31,7 @@
       },
       {
         "type": "FunctionDeclaration",
-        "start":20,"end":111,"loc":{"start":{"line":2,"column":0},"end":{"line":5,"column":1}},
+        "start":20,"end":139,"loc":{"start":{"line":2,"column":0},"end":{"line":6,"column":1}},
         "id": {
           "type": "Identifier",
           "start":29,"end":32,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":12},"identifierName":"foo"},
@@ -74,7 +74,7 @@
         },
         "body": {
           "type": "BlockStatement",
-          "start":58,"end":111,"loc":{"start":{"line":2,"column":38},"end":{"line":5,"column":1}},
+          "start":58,"end":139,"loc":{"start":{"line":2,"column":38},"end":{"line":6,"column":1}},
           "body": [
             {
               "type": "VariableDeclaration",
@@ -149,6 +149,33 @@
                     }
                   }
                 ]
+              }
+            },
+            {
+              "type": "TSTypeAliasDeclaration",
+              "start":112,"end":137,"loc":{"start":{"line":5,"column":2},"end":{"line":5,"column":27}},
+              "id": {
+                "type": "Identifier",
+                "start":117,"end":120,"loc":{"start":{"line":5,"column":7},"end":{"line":5,"column":10},"identifierName":"Foo"},
+                "name": "Foo"
+              },
+              "typeAnnotation": {
+                "type": "TSTypeReference",
+                "start":123,"end":136,"loc":{"start":{"line":5,"column":13},"end":{"line":5,"column":26}},
+                "typeName": {
+                  "type": "TSQualifiedName",
+                  "start":123,"end":136,"loc":{"start":{"line":5,"column":13},"end":{"line":5,"column":26}},
+                  "left": {
+                    "type": "Identifier",
+                    "start":123,"end":132,"loc":{"start":{"line":5,"column":13},"end":{"line":5,"column":22},"identifierName":"intrinsic"},
+                    "name": "intrinsic"
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start":133,"end":136,"loc":{"start":{"line":5,"column":23},"end":{"line":5,"column":26},"identifierName":"bar"},
+                    "name": "bar"
+                  }
+                }
               }
             }
           ],

--- a/packages/babel-parser/test/fixtures/typescript/types/intrinsic-identifier/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/intrinsic-identifier/output.json
@@ -1,0 +1,161 @@
+{
+  "type": "File",
+  "start":0,"end":111,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":111,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start":0,"end":19,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":19}},
+        "id": {
+          "type": "Identifier",
+          "start":5,"end":14,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":14},"identifierName":"intrinsic"},
+          "name": "intrinsic"
+        },
+        "typeAnnotation": {
+          "type": "TSLiteralType",
+          "start":17,"end":18,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":18}},
+          "literal": {
+            "type": "NumericLiteral",
+            "start":17,"end":18,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":18}},
+            "extra": {
+              "rawValue": 2,
+              "raw": "2"
+            },
+            "value": 2
+          }
+        }
+      },
+      {
+        "type": "FunctionDeclaration",
+        "start":20,"end":111,"loc":{"start":{"line":2,"column":0},"end":{"line":5,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":29,"end":32,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":12},"identifierName":"foo"},
+          "name": "foo"
+        },
+        "generator": false,
+        "async": false,
+        "params": [
+          {
+            "type": "Identifier",
+            "start":33,"end":45,"loc":{"start":{"line":2,"column":13},"end":{"line":2,"column":25},"identifierName":"x"},
+            "name": "x",
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start":34,"end":45,"loc":{"start":{"line":2,"column":14},"end":{"line":2,"column":25}},
+              "typeAnnotation": {
+                "type": "TSTypeReference",
+                "start":36,"end":45,"loc":{"start":{"line":2,"column":16},"end":{"line":2,"column":25}},
+                "typeName": {
+                  "type": "Identifier",
+                  "start":36,"end":45,"loc":{"start":{"line":2,"column":16},"end":{"line":2,"column":25},"identifierName":"intrinsic"},
+                  "name": "intrinsic"
+                }
+              }
+            }
+          }
+        ],
+        "returnType": {
+          "type": "TSTypeAnnotation",
+          "start":46,"end":57,"loc":{"start":{"line":2,"column":26},"end":{"line":2,"column":37}},
+          "typeAnnotation": {
+            "type": "TSTypeReference",
+            "start":48,"end":57,"loc":{"start":{"line":2,"column":28},"end":{"line":2,"column":37}},
+            "typeName": {
+              "type": "Identifier",
+              "start":48,"end":57,"loc":{"start":{"line":2,"column":28},"end":{"line":2,"column":37},"identifierName":"intrinsic"},
+              "name": "intrinsic"
+            }
+          }
+        },
+        "body": {
+          "type": "BlockStatement",
+          "start":58,"end":111,"loc":{"start":{"line":2,"column":38},"end":{"line":5,"column":1}},
+          "body": [
+            {
+              "type": "VariableDeclaration",
+              "start":62,"end":83,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":23}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":66,"end":82,"loc":{"start":{"line":3,"column":6},"end":{"line":3,"column":22}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":66,"end":78,"loc":{"start":{"line":3,"column":6},"end":{"line":3,"column":18},"identifierName":"a"},
+                    "name": "a",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start":67,"end":78,"loc":{"start":{"line":3,"column":7},"end":{"line":3,"column":18}},
+                      "typeAnnotation": {
+                        "type": "TSTypeReference",
+                        "start":69,"end":78,"loc":{"start":{"line":3,"column":9},"end":{"line":3,"column":18}},
+                        "typeName": {
+                          "type": "Identifier",
+                          "start":69,"end":78,"loc":{"start":{"line":3,"column":9},"end":{"line":3,"column":18},"identifierName":"intrinsic"},
+                          "name": "intrinsic"
+                        }
+                      }
+                    }
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":81,"end":82,"loc":{"start":{"line":3,"column":21},"end":{"line":3,"column":22}},
+                    "extra": {
+                      "rawValue": 2,
+                      "raw": "2"
+                    },
+                    "value": 2
+                  }
+                }
+              ],
+              "kind": "var"
+            },
+            {
+              "type": "TSTypeAliasDeclaration",
+              "start":86,"end":109,"loc":{"start":{"line":4,"column":2},"end":{"line":4,"column":25}},
+              "id": {
+                "type": "Identifier",
+                "start":91,"end":92,"loc":{"start":{"line":4,"column":7},"end":{"line":4,"column":8},"identifierName":"X"},
+                "name": "X"
+              },
+              "typeAnnotation": {
+                "type": "TSUnionType",
+                "start":95,"end":108,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":24}},
+                "types": [
+                  {
+                    "type": "TSLiteralType",
+                    "start":95,"end":96,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":12}},
+                    "literal": {
+                      "type": "NumericLiteral",
+                      "start":95,"end":96,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":12}},
+                      "extra": {
+                        "rawValue": 1,
+                        "raw": "1"
+                      },
+                      "value": 1
+                    }
+                  },
+                  {
+                    "type": "TSTypeReference",
+                    "start":99,"end":108,"loc":{"start":{"line":4,"column":15},"end":{"line":4,"column":24}},
+                    "typeName": {
+                      "type": "Identifier",
+                      "start":99,"end":108,"loc":{"start":{"line":4,"column":15},"end":{"line":4,"column":24},"identifierName":"intrinsic"},
+                      "name": "intrinsic"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword-error/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword-error/input.ts
@@ -1,0 +1,2 @@
+type Foo = intrinsic["foo"];
+

--- a/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword-error/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword-error/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token, expected \";\" (1:20)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword/input.ts
@@ -1,0 +1,2 @@
+type Foo = intrinsic;
+type Bar<T> = intrinsic;

--- a/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword/output.json
@@ -1,0 +1,50 @@
+{
+  "type": "File",
+  "start":0,"end":46,"loc":{"start":{"line":1,"column":0},"end":{"line":2,"column":24}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":46,"loc":{"start":{"line":1,"column":0},"end":{"line":2,"column":24}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start":0,"end":21,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":21}},
+        "id": {
+          "type": "Identifier",
+          "start":5,"end":8,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":8},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "typeAnnotation": {
+          "type": "TSIntrinsicKeyword",
+          "start":11,"end":20,"loc":{"start":{"line":1,"column":11},"end":{"line":1,"column":20}}
+        }
+      },
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start":22,"end":46,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":24}},
+        "id": {
+          "type": "Identifier",
+          "start":27,"end":30,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":8},"identifierName":"Bar"},
+          "name": "Bar"
+        },
+        "typeParameters": {
+          "type": "TSTypeParameterDeclaration",
+          "start":30,"end":33,"loc":{"start":{"line":2,"column":8},"end":{"line":2,"column":11}},
+          "params": [
+            {
+              "type": "TSTypeParameter",
+              "start":31,"end":32,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":10}},
+              "name": "T"
+            }
+          ]
+        },
+        "typeAnnotation": {
+          "type": "TSIntrinsicKeyword",
+          "start":36,"end":45,"loc":{"start":{"line":2,"column":14},"end":{"line":2,"column":23}}
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-types/src/asserts/generated/index.js
+++ b/packages/babel-types/src/asserts/generated/index.js
@@ -857,6 +857,12 @@ export function assertTSBooleanKeyword(node: Object, opts?: Object = {}): void {
 export function assertTSBigIntKeyword(node: Object, opts?: Object = {}): void {
   assert("TSBigIntKeyword", node, opts);
 }
+export function assertTSIntrinsicKeyword(
+  node: Object,
+  opts?: Object = {},
+): void {
+  assert("TSIntrinsicKeyword", node, opts);
+}
 export function assertTSNeverKeyword(node: Object, opts?: Object = {}): void {
   assert("TSNeverKeyword", node, opts);
 }

--- a/packages/babel-types/src/builders/generated/index.js
+++ b/packages/babel-types/src/builders/generated/index.js
@@ -794,6 +794,11 @@ export function tsBigIntKeyword(...args: Array<any>): Object {
 }
 export { tsBigIntKeyword as TSBigIntKeyword };
 export { tsBigIntKeyword as tSBigIntKeyword };
+export function tsIntrinsicKeyword(...args: Array<any>): Object {
+  return builder("TSIntrinsicKeyword", ...args);
+}
+export { tsIntrinsicKeyword as TSIntrinsicKeyword };
+export { tsIntrinsicKeyword as tSIntrinsicKeyword };
 export function tsNeverKeyword(...args: Array<any>): Object {
   return builder("TSNeverKeyword", ...args);
 }

--- a/packages/babel-types/src/definitions/typescript.js
+++ b/packages/babel-types/src/definitions/typescript.js
@@ -132,6 +132,7 @@ const tsKeywordTypes = [
   "TSAnyKeyword",
   "TSBooleanKeyword",
   "TSBigIntKeyword",
+  "TSIntrinsicKeyword",
   "TSNeverKeyword",
   "TSNullKeyword",
   "TSNumberKeyword",

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -2761,6 +2761,20 @@ export function isTSBigIntKeyword(node: ?Object, opts?: Object): boolean {
 
   return false;
 }
+export function isTSIntrinsicKeyword(node: ?Object, opts?: Object): boolean {
+  if (!node) return false;
+
+  const nodeType = node.type;
+  if (nodeType === "TSIntrinsicKeyword") {
+    if (typeof opts === "undefined") {
+      return true;
+    } else {
+      return shallowEqual(node, opts);
+    }
+  }
+
+  return false;
+}
 export function isTSNeverKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
@@ -4616,6 +4630,7 @@ export function isTSType(node: ?Object, opts?: Object): boolean {
     "TSAnyKeyword" === nodeType ||
     "TSBooleanKeyword" === nodeType ||
     "TSBigIntKeyword" === nodeType ||
+    "TSIntrinsicKeyword" === nodeType ||
     "TSNeverKeyword" === nodeType ||
     "TSNullKeyword" === nodeType ||
     "TSNumberKeyword" === nodeType ||
@@ -4666,6 +4681,7 @@ export function isTSBaseType(node: ?Object, opts?: Object): boolean {
     "TSAnyKeyword" === nodeType ||
     "TSBooleanKeyword" === nodeType ||
     "TSBigIntKeyword" === nodeType ||
+    "TSIntrinsicKeyword" === nodeType ||
     "TSNeverKeyword" === nodeType ||
     "TSNullKeyword" === nodeType ||
     "TSNumberKeyword" === nodeType ||


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

From what I understood [from the TS PR](https://github.com/microsoft/TypeScript/pull/40580), `intrinsic` is a keyword only when it's immediately after `=` in a type declaration.
Hopefully TS [will have a spec](https://twitter.com/orta/status/1313127390558773248) one day :stuck_out_tongue: 


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12147"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/5f47c84725a035ddaf2957cc57c4b876b396327c.svg" /></a>

