### PR TITLE
Do not cache non-existent JS config files forever

### DIFF
--- a/packages/babel-core/src/config/files/configuration.js
+++ b/packages/babel-core/src/config/files/configuration.js
@@ -168,7 +168,7 @@ const readConfigJS = makeStrongCache(function* readConfigJS(
   }>,
 ): Handler<ConfigFile | null> {
   if (!fs.exists.sync(filepath)) {
-    cache.forever();
+    cache.never();
     return null;
   }
 


### PR DESCRIPTION
Missed a spot in #11906. Currently if you don't have a JS config file and then add one to your project, it will not be picked up without restarting the process. Changing from caching forever to never caching when files don't exist fixes the issue.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12211"><img src="https://gitpod.io/api/apps/github/pbs/github.com/devongovett/babel.git/b2382aa36e48ddbf4c69b2876a50aa2fbfbda3db.svg" /></a>

