### PR TITLE
fix: properly wrap private class methods

### DIFF
--- a/packages/babel-helper-wrap-function/src/index.js
+++ b/packages/babel-helper-wrap-function/src/index.js
@@ -124,7 +124,7 @@ function plainFunction(path: NodePath, callId: Object) {
 }
 
 export default function wrapFunction(path: NodePath, callId: Object) {
-  if (path.isClassMethod() || path.isObjectMethod()) {
+  if (path.isMethod()) {
     classOrObjectMethod(path, callId);
   } else {
     plainFunction(path, callId);

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-private-method/input.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-private-method/input.js
@@ -1,0 +1,8 @@
+class C {
+  async * #g() {
+    this;
+    await 1;
+    yield 2;
+    return 3;
+  }
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-private-method/options.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-private-method/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "proposal-private-methods", "proposal-async-generator-functions"]
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-private-method/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-private-method/output.js
@@ -1,0 +1,19 @@
+var _g = new WeakSet();
+
+class C {
+  constructor() {
+    _g.add(this);
+  }
+
+}
+
+var _g2 = function _g2() {
+  var _this = this;
+
+  return babelHelpers.wrapAsyncGenerator(function* () {
+    _this;
+    yield babelHelpers.awaitAsyncGenerator(1);
+    yield 2;
+    return 3;
+  })();
+};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Babel throws on transforming `class C { async * #g() {} }` ([REPL](https://babel.dev/repl#?browsers=chrome%2062&build=&builtIns=false&spec=false&loose=false&code_lz=MYGwhgzhAEDC0G8BQ1qQJ4DtjQFTQGIBbAUwBcALAewBMAKASkRWgF8lWBuIA&debug=false&forceAllTransforms=false&shippedProposals=true&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=false&presets=env%2Cenv&prettier=false&targets=&version=7.12.1&externalPlugins=))
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes a bug caught by the [test262 tests](https://circleci.com/api/v1.1/project/github/babel/babel/30154/output/107/0?file=true&allocation-id=5f888f10deed90431f98dce0-0-build%2F2FE4C97C) (Search "not ok 107")

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12192"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/b13fee587e41f92db323a1ad2104389dd333c2fa.svg" /></a>

