### PR TITLE
Mark `ThisExpression` and `Super` as `Purish`

### DIFF
--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -232,6 +232,15 @@ describe("scope", () => {
       expect(
         getPath("String.raw`foo`").get("body")[0].get("expression").isPure(),
       ).toBeTruthy();
+      expect(getPath("this").get("body.0.expression").isPure()).toBeTruthy();
+      expect(getPath("this.foo").get("body.0.expression").isPure()).toBeFalsy();
+      expect(
+        getPath("super.foo").get("body.0.expression").isPure(),
+      ).toBeFalsy();
+      expect(
+        // This only tests "super", not "super.foo"
+        getPath("super.foo").get("body.0.expression.object").isPure(),
+      ).toBeTruthy();
     });
 
     test("label", function () {

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -235,11 +235,15 @@ describe("scope", () => {
       expect(getPath("this").get("body.0.expression").isPure()).toBeTruthy();
       expect(getPath("this.foo").get("body.0.expression").isPure()).toBeFalsy();
       expect(
-        getPath("super.foo").get("body.0.expression").isPure(),
+        getPath("({ m() { super.foo } })")
+          .get("body.0.expression.properties.0.body.body.0.expression")
+          .isPure(),
       ).toBeFalsy();
       expect(
         // This only tests "super", not "super.foo"
-        getPath("super.foo").get("body.0.expression.object").isPure(),
+        getPath("({ m() { super.foo } })")
+          .get("body.0.expression.properties.0.body.body.0.expression.object")
+          .isPure(),
       ).toBeTruthy();
     });
 

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -980,7 +980,7 @@ defineType("SwitchStatement", {
 });
 
 defineType("ThisExpression", {
-  aliases: ["Expression"],
+  aliases: ["Expression", "Pureish"],
 });
 
 defineType("ThrowStatement", {

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -1785,7 +1785,7 @@ defineType("SpreadElement", {
 });
 
 defineType("Super", {
-  aliases: ["Expression"],
+  aliases: ["Expression", "Pureish"],
 });
 
 defineType("TaggedTemplateExpression", {

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -3967,6 +3967,7 @@ export function isPureish(node: ?Object, opts?: Object): boolean {
     "RegExpLiteral" === nodeType ||
     "ThisExpression" === nodeType ||
     "ArrowFunctionExpression" === nodeType ||
+    "Super" === nodeType ||
     "BigIntLiteral" === nodeType ||
     "DecimalLiteral" === nodeType ||
     (nodeType === "Placeholder" && "StringLiteral" === node.expectedNode)

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -3965,6 +3965,7 @@ export function isPureish(node: ?Object, opts?: Object): boolean {
     "NullLiteral" === nodeType ||
     "BooleanLiteral" === nodeType ||
     "RegExpLiteral" === nodeType ||
+    "ThisExpression" === nodeType ||
     "ArrowFunctionExpression" === nodeType ||
     "BigIntLiteral" === nodeType ||
     "DecimalLiteral" === nodeType ||


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Maybe?
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I noticed that `Pureish` was used for literals and for functions, so it means "something that doesn't have side-effects when evaluated".
This has the effect of returning `true` from `path.isPure()` for this, potentially removing `this` when it's not used in some transforms.

Extracted from https://github.com/babel/babel/pull/12250.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12251"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/f962a324514996eb238535ae55592c24c0ffcfac.svg" /></a>

