### PR TITLE
Config loading updates

### DIFF
--- a/packages/babel-core/src/config/full.js
+++ b/packages/babel-core/src/config/full.js
@@ -63,7 +63,11 @@ export default gensync<[any], ResolvedConfig | null>(function* loadFullConfig(
   if (!result) {
     return null;
   }
-  const { options, context } = result;
+  const { options, context, fileHandling } = result;
+
+  if (fileHandling === "ignored") {
+    return null;
+  }
 
   const optionDefaults = {};
   const passes: Array<Array<Plugin>> = [[]];

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -454,12 +454,16 @@ function assertOverridesList(loc: OptionPath, value: mixed): OverridesList {
 }
 
 export function checkNoUnwrappedItemOptionPairs(
-  lastItem: UnloadedDescriptor,
-  thisItem: UnloadedDescriptor,
-  type: "plugin" | "preset",
+  items: Array<UnloadedDescriptor>,
   index: number,
+  type: "plugin" | "preset",
   e: Error,
 ): void {
+  if (index === 0) return;
+
+  const lastItem = items[index - 1];
+  const thisItem = items[index];
+
   if (
     lastItem.file &&
     lastItem.options === undefined &&

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -423,6 +423,8 @@ describe("api", function () {
         "argone;",
         "five;",
         "six;",
+        "twentyone;",
+        "twentytwo;",
         "three;",
         "four;",
         "nineteen;",

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -1271,6 +1271,65 @@ describe("buildConfigChain", function () {
           loadOptionsAsync({ filename, cwd: path.dirname(filename) }),
         ).rejects.toThrow(error);
       });
+
+      it("loadPartialConfig should return a list of files that were extended", () => {
+        const filename = fixture("config-files", "babelrc-extended", "src.js");
+
+        expect(
+          babel.loadPartialConfig({ filename, cwd: path.dirname(filename) }),
+        ).toEqual({
+          babelignore: fixture("config-files", ".babelignore"),
+          babelrc: fixture("config-files", "babelrc-extended", ".babelrc"),
+          config: undefined,
+          fileHandling: "transpile",
+          options: {
+            ...getDefaults(),
+            filename: filename,
+            cwd: path.dirname(filename),
+            root: path.dirname(filename),
+            comments: true,
+          },
+          files: new Set([
+            fixture("config-files", ".babelignore"),
+            fixture("config-files", "babelrc-extended", ".babelrc-extended"),
+            fixture("config-files", "babelrc-extended", ".babelrc"),
+          ]),
+        });
+      });
+
+      it("loadPartialConfig should return null when ignored", () => {
+        const filename = fixture("config-files", "babelignore", "src.js");
+
+        expect(
+          babel.loadPartialConfig({ filename, cwd: path.dirname(filename) }),
+        ).toBeNull();
+      });
+
+      it("loadPartialConfig should return a list of files when ignored with showIgnoredFiles option", () => {
+        const filename = fixture("config-files", "babelignore", "src.js");
+
+        expect(
+          babel.loadPartialConfig({
+            filename,
+            cwd: path.dirname(filename),
+            showIgnoredFiles: true,
+          }),
+        ).toEqual({
+          babelignore: fixture("config-files", "babelignore", ".babelignore"),
+          babelrc: undefined,
+          config: undefined,
+          fileHandling: "ignored",
+          options: {
+            ...getDefaults(),
+            filename: filename,
+            cwd: path.dirname(filename),
+            root: path.dirname(filename),
+          },
+          files: new Set([
+            fixture("config-files", "babelignore", ".babelignore"),
+          ]),
+        });
+      });
     });
 
     it("should throw when `test` presents but `filename` is not passed", () => {

--- a/packages/babel-core/test/fixtures/config/complex-plugin-config/.babelrc
+++ b/packages/babel-core/test/fixtures/config/complex-plugin-config/.babelrc
@@ -14,6 +14,12 @@
       "./five",
       "./six",
     ],
+    presets: [{
+      plugins: [
+        "./twentyone",
+        "./twentytwo",
+      ]
+    }]
   }, {
     passPerPreset: true,
     presets: [{

--- a/packages/babel-core/test/fixtures/config/complex-plugin-config/twentyone.js
+++ b/packages/babel-core/test/fixtures/config/complex-plugin-config/twentyone.js
@@ -1,0 +1,1 @@
+module.exports = require("./plugin")("twentyone");

--- a/packages/babel-core/test/fixtures/config/complex-plugin-config/twentytwo.js
+++ b/packages/babel-core/test/fixtures/config/complex-plugin-config/twentytwo.js
@@ -1,0 +1,1 @@
+module.exports = require("./plugin")("twentytwo");

--- a/packages/babel-core/test/fixtures/config/config-files/babelrc-extended/.babelrc
+++ b/packages/babel-core/test/fixtures/config/config-files/babelrc-extended/.babelrc
@@ -1,0 +1,3 @@
+{
+  "extends": "./.babelrc-extended"
+}

--- a/packages/babel-core/test/fixtures/config/config-files/babelrc-extended/.babelrc-extended
+++ b/packages/babel-core/test/fixtures/config/config-files/babelrc-extended/.babelrc-extended
@@ -1,0 +1,3 @@
+{
+  "comments": true
+}


### PR DESCRIPTION
- [x] #11907 - Return a list of files that were read from loadPartialConfig
- [x] #11689 - Instantiate presets before plugins (Does not block 7.12)
- [ ] #12151 - Support "extensions" option in config files and presets (Does not block 7.12)

# :warning: Use "Rebase and merge", not "Squash and merge"

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12159"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/9770811af3e4904d49dddc8b270b5e00fdd6e359.svg" /></a>

