### PR TITLE
[ts] Make ImportDeclaration always have `importKind`

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1984,9 +1984,11 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         ) {
           node.importKind = "type";
           this.next();
-        } else {
-          node.importKind = "value";
         }
+      }
+
+      if (!node.importKind) {
+        node.importKind = "value";
       }
 
       const importNode = super.parseImport(node);

--- a/packages/babel-parser/test/fixtures/typescript/import/import-side-effects/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/import/import-side-effects/input.ts
@@ -1,0 +1,1 @@
+import "foo";

--- a/packages/babel-parser/test/fixtures/typescript/import/import-side-effects/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/import-side-effects/output.json
@@ -1,0 +1,28 @@
+{
+  "type": "File",
+  "start":0,"end":13,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":13}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":13,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":13}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start":0,"end":13,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":13}},
+        "importKind": "value",
+        "specifiers": [],
+        "source": {
+          "type": "StringLiteral",
+          "start":7,"end":12,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":12}},
+          "extra": {
+            "rawValue": "foo",
+            "raw": "\"foo\""
+          },
+          "value": "foo"
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
See https://github.com/typescript-eslint/typescript-eslint/blob/c41dbe56e0514846e4d21fc5fcd8847da50e92c6/packages/typescript-estree/tests/ast-alignment/utils.ts#L269-L276. The `ImportDeclaration` of an AST in the typescript-estree always has an `importKind`. However, the Side Effect Import of Babel's TypeScript ASTs does not have an `importKind`.

This PR aligns it.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12170"><img src="https://gitpod.io/api/apps/github/pbs/github.com/sosukesuzuki/babel.git/2262beb5d54b37f045f707e15e5aa04947681bfe.svg" /></a>

