### PR TITLE
Update node versions in CI configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,12 @@ aliases:
 executors:
   node-executor:
     docker:
-      - image: cimg/node:latest
+      - image: cimg/node:current
     working_directory: ~/babel
   # e2e-vue-cli test requires chromium
   node-browsers-executor:
     docker:
-      - image: cimg/node:latest-browsers
+      - image: cimg/node:current-browsers
     working_directory: ~/babel
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,14 @@ executors:
     docker:
       - image: cimg/node:current-browsers
     working_directory: ~/babel
+  # e2e-jest test requires python
+  node-python-executor:
+    docker:
+      - image: cimg/python:3.9-node
+    working_directory: ~/babel
+
+orbs:
+  browser-tools: circleci/browser-tools@1.1.0
 
 jobs:
   build-standalone:
@@ -151,10 +159,12 @@ jobs:
       - checkout
       - attach_workspace:
           at: /tmp/verdaccio-workspace
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run: ./scripts/integration-tests/e2e-vue-cli.sh
 
   e2e-jest:
-    executor: node-executor
+    executor: node-python-executor
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,12 @@ aliases:
 executors:
   node-executor:
     docker:
-      - image: circleci/node:latest
+      - image: cimg/node:latest
     working_directory: ~/babel
   # e2e-vue-cli test requires chromium
   node-browsers-executor:
     docker:
-      - image: circleci/node:latest-browsers
+      - image: cimg/node:latest-browsers
     working_directory: ~/babel
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [13, 12, 10, 8, 6]
+        node-version: [14, 13, 12, 10, 8, 6]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

1. Add Node.js 14 to the "old" versions on GH action since latest is now Node.js 15
2. Replace the CI images with [`cimg/node`](https://circleci.com/developer/images/image/cimg/node): hopefully it will pick up 15.0.1 and the CRA e2e test will start working again.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12243"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/3df05e89cf556220ad412c66725801724513247d.svg" /></a>

