### PR TITLE
Remove unused `dependencies` and `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,6 @@
     "lint-staged": "^9.2.0",
     "mergeiterator": "^1.2.5",
     "prettier": "^2.0.5",
-    "pump": "^3.0.0",
-    "rimraf": "^2.6.3",
     "rollup": "^2.26.5",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-terser": "^7.0.0",

--- a/packages/babel-compat-data/package.json
+++ b/packages/babel-compat-data/package.json
@@ -29,7 +29,6 @@
     "compat-data"
   ],
   "devDependencies": {
-    "@babel/helper-compilation-targets": "workspace:^7.12.0",
     "electron-to-chromium": "1.3.574",
     "lodash": "^4.17.19",
     "mdn-browser-compat-data": "1.0.38"

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -30,7 +30,6 @@
     "@babel/core": "^7.0.0"
   },
   "devDependencies": {
-    "@babel/core": "workspace:^7.12.0",
-    "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
+    "@babel/core": "workspace:^7.12.0"
   }
 }

--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -21,7 +21,6 @@
     "@babel/helper-function-name": "workspace:^7.10.4",
     "@babel/helper-member-expression-to-functions": "workspace:^7.12.0",
     "@babel/helper-optimise-call-expression": "workspace:^7.10.4",
-    "@babel/helper-plugin-utils": "workspace:^7.10.4",
     "@babel/helper-replace-supers": "workspace:^7.12.0",
     "@babel/helper-split-export-declaration": "workspace:^7.10.4"
   },

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@babel/helper-annotate-as-pure": "workspace:^7.10.4",
     "@babel/helper-wrap-function": "workspace:^7.10.4",
-    "@babel/template": "workspace:^7.10.4",
     "@babel/types": "workspace:^7.10.4"
   },
   "devDependencies": {

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -15,7 +15,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/template": "workspace:^7.10.4",
     "@babel/types": "workspace:^7.10.4"
   }
 }

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -20,7 +20,6 @@
     "@babel/helper-fixtures": "workspace:^7.10.5",
     "@babel/polyfill": "workspace:^7.10.4",
     "babel-check-duplicated-nodes": "^1.0.0",
-    "jest": "^24.8.0",
     "jest-diff": "^24.8.0",
     "lodash": "^4.17.19",
     "quick-lru": "5.1.0",

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "@babel/core": "workspace:^7.10.4",
     "@babel/helper-plugin-test-runner": "workspace:^7.10.4",
-    "core-js": "^3.2.1",
-    "core-js-pure": "^3.2.1"
+    "core-js": "^3.2.1"
   }
 }

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -23,7 +23,6 @@
     "@babel/core": "^7.0.0-0"
   },
   "devDependencies": {
-    "@babel/core": "workspace:^7.10.4",
-    "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
+    "@babel/core": "workspace:^7.10.4"
   }
 }

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -13,7 +13,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/helper-get-function-arity": "workspace:^7.10.4",
     "@babel/helper-plugin-utils": "workspace:^7.10.4"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -16,14 +16,14 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "@babel/helper-plugin-utils": "workspace:^7.10.4",
-    "@babel/plugin-syntax-jsx": "workspace:^7.10.4"
+    "@babel/helper-plugin-utils": "workspace:^7.10.4"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"
   },
   "devDependencies": {
     "@babel/core": "workspace:^7.10.4",
-    "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
+    "@babel/helper-plugin-test-runner": "workspace:^7.10.4",
+    "@babel/plugin-syntax-jsx": "workspace:^7.10.4"
   }
 }

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -16,14 +16,14 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "@babel/helper-plugin-utils": "workspace:^7.10.4",
-    "@babel/plugin-syntax-jsx": "workspace:^7.10.4"
+    "@babel/helper-plugin-utils": "workspace:^7.10.4"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"
   },
   "devDependencies": {
     "@babel/core": "workspace:^7.10.5",
-    "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
+    "@babel/helper-plugin-test-runner": "workspace:^7.10.4",
+    "@babel/plugin-syntax-jsx": "workspace:^7.10.4"
   }
 }

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -13,7 +13,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/helper-annotate-as-pure": "workspace:^7.10.4",
     "@babel/helper-plugin-utils": "workspace:^7.10.4"
   },
   "keywords": [

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -79,7 +79,6 @@
     "@babel/plugin-transform-unicode-regex": "workspace:^7.10.4",
     "@babel/preset-modules": "^0.1.3",
     "@babel/types": "workspace:^7.12.0",
-    "browserslist": "^4.12.0",
     "core-js-compat": "^3.6.2",
     "semver": "^5.5.0"
   },
@@ -87,9 +86,7 @@
     "@babel/core": "^7.0.0-0"
   },
   "devDependencies": {
-    "@babel/cli": "workspace:^7.12.0",
     "@babel/core": "workspace:^7.12.0",
-    "@babel/helper-fixtures": "workspace:^7.10.4",
     "@babel/helper-plugin-test-runner": "workspace:^7.10.4",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0"
   }

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@babel/core": "workspace:^7.10.4",
-    "@babel/helper-plugin-test-runner": "workspace:^7.10.4",
-    "@babel/helper-transform-fixture-test-runner": "workspace:^7.10.4"
+    "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
   }
 }

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -16,9 +16,6 @@
     "core-js": "^2.6.5",
     "regenerator-runtime": "^0.13.4"
   },
-  "devDependencies": {
-    "@babel/helpers": "workspace:^7.10.4"
-  },
   "exports": {
     "./helpers/": "./helpers/",
     "./helpers/typeof": "./helpers/typeof.js",

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -16,9 +16,6 @@
   "dependencies": {
     "regenerator-runtime": "^0.13.4"
   },
-  "devDependencies": {
-    "@babel/helpers": "workspace:^7.10.4"
-  },
   "exports": {
     "./helpers/": "./helpers/",
     "./helpers/typeof": "./helpers/typeof.js",

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -9,7 +9,6 @@
   ],
   "devDependencies": {
     "@babel/core": "workspace:^7.12.0",
-    "@babel/helper-plugin-utils": "workspace:^7.10.4",
     "@babel/plugin-external-helpers": "workspace:^7.10.4",
     "@babel/plugin-proposal-async-generator-functions": "workspace:^7.10.5",
     "@babel/plugin-proposal-class-properties": "workspace:^7.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/cli@workspace:^7.12.0, @babel/cli@workspace:packages/babel-cli":
+"@babel/cli@workspace:packages/babel-cli":
   version: 0.0.0-use.local
   resolution: "@babel/cli@workspace:packages/babel-cli"
   dependencies:
@@ -94,7 +94,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/compat-data@workspace:packages/babel-compat-data"
   dependencies:
-    "@babel/helper-compilation-targets": "workspace:^7.12.0"
     electron-to-chromium: 1.3.574
     lodash: ^4.17.19
     mdn-browser-compat-data: 1.0.38
@@ -353,7 +352,6 @@ __metadata:
   dependencies:
     "@babel/compat-data": "workspace:^7.12.0"
     "@babel/core": "workspace:^7.12.0"
-    "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
     "@babel/helper-validator-option": "workspace:^7.12.0"
     browserslist: ^4.12.0
     semver: ^5.5.0
@@ -387,7 +385,6 @@ __metadata:
     "@babel/helper-member-expression-to-functions": "workspace:^7.12.0"
     "@babel/helper-optimise-call-expression": "workspace:^7.10.4"
     "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
-    "@babel/helper-plugin-utils": "workspace:^7.10.4"
     "@babel/helper-replace-supers": "workspace:^7.12.0"
     "@babel/helper-split-export-declaration": "workspace:^7.10.4"
   peerDependencies:
@@ -471,7 +468,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/helper-fixtures@workspace:^7.10.4, @babel/helper-fixtures@workspace:^7.10.5, @babel/helper-fixtures@workspace:packages/babel-helper-fixtures":
+"@babel/helper-fixtures@workspace:^7.10.5, @babel/helper-fixtures@workspace:packages/babel-helper-fixtures":
   version: 0.0.0-use.local
   resolution: "@babel/helper-fixtures@workspace:packages/babel-helper-fixtures"
   dependencies:
@@ -674,7 +671,6 @@ __metadata:
   dependencies:
     "@babel/helper-annotate-as-pure": "workspace:^7.10.4"
     "@babel/helper-wrap-function": "workspace:^7.10.4"
-    "@babel/template": "workspace:^7.10.4"
     "@babel/traverse": "workspace:^7.10.4"
     "@babel/types": "workspace:^7.10.4"
   languageName: unknown
@@ -717,7 +713,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-simple-access@workspace:packages/babel-helper-simple-access"
   dependencies:
-    "@babel/template": "workspace:^7.10.4"
     "@babel/types": "workspace:^7.10.4"
   languageName: unknown
   linkType: soft
@@ -766,7 +761,6 @@ __metadata:
     "@babel/helper-fixtures": "workspace:^7.10.5"
     "@babel/polyfill": "workspace:^7.10.4"
     babel-check-duplicated-nodes: ^1.0.0
-    jest: ^24.8.0
     jest-diff: ^24.8.0
     lodash: ^4.17.19
     quick-lru: 5.1.0
@@ -2304,7 +2298,6 @@ __metadata:
     "@babel/helper-create-regexp-features-plugin": "workspace:^7.10.4"
     "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
     core-js: ^3.2.1
-    core-js-pure: ^3.2.1
   peerDependencies:
     "@babel/core": ^7.0.0
   languageName: unknown
@@ -2340,7 +2333,6 @@ __metadata:
   resolution: "@babel/plugin-transform-object-assign@workspace:packages/babel-plugin-transform-object-assign"
   dependencies:
     "@babel/core": "workspace:^7.10.4"
-    "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
     "@babel/helper-plugin-utils": "workspace:^7.10.4"
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -2401,7 +2393,6 @@ __metadata:
   resolution: "@babel/plugin-transform-parameters@workspace:packages/babel-plugin-transform-parameters"
   dependencies:
     "@babel/core": "workspace:^7.10.5"
-    "@babel/helper-get-function-arity": "workspace:^7.10.4"
     "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
     "@babel/helper-plugin-utils": "workspace:^7.10.4"
   peerDependencies:
@@ -2761,7 +2752,6 @@ __metadata:
   resolution: "@babel/plugin-transform-template-literals@workspace:packages/babel-plugin-transform-template-literals"
   dependencies:
     "@babel/core": "workspace:^7.10.5"
-    "@babel/helper-annotate-as-pure": "workspace:^7.10.4"
     "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
     "@babel/helper-plugin-utils": "workspace:^7.10.4"
   peerDependencies:
@@ -2953,11 +2943,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/preset-env@workspace:packages/babel-preset-env"
   dependencies:
-    "@babel/cli": "workspace:^7.12.0"
     "@babel/compat-data": "workspace:^7.12.0"
     "@babel/core": "workspace:^7.12.0"
     "@babel/helper-compilation-targets": "workspace:^7.12.0"
-    "@babel/helper-fixtures": "workspace:^7.10.4"
     "@babel/helper-module-imports": "workspace:^7.10.4"
     "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
     "@babel/helper-plugin-utils": "workspace:^7.10.4"
@@ -3021,7 +3009,6 @@ __metadata:
     "@babel/plugin-transform-unicode-regex": "workspace:^7.10.4"
     "@babel/preset-modules": ^0.1.3
     "@babel/types": "workspace:^7.12.0"
-    browserslist: ^4.12.0
     core-js-compat: ^3.6.2
     semver: ^5.5.0
   peerDependencies:
@@ -3076,7 +3063,6 @@ __metadata:
     "@babel/core": "workspace:^7.10.4"
     "@babel/helper-plugin-test-runner": "workspace:^7.10.4"
     "@babel/helper-plugin-utils": "workspace:^7.10.4"
-    "@babel/helper-transform-fixture-test-runner": "workspace:^7.10.4"
     "@babel/plugin-transform-react-display-name": "workspace:^7.10.4"
     "@babel/plugin-transform-react-jsx": "workspace:^7.10.4"
     "@babel/plugin-transform-react-jsx-development": "workspace:^7.10.4"
@@ -3137,7 +3123,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/runtime-corejs2@workspace:packages/babel-runtime-corejs2"
   dependencies:
-    "@babel/helpers": "workspace:^7.10.4"
     core-js: ^2.6.5
     regenerator-runtime: ^0.13.4
   languageName: unknown
@@ -3175,7 +3160,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/runtime@workspace:packages/babel-runtime"
   dependencies:
-    "@babel/helpers": "workspace:^7.10.4"
     regenerator-runtime: ^0.13.4
   languageName: unknown
   linkType: soft
@@ -3185,7 +3169,6 @@ __metadata:
   resolution: "@babel/standalone@workspace:packages/babel-standalone"
   dependencies:
     "@babel/core": "workspace:^7.12.0"
-    "@babel/helper-plugin-utils": "workspace:^7.10.4"
     "@babel/plugin-external-helpers": "workspace:^7.10.4"
     "@babel/plugin-proposal-async-generator-functions": "workspace:^7.10.5"
     "@babel/plugin-proposal-class-properties": "workspace:^7.10.4"
@@ -4612,8 +4595,6 @@ __metadata:
     lint-staged: ^9.2.0
     mergeiterator: ^1.2.5
     prettier: ^2.0.5
-    pump: ^3.0.0
-    rimraf: ^2.6.3
     rollup: ^2.26.5
     rollup-plugin-node-polyfills: ^0.2.1
     rollup-plugin-terser: ^7.0.0
@@ -5592,7 +5573,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-pure@npm:^3.0.0, core-js-pure@npm:^3.2.1":
+"core-js-pure@npm:^3.0.0":
   version: 3.6.5
   resolution: "core-js-pure@npm:3.6.5"
   checksum: 91fc8e0b699d5bcb11f265ad4544d08c98096b86ad6c9b4c00109616db0aa992ceb58ea82d0dbae2a16658a7aaf2922aa6f9fc1107dc3b0055270799d0414a3f
@@ -8828,7 +8809,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"jest@npm:^24.8.0, jest@npm:^24.9.0":
+"jest@npm:^24.9.0":
   version: 24.9.0
   resolution: "jest@npm:24.9.0"
   dependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I found them using `yarn dlx depcheck` in every package, and then manually checking that the reported deps where actually unused.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12175"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/3c116544c5bbefb96399517248112845ac231550.svg" /></a>

