### PR TITLE
Add `@babel/core` support for the new `assumptions` option

### DIFF
--- a/packages/babel-core/src/config/cache-contexts.js
+++ b/packages/babel-core/src/config/cache-contexts.js
@@ -1,0 +1,32 @@
+// @flow
+
+import type { Targets } from "@babel/helper-compilation-targets";
+
+import type { ConfigContext } from "./config-chain";
+import type { CallerMetadata } from "./validation/options";
+
+export type { ConfigContext as FullConfig };
+
+export type FullPreset = {
+  ...ConfigContext,
+  targets: Targets,
+};
+export type FullPlugin = {
+  ...FullPreset,
+  assumptions: { [name: string]: boolean },
+};
+
+// Context not including filename since it is used in places that cannot
+// process 'ignore'/'only' and other filename-based logic.
+export type SimpleConfig = {
+  envName: string,
+  caller: CallerMetadata | void,
+};
+export type SimplePreset = {
+  ...SimpleConfig,
+  targets: Targets,
+};
+export type SimplePlugin = {
+  ...SimplePreset,
+  assumptions: { [name: string]: boolean },
+};

--- a/packages/babel-core/src/config/helpers/config-api.js
+++ b/packages/babel-core/src/config/helpers/config-api.js
@@ -26,7 +26,7 @@ type CallerFactory = ((CallerMetadata | void) => mixed) => SimpleType;
 
 type TargetsFunction = () => Targets;
 
