### PR TITLE
fix: disallow import assertions in export without from

### DIFF
--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1906,17 +1906,16 @@ export default class StatementParser extends ExpressionParser {
     if (this.eatContextual("from")) {
       node.source = this.parseImportSource();
       this.checkExport(node);
+      const assertions = this.maybeParseImportAssertions();
+      if (assertions) {
+        node.assertions = assertions;
+      }
     } else {
       if (expect) {
         this.unexpected();
       } else {
         node.source = null;
       }
-    }
-
-    const assertions = this.maybeParseImportAssertions();
-    if (assertions) {
-      node.assertions = assertions;
     }
 
     this.semicolon();

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/invalid-export-without-from/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/invalid-export-without-from/input.js
@@ -1,0 +1,2 @@
+const foo = 1;
+export { foo } assert { type: "json" };

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/invalid-export-without-from/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/invalid-export-without-from/options.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    [
+      "importAssertions"
+    ]
+  ],
+  "sourceType": "module",
+  "throws": "Unexpected token, expected \";\" (2:15)"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `export { foo } assert { type: "json" };` should be disallowed 
| Patch: Bug Fix?          | Y
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes a bug we introduced in #12249, import assertions should only be parsed when we have seen `from`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12264"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/c877a7af61aa48f3848b16df89ffabf446d420a6.svg" /></a>

