### PR TITLE
[ts] Add `asserts: false` to `TSTypePredicate` node

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1039,7 +1039,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         const t: N.TsTypeAnnotation = this.startNode();
         this.expect(returnToken);
 
-        const asserts = this.tsTryParse(
+        const asserts = !!this.tsTryParse(
           this.tsParseTypePredicateAsserts.bind(this),
         );
 

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/predicate-types/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/predicate-types/output.json
@@ -31,7 +31,8 @@
                   "type": "TSStringKeyword",
                   "start":15,"end":21,"loc":{"start":{"line":1,"column":15},"end":{"line":1,"column":21}}
                 }
-              }
+              },
+              "asserts": false
             }
           },
           "id": null,

--- a/packages/babel-parser/test/fixtures/typescript/function/predicate-types/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/function/predicate-types/output.json
@@ -50,7 +50,8 @@
                 "type": "TSBooleanKeyword",
                 "start":25,"end":32,"loc":{"start":{"line":1,"column":25},"end":{"line":1,"column":32}}
               }
-            }
+            },
+            "asserts": false
           }
         },
         "body": {
@@ -66,6 +67,10 @@
         "expression": {
           "type": "FunctionExpression",
           "start":37,"end":70,"loc":{"start":{"line":2,"column":1},"end":{"line":2,"column":34}},
+          "extra": {
+            "parenthesized": true,
+            "parenStart": 36
+          },
           "id": null,
           "generator": false,
           "async": false,
@@ -102,7 +107,8 @@
                   "type": "TSBooleanKeyword",
                   "start":60,"end":67,"loc":{"start":{"line":2,"column":24},"end":{"line":2,"column":31}}
                 }
-              }
+              },
+              "asserts": false
             }
           },
           "body": {
@@ -110,10 +116,6 @@
             "start":68,"end":70,"loc":{"start":{"line":2,"column":32},"end":{"line":2,"column":34}},
             "body": [],
             "directives": []
-          },
-          "extra": {
-            "parenthesized": true,
-            "parenStart": 36
           }
         }
       }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When babel-parser parses asserts function, it attach `asserts: true` to `TSTypePredicate`. 

However, when parsing the normal type predication function, it **doesn't** attach `asserts: false` to `TSTypePredicate`.

typescript-eslint/typescript-estree adds `asserts: true/false` to both. This PR aligns AST for Babel and typescript-estree. (ref: https://github.com/typescript-eslint/typescript-eslint/blob/c41dbe56e0514846e4d21fc5fcd8847da50e92c6/packages/typescript-estree/tests/ast-alignment/utils.ts#L259-L268)

Please close this PR if the current behavior is intentional:smile:

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12167"><img src="https://gitpod.io/api/apps/github/pbs/github.com/sosukesuzuki/babel.git/5f78410d90b91e7c1de1f2bcf8a92765439ff46e.svg" /></a>

