### PR TITLE
Throw a `TypeError` when reassigning a `const`

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -871,7 +871,7 @@ helpers.taggedTemplateLiteralLoose = helper("7.0.0-beta.0")`
 
 helpers.readOnlyError = helper("7.0.0-beta.0")`
   export default function _readOnlyError(name) {
-    throw new Error("\\"" + name + "\\" is read-only");
+    throw new TypeError("\\"" + name + "\\" is read-only");
   }
 `;
 

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/deadcode-violation/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/deadcode-violation/output.js
@@ -1,4 +1,4 @@
-function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+function _readOnlyError(name) { throw new TypeError("\"" + name + "\" is read-only"); }
 
 (function () {
   var a = "foo";

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/destructuring-assignment/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/destructuring-assignment/output.js
@@ -1,4 +1,4 @@
-function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+function _readOnlyError(name) { throw new TypeError("\"" + name + "\" is read-only"); }
 
 var a = 1,
     b = 2;

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/loop/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/loop/output.js
@@ -1,4 +1,4 @@
-function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+function _readOnlyError(name) { throw new TypeError("\"" + name + "\" is read-only"); }
 
 for (var i = 0; i < 3; i = (_readOnlyError("i"), i + 1)) {
   console.log(i);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/nested-update-expressions/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/nested-update-expressions/output.js
@@ -1,4 +1,4 @@
-function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+function _readOnlyError(name) { throw new TypeError("\"" + name + "\" is read-only"); }
 
 var c = 17;
 var a = 0;

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-assignment/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-assignment/output.js
@@ -1,4 +1,4 @@
-function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+function _readOnlyError(name) { throw new TypeError("\"" + name + "\" is read-only"); }
 
 var MULTIPLIER = 5;
 MULTIPLIER = (_readOnlyError("MULTIPLIER"), "overwrite");

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-for-in/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-for-in/output.js
@@ -1,4 +1,4 @@
-function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+function _readOnlyError(name) { throw new TypeError("\"" + name + "\" is read-only"); }
 
 var MULTIPLIER = 5;
 

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/update-expression-prefix/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/update-expression-prefix/output.js
@@ -1,4 +1,4 @@
-function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+function _readOnlyError(name) { throw new TypeError("\"" + name + "\" is read-only"); }
 
 var a = "str";
 _readOnlyError("a"), --a;

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/update-expression/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/update-expression/output.js
@@ -1,4 +1,4 @@
-function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+function _readOnlyError(name) { throw new TypeError("\"" + name + "\" is read-only"); }
 
 var foo = 1;
 _readOnlyError("foo"), foo++;

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/constant-violation.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/constant-violation.js
@@ -1,0 +1,2 @@
+const a = 1;
+expect(() => { a = 2 }).toThrow(TypeError);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Extracted from https://github.com/babel/babel/pull/12250


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12252"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/42bf8b0763f8523f6816d1f819147f9811702bda.svg" /></a>

