### PR TITLE
chore: bump gulp-cli to 2.3.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8490,6 +8490,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-levenshtein@npm:^1.0.0":
+  version: 1.1.4
+  resolution: "fast-levenshtein@npm:1.1.4"
+  checksum: cb08cd9e28c434ad7ee3e3853c795656e020cc803373c98437785162c6ec4bb49f6b6af14301e0275d63d249b121ed54647d19a1f7a753d98ee57c740db0d696
+  languageName: node
+  linkType: hard
+
 "fast-levenshtein@npm:^2.0.6, fast-levenshtein@npm:~2.0.6":
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
@@ -9130,16 +9137,17 @@ fsevents@~2.1.2:
   linkType: hard
 
 "glob-watcher@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "glob-watcher@npm:5.0.3"
+  version: 5.0.5
+  resolution: "glob-watcher@npm:5.0.5"
   dependencies:
     anymatch: ^2.0.0
     async-done: ^1.2.0
     chokidar: ^2.0.0
     is-negated-glob: ^1.0.0
     just-debounce: ^1.0.0
+    normalize-path: ^3.0.0
     object.defaults: ^1.1.0
-  checksum: 6a24d847bbb0d510289e22b4e4d7a0c6a281aea1da674c0b0585537bb57eb32c7c59af1e2158e43687a0f82145fd472cac7f6df05f86980971aa8d88314f0256
+  checksum: 0d1e529fbce75d6c0b32e4872c82cd927f9ad4a5750455f1467530344e6a718e32eef2339323e23cf4a1aceb90fb582f5444ef6a43dabfdaba8d0c06fe2a4518
   languageName: node
   linkType: hard
 
@@ -9239,9 +9247,9 @@ fsevents@~2.1.2:
   linkType: hard
 
 "graceful-fs@npm:^4.0.0, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3":
-  version: 4.2.3
-  resolution: "graceful-fs@npm:4.2.3"
-  checksum: 67b7e3f6a687c91287f17a2adfcce462406e2aa16ea4440618e1daaecd579ae6362c0b13303f86c77c165ed8074fa8b0868bb0a73173fa3407c2b747e89353f9
+  version: 4.2.4
+  resolution: "graceful-fs@npm:4.2.4"
+  checksum: d095ee4dc6eacc76814cd52d5d185b860119378a6fd4888e7d4e94983095c54d4f6369942a5e3d759cdbdd4e3ee7eaeb27a39ff938c6ee4610894fd9de46b6cb
   languageName: node
   linkType: hard
 
@@ -9267,8 +9275,8 @@ fsevents@~2.1.2:
   linkType: hard
 
 "gulp-cli@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "gulp-cli@npm:2.2.0"
+  version: 2.3.0
+  resolution: "gulp-cli@npm:2.3.0"
   dependencies:
     ansi-colors: ^1.0.1
     archy: ^1.0.0
@@ -9278,7 +9286,7 @@ fsevents@~2.1.2:
     copy-props: ^2.0.1
     fancy-log: ^1.3.2
     gulplog: ^1.0.0
-    interpret: ^1.1.0
+    interpret: ^1.4.0
     isobject: ^3.0.1
     liftoff: ^3.1.0
     matchdep: ^2.0.0
@@ -9286,11 +9294,11 @@ fsevents@~2.1.2:
     pretty-hrtime: ^1.0.0
     replace-homedir: ^1.0.0
     semver-greatest-satisfied-range: ^1.1.0
-    v8flags: ^3.0.1
+    v8flags: ^3.2.0
     yargs: ^7.1.0
   bin:
     gulp: bin/gulp.js
-  checksum: 7be2d781a272256207c82961e895c47c4d2baaba42cf8442ac39e98d080d3857398cbdf8a93d342fa1e774ae49c4a0c060c9edef8e5e907a5cb7d7d1e1e3d604
+  checksum: e18372ad74653054a9cabb849824894a9d4cb554683d99cc258b4aee0296d7d5870d33ab86aa3cd6a5d74b73e76886d7f71e1f80f467a797dd2439a120ef49e3
   languageName: node
   linkType: hard
 
