### PR TITLE
fix: babel-types: ImportDeclaration: add assertions

### DIFF
--- a/packages/babel-template/test/index.js
+++ b/packages/babel-template/test/index.js
@@ -215,6 +215,17 @@ describe("@babel/template", function () {
       expect(result.test.left).toBe(value);
     });
 
+    it("should return assertions when using .ast", () => {
+      const result = template.ast(
+        `import json from "./foo.json" assert { type: "json" };`,
+        {
+          plugins: ["importAssertions"],
+        },
+      );
+
+      expect(result.assertions[0].type).toBe("ImportAttribute");
+    });
+
     it("should replace JSX placeholder", () => {
       const result = template.expression(
         `

--- a/packages/babel-template/test/index.js
+++ b/packages/babel-template/test/index.js
@@ -215,11 +215,33 @@ describe("@babel/template", function () {
       expect(result.test.left).toBe(value);
     });
 
-    it("should return assertions when using .ast", () => {
+    it("should return assertions in ImportDeclaration when using .ast", () => {
       const result = template.ast(
         `import json from "./foo.json" assert { type: "json" };`,
         {
           plugins: ["importAssertions"],
+        },
+      );
+
+      expect(result.assertions[0].type).toBe("ImportAttribute");
+    });
+
+    it("should return assertions in ExportNamedDeclaration when using .ast", () => {
+      const result = template.ast(
+        `export { foo2 } from "foo.json" assert { type: "json" };`,
+        {
+          plugins: ["importAssertions"],
+        },
+      );
+
+      expect(result.assertions[0].type).toBe("ImportAttribute");
+    });
+
+    it("should return assertions in ExportDefaultDeclaration when using .ast", () => {
+      const result = template.ast(
+        `export foo2 from "foo.json" assert { type: "json" };`,
+        {
+          plugins: ["importAssertions", "exportDefaultFrom"],
         },
       );
 

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -1559,6 +1559,12 @@ defineType("ImportDeclaration", {
   visitor: ["specifiers", "source"],
   aliases: ["Statement", "Declaration", "ModuleDeclaration"],
   fields: {
+    assertions: {
+      validate: chain(
+        assertValueType("array"),
+        assertNodeType("ImportAttribute"),
+      ),
+    },
     specifiers: {
       validate: chain(
         assertValueType("array"),

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -1464,6 +1464,12 @@ defineType("ExportNamedDeclaration", {
         },
       ),
     },
+    assertions: {
+      validate: chain(
+        assertValueType("array"),
+        assertNodeType("ImportAttribute"),
+      ),
+    },
     specifiers: {
       default: [],
       validate: chain(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12262
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When using `template.ast` with code:

```js
import json from "./foo.json" assert { type: "json" };
```

Resulting `AST` contains no `assertions` field. This PR fixes this.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12263"><img src="https://gitpod.io/api/apps/github/pbs/github.com/coderaiser/babel.git/c2918df0aa0ccb9a7955f1a8e665bff5c736034d.svg" /></a>

