### PR TITLE
Revert "add `.js` extension to react runtime for JSX transform"

### DIFF
--- a/packages/babel-helper-builder-react-jsx-experimental/src/index.js
+++ b/packages/babel-helper-builder-react-jsx-experimental/src/index.js
@@ -342,12 +342,12 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
       case "Fragment":
         return `${source}/${
           options.development ? "jsx-dev-runtime" : "jsx-runtime"
-        }.js`;
+        }`;
       case "jsxDEV":
-        return `${source}/jsx-dev-runtime.js`;
+        return `${source}/jsx-dev-runtime`;
       case "jsx":
       case "jsxs":
-        return `${source}/jsx-runtime.js`;
+        return `${source}/jsx-runtime`;
       case "createElement":
         return source;
     }

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/generated-jsx/output.js
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/generated-jsx/output.js
@@ -1,6 +1,6 @@
 // empty
 
-var _reactJsxDevRuntimeJs = require("react/jsx-dev-runtime.js");
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
 
 /*#__PURE__*/
-_reactJsxDevRuntimeJs.jsxDEV("div", {}, void 0, false, void 0, this)
+_reactJsxDevRuntime.jsxDEV("div", {}, void 0, false, void 0, this)

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/auto-import-dev/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/auto-import-dev/output.mjs
@@ -1,6 +1,6 @@
 import { createElement as _createElement } from "react";
-import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime.js";
-import { Fragment as _Fragment } from "react/jsx-dev-runtime.js";
+import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
+import { Fragment as _Fragment } from "react/jsx-dev-runtime";
 var _jsxFileName = "<CWD>/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/auto-import-dev/input.js";
 
 var x = /*#__PURE__*/_jsxDEV(_Fragment, {

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/fragments/output.js
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/fragments/output.js
@@ -1,9 +1,9 @@
-var _reactJsxDevRuntimeJs = require("react/jsx-dev-runtime.js");
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
 
 var _jsxFileName = "<CWD>/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/fragments/input.js";
 
-var x = /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV(_reactJsxDevRuntimeJs.Fragment, {
-  children: /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("div", {}, void 0, false, {
+var x = /*#__PURE__*/_reactJsxDevRuntime.jsxDEV(_reactJsxDevRuntime.Fragment, {
+  children: /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("div", {}, void 0, false, {
     fileName: _jsxFileName,
     lineNumber: 1,
     columnNumber: 11

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/handle-fragments-with-key/output.js
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/handle-fragments-with-key/output.js
@@ -1,8 +1,8 @@
-var _reactJsxDevRuntimeJs = require("react/jsx-dev-runtime.js");
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
 
 var _jsxFileName = "<CWD>/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/handle-fragments-with-key/input.js";
 
-var x = /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV(React.Fragment, {}, "foo", false, {
+var x = /*#__PURE__*/_reactJsxDevRuntime.jsxDEV(React.Fragment, {}, "foo", false, {
   fileName: _jsxFileName,
   lineNumber: 1,
   columnNumber: 9

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/handle-nonstatic-children/output.js
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/handle-nonstatic-children/output.js
@@ -1,13 +1,13 @@
-var _reactJsxDevRuntimeJs = require("react/jsx-dev-runtime.js");
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
 
 var _jsxFileName = "<CWD>/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/handle-nonstatic-children/input.js";
 
-var x = /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("div", {
-  children: [/*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("span", {}, "0", false, {
+var x = /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("div", {
+  children: [/*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, "0", false, {
     fileName: _jsxFileName,
     lineNumber: 1,
     columnNumber: 16
-  }, this), /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("span", {}, "1", false, {
+  }, this), /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, "1", false, {
     fileName: _jsxFileName,
     lineNumber: 1,
     columnNumber: 36

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/handle-static-children/output.js
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/handle-static-children/output.js
@@ -1,17 +1,17 @@
-var _reactJsxDevRuntimeJs = require("react/jsx-dev-runtime.js");
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
 
 var _jsxFileName = "<CWD>/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/handle-static-children/input.js";
 
-var x = /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("div", {
-  children: [/*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("span", {}, void 0, false, {
+var x = /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("div", {
+  children: [/*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, void 0, false, {
     fileName: _jsxFileName,
     lineNumber: 3,
     columnNumber: 5
-  }, this), [/*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("span", {}, "0", false, {
+  }, this), [/*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, "0", false, {
     fileName: _jsxFileName,
     lineNumber: 4,
     columnNumber: 7
-  }, this), /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("span", {}, "1", false, {
+  }, this), /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, "1", false, {
     fileName: _jsxFileName,
     lineNumber: 4,
     columnNumber: 27

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/self-inside-arrow/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/self-inside-arrow/output.mjs
@@ -1,4 +1,4 @@
-import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime.js";
+import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
 
 var _jsxFileName = "<CWD>/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/self-inside-arrow/input.mjs",
     _this = this;

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/auto-import-dev-windows/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/auto-import-dev-windows/output.mjs
@@ -1,6 +1,6 @@
 import { createElement as _createElement } from "react";
-import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime.js";
-import { Fragment as _Fragment } from "react/jsx-dev-runtime.js";
+import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
+import { Fragment as _Fragment } from "react/jsx-dev-runtime";
 var _jsxFileName = "<CWD>\\packages\\babel-plugin-transform-react-jsx-development\\test\\fixtures\\windows\\auto-import-dev-windows\\input.js";
 
 var x = /*#__PURE__*/_jsxDEV(_Fragment, {

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/fragments-windows/output.js
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/fragments-windows/output.js
@@ -1,9 +1,9 @@
-var _reactJsxDevRuntimeJs = require("react/jsx-dev-runtime.js");
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
 
 var _jsxFileName = "<CWD>\\packages\\babel-plugin-transform-react-jsx-development\\test\\fixtures\\windows\\fragments-windows\\input.js";
 
-var x = /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV(_reactJsxDevRuntimeJs.Fragment, {
-  children: /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("div", {}, void 0, false, {
+var x = /*#__PURE__*/_reactJsxDevRuntime.jsxDEV(_reactJsxDevRuntime.Fragment, {
+  children: /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("div", {}, void 0, false, {
     fileName: _jsxFileName,
     lineNumber: 1,
     columnNumber: 11

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/handle-fragments-with-key-windows/output.js
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/handle-fragments-with-key-windows/output.js
@@ -1,8 +1,8 @@
-var _reactJsxDevRuntimeJs = require("react/jsx-dev-runtime.js");
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
 
 var _jsxFileName = "<CWD>\\packages\\babel-plugin-transform-react-jsx-development\\test\\fixtures\\windows\\handle-fragments-with-key-windows\\input.js";
 
-var x = /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV(React.Fragment, {}, 'foo', false, {
+var x = /*#__PURE__*/_reactJsxDevRuntime.jsxDEV(React.Fragment, {}, 'foo', false, {
   fileName: _jsxFileName,
   lineNumber: 1,
   columnNumber: 9

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/handle-nonstatic-children-windows/output.js
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/handle-nonstatic-children-windows/output.js
@@ -1,13 +1,13 @@
-var _reactJsxDevRuntimeJs = require("react/jsx-dev-runtime.js");
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
 
 var _jsxFileName = "<CWD>\\packages\\babel-plugin-transform-react-jsx-development\\test\\fixtures\\windows\\handle-nonstatic-children-windows\\input.js";
 
-var x = /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("div", {
-  children: [/*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("span", {}, '0', false, {
+var x = /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("div", {
+  children: [/*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, '0', false, {
     fileName: _jsxFileName,
     lineNumber: 3,
     columnNumber: 11
-  }, this), /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("span", {}, '1', false, {
+  }, this), /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, '1', false, {
     fileName: _jsxFileName,
     lineNumber: 3,
     columnNumber: 31

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/handle-static-children-windows/output.js
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/handle-static-children-windows/output.js
@@ -1,17 +1,17 @@
-var _reactJsxDevRuntimeJs = require("react/jsx-dev-runtime.js");
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
 
 var _jsxFileName = "<CWD>\\packages\\babel-plugin-transform-react-jsx-development\\test\\fixtures\\windows\\handle-static-children-windows\\input.js";
 
-var x = /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("div", {
-  children: [/*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("span", {}, void 0, false, {
+var x = /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("div", {
+  children: [/*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, void 0, false, {
     fileName: _jsxFileName,
     lineNumber: 3,
     columnNumber: 9
-  }, this), [/*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("span", {}, '0', false, {
+  }, this), [/*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, '0', false, {
     fileName: _jsxFileName,
     lineNumber: 4,
     columnNumber: 11
-  }, this), /*#__PURE__*/_reactJsxDevRuntimeJs.jsxDEV("span", {}, '1', false, {
+  }, this), /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, '1', false, {
     fileName: _jsxFileName,
     lineNumber: 4,
     columnNumber: 31

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/self-inside-arrow-windows/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/self-inside-arrow-windows/output.mjs
@@ -1,4 +1,4 @@
-import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime.js";
+import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
 
 var _jsxFileName = "<CWD>\\packages\\babel-plugin-transform-react-jsx-development\\test\\fixtures\\windows\\self-inside-arrow-windows\\input.mjs",
     _this = this;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/auto-import-react-source-type-module/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/auto-import-react-source-type-module/output.mjs
@@ -1,7 +1,7 @@
 import { createElement as _createElement } from "react";
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
-import { jsx as _jsx } from "react/jsx-runtime.js";
-import { Fragment as _Fragment } from "react/jsx-runtime.js";
+import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { Fragment as _Fragment } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx(_Fragment, {
   children: /*#__PURE__*/_jsxs("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/auto-import-react-source-type-script/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/auto-import-react-source-type-script/output.js
@@ -1,12 +1,12 @@
 var _react = require("react");
 
-var _reactJsxRuntimeJs = require("react/jsx-runtime.js");
+var _reactJsxRuntime = require("react/jsx-runtime");
 
-var x = /*#__PURE__*/_reactJsxRuntimeJs.jsx(_reactJsxRuntimeJs.Fragment, {
-  children: /*#__PURE__*/_reactJsxRuntimeJs.jsxs("div", {
-    children: [/*#__PURE__*/_reactJsxRuntimeJs.jsx("div", {}, "1"), /*#__PURE__*/_reactJsxRuntimeJs.jsx("div", {
+var x = /*#__PURE__*/_reactJsxRuntime.jsx(_reactJsxRuntime.Fragment, {
+  children: /*#__PURE__*/_reactJsxRuntime.jsxs("div", {
+    children: [/*#__PURE__*/_reactJsxRuntime.jsx("div", {}, "1"), /*#__PURE__*/_reactJsxRuntime.jsx("div", {
       meow: "wolf"
-    }, "2"), /*#__PURE__*/_reactJsxRuntimeJs.jsx("div", {}, "3"), /*#__PURE__*/_react.createElement("div", { ...props,
+    }, "2"), /*#__PURE__*/_reactJsxRuntime.jsx("div", {}, "3"), /*#__PURE__*/_react.createElement("div", { ...props,
       key: "4"
     })]
   })

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/complicated-scope-module/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/complicated-scope-module/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx2 } from "react/jsx-runtime.js";
+import { jsx as _jsx2 } from "react/jsx-runtime";
 
 const Bar = () => {
   const Foo = () => {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/complicated-scope-script/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/complicated-scope-script/output.js
@@ -1,4 +1,4 @@
-var _reactJsxRuntimeJs = require("react/jsx-runtime.js");
+var _reactJsxRuntime = require("react/jsx-runtime");
 
 const Bar = () => {
   const Foo = () => {
@@ -15,11 +15,11 @@ const Bar = () => {
 
         var jsx = 1;
         var _jsx = 2;
-        return /*#__PURE__*/_reactJsxRuntimeJs.jsx("div", {});
+        return /*#__PURE__*/_reactJsxRuntime.jsx("div", {});
       }
 
       ;
-      return /*#__PURE__*/_reactJsxRuntimeJs.jsx("span", {});
+      return /*#__PURE__*/_reactJsxRuntime.jsx("span", {});
     };
   };
 };

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/import-source-pragma/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/import-source-pragma/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "baz/jsx-runtime.js";
+import { jsx as _jsx } from "baz/jsx-runtime";
 
 /** @jsxImportSource baz */
 var x = _jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/import-source/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/import-source/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "foo/jsx-runtime.js";
+import { jsx as _jsx } from "foo/jsx-runtime";
 
 var x = _jsx("div", {
   children: _jsx("span", {})

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/react-defined/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextAutoImport/react-defined/output.mjs
@@ -1,6 +1,6 @@
 import { createElement as _createElement } from "react";
-import { jsx as _jsx } from "react/jsx-runtime.js";
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { jsxs as _jsxs } from "react/jsx-runtime";
 import * as react from "react";
 var y = react.createElement("div", {
   foo: 1

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/adds-appropriate-newlines-when-using-spread-attribute/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/adds-appropriate-newlines-when-using-spread-attribute/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx(Component, { ...props,

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/arrow-functions/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/arrow-functions/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var foo = function () {
   var _this = this;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/assignment/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/assignment/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var div = /*#__PURE__*/_jsx(Component, { ...props,
   foo: "bar"

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/concatenates-adjacent-string-literals/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/concatenates-adjacent-string-literals/output.mjs
@@ -1,5 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { jsxs as _jsxs } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: ["foo", "bar", "baz", /*#__PURE__*/_jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/does-not-add-source-self-automatic/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/does-not-add-source-self-automatic/output.mjs
@@ -1,7 +1,7 @@
 import { createElement as _createElement } from "react";
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
-import { jsx as _jsx } from "react/jsx-runtime.js";
-import { Fragment as _Fragment } from "react/jsx-runtime.js";
+import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { Fragment as _Fragment } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx(_Fragment, {
   children: /*#__PURE__*/_jsxs("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/dont-coerce-expression-containers/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/dont-coerce-expression-containers/output.mjs
@@ -1,4 +1,4 @@
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
+import { jsxs as _jsxs } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsxs(Text, {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/handle-fragments-with-key/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/handle-fragments-with-key/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 import * as React from "react";
 
 var x = /*#__PURE__*/_jsx(React.Fragment, {}, "foo");

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/handle-fragments-with-no-children/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/handle-fragments-with-no-children/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
-import { Fragment as _Fragment } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { Fragment as _Fragment } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx(_Fragment, {});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/handle-fragments/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/handle-fragments/output.mjs
@@ -1,5 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
-import { Fragment as _Fragment } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { Fragment as _Fragment } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx(_Fragment, {
   children: /*#__PURE__*/_jsx("div", {})

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/handle-nonstatic-children/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/handle-nonstatic-children/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx("div", {
   children: [/*#__PURE__*/_jsx("span", {}, '0'), /*#__PURE__*/_jsx("span", {}, '1')]

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/handle-static-children/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/handle-static-children/output.mjs
@@ -1,5 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { jsxs as _jsxs } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: [/*#__PURE__*/_jsx("span", {}), [/*#__PURE__*/_jsx("span", {}, '0'), /*#__PURE__*/_jsx("span", {}, '1')]]

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/honor-custom-jsx-comment/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/honor-custom-jsx-comment/output.mjs
@@ -1,5 +1,5 @@
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx(Foo, {});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/jsx-with-retainlines-option/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/jsx-with-retainlines-option/output.mjs
@@ -1,1 +1,1 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";var div = /*#__PURE__*/_jsx("div", { children: "test" });
+import { jsx as _jsx } from "react/jsx-runtime";var div = /*#__PURE__*/_jsx("div", { children: "test" });

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/jsx-without-retainlines-option/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/jsx-without-retainlines-option/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var div = /*#__PURE__*/_jsx("div", {
   children: "test"

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/pragma-works-with-no-space-at-the-end/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/pragma-works-with-no-space-at-the-end/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "foo/jsx-runtime.js";
+import { jsx as _jsx } from "foo/jsx-runtime";
 
 /* @jsxImportSource foo*/
 _jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-add-quotes-es3/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-add-quotes-es3/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var es3 = /*#__PURE__*/_jsx(F, {
   aaa: true,

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-allow-constructor-as-prop/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-allow-constructor-as-prop/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx(Component, {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-allow-deeper-js-namespacing/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-allow-deeper-js-namespacing/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx(Namespace.DeepNamespace.Component, {});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-allow-elements-as-attributes/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-allow-elements-as-attributes/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-allow-js-namespacing/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-allow-js-namespacing/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx(Namespace.Component, {});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-allow-nested-fragments/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-allow-nested-fragments/output.mjs
@@ -1,6 +1,6 @@
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
-import { Fragment as _Fragment } from "react/jsx-runtime.js";
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsxs as _jsxs } from "react/jsx-runtime";
+import { Fragment as _Fragment } from "react/jsx-runtime";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-avoid-wrapping-in-extra-parens-if-not-needed/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-avoid-wrapping-in-extra-parens-if-not-needed/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx("div", {
   children: /*#__PURE__*/_jsx(Component, {})

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-convert-simple-tags/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-convert-simple-tags/output.mjs
@@ -1,3 +1,3 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx("div", {});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-convert-simple-text/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-convert-simple-text/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx("div", {
   children: "text"

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-escape-xhtml-jsxattribute/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-escape-xhtml-jsxattribute/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-escape-xhtml-jsxtext/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-escape-xhtml-jsxtext/output.mjs
@@ -1,5 +1,5 @@
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-handle-attributed-elements/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-handle-attributed-elements/output.mjs
@@ -1,5 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { jsxs as _jsxs } from "react/jsx-runtime";
 var HelloMessage = React.createClass({
   displayName: "HelloMessage",
   render: function () {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-handle-has-own-property-correctly/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-handle-has-own-property-correctly/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("hasOwnProperty", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-have-correct-comma-in-nested-children/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-have-correct-comma-in-nested-children/output.mjs
@@ -1,5 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { jsxs as _jsxs } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: [/*#__PURE__*/_jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-insert-commas-after-expressions-before-whitespace/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-insert-commas-after-expressions-before-whitespace/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx("div", {
   attr1: "foo" + "bar",

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-not-add-quotes-to-identifier-names/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-not-add-quotes-to-identifier-names/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var e = /*#__PURE__*/_jsx(F, {
   aaa: true,

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-not-mangle-expressioncontainer-attribute-values/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-not-mangle-expressioncontainer-attribute-values/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("button", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-not-strip-nbsp-even-coupled-with-other-whitespace/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-not-strip-nbsp-even-coupled-with-other-whitespace/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-not-strip-tags-with-a-single-child-of-nbsp/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-not-strip-tags-with-a-single-child-of-nbsp/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-properly-handle-comments-between-props/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-properly-handle-comments-between-props/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx("div", {
   /* a multi-line

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-properly-handle-keys/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-properly-handle-keys/output.mjs
@@ -1,5 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { jsxs as _jsxs } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: [/*#__PURE__*/_jsx("div", {}, "1"), /*#__PURE__*/_jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-properly-handle-null-prop-spread/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-properly-handle-null-prop-spread/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 var foo = null;
 
 var x = /*#__PURE__*/_jsx("div", { ...foo

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-quote-jsx-attributes/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-quote-jsx-attributes/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("button", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-support-xml-namespaces-if-flag/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-support-xml-namespaces-if-flag/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("f:image", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-transform-known-hyphenated-tags/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-transform-known-hyphenated-tags/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("font-face", {});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-use-jsx-when-key-comes-before-spread/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/should-use-jsx-when-key-comes-before-spread/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx("div", { ...props,
   foo: "bar"

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/this-tag-name/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/this-tag-name/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var div = /*#__PURE__*/_jsx(this.foo, {
   children: "test"

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/weird-symbols/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/weird-symbols/output.mjs
@@ -1,4 +1,4 @@
-import { jsxs as _jsxs } from "react/jsx-runtime.js";
+import { jsxs as _jsxs } from "react/jsx-runtime";
 
 class MobileHomeActivityTaskPriorityIcon extends React.PureComponent {
   render() {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/wraps-props-in-react-spread-for-last-spread-attributes/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/wraps-props-in-react-spread-for-last-spread-attributes/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx(Component, {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/wraps-props-in-react-spread-for-middle-spread-attributes/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/nextReact/wraps-props-in-react-spread-for-middle-spread-attributes/output.mjs
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime.js";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx(Component, {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/runtime/runtime-automatic/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/runtime/runtime-automatic/output.js
@@ -1,5 +1,5 @@
-var _reactJsxRuntimeJs = require("react/jsx-runtime.js");
+var _reactJsxRuntime = require("react/jsx-runtime");
 
-var x = /*#__PURE__*/_reactJsxRuntimeJs.jsx("div", {
-  children: /*#__PURE__*/_reactJsxRuntimeJs.jsx("span", {})
+var x = /*#__PURE__*/_reactJsxRuntime.jsx("div", {
+  children: /*#__PURE__*/_reactJsxRuntime.jsx("span", {})
 });

--- a/packages/babel-preset-react/test/fixtures/preset-options/development-runtime-automatic-windows/output.js
+++ b/packages/babel-preset-react/test/fixtures/preset-options/development-runtime-automatic-windows/output.js
@@ -1,9 +1,9 @@
-var _reactJsxDevRuntimeJs = require("react/jsx-dev-runtime.js");
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
 
 var _jsxFileName = "<CWD>\\packages\\babel-preset-react\\test\\fixtures\\preset-options\\development-runtime-automatic-windows\\input.js";
 
 /*#__PURE__*/
-_reactJsxDevRuntimeJs.jsxDEV(Foo, {
+_reactJsxDevRuntime.jsxDEV(Foo, {
   bar: "baz"
 }, void 0, false, {
   fileName: _jsxFileName,

--- a/packages/babel-preset-react/test/fixtures/preset-options/development-runtime-automatic/output.js
+++ b/packages/babel-preset-react/test/fixtures/preset-options/development-runtime-automatic/output.js
@@ -1,9 +1,9 @@
-var _reactJsxDevRuntimeJs = require("react/jsx-dev-runtime.js");
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
 
 var _jsxFileName = "<CWD>/packages/babel-preset-react/test/fixtures/preset-options/development-runtime-automatic/input.js";
 
 /*#__PURE__*/
-_reactJsxDevRuntimeJs.jsxDEV(Foo, {
+_reactJsxDevRuntime.jsxDEV(Foo, {
   bar: "baz"
 }, void 0, false, {
   fileName: _jsxFileName,

--- a/packages/babel-preset-react/test/fixtures/preset-options/runtime-automatic/output.js
+++ b/packages/babel-preset-react/test/fixtures/preset-options/runtime-automatic/output.js
@@ -1,6 +1,6 @@
-var _reactJsxRuntimeJs = require("react/jsx-runtime.js");
+var _reactJsxRuntime = require("react/jsx-runtime");
 
 /*#__PURE__*/
-_reactJsxRuntimeJs.jsx(Foo, {
+_reactJsxRuntime.jsx(Foo, {
   bar: "baz"
 });


### PR DESCRIPTION
Reverts babel/babel#12116

Fixes https://github.com/preactjs/preact/issues/2801, fixes https://github.com/babel/babel/issues/12210 (let's keep the discussion in the issue)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12213"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/1ab010b742e1172f1cc6802fe7cbbe8c917b3867.svg" /></a>