@@ -9845,10 +9853,10 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"interpret@npm:^1.1.0":
-  version: 1.2.0
-  resolution: "interpret@npm:1.2.0"
-  checksum: 06d0dd4af01f9d0a99af8fb20c888db99e7c1bd28835951646a7e426dd99ccfffb9d06ad2e8f7cb60dd2ecc3e5bc61fe83e04c2cc47d92c7b144ff935673463c
+"interpret@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "interpret@npm:1.4.0"
+  checksum: f15725d76206525546f559030ddc967db025c6db904eb8798a70ec3c07e42c5537c5cbc73a15eafd4ae5cdabad35601abf8878261c03dcc8217747e8037575fe
   languageName: node
   linkType: hard
 
@@ -15826,19 +15834,20 @@ typescript@^3.6.3:
   linkType: hard
 
 "undertaker@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "undertaker@npm:1.2.1"
+  version: 1.3.0
+  resolution: "undertaker@npm:1.3.0"
   dependencies:
     arr-flatten: ^1.0.1
     arr-map: ^2.0.0
     bach: ^1.0.0
     collection-map: ^1.0.0
     es6-weak-map: ^2.0.1
+    fast-levenshtein: ^1.0.0
     last-run: ^1.1.0
     object.defaults: ^1.0.0
     object.reduce: ^1.0.0
     undertaker-registry: ^1.0.0
-  checksum: d405ac8610e06feb234176b87ae766e8c20b3d44af5d838a37e239fb923094cb96284d5c2cea1bd59152ea69ac7b2b0fc9d766ce7d9874bea423d639969af448
+  checksum: 8fd661579a6a3dfdedb853344f10d4191b1db8e11c7b5ef21a9a9ecf17f4052db58511a4de46391c4f29e6ce6577ec2a2e016dc9d288b834ee756db2e550c406
   languageName: node
   linkType: hard
 
@@ -16046,7 +16055,7 @@ typescript@^3.6.3:
   languageName: node
   linkType: hard
 
-"v8flags@npm:^3.0.1, v8flags@npm:^3.1.1":
+"v8flags@npm:^3.1.1, v8flags@npm:^3.2.0":
   version: 3.2.0
   resolution: "v8flags@npm:3.2.0"
   dependencies:
@@ -16142,8 +16151,8 @@ typescript@^3.6.3:
   linkType: hard
 
 "vinyl@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "vinyl@npm:2.2.0"
+  version: 2.2.1
+  resolution: "vinyl@npm:2.2.1"
   dependencies:
     clone: ^2.1.1
     clone-buffer: ^1.0.0
@@ -16151,7 +16160,7 @@ typescript@^3.6.3:
     cloneable-readable: ^1.0.0
     remove-trailing-separator: ^1.0.1
     replace-ext: ^1.0.0
-  checksum: a8c27638aafd77078d210e7ff0eff5724ec39cca1c5e8997b9c39024023e65037bcb4f775fd7903d8099a4d32b135950f937174a945619082c3ce704e66cd0a0
+  checksum: 9f4088a075cc3eb2ecbd88b09cb5c7571c4edb64d6ebb80eeaaf18ddb47bbca1ee2808dea4ae6ee338e38e60715c253c67b5f2fe34be630a914e54fae618db9c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | `gulp-cli` is bumped to 2.3.0
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`gulp-cli@2.3.0` supports `Gulpfile.mjs`. It should help #12137 that migrates `Gulpfile.js` to `Gulpfile.mjs`.

It seems that `yarn up` does not support upgrading indirect dependencies. I have run
```
yarn remove gulp && yarn add gulp --dev && yarn dedupe
```
to get `gulp` dependencies up-to-date.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12154"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/32d00f3caf5c97e08e553051a1325c681e6fa7c6.svg" /></a>

