### PR TITLE
add declare to class properties type annotations

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -102,14 +102,11 @@ module.exports = function (api) {
     ]
       .filter(Boolean)
       .map(normalize),
-    presets: [["@babel/env", envOpts]],
+    presets: [
+      ["@babel/env", envOpts],
+      ["@babel/preset-flow", { allowDeclareFields: true }],
+    ],
     plugins: [
-      // TODO: Use @babel/preset-flow when
-      // https://github.com/babel/babel/issues/7233 is fixed
-      [
-        "@babel/plugin-transform-flow-strip-types",
-        { allowDeclareFields: true },
-      ],
       [
         "@babel/proposal-object-rest-spread",
         { useBuiltIns: true, loose: true },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@babel/eslint-plugin-development-internal": "workspace:*",
     "@babel/plugin-proposal-dynamic-import": "^7.10.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
-    "@babel/plugin-transform-flow-strip-types": "^7.10.4",
     "@babel/plugin-transform-for-of": "^7.10.4",
     "@babel/plugin-transform-modules-commonjs": "^7.10.4",
     "@babel/plugin-transform-runtime": "^7.12.0",

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -33,10 +33,10 @@ export default class Printer {
     this._buf = new Buffer(map);
   }
 
-  format: Format;
+  declare format: Format;
   inForStatementInitCounter: number = 0;
 
-  _buf: Buffer;
+  declare _buf: Buffer;
   _printStack: Array<Node> = [];
   _indent: number = 0;
   _insideAux: boolean = false;

--- a/packages/babel-helper-module-imports/src/import-injector.js
+++ b/packages/babel-helper-module-imports/src/import-injector.js
@@ -98,17 +98,17 @@ export default class ImportInjector {
   /**
    * The path used for manipulation.
    */
-  _programPath: NodePath;
+  declare _programPath: NodePath;
 
   /**
    * The scope used to generate unique variable names.
    */
-  _programScope;
+  declare _programScope;
 
   /**
    * The file used to inject helpers and resolve paths.
    */
-  _hub;
+  declare _hub;
 
   /**
    * The default options to use with this instance when imports are added.

--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -272,14 +272,14 @@ export default class ReplaceSupers {
     this.opts = opts;
   }
 
-  file: HubInterface;
-  isDerivedConstructor: boolean;
-  isLoose: boolean;
-  isPrivateMethod: boolean;
-  isStatic: boolean;
-  methodPath: NodePath;
-  opts: ReplaceSupersOptions;
-  superRef: Object;
+  declare file: HubInterface;
+  declare isDerivedConstructor: boolean;
+  declare isLoose: boolean;
+  declare isPrivateMethod: boolean;
+  declare isStatic: boolean;
+  declare methodPath: NodePath;
+  declare opts: ReplaceSupersOptions;
+  declare superRef: Object;
 
   getObjectRef() {
     return t.cloneNode(this.opts.objectRef || this.opts.getObjectRef());

--- a/packages/babel-parser/src/parser/base.js
+++ b/packages/babel-parser/src/parser/base.js
@@ -10,23 +10,23 @@ import type ProductionParameterHandler from "../util/production-parameter";
 
 export default class BaseParser {
   // Properties set by constructor in index.js
-  options: Options;
-  inModule: boolean;
-  scope: ScopeHandler<*>;
-  classScope: ClassScopeHandler;
-  prodParam: ProductionParameterHandler;
-  expressionScope: ExpressionScopeHandler;
-  plugins: PluginsMap;
-  filename: ?string;
+  declare options: Options;
+  declare inModule: boolean;
+  declare scope: ScopeHandler<*>;
+  declare classScope: ClassScopeHandler;
+  declare prodParam: ProductionParameterHandler;
+  declare expressionScope: ExpressionScopeHandler;
+  declare plugins: PluginsMap;
+  declare filename: ?string;
   sawUnambiguousESM: boolean = false;
   ambiguousScriptDifferentAst: boolean = false;
 
   // Initialized by Tokenizer
-  state: State;
+  declare state: State;
   // input and length are not in state as they are constant and we do
   // not want to ever copy them, which happens if state gets cloned
-  input: string;
-  length: number;
+  declare input: string;
+  declare length: number;
 
   hasPlugin(name: string): boolean {
     return this.plugins.has(name);

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -101,11 +101,11 @@ export class Token {
     this.loc = new SourceLocation(state.startLoc, state.endLoc);
   }
 
-  type: TokenType;
-  value: any;
-  start: number;
-  end: number;
-  loc: SourceLocation;
+  declare type: TokenType;
+  declare value: any;
+  declare start: number;
+  declare end: number;
+  declare loc: SourceLocation;
 }
 
 // ## Tokenizer

--- a/packages/babel-parser/src/util/class-scope.js
+++ b/packages/babel-parser/src/util/class-scope.js
@@ -23,7 +23,7 @@ type raiseFunction = (number, string, ...any) => void;
 
 export default class ClassScopeHandler {
   stack: Array<ClassScope> = [];
-  raise: raiseFunction;
+  declare raise: raiseFunction;
   undefinedPrivateNames: Map<string, number> = new Map();
 
   constructor(raise: raiseFunction) {

--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -39,8 +39,8 @@ type raiseFunction = (number, string, ...any) => void;
 // current scope in order to detect duplicate variable names.
 export default class ScopeHandler<IScope: Scope = Scope> {
   scopeStack: Array<IScope> = [];
-  raise: raiseFunction;
-  inModule: boolean;
+  declare raise: raiseFunction;
+  declare inModule: boolean;
   undefinedExports: Map<string, number> = new Map();
   undefinedPrivateNames: Map<string, number> = new Map();
 

--- a/packages/babel-traverse/src/context.js
+++ b/packages/babel-traverse/src/context.js
@@ -11,10 +11,10 @@ export default class TraversalContext {
     this.opts = opts;
   }
 
-  parentPath: NodePath;
-  scope;
-  state;
-  opts;
+  declare parentPath: NodePath;
+  declare scope;
+  declare state;
+  declare opts;
   queue: ?Array<NodePath> = null;
 
   /**

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -31,42 +31,30 @@ export default class NodePath {
   constructor(hub: HubInterface, parent: Object) {
     this.parent = parent;
     this.hub = hub;
-    this.contexts = [];
     this.data = null;
-    // this.shouldSkip = false; this.shouldStop = false; this.removed = false;
-    this._traverseFlags = 0;
-    this.state = null;
-    this.opts = null;
-    this.skipKeys = null;
-    this.parentPath = null;
+
     this.context = null;
-    this.container = null;
-    this.listKey = null;
-    this.key = null;
-    this.node = null;
     this.scope = null;
-    this.type = null;
   }
 
-  parent: Object;
-  hub: HubInterface;
-  contexts: Array<TraversalContext>;
-  data: Object;
-  shouldSkip: boolean;
-  shouldStop: boolean;
-  removed: boolean;
-  state: any;
-  opts: ?Object;
-  _traverseFlags: number;
-  skipKeys: ?Object;
-  parentPath: ?NodePath;
-  context: TraversalContext;
-  container: ?Object | Array<Object>;
-  listKey: ?string;
-  key: ?string;
-  node: ?Object;
-  scope: Scope;
-  type: ?string;
+  declare parent: Object;
+  declare hub: HubInterface;
+  declare data: Object;
+  declare context: TraversalContext;
+  declare scope: Scope;
+
+  contexts: Array<TraversalContext> = [];
+  state: any = null;
+  opts: ?Object = null;
+  // this.shouldSkip = false; this.shouldStop = false; this.removed = false;
+  _traverseFlags: number = 0;
+  skipKeys: ?Object = null;
+  parentPath: ?NodePath = null;
+  container: ?Object | Array<Object> = null;
+  listKey: ?string = null;
+  key: ?string = null;
+  node: ?Object = null;
+  type: ?string = null;
 
   static get({ hub, parentPath, parent, container, listKey, key }): NodePath {
     if (!hub && parentPath) {

--- a/packages/babel-traverse/src/scope/binding.js
+++ b/packages/babel-traverse/src/scope/binding.js
@@ -18,26 +18,19 @@ export default class Binding {
     this.path = path;
     this.kind = kind;
 
-    this.constantViolations = [];
-    this.constant = true;
-
-    this.referencePaths = [];
-    this.referenced = false;
-    this.references = 0;
-
     this.clearValue();
   }
 
-  constantViolations: Array<NodePath>;
-  constant: boolean;
+  constantViolations: Array<NodePath> = [];
+  constant: boolean = true;
 
-  referencePaths: Array<NodePath>;
-  referenced: boolean;
-  references: number;
+  referencePaths: Array<NodePath> = [];
+  referenced: boolean = false;
+  references: number = 0;
 
-  hasDeoptedValue: boolean;
-  hasValue: boolean;
-  value: any;
+  declare hasDeoptedValue: boolean;
+  declare hasValue: boolean;
+  declare value: any;
 
   deoptValue() {
     this.clearValue();

--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -37,9 +37,9 @@ export default class Renamer {
     this.binding = binding;
   }
 
-  oldName: string;
-  newName: string;
-  binding: Binding;
+  declare oldName: string;
+  declare newName: string;
+  declare binding: Binding;
 
   maybeConvertFromExportDeclaration(parentDeclar) {
     const maybeExportDeclar = parentDeclar.parentPath;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4575,7 +4575,6 @@ __metadata:
     "@babel/eslint-plugin-development-internal": "workspace:*"
     "@babel/plugin-proposal-dynamic-import": ^7.10.4
     "@babel/plugin-proposal-object-rest-spread": ^7.11.0
-    "@babel/plugin-transform-flow-strip-types": ^7.10.4
     "@babel/plugin-transform-for-of": ^7.10.4
     "@babel/plugin-transform-modules-commonjs": ^7.10.4
     "@babel/plugin-transform-runtime": ^7.12.0


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes e2e errors in #12244 
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Currently we have redundant initializer code unshifted in the `constructors` from type annotations. For example

https://github.com/babel/babel/blob/2782a549e99d2ef1816332d23d7dfd5190f58a0f/packages/babel-traverse/src/path/index.js#L31-L69

is transformed as (See [here](https://unpkg.com/@babel/traverse@7.12.1/lib/path/index.js) for the full outputs)
```js
constructor(hub, parent) {
    // ... ignored initializer code
    this.shouldSkip = void 0;
    this.shouldStop = void 0;
    this.removed = void 0;
    // ... ignored initializer code
    this._traverseFlags = void 0;
  }
```

`this.shouldSkip = void 0;` transformed from the property type annotations, is redundant because we have initialized it in `constructors`. What's more, it causes side effects if we skip `proposal-class-properties` when building Babel in #12244, in which it is transformed to

```js
constructor(hub, parent) {
  this._traverseFlags = void 0;
}
removed;
get removed() {}
set removed(removed) {}
```

When these class property annotations were authored, `flow` didn't support `declare` class properties and they happen to be removed in the built artifacts via `proposal-class-properties`. This PR adds `declare` to these properties so it is future-safe (removed by `flow-types`) after we skip `proposal-class-properties`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12257"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/19777ce578eecd7d8525ff64baaf5848e50c551e.svg" /></a>