-type AssumptionFunction = (name: string) => boolean;
+type AssumptionFunction = (name: string) => boolean | void;
 
 export type ConfigAPI = {|
   version: string,
@@ -94,7 +94,7 @@ export function makePresetAPI<SideChannel: Context.SimplePreset>(
 export function makePluginAPI<SideChannel: Context.SimplePlugin>(
   cache: CacheConfigurator<SideChannel>,
 ): PluginAPI {
-  const assumption = name => cache.using(data => !!data.assumptions[name]);
+  const assumption = name => cache.using(data => data.assumptions[name]);
 
   return { ...makePresetAPI(cache), assumption };
 }

--- a/packages/babel-core/src/config/helpers/config-api.js
+++ b/packages/babel-core/src/config/helpers/config-api.js
@@ -13,6 +13,8 @@ import {
 
 import type { CallerMetadata } from "../validation/options";
 
+import * as Context from "../cache-contexts";
+
 type EnvFunction = {
   (): string,
   <T>((string) => T): T,
@@ -24,6 +26,8 @@ type CallerFactory = ((CallerMetadata | void) => mixed) => SimpleType;
 
 type TargetsFunction = () => Targets;
 
+type AssumptionFunction = (name: string) => boolean;
+
 export type ConfigAPI = {|
   version: string,
   cache: SimpleCacheConfigurator,
@@ -33,14 +37,19 @@ export type ConfigAPI = {|
   caller?: CallerFactory,
 |};
 
-export type PluginAPI = {|
+export type PresetAPI = {|
   ...ConfigAPI,
   targets: TargetsFunction,
 |};
 
-export function makeConfigAPI<
-  SideChannel: { envName: string, caller: CallerMetadata | void },
->(cache: CacheConfigurator<SideChannel>): ConfigAPI {
+export type PluginAPI = {|
+  ...PresetAPI,
+  assumption: AssumptionFunction,
+|};
+
+export function makeConfigAPI<SideChannel: Context.SimpleConfig>(
+  cache: CacheConfigurator<SideChannel>,
+): ConfigAPI {
   const env: any = value =>
     cache.using(data => {
       if (typeof value === "undefined") return data.envName;
@@ -70,13 +79,9 @@ export function makeConfigAPI<
   };
 }
 
-export function makePluginAPI(
-  cache: CacheConfigurator<{
-    envName: string,
-    caller: CallerMetadata | void,
-    targets: Targets,
-  }>,
-): PluginAPI {
+export function makePresetAPI<SideChannel: Context.SimplePreset>(
+  cache: CacheConfigurator<SideChannel>,
+): PresetAPI {
   const targets = () =>
     // We are using JSON.parse/JSON.stringify because it's only possible to cache
     // primitive values. We can safely stringify the targets object because it
@@ -84,6 +89,14 @@ export function makePluginAPI(
     // Please make the Record and Tuple proposal happen!
     JSON.parse(cache.using(data => JSON.stringify(data.targets)));
   return { ...makeConfigAPI(cache), targets };
+}
+
+export function makePluginAPI<SideChannel: Context.SimplePlugin>(
+  cache: CacheConfigurator<SideChannel>,
+): PluginAPI {
+  const assumption = name => cache.using(data => !!data.assumptions[name]);
+
+  return { ...makePresetAPI(cache), assumption };
 }
 
 function assertVersion(range: string | number): void {

--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -117,7 +117,12 @@ export default function* loadPrivatePartialConfig(
   const configChain = yield* buildRootChain(args, context);
   if (!configChain) return null;
 
-  const merged: ValidatedOptions = {};
+  const merged: ValidatedOptions = {
+    // TODO(Babel 8): everything should default to false. Remove this object.
+    assumptions: {
+      newableArrowFunctions: true,
+    },
+  };
   configChain.options.forEach(opts => {
     mergeOptions((merged: any), opts);
   });

--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -118,10 +118,7 @@ export default function* loadPrivatePartialConfig(
   if (!configChain) return null;
 
   const merged: ValidatedOptions = {
-    // TODO(Babel 8): everything should default to false. Remove this object.
-    assumptions: {
-      newableArrowFunctions: true,
-    },
+    assumptions: {},
   };
   configChain.options.forEach(opts => {
     mergeOptions((merged: any), opts);

--- a/packages/babel-core/src/config/util.js
+++ b/packages/babel-core/src/config/util.js
@@ -7,14 +7,13 @@ export function mergeOptions(
   source: ValidatedOptions | NormalizedOptions,
 ): void {
   for (const k of Object.keys(source)) {
-    if (k === "parserOpts" && source.parserOpts) {
-      const parserOpts = source.parserOpts;
-      const targetObj = (target.parserOpts = target.parserOpts || {});
+    if (
+      (k === "parserOpts" || k === "generatorOpts" || k === "assumptions") &&
+      source[k]
+    ) {
+      const parserOpts = source[k];
+      const targetObj = target[k] || (target[k] = {});
       mergeDefaultFields(targetObj, parserOpts);
-    } else if (k === "generatorOpts" && source.generatorOpts) {
-      const generatorOpts = source.generatorOpts;
-      const targetObj = (target.generatorOpts = target.generatorOpts || {});
-      mergeDefaultFields(targetObj, generatorOpts);
     } else {
       const val = source[k];
       if (val !== undefined) target[k] = (val: any);

--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -24,6 +24,8 @@ import type {
   TargetsListOrObject,
 } from "./options";
 
+import { assumptionsNames } from "./options";
+
 export type { RootPath } from "./options";
 
 export type ValidatorSet = {
@@ -430,4 +432,27 @@ function assertBrowserVersion(loc: GeneralPath, value: mixed) {
   if (typeof value === "string") return;
 
   throw new Error(`${msg(loc)} must be a string or an integer number`);
+}
+
+export function assertAssumptions(
+  loc: GeneralPath,
+  value: mixed,
+): { [name: string]: boolean } | void {
+  if (value === undefined) return;
+
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`${msg(loc)} must be an object or undefined.`);
+  }
+
+  for (const name of Object.keys(value)) {
+    const subLoc = access(loc, name);
+    if (!assumptionsNames.has(name)) {
+      throw new Error(`${msg(subLoc)} is not a supported assumption.`);
+    }
+    if (typeof value[name] !== "boolean") {
+      throw new Error(`${msg(subLoc)} must be a boolean.`);
+    }
+  }
+
+  return (value: any);
 }

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -333,7 +333,6 @@ export type NestingPath = RootPath | OverridesPath | EnvPath;
 
 export const assumptionsNames = new Set<string>([
   "mutableTemplateObject",
-  "newableArrowFunctions",
   "setPublicClassFields",
 ]);
 

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -332,25 +332,9 @@ type EnvPath = $ReadOnly<{
 export type NestingPath = RootPath | OverridesPath | EnvPath;
 
 export const assumptionsNames = new Set<string>([
-  "arrayLikeIsIterable",
-  "arrayIndexedIteration",
-  "copyReexports",
-  "ignoreFunctionLength",
-  "ignoreToPrimitiveHint",
-  "inheritsAsObjectCreate",
-  "iterableIsArray",
   "mutableTemplateObject",
   "newableArrowFunctions",
-  "noDocumentAll",
-  "objectRestNoSymbols",
-  "privateFieldsAsPublic",
-  "setClassMethods",
-  "setComputedProperties",
-  "setModuleMeta",
   "setPublicClassFields",
-  "setSpreadProperties",
-  "skipForOfIterationClosing",
-  "superAsFunctionCall",
 ]);
 
 function getSource(loc: NestingPath): OptionsSource {

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -29,6 +29,7 @@ import {
   type ValidatorSet,
   type Validator,
   type OptionPath,
+  assertAssumptions,
 } from "./option-assertions";
 import type { UnloadedDescriptor } from "../config-descriptors";
 
@@ -107,6 +108,9 @@ const COMMON_VALIDATORS: ValidatorSet = {
   >),
   passPerPreset: (assertBoolean: Validator<
     $PropertyType<ValidatedOptions, "passPerPreset">,
+  >),
+  assumptions: (assertAssumptions: Validator<
+    $PropertyType<ValidatedOptions, "assumptions">,
   >),
 
   env: (assertEnvSet: Validator<$PropertyType<ValidatedOptions, "env">>),
@@ -221,6 +225,8 @@ export type ValidatedOptions = {
   plugins?: PluginList,
   passPerPreset?: boolean,
 
+  assumptions?: { [name: string]: boolean },
+
   // browserslists-related options
   targets?: TargetsListOrObject,
   browserslistConfigFile?: ConfigFileSearch,
@@ -324,6 +330,28 @@ type EnvPath = $ReadOnly<{
   parent: RootPath | OverridesPath,
 }>;
 export type NestingPath = RootPath | OverridesPath | EnvPath;
+
+export const assumptionsNames = new Set<string>([
+  "arrayLikeIsIterable",
+  "arrayIndexedIteration",
+  "copyReexports",
+  "ignoreFunctionLength",
+  "ignoreToPrimitiveHint",
+  "inheritsAsObjectCreate",
+  "iterableIsArray",
+  "mutableTemplateObject",
+  "newableArrowFunctions",
+  "noDocumentAll",
+  "objectRestNoSymbols",
+  "privateFieldsAsPublic",
+  "setClassMethods",
+  "setComputedProperties",
+  "setModuleMeta",
+  "setPublicClassFields",
+  "setSpreadProperties",
+  "skipForOfIterationClosing",
+  "superAsFunctionCall",
+]);
 
 function getSource(loc: NestingPath): OptionsSource {
   return loc.type === "root" ? loc.source : getSource(loc.parent);

--- a/packages/babel-core/test/assumptions.js
+++ b/packages/babel-core/test/assumptions.js
@@ -39,8 +39,6 @@ describe("assumptions", () => {
     ).toEqual({
       setPublicClassFields: true,
       mutableTemplateObject: true,
-      // This is enabled by default
-      newableArrowFunctions: true,
     });
   });
 
@@ -58,9 +56,9 @@ describe("assumptions", () => {
         api => {
           setPublicClassFields = api.assumption("setPublicClassFields");
 
-          // Unknown assumptions default to "false" and don't throw, so
-          // that plugins can keep compat with older @babel/core versions
-          // when they introduce support for a new assumption.
+          // Unknown assumptions don't throw, so that plugins can keep compat
+          // with older @babel/core versions when they introduce support for
+          // a new assumption.
           unknownAssumption = api.assumption("unknownAssumption");
 
           return {};
@@ -69,7 +67,7 @@ describe("assumptions", () => {
     });
 
     expect(setPublicClassFields).toBe(true);
-    expect(unknownAssumption).toBe(false);
+    expect(unknownAssumption).toBe(undefined);
   });
 
   it("cannot be queried from presets", () => {

--- a/packages/babel-core/test/assumptions.js
+++ b/packages/babel-core/test/assumptions.js
@@ -34,11 +34,11 @@ describe("assumptions", () => {
         assumptions: {
           setPublicClassFields: true,
         },
-        presets: [() => ({ assumptions: { setClassMethods: true } })],
+        presets: [() => ({ assumptions: { mutableTemplateObject: true } })],
       }).assumptions,
     ).toEqual({
       setPublicClassFields: true,
-      setClassMethods: true,
+      mutableTemplateObject: true,
       // This is enabled by default
       newableArrowFunctions: true,
     });
@@ -93,7 +93,6 @@ describe("assumptions", () => {
     const makePlugin = () =>
       jest.fn(api => {
         api.assumption("setPublicClassFields");
-        api.assumption("mutableTemplateObject");
         return {};
       });
 
@@ -110,11 +109,11 @@ describe("assumptions", () => {
 
       run(plugin, {
         setPublicClassFields: true,
-        setClassMethods: false,
+        mutableTemplateObject: false,
       });
       run(plugin, {
         setPublicClassFields: true,
-        setClassMethods: false,
+        mutableTemplateObject: false,
       });
 
       expect(plugin).toHaveBeenCalledTimes(1);
@@ -125,11 +124,11 @@ describe("assumptions", () => {
 
       run(plugin, {
         setPublicClassFields: true,
-        setClassMethods: false,
+        mutableTemplateObject: false,
       });
       run(plugin, {
         setPublicClassFields: true,
-        setClassMethods: true,
+        mutableTemplateObject: true,
       });
 
       expect(plugin).toHaveBeenCalledTimes(1);
@@ -140,11 +139,11 @@ describe("assumptions", () => {
 
       run(plugin, {
         setPublicClassFields: true,
-        setClassMethods: false,
+        mutableTemplateObject: false,
       });
       run(plugin, {
         setPublicClassFields: false,
-        setClassMethods: true,
+        mutableTemplateObject: true,
       });
 
       expect(plugin).toHaveBeenCalledTimes(2);
@@ -154,13 +153,11 @@ describe("assumptions", () => {
       const plugin = makePlugin();
 
       run(plugin, {
-        setPublicClassFields: true,
-        setClassMethods: false,
+        mutableTemplateObject: false,
       });
       run(plugin, {
-        setPublicClassFields: false,
-        setClassMethods: true,
-        mutableTemplateObject: true,
+        mutableTemplateObject: false,
+        setPublicClassFields: true,
       });
 
       expect(plugin).toHaveBeenCalledTimes(2);
@@ -171,10 +168,10 @@ describe("assumptions", () => {
 
       run(plugin, {
         setPublicClassFields: true,
-        setClassMethods: false,
+        mutableTemplateObject: false,
       });
       run(plugin, {
-        setClassMethods: true,
+        mutableTemplateObject: true,
       });
 
       expect(plugin).toHaveBeenCalledTimes(2);

--- a/packages/babel-core/test/assumptions.js
+++ b/packages/babel-core/test/assumptions.js
@@ -1,0 +1,183 @@
+import { loadOptions as loadOptionsOrig, transformSync } from "../lib";
+
+function loadOptions(opts) {
+  return loadOptionsOrig({ cwd: __dirname, ...opts });
+}
+
+function withAssumptions(assumptions) {
+  return loadOptions({ assumptions });
+}
+
+describe("assumptions", () => {
+  it("throws if invalid name", () => {
+    expect(() => withAssumptions({ foo: true })).toThrow(
+      `.assumptions["foo"] is not a supported assumption.`,
+    );
+
+    expect(() => withAssumptions({ setPublicClassFields: true })).not.toThrow();
+  });
+
+  it("throws if not boolean", () => {
+    expect(() => withAssumptions({ setPublicClassFields: "yes" })).toThrow(
+      `.assumptions["setPublicClassFields"] must be a boolean.`,
+    );
+
+    expect(() => withAssumptions({ setPublicClassFields: true })).not.toThrow();
+    expect(() =>
+      withAssumptions({ setPublicClassFields: false }),
+    ).not.toThrow();
+  });
+
+  it("can be set by presets", () => {
+    expect(
+      loadOptions({
+        assumptions: {
+          setPublicClassFields: true,
+        },
+        presets: [() => ({ assumptions: { setClassMethods: true } })],
+      }).assumptions,
+    ).toEqual({
+      setPublicClassFields: true,
+      setClassMethods: true,
+      // This is enabled by default
+      newableArrowFunctions: true,
+    });
+  });
+
+  it("can be queried from plugins", () => {
+    let setPublicClassFields;
+    let unknownAssumption;
+
+    transformSync("", {
+      configFile: false,
+      browserslistConfigFile: false,
+      assumptions: {
+        setPublicClassFields: true,
+      },
+      plugins: [
+        api => {
+          setPublicClassFields = api.assumption("setPublicClassFields");
+
+          // Unknown assumptions default to "false" and don't throw, so
+          // that plugins can keep compat with older @babel/core versions
+          // when they introduce support for a new assumption.
+          unknownAssumption = api.assumption("unknownAssumption");
+
+          return {};
+        },
+      ],
+    });
+
+    expect(setPublicClassFields).toBe(true);
+    expect(unknownAssumption).toBe(false);
+  });
+
+  it("cannot be queried from presets", () => {
+    let assumptionFn;
+
+    transformSync("", {
+      configFile: false,
+      browserslistConfigFile: false,
+      presets: [
+        api => {
+          assumptionFn = api.assumption;
+          return {};
+        },
+      ],
+    });
+
+    expect(assumptionFn).toBeUndefined();
+  });
+
+  describe("plugin cache", () => {
+    const makePlugin = () =>
+      jest.fn(api => {
+        api.assumption("setPublicClassFields");
+        api.assumption("mutableTemplateObject");
+        return {};
+      });
+
+    const run = (plugin, assumptions) =>
+      transformSync("", {
+        assumptions,
+        configFile: false,
+        browserslistConfigFile: false,
+        plugins: [plugin],
+      });
+
+    it("is not invalidated when assumptions don't change", () => {
+      const plugin = makePlugin();
+
+      run(plugin, {
+        setPublicClassFields: true,
+        setClassMethods: false,
+      });
+      run(plugin, {
+        setPublicClassFields: true,
+        setClassMethods: false,
+      });
+
+      expect(plugin).toHaveBeenCalledTimes(1);
+    });
+
+    it("is not invalidated when unused assumptions change", () => {
+      const plugin = makePlugin();
+
+      run(plugin, {
+        setPublicClassFields: true,
+        setClassMethods: false,
+      });
+      run(plugin, {
+        setPublicClassFields: true,
+        setClassMethods: true,
+      });
+
+      expect(plugin).toHaveBeenCalledTimes(1);
+    });
+
+    it("is invalidated when used assumptions change", () => {
+      const plugin = makePlugin();
+
+      run(plugin, {
+        setPublicClassFields: true,
+        setClassMethods: false,
+      });
+      run(plugin, {
+        setPublicClassFields: false,
+        setClassMethods: true,
+      });
+
+      expect(plugin).toHaveBeenCalledTimes(2);
+    });
+
+    it("is invalidated when used assumptions are added", () => {
+      const plugin = makePlugin();
+
+      run(plugin, {
+        setPublicClassFields: true,
+        setClassMethods: false,
+      });
+      run(plugin, {
+        setPublicClassFields: false,
+        setClassMethods: true,
+        mutableTemplateObject: true,
+      });
+
+      expect(plugin).toHaveBeenCalledTimes(2);
+    });
+
+    it("is invalidated when used assumptions are removed", () => {
+      const plugin = makePlugin();
+
+      run(plugin, {
+        setPublicClassFields: true,
+        setClassMethods: false,
+      });
+      run(plugin, {
+        setClassMethods: true,
+      });
+
+      expect(plugin).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -985,6 +985,7 @@ describe("buildConfigChain", function () {
       presets: [],
       cloneInputAst: true,
       targets: {},
+      assumptions: { newableArrowFunctions: true },
     });
     const realEnv = process.env.NODE_ENV;
     const realBabelEnv = process.env.BABEL_ENV;

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -985,7 +985,7 @@ describe("buildConfigChain", function () {
       presets: [],
       cloneInputAst: true,
       targets: {},
-      assumptions: { newableArrowFunctions: true },
+      assumptions: {},
     });
     const realEnv = process.env.NODE_ENV;
     const realBabelEnv = process.env.BABEL_ENV;

--- a/packages/babel-helper-plugin-utils/src/index.js
+++ b/packages/babel-helper-plugin-utils/src/index.js
@@ -28,9 +28,7 @@ const apiPolyfills = {
   },
   // This is supported starting from Babel 7.13
   // TODO(Babel 8): Remove this polyfill
-  assumption: () => () => {
-    return false;
-  },
+  assumption: () => () => {},
 };
 
 function copyApiObject(api) {

--- a/packages/babel-helper-plugin-utils/src/index.js
+++ b/packages/babel-helper-plugin-utils/src/index.js
@@ -26,6 +26,11 @@ const apiPolyfills = {
   targets: () => () => {
     return {};
   },
+  // This is supported starting from Babel 7.13
+  // TODO(Babel 8): Remove this polyfill
+  assumption: () => () => {
+    return false;
+  },
 };
 
 function copyApiObject(api) {

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -245,7 +245,7 @@ export default function normalizeOptions(opts: Options) {
       opts.ignoreBrowserslistConfig,
       false,
     ),
-    loose: v.validateBooleanOption(TopLevelOptions.loose, opts.loose, false),
+    loose: v.validateBooleanOption(TopLevelOptions.loose, opts.loose),
     modules: validateModulesOption(opts.modules),
     shippedProposals: v.validateBooleanOption(
       TopLevelOptions.shippedProposals,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | RFC: https://github.com/babel/rfcs/pull/5 **<-- Please read and review it!**
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR _only_ introduces support for the `assumptions` option in `@babel/core`. I will make plugins check it in separate PRs, otherwise this one would be too big to be properly reviewed.

Assumptions implementation:
- [ ] `setClassMethods`: #12407 
- [ ] `mutableTemplateObject`, `ignoreToPrimitiveHint`: #12408

Those PRs can be reviewed one by one (you can even review those PRs before this one), and I'll merge them here after that both this PR and the specific implementation PR have been approved.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12219"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/8affe9b6d9892fd567187057237f3d028adec825.svg" /></a>

