### PR TITLE
fix: support optionalCall in replace super handler

### DIFF
--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -166,6 +166,16 @@ const specHandlers = {
       false,
     );
   },
+
+  optionalCall(superMember, args) {
+    const thisRefs = this._getThisRefs();
+    return optimiseCall(
+      this._get(superMember, thisRefs),
+      t.cloneNode(thisRefs.this),
+      args,
+      true,
+    );
+  },
 };
 
 const looseHandlers = {
@@ -222,6 +232,10 @@ const looseHandlers = {
 
   call(superMember, args) {
     return optimiseCall(this.get(superMember), t.thisExpression(), args, false);
+  },
+
+  optionalCall(superMember, args) {
+    return optimiseCall(this.get(superMember), t.thisExpression(), args, true);
   },
 };
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-property-optional-chain/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-property-optional-chain/input.js
@@ -1,0 +1,6 @@
+class Test extends Foo {
+  constructor() {
+    super.foo?.bar;
+    super.foo?.();
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-property-optional-chain/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-property-optional-chain/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    ["proposal-optional-chaining", { "loose": true }],
+    "transform-function-name",
+    ["transform-classes", { "loose": true }],
+    ["transform-spread", { "loose": true }],
+    "transform-block-scoping"
+  ]
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-property-optional-chain/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-property-optional-chain/output.js
@@ -1,0 +1,17 @@
+var Test = /*#__PURE__*/function (_Foo) {
+  "use strict";
+
+  babelHelpers.inheritsLoose(Test, _Foo);
+
+  function Test() {
+    var _Foo$prototype$foo, _Foo$prototype$foo2;
+
+    var _this;
+
+    (_Foo$prototype$foo = _Foo.prototype.foo) == null ? void 0 : _Foo$prototype$foo.bar;
+    (_Foo$prototype$foo2 = _Foo.prototype.foo) == null ? void 0 : _Foo$prototype$foo2.call(babelHelpers.assertThisInitialized(_this));
+    return babelHelpers.assertThisInitialized(_this);
+  }
+
+  return Test;
+}(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-property-optional-chain/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-property-optional-chain/input.js
@@ -1,0 +1,6 @@
+class Test extends Foo {
+  constructor() {
+    super.foo?.bar;
+    super.foo?.();
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-property-optional-chain/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-property-optional-chain/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "proposal-optional-chaining",
+    "transform-function-name",
+    "transform-classes",
+    "transform-spread",
+    "transform-block-scoping"
+  ]
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-property-optional-chain/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-property-optional-chain/output.js
@@ -1,0 +1,20 @@
+var Test = /*#__PURE__*/function (_Foo) {
+  "use strict";
+
+  babelHelpers.inherits(Test, _Foo);
+
+  var _super = babelHelpers.createSuper(Test);
+
+  function Test() {
+    var _babelHelpers$get, _babelHelpers$get2;
+
+    var _thisSuper, _thisSuper2, _this;
+
+    babelHelpers.classCallCheck(this, Test);
+    (_babelHelpers$get = babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "foo", _thisSuper)) === null || _babelHelpers$get === void 0 ? void 0 : _babelHelpers$get.bar;
+    (_babelHelpers$get2 = babelHelpers.get((_thisSuper2 = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "foo", _thisSuper2)) === null || _babelHelpers$get2 === void 0 ? void 0 : _babelHelpers$get2.call(_thisSuper2);
+    return babelHelpers.possibleConstructorReturn(_this);
+  }
+
+  return Test;
+}(Foo);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12229 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is a follow-up to #11248. Although `plugin-optional-chaining` is applied before `transform-classes`, the `transform-classes` plugin works on the `Class` node, ancestry of the optional chain. It is possible that `replace-supers` might see `super.foo?.()` and don't know how to handle that.

This PR adds `optionalCall` handler, so `super.foo?.()` will be transformed to
```js
Foo.foo?.call(babelHelpers.assertThisInitialized(this));
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12238"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/f58c9aa9156e9b1ca34a9311bfc4f1af2883abaa.svg" /></a>

