### PR TITLE
Polish parser errors

### DIFF
--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -16,8 +16,9 @@ export const ErrorMessages = Object.freeze({
     "Can not use 'await' as identifier inside an async function",
   AwaitExpressionFormalParameter:
     "await is not allowed in async function parameters",
-  AwaitNotInAsyncFunction:
-    "Can not use keyword 'await' outside an async function",
+  AwaitNotInAsyncContext:
+    "'await' is only valid in async functions and the top level bodies of modules",
+  AwaitNotInAsyncFunction: "'await' is only valid in async function",
   BadGetterArity: "getter must not have any formal parameters",
   BadSetterArity: "setter must have exactly one formal parameter",
   BadSetterRestParameter:

--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -211,7 +211,7 @@ export const ErrorMessages = Object.freeze({
   VarRedeclaration: "Identifier '%0' has already been declared",
   YieldBindingIdentifier:
     "Can not use 'yield' as identifier inside a generator",
-  YieldInParameter: "yield is not allowed in generator parameters",
+  YieldInParameter: "Yield expression is not allowed in formal parameters",
   ZeroDigitNumericSeparator:
     "Numeric separator can not be used after leading 0",
 });

--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -17,8 +17,8 @@ export const ErrorMessages = Object.freeze({
   AwaitExpressionFormalParameter:
     "await is not allowed in async function parameters",
   AwaitNotInAsyncContext:
-    "'await' is only valid in async functions and the top level bodies of modules",
-  AwaitNotInAsyncFunction: "'await' is only valid in async function",
+    "'await' is only allowed within async functions and at the top levels of modules",
+  AwaitNotInAsyncFunction: "'await' is only allowed within async functions",
   BadGetterArity: "getter must not have any formal parameters",
   BadSetterArity: "setter must have exactly one formal parameter",
   BadSetterRestParameter:

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -2343,7 +2343,12 @@ export default class ExpressionParser extends LValParser {
 
     if (reservedTest(word, this.inModule)) {
       if (!this.prodParam.hasAwait && word === "await") {
-        this.raise(startLoc, Errors.AwaitNotInAsyncFunction);
+        this.raise(
+          startLoc,
+          this.hasPlugin("topLevelAwait")
+            ? Errors.AwaitNotInAsyncContext
+            : Errors.AwaitNotInAsyncFunction,
+        );
       } else {
         this.raise(startLoc, Errors.UnexpectedReservedWord, word);
       }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/357/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/357/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":14,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":14}},
   "errors": [
-    "SyntaxError: 'await' is only valid in async function (1:0)"
+    "SyntaxError: 'await' is only allowed within async functions (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/357/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/357/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":14,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":14}},
   "errors": [
-    "SyntaxError: Can not use keyword 'await' outside an async function (1:0)"
+    "SyntaxError: 'await' is only valid in async function (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/359/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/359/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":20,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":20}},
   "errors": [
-    "SyntaxError: 'await' is only valid in async function (1:6)"
+    "SyntaxError: 'await' is only allowed within async functions (1:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/359/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/359/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":20,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":20}},
   "errors": [
-    "SyntaxError: Can not use keyword 'await' outside an async function (1:6)"
+    "SyntaxError: 'await' is only valid in async function (1:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/361/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/361/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":24}},
   "errors": [
-    "SyntaxError: 'await' is only valid in async function (1:8)"
+    "SyntaxError: 'await' is only allowed within async functions (1:8)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/361/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/361/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":24}},
   "errors": [
-    "SyntaxError: Can not use keyword 'await' outside an async function (1:8)"
+    "SyntaxError: 'await' is only valid in async function (1:8)"
   ],
   "program": {
     "type": "Program",
@@ -24,6 +24,9 @@
                 {
                   "type": "ObjectProperty",
                   "start":8,"end":13,"loc":{"start":{"line":1,"column":8},"end":{"line":1,"column":13}},
+                  "extra": {
+                    "shorthand": true
+                  },
                   "method": false,
                   "key": {
                     "type": "Identifier",
@@ -36,9 +39,6 @@
                     "type": "Identifier",
                     "start":8,"end":13,"loc":{"start":{"line":1,"column":8},"end":{"line":1,"column":13},"identifierName":"await"},
                     "name": "await"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/363/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/363/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":26}},
   "errors": [
-    "SyntaxError: 'await' is only valid in async function (1:15)"
+    "SyntaxError: 'await' is only allowed within async functions (1:15)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/363/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/363/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":26}},
   "errors": [
-    "SyntaxError: Can not use keyword 'await' outside an async function (1:15)"
+    "SyntaxError: 'await' is only valid in async function (1:15)"
   ],
   "program": {
     "type": "Program",
@@ -28,6 +28,9 @@
               {
                 "type": "ObjectProperty",
                 "start":15,"end":20,"loc":{"start":{"line":1,"column":15},"end":{"line":1,"column":20}},
+                "extra": {
+                  "shorthand": true
+                },
                 "method": false,
                 "key": {
                   "type": "Identifier",
@@ -40,9 +43,6 @@
                   "type": "Identifier",
                   "start":15,"end":20,"loc":{"start":{"line":1,"column":15},"end":{"line":1,"column":20},"identifierName":"await"},
                   "name": "await"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/365/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/365/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":19,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":19}},
   "errors": [
-    "SyntaxError: 'await' is only valid in async function (1:9)"
+    "SyntaxError: 'await' is only allowed within async functions (1:9)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/365/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/365/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":19,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":19}},
   "errors": [
-    "SyntaxError: Can not use keyword 'await' outside an async function (1:9)"
+    "SyntaxError: 'await' is only valid in async function (1:9)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/367/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/367/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":14,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":14}},
   "errors": [
-    "SyntaxError: 'await' is only valid in async function (1:6)"
+    "SyntaxError: 'await' is only allowed within async functions (1:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/367/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/367/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":14,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":14}},
   "errors": [
-    "SyntaxError: Can not use keyword 'await' outside an async function (1:6)"
+    "SyntaxError: 'await' is only valid in async function (1:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-1/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-1/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":39,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (2:7)"
+    "SyntaxError: Yield expression is not allowed in formal parameters (2:7)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-2/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-2/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":53,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (2:15)"
+    "SyntaxError: Yield expression is not allowed in formal parameters (2:15)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-3/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-3/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":42,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (2:7)"
+    "SyntaxError: Yield expression is not allowed in formal parameters (2:7)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-4/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-4/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":49,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (2:17)"
+    "SyntaxError: Yield expression is not allowed in formal parameters (2:17)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-5/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-5/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":47,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (2:8)",
+    "SyntaxError: Yield expression is not allowed in formal parameters (2:8)",
     "SyntaxError: Binding invalid left-hand side in function parameter list (2:8)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-6/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-6/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":41,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (2:8)"
+    "SyntaxError: Yield expression is not allowed in formal parameters (2:8)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-generator-method/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-generator-method/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":27,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":27}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (1:15)"
+    "SyntaxError: Yield expression is not allowed in formal parameters (1:15)"
   ],
   "program": {
     "type": "Program",
@@ -16,6 +16,10 @@
         "expression": {
           "type": "ObjectExpression",
           "start":1,"end":26,"loc":{"start":{"line":1,"column":1},"end":{"line":1,"column":26}},
+          "extra": {
+            "parenthesized": true,
+            "parenStart": 0
+          },
           "properties": [
             {
               "type": "ObjectMethod",
@@ -55,11 +59,7 @@
                 "directives": []
               }
             }
-          ],
-          "extra": {
-            "parenthesized": true,
-            "parenStart": 0
-          }
+          ]
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-generator/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-generator/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":26}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (1:17)"
+    "SyntaxError: Yield expression is not allowed in formal parameters (1:17)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-1/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-1/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (2:3)",
+    "SyntaxError: Yield expression is not allowed in formal parameters (2:3)",
     "SyntaxError: Binding invalid left-hand side in function parameter list (2:3)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-2/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-2/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":38,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (2:3)",
+    "SyntaxError: Yield expression is not allowed in formal parameters (2:3)",
     "SyntaxError: Binding invalid left-hand side in function parameter list (2:3)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-3/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-3/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":41,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (2:9)",
+    "SyntaxError: Yield expression is not allowed in formal parameters (2:9)",
     "SyntaxError: Binding invalid left-hand side in function parameter list (2:9)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/es2015/yield/yield-star-parameter-default-inside-generator/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/yield-star-parameter-default-inside-generator/output.json
@@ -2,8 +2,8 @@
   "type": "File",
   "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":33}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (1:17)",
-    "SyntaxError: yield is not allowed in generator parameters (1:24)"
+    "SyntaxError: Yield expression is not allowed in formal parameters (1:17)",
+    "SyntaxError: Yield expression is not allowed in formal parameters (1:24)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-default/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-default/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":38,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":38}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (1:21)"
+    "SyntaxError: Yield expression is not allowed in formal parameters (1:21)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameter/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameter/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":30,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":30}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (1:16)",
+    "SyntaxError: Yield expression is not allowed in formal parameters (1:16)",
     "SyntaxError: Binding invalid left-hand side in function parameter list (1:16)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameters/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameters/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":39,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":39}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (1:25)",
+    "SyntaxError: Yield expression is not allowed in formal parameters (1:25)",
     "SyntaxError: Binding invalid left-hand side in function parameter list (1:25)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/yield-generator-arrow-default/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/yield-generator-arrow-default/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":35}},
   "errors": [
-    "SyntaxError: yield is not allowed in generator parameters (1:21)"
+    "SyntaxError: Yield expression is not allowed in formal parameters (1:21)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-arrow/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-arrow/options.json
@@ -1,6 +1,8 @@
 {
-  "plugins": ["topLevelAwait"],
+  "plugins": [
+    "topLevelAwait"
+  ],
   "sourceType": "module",
   "errorRecovery": false,
-  "throws": "Can not use keyword 'await' outside an async function (1:6)"
+  "throws": "'await' is only valid in async functions and the top level bodies of modules (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-arrow/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-arrow/options.json
@@ -4,5 +4,5 @@
   ],
   "sourceType": "module",
   "errorRecovery": false,
-  "throws": "'await' is only valid in async functions and the top level bodies of modules (1:6)"
+  "throws": "'await' is only allowed within async functions and at the top levels of modules (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-function/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-function/options.json
@@ -1,6 +1,8 @@
 {
-  "plugins": ["topLevelAwait"],
+  "plugins": [
+    "topLevelAwait"
+  ],
   "sourceType": "module",
   "errorRecovery": false,
-  "throws": "Can not use keyword 'await' outside an async function (2:2)"
+  "throws": "'await' is only valid in async functions and the top level bodies of modules (2:2)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-function/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-function/options.json
@@ -4,5 +4,5 @@
   ],
   "sourceType": "module",
   "errorRecovery": false,
-  "throws": "'await' is only valid in async functions and the top level bodies of modules (2:2)"
+  "throws": "'await' is only allowed within async functions and at the top levels of modules (2:2)"
 }

--- a/packages/babel-preset-env/test/fixtures/top-level-await/unsupported/options.json
+++ b/packages/babel-preset-env/test/fixtures/top-level-await/unsupported/options.json
@@ -6,5 +6,5 @@
     "supportsTopLevelAwait": false
   },
   "presets": ["env"],
-  "throws": "Can not use keyword 'await' outside an async function (1:0)"
+  "throws": "'await' is only valid in async function (1:0)"
 }

--- a/packages/babel-preset-env/test/fixtures/top-level-await/unsupported/options.json
+++ b/packages/babel-preset-env/test/fixtures/top-level-await/unsupported/options.json
@@ -6,5 +6,5 @@
     "supportsTopLevelAwait": false
   },
   "presets": ["env"],
-  "throws": "'await' is only valid in async function (1:0)"
+  "throws": "'await' is only allowed within async functions (1:0)"
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Follow up to https://github.com/babel/babel/pull/12230#discussion_r509771691
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR updates `YieldInParameter` error messages and `AwaitNotInAsyncFunction` error messages. We also introduces a new `AwaitNotInAsyncContext` error messages, an alternative of `AwaitNotInAsyncFunction` when `topLevelAwait` is enabled.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12258"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/ad09b295783f9d92bc5e2ab911d38eae494ed3d5.svg" /></a>

