### PR TITLE
SystemJS top-level await support

### DIFF
--- a/packages/babel-plugin-transform-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.js
@@ -554,6 +554,7 @@ export default declare((api, options) => {
             Function(path) {
               path.skip();
             },
+            noScope: true,
           });
 
           path.node.body = [

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/not-tla/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/not-tla/input.mjs
@@ -1,0 +1,1 @@
+async () => await test;

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/not-tla/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/not-tla/output.mjs
@@ -1,0 +1,10 @@
+System.register([], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [],
+    execute: function () {
+      async () => await test;
+    }
+  };
+});

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/options.json
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-modules-systemjs", "syntax-top-level-await"]
+}

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/tla-block/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/tla-block/input.mjs
@@ -1,0 +1,3 @@
+if (maybe) {
+  await test;
+}

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/tla-block/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/tla-block/output.mjs
@@ -1,0 +1,12 @@
+System.register([], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [],
+    execute: async function () {
+      if (maybe) {
+        await test;
+      }
+    }
+  };
+});

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/tla/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/tla/input.mjs
@@ -1,0 +1,2 @@
+await test;
+

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/tla/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/tla/tla/output.mjs
@@ -1,0 +1,10 @@
+System.register([], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [],
+    execute: async function () {
+      await test;
+    }
+  };
+});


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/9426
| Minor: New Feature?      | Feature
| Tests Added + Pass?      | Yes
| License                  | MIT

Now that Chrome has expressed an intent to ship top-level await, this adds automatic support for this feature to the SystemJS output.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12163"><img src="https://gitpod.io/api/apps/github/pbs/github.com/guybedford/babel.git/a6e0ff025f3cae0e3b6c522ba4cfaf453c104a78.svg" /></a>

