### PR TITLE
Update to Browserslist 4.14.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test/esm"
   ],
   "resolutions": {
-    "browserslist": "npm:4.12.0",
+    "browserslist": "npm:4.14.5",
     "caniuse-lite": "npm:1.0.30001077"
   },
   "engines": {

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@babel/compat-data": "workspace:^7.12.1",
     "@babel/helper-validator-option": "workspace:^7.12.1",
-    "browserslist": "^4.12.0",
+    "browserslist": "^4.14.5",
     "semver": "^5.5.0"
   },
   "peerDependencies": {

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -5,7 +5,7 @@ Using targets:
   "android": "81",
   "chrome": "80",
   "edge": "18",
-  "firefox": "68",
+  "firefox": "74",
   "ios": "12.2",
   "opera": "67",
   "safari": "13",
@@ -15,21 +15,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "edge":"18", "firefox":"68", "ios":"12.2", "samsung":"10.1" }
-  proposal-logical-assignment-operators { "android":"81", "chrome":"80", "edge":"18", "firefox":"68", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
-  proposal-nullish-coalescing-operator { "edge":"18", "firefox":"68", "ios":"12.2", "safari":"13", "samsung":"10.1" }
-  proposal-optional-chaining { "edge":"18", "firefox":"68", "ios":"12.2", "safari":"13", "samsung":"10.1" }
+  proposal-numeric-separator { "edge":"18", "ios":"12.2", "samsung":"10.1" }
+  proposal-logical-assignment-operators { "android":"81", "chrome":"80", "edge":"18", "firefox":"74", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
+  proposal-nullish-coalescing-operator { "edge":"18", "ios":"12.2", "safari":"13", "samsung":"10.1" }
+  proposal-optional-chaining { "edge":"18", "ios":"12.2", "safari":"13", "samsung":"10.1" }
   proposal-json-strings { "edge":"18" }
   proposal-optional-catch-binding { "edge":"18" }
   proposal-async-generator-functions { "edge":"18" }
   proposal-object-rest-spread { "edge":"18" }
-  transform-dotall-regex { "edge":"18", "firefox":"68" }
-  proposal-unicode-property-regex { "edge":"18", "firefox":"68" }
-  transform-named-capturing-groups-regex { "edge":"18", "firefox":"68" }
+  transform-dotall-regex { "edge":"18", "firefox":"74" }
+  proposal-unicode-property-regex { "edge":"18", "firefox":"74" }
+  transform-named-capturing-groups-regex { "edge":"18", "firefox":"74" }
   transform-template-literals { "ios":"12.2" }
   transform-function-name { "edge":"18" }
-  proposal-export-namespace-from { "edge":"18", "firefox":"68", "ios":"12.2", "safari":"13", "samsung":"10.1" }
-  transform-modules-commonjs { "android":"81", "chrome":"80", "edge":"18", "firefox":"68", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
-  proposal-dynamic-import { "android":"81", "chrome":"80", "edge":"18", "firefox":"68", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
+  proposal-export-namespace-from { "edge":"18", "firefox":"74", "ios":"12.2", "safari":"13", "samsung":"10.1" }
+  transform-modules-commonjs { "android":"81", "chrome":"80", "edge":"18", "firefox":"74", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
+  proposal-dynamic-import { "android":"81", "chrome":"80", "edge":"18", "firefox":"74", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -5,7 +5,7 @@ Using targets:
   "android": "81",
   "chrome": "80",
   "edge": "18",
-  "firefox": "68",
+  "firefox": "74",
   "ie": "11",
   "ios": "12.2",
   "opera": "67",
@@ -16,18 +16,18 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "edge":"18", "firefox":"68", "ie":"11", "ios":"12.2", "samsung":"10.1" }
-  proposal-logical-assignment-operators { "android":"81", "chrome":"80", "edge":"18", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
-  proposal-nullish-coalescing-operator { "edge":"18", "firefox":"68", "ie":"11", "ios":"12.2", "safari":"13", "samsung":"10.1" }
-  proposal-optional-chaining { "edge":"18", "firefox":"68", "ie":"11", "ios":"12.2", "safari":"13", "samsung":"10.1" }
+  proposal-numeric-separator { "edge":"18", "ie":"11", "ios":"12.2", "samsung":"10.1" }
+  proposal-logical-assignment-operators { "android":"81", "chrome":"80", "edge":"18", "firefox":"74", "ie":"11", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
+  proposal-nullish-coalescing-operator { "edge":"18", "ie":"11", "ios":"12.2", "safari":"13", "samsung":"10.1" }
+  proposal-optional-chaining { "edge":"18", "ie":"11", "ios":"12.2", "safari":"13", "samsung":"10.1" }
   proposal-json-strings { "edge":"18", "ie":"11" }
   proposal-optional-catch-binding { "edge":"18", "ie":"11" }
   transform-parameters { "ie":"11" }
   proposal-async-generator-functions { "edge":"18", "ie":"11" }
   proposal-object-rest-spread { "edge":"18", "ie":"11" }
-  transform-dotall-regex { "edge":"18", "firefox":"68", "ie":"11" }
-  proposal-unicode-property-regex { "edge":"18", "firefox":"68", "ie":"11" }
-  transform-named-capturing-groups-regex { "edge":"18", "firefox":"68", "ie":"11" }
+  transform-dotall-regex { "edge":"18", "firefox":"74", "ie":"11" }
+  proposal-unicode-property-regex { "edge":"18", "firefox":"74", "ie":"11" }
+  transform-named-capturing-groups-regex { "edge":"18", "firefox":"74", "ie":"11" }
   transform-async-to-generator { "ie":"11" }
   transform-exponentiation-operator { "ie":"11" }
   transform-template-literals { "ie":"11", "ios":"12.2" }
@@ -49,8 +49,8 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "ie":"11" }
-  proposal-export-namespace-from { "edge":"18", "firefox":"68", "ie":"11", "ios":"12.2", "safari":"13", "samsung":"10.1" }
-  transform-modules-commonjs { "android":"81", "chrome":"80", "edge":"18", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
-  proposal-dynamic-import { "android":"81", "chrome":"80", "edge":"18", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
+  proposal-export-namespace-from { "edge":"18", "firefox":"74", "ie":"11", "ios":"12.2", "safari":"13", "samsung":"10.1" }
+  transform-modules-commonjs { "android":"81", "chrome":"80", "edge":"18", "firefox":"74", "ie":"11", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
+  proposal-dynamic-import { "android":"81", "chrome":"80", "edge":"18", "firefox":"74", "ie":"11", "ios":"12.2", "opera":"67", "safari":"13", "samsung":"10.1" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,7 +351,7 @@ __metadata:
     "@babel/compat-data": "workspace:^7.12.1"
     "@babel/core": "workspace:*"
     "@babel/helper-validator-option": "workspace:^7.12.1"
-    browserslist: ^4.12.0
+    browserslist: ^4.14.5
     semver: ^5.5.0
   peerDependencies:
     "@babel/core": ^7.0.0
@@ -4952,17 +4952,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:4.12.0":
-  version: 4.12.0
-  resolution: "browserslist@npm:4.12.0"
+"browserslist@npm:4.14.5":
+  version: 4.14.5
+  resolution: "browserslist@npm:4.14.5"
   dependencies:
-    caniuse-lite: ^1.0.30001043
-    electron-to-chromium: ^1.3.413
-    node-releases: ^1.1.53
-    pkg-up: ^2.0.0
+    caniuse-lite: ^1.0.30001135
+    electron-to-chromium: ^1.3.571
+    escalade: ^3.1.0
+    node-releases: ^1.1.61
   bin:
     browserslist: cli.js
-  checksum: 564af87b3300321d885c22b6fb010a4d702b1cc77591d684d8f79411d5df65b9290a043348bcb5e4ca96b423c703aeb83fa25979ee3b140b28c48fc965dea0ed
+  checksum: 18261764bd01f559059a57b1536b75b93e8b448c3e9ccd4de1699b40fcd0697feebbd2e76cc573cbfd0c3f308d29e441435591f93f81bc60596101f5a3d58bbb
   languageName: node
   linkType: hard
 
@@ -6090,7 +6090,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:1.3.574, electron-to-chromium@npm:^1.3.413":
+"electron-to-chromium@npm:1.3.574, electron-to-chromium@npm:^1.3.571":
   version: 1.3.574
   resolution: "electron-to-chromium@npm:1.3.574"
   checksum: 671aa9db3fbebb2538612195d667e73b981ea60bd64f7d1d42b55f406321fd4111d6409c4453ef2138f9ab36f303e84269490e9e1fb18762bc9529f89ab076b6
@@ -6284,6 +6284,13 @@ __metadata:
     es6-iterator: ^2.0.3
     es6-symbol: ^3.1.1
   checksum: 8dfd50b2919e16cf246ea9d5f9271eef466924248bc98a48a718cc149d0f67b708628c8e4bd32fa945a813c7780f94270f21ac16fff33c854a348db7e19f084d
+  languageName: node
+  linkType: hard
+
+"escalade@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "escalade@npm:3.1.1"
+  checksum: 1e31ff50d66f47cd0dfffa702061127116ccf9886d1f54a802a7b3bc95b94cab0cbf5b145cc5ac199036df6fd9d1bb24af1fa1bfed87c94879e950fbee5f86d1
   languageName: node
   linkType: hard
 
@@ -9855,10 +9862,10 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^1.1.53":
-  version: 1.1.58
-  resolution: "node-releases@npm:1.1.58"
-  checksum: cd590a387e59206a3ed3c3624234f5848f8176e04f61b8e67c4f52df631c7e61f2ef2b7b320a2f5a42c92b65d31b2911d3a5aedacc86267e06f39155a6ce4d13
+"node-releases@npm:^1.1.61":
+  version: 1.1.64
+  resolution: "node-releases@npm:1.1.64"
+  checksum: 09e85fd0eccee979c56c8582dac19a6f88fe4444f0ae0c2c55a7e70df10cf11530f76d3203150e9961fa59d0448cab406d450cef3bc4681f12c3edd070d68b36
   languageName: node
   linkType: hard
 
@@ -10633,15 +10640,6 @@ fsevents@~2.1.2:
   dependencies:
     find-up: ^4.0.0
   checksum: 1956ebf3cf5cc36a5d20e93851fcadd5a786774eb08667078561e72e0ab8ace91fc36a028d5305f0bfe7c89f9bf51886e2a3c8cb2c2620accfa3feb8da3c256b
-  languageName: node
-  linkType: hard
-
-"pkg-up@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "pkg-up@npm:2.0.0"
-  dependencies:
-    find-up: ^2.1.0
-  checksum: 0a8fcbebf0f1aadc7a52c576352a698abef6c389cb00a0847db2d370d05d4c005f855e196d29618b088062f1394711ca6dadd232692ed225511d7e75a198d246
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | `browserslist` update
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PRs updates to Browserslist 4.14, and uses the new `supports es6-module` query instead of our custom logic to build the `esmodules: true` query.

I wanted to include this in https://github.com/babel/babel/pull/12189, but since it's just a small refactoring I moved it to a separate PR.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12241"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/d7df4c3f90ece7b6a1dfb65214a0f0855deaaffa.svg" /></a>

