### PR TITLE
chore: avoid duplicate coverage data upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,6 @@ test-ci-coverage: SHELL:=/bin/bash
 test-ci-coverage:
 	BABEL_COVERAGE=true BABEL_ENV=test $(MAKE) bootstrap
 	BABEL_ENV=test TEST_TYPE=cov ./scripts/test-cov.sh
-	bash <(curl -s https://codecov.io/bash) -f coverage/coverage-final.json
 
 bootstrap-flow:
 	rm -rf build/flow


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Avoid calling codecov API twice, reduce carbon footprint 😄
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Recently I noticed that the coverage data of `@babel/traverse` is incorrect: https://codecov.io/gh/babel/babel/src/eec01fe078decb7d369cd2111c9f3881c4482788/packages/babel-traverse/src/path/index.js

i.e. The `NodePath` is a very popular. It is unlikely that `NodePath` had been executed only twice in the test suites. In fact I have checked out my local coverage report, the `NodePath` has been executed for a million times:

![image](https://user-images.githubusercontent.com/3607926/96175154-73a7ff00-0ef8-11eb-8ca1-8dac340c656a.png)

I checked out test process and realized that we uploaded coverage twice. I removed the one in `Makefile` and see the coverage on `codecov.io` is back to normal.

I will mark as ready when this issue is resolved.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12187"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/83ee084a3c4f8fb19ca9917b2feecfb93797db15.svg" /></a>

