### PR TITLE
Support `.mjs` plugins/presets and async factories

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -53,7 +53,7 @@
     "@babel/types": "workspace:^7.12.1",
     "convert-source-map": "^1.7.0",
     "debug": "^4.1.0",
-    "gensync": "^1.0.0-beta.1",
+    "gensync": "^1.0.0-beta.2",
     "json5": "^2.1.2",
     "lodash": "^4.17.19",
     "resolve": "^1.3.2",

--- a/packages/babel-core/src/config/config-chain.js
+++ b/packages/babel-core/src/config/config-chain.js
@@ -154,7 +154,7 @@ export function* buildRootChain(
     programmaticLogger,
   );
   if (!programmaticChain) return null;
-  const programmaticReport = programmaticLogger.output();
+  const programmaticReport = yield* programmaticLogger.output();
 
   let configFile;
   if (typeof opts.configFile === "string") {
@@ -186,7 +186,7 @@ export function* buildRootChain(
       configFileLogger,
     );
     if (!result) return null;
-    configReport = configFileLogger.output();
+    configReport = yield* configFileLogger.output();
 
     // Allow config files to toggle `.babelrc` resolution on and off and
     // specify where the roots are.
@@ -244,7 +244,7 @@ export function* buildRootChain(
       if (!result) {
         isIgnored = true;
       } else {
-        babelRcReport = babelrcLogger.output();
+        babelRcReport = yield* babelrcLogger.output();
         mergeChain(fileChain, result);
       }
     }
@@ -599,7 +599,7 @@ function makeChainWalker<ArgT: { options: ValidatedOptions, dirname: string }>({
       }
 
       logger(config, index, envName);
-      mergeChainOpts(chain, config);
+      yield* mergeChainOpts(chain, config);
     }
     return chain;
   };
@@ -657,13 +657,13 @@ function mergeChain(target: ConfigChain, source: ConfigChain): ConfigChain {
   return target;
 }
 
-function mergeChainOpts(
+function* mergeChainOpts(
   target: ConfigChain,
   { options, plugins, presets }: OptionsAndDescriptors,
-): ConfigChain {
+): Handler<ConfigChain> {
   target.options.push(options);
-  target.plugins.push(...plugins());
-  target.presets.push(...presets());
+  target.plugins.push(...(yield* plugins()));
+  target.presets.push(...(yield* presets()));
 
   return target;
 }

--- a/packages/babel-core/src/config/files/index-browser.js
+++ b/packages/babel-core/src/config/files/index-browser.js
@@ -80,7 +80,7 @@ export function resolvePreset(name: string, dirname: string): string | null {
 export function loadPlugin(
   name: string,
   dirname: string,
-): { filepath: string, value: mixed } {
+): Handler<{ filepath: string, value: mixed }> {
   throw new Error(
     `Cannot load plugin ${name} relative to ${dirname} in a browser`,
   );
@@ -89,7 +89,7 @@ export function loadPlugin(
 export function loadPreset(
   name: string,
   dirname: string,
-): { filepath: string, value: mixed } {
+): Handler<{ filepath: string, value: mixed }> {
   throw new Error(
     `Cannot load preset ${name} relative to ${dirname} in a browser`,
   );

--- a/packages/babel-core/src/config/files/plugins.js
+++ b/packages/babel-core/src/config/files/plugins.js
@@ -7,6 +7,8 @@
 import buildDebug from "debug";
 import resolve from "resolve";
 import path from "path";
+import { type Handler } from "gensync";
+import loadCjsOrMjsDefault from "./module-types";
 
 const debug = buildDebug("babel:config:loading:files:plugins");
 
@@ -27,31 +29,31 @@ export function resolvePreset(name: string, dirname: string): string | null {
   return resolveStandardizedName("preset", name, dirname);
 }
 
-export function loadPlugin(
+export function* loadPlugin(
   name: string,
   dirname: string,
-): { filepath: string, value: mixed } {
+): Handler<{ filepath: string, value: mixed }> {
   const filepath = resolvePlugin(name, dirname);
   if (!filepath) {
     throw new Error(`Plugin ${name} not found relative to ${dirname}`);
   }
 
-  const value = requireModule("plugin", filepath);
+  const value = yield* requireModule("plugin", filepath);
   debug("Loaded plugin %o from %o.", name, dirname);
 
   return { filepath, value };
 }
 
-export function loadPreset(
+export function* loadPreset(
   name: string,
   dirname: string,
-): { filepath: string, value: mixed } {
+): Handler<{ filepath: string, value: mixed }> {
   const filepath = resolvePreset(name, dirname);
   if (!filepath) {
     throw new Error(`Preset ${name} not found relative to ${dirname}`);
   }
 
-  const value = requireModule("preset", filepath);
+  const value = yield* requireModule("preset", filepath);
 
   debug("Loaded preset %o from %o.", name, dirname);
 
@@ -140,7 +142,7 @@ function resolveStandardizedName(
 }
 
 const LOADING_MODULES = new Set();
-function requireModule(type: string, name: string): mixed {
+function* requireModule(type: string, name: string): Handler<mixed> {
   if (LOADING_MODULES.has(name)) {
     throw new Error(
       `Reentrant ${type} detected trying to load "${name}". This module is not ignored ` +
@@ -151,7 +153,19 @@ function requireModule(type: string, name: string): mixed {
 
   try {
     LOADING_MODULES.add(name);
-    return require(name);
+    return (yield* loadCjsOrMjsDefault(
+      name,
+      `You appear to be using a native ECMAScript module ${type}, ` +
+        "which is only supported when running Babel asynchronously.",
+      // For backward compatiblity, we need to support malformed presets
+      // defined as separate named exports rather than a single default
+      // export.
+      // See packages/babel-core/test/fixtures/option-manager/presets/es2015_named.js
+      true,
+    ): mixed);
+  } catch (err) {
+    err.message = `[BABEL]: ${err.message} (While processing: ${name})`;
+    throw err;
   } finally {
     LOADING_MODULES.delete(name);
   }

--- a/packages/babel-core/src/config/full.js
+++ b/packages/babel-core/src/config/full.js
@@ -214,8 +214,6 @@ function enhanceError<T: Function>(context, fn: T): T {
   }: any);
 }
 
-const ASYNC_PLUGIN_ERROR = `You appear to be using an async plugin/preset, but Babel has been called synchronously`;
-
 /**
  * Load a generic plugin/preset from the given descriptor loaded from the config object.
  */
@@ -230,7 +228,10 @@ const loadDescriptor = makeWeakCache(function* (
 
   let item = value;
   if (typeof value === "function") {
-    const factory = maybeAsync(value, ASYNC_PLUGIN_ERROR);
+    const factory = maybeAsync(
+      value,
+      `You appear to be using an async plugin/preset, but Babel has been called synchronously`,
+    );
 
     const api = {
       ...context,

--- a/packages/babel-core/src/config/item.js
+++ b/packages/babel-core/src/config/item.js
@@ -2,6 +2,7 @@
 
 /*:: declare var invariant; */
 
+import type { Handler } from "gensync";
 import type { PluginTarget, PluginOptions } from "./validation/options";
 
 import path from "path";
@@ -20,7 +21,7 @@ export function createItemFromDescriptor(desc: UnloadedDescriptor): ConfigItem {
  * ideally, as recreating the config item will mean re-resolving the item
  * and re-evaluating the plugin/preset function.
  */
-export function createConfigItem(
+export function* createConfigItem(
   value:
     | PluginTarget
     | [PluginTarget, PluginOptions]
@@ -32,8 +33,8 @@ export function createConfigItem(
     dirname?: string,
     type?: "preset" | "plugin",
   } = {},
-): ConfigItem {
-  const descriptor = createDescriptor(value, path.resolve(dirname), {
+): Handler<ConfigItem> {
+  const descriptor = yield* createDescriptor(value, path.resolve(dirname), {
     type,
     alias: "programmatic item",
   });

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -15,6 +15,7 @@ function assertNotIgnored(result) {
 function parse(code, opts) {
   return babel.parse(code, {
     cwd: __dirname,
+    configFile: false,
     ...opts,
   });
 }
@@ -22,6 +23,7 @@ function parse(code, opts) {
 function transform(code, opts) {
   return babel.transform(code, {
     cwd: __dirname,
+    configFile: false,
     ...opts,
   });
 }
@@ -31,6 +33,7 @@ function transformFile(filename, opts, cb) {
     filename,
     {
       cwd: __dirname,
+      configFile: false,
       ...opts,
     },
     cb,
@@ -39,6 +42,7 @@ function transformFile(filename, opts, cb) {
 function transformFileSync(filename, opts) {
   return babel.transformFileSync(filename, {
     cwd: __dirname,
+    configFile: false,
     ...opts,
   });
 }
@@ -46,6 +50,7 @@ function transformFileSync(filename, opts) {
 function transformAsync(code, opts) {
   return babel.transformAsync(code, {
     cwd: __dirname,
+    configFile: false,
     ...opts,
   });
 }
@@ -53,6 +58,7 @@ function transformAsync(code, opts) {
 function transformFromAst(ast, code, opts) {
   return babel.transformFromAst(ast, code, {
     cwd: __dirname,
+    configFile: false,
     ...opts,
   });
 }

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -217,7 +217,7 @@ describe("asynchronicity", () => {
     describe(".mjs files", () => {
       if (process.env.IS_PUBLISH) {
         it("called synchronously", async () => {
-          process.chdir("plugin-mjs");
+          process.chdir("plugin-mjs-native");
 
           await expect(compileInSpawedProcess(false)).rejects.toThrow(
             `[BABEL]: You appear to be using a native ECMAScript module plugin, which is` +
@@ -226,7 +226,7 @@ describe("asynchronicity", () => {
         });
 
         it("called asynchronously", async () => {
-          process.chdir("plugin-mjs");
+          process.chdir("plugin-mjs-native");
 
           await expect(compileInSpawedProcess(true)).resolves.toMatchObject({
             code: `"success"`,
@@ -300,7 +300,7 @@ describe("asynchronicity", () => {
     describe(".mjs files", () => {
       if (process.env.IS_PUBLISH) {
         it("called synchronously", async () => {
-          process.chdir("preset-mjs");
+          process.chdir("preset-mjs-native");
 
           await expect(compileInSpawedProcess(false)).rejects.toThrow(
             `[BABEL]: You appear to be using a native ECMAScript module preset, which is` +
@@ -309,7 +309,7 @@ describe("asynchronicity", () => {
         });
 
         it("called asynchronously", async () => {
-          process.chdir("preset-mjs");
+          process.chdir("preset-mjs-native");
 
           await expect(compileInSpawedProcess(true)).resolves.toMatchObject({
             code: `"success"`,
@@ -317,7 +317,7 @@ describe("asynchronicity", () => {
         });
 
         it("must use the 'default' export", async () => {
-          process.chdir("preset-mjs-named-exports");
+          process.chdir("preset-mjs-named-exports-native");
 
           await expect(compileInSpawedProcess(true)).rejects.toThrow(
             `Unexpected falsy value: undefined`,

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -1,4 +1,4 @@
-import path from "path";
+import { join } from "path";
 import * as babel from "..";
 
 const nodeGte8 = (...args) => {
@@ -8,7 +8,7 @@ const nodeGte8 = (...args) => {
 };
 
 describe("asynchronicity", () => {
-  const base = path.join(__dirname, "fixtures", "async");
+  const base = join(__dirname, "fixtures", "async");
   let cwd;
 
   beforeEach(function () {
@@ -106,14 +106,17 @@ describe("asynchronicity", () => {
     });
   });
 
+  const path = (...parts) => join(base, ...parts);
+
   describe("plugin", () => {
     describe("factory function", () => {
       nodeGte8("called synchronously", () => {
         process.chdir("plugin");
 
         expect(() => babel.transformSync("")).toThrow(
-          `[BABEL] unknown: You appear to be using an async plugin/preset, but Babel has been` +
-            ` called synchronously (While processing: "${__dirname}/fixtures/async/plugin/plugin.js")`,
+          `[BABEL] unknown: You appear to be using an async plugin/preset, but Babel` +
+            ` has been called synchronously (While processing: ` +
+            `"${path("plugin", "plugin.js")}")`,
         );
       });
 
@@ -185,7 +188,7 @@ describe("asynchronicity", () => {
         expect(() => babel.transformSync("")).toThrow(
           `[BABEL] unknown: You appear to be using an async plugin/preset, but Babel has been` +
             ` called synchronously (While processing: ` +
-            `"${__dirname}/fixtures/async/plugin-inherits/plugin.js$inherits")`,
+            `"${path("plugin-inherits", "plugin.js")}$inherits")`,
         );
       });
 
@@ -208,7 +211,7 @@ describe("asynchronicity", () => {
           expect(() => babel.transformSync("")).toThrow(
             `[BABEL]: You appear to be using a native ECMAScript module plugin, which is` +
               ` only supported when running Babel asynchronously. (While processing: ` +
-              `${__dirname}/fixtures/async/plugin-mjs/plugin.mjs)`,
+              `${path("plugin-mjs", "plugin.mjs")})`,
           );
         });
 
@@ -229,8 +232,9 @@ describe("asynchronicity", () => {
         process.chdir("preset");
 
         expect(() => babel.transformSync("")).toThrow(
-          `[BABEL] unknown: You appear to be using an async plugin/preset, but Babel has been` +
-            ` called synchronously (While processing: "${__dirname}/fixtures/async/preset/preset.js")`,
+          `[BABEL] unknown: You appear to be using an async plugin/preset, ` +
+            `but Babel has been called synchronously ` +
+            `(While processing: "${path("preset", "preset.js")}")`,
         );
       });
 
@@ -248,10 +252,11 @@ describe("asynchronicity", () => {
         process.chdir("preset-plugin-promise");
 
         expect(() => babel.transformSync("")).toThrow(
-          `[BABEL] unknown: You appear to be using a promise as a plugin, which your current version` +
-            ` of Babel does not support. If you're using a published plugin, you may need to upgrade` +
-            ` your @babel/core version. As an alternative, you can prefix the promise with "await". ` +
-            `(While processing: "${__dirname}/fixtures/async/preset-plugin-promise/preset.js$0")`,
+          `[BABEL] unknown: You appear to be using a promise as a plugin, which your` +
+            ` current version of Babel does not support. If you're using a published` +
+            ` plugin, you may need to upgrade your @babel/core version. As an` +
+            ` alternative, you can prefix the promise with "await". (While processing:` +
+            ` "${path("preset-plugin-promise", "preset.js")}$0")`,
         );
       });
 
@@ -259,10 +264,11 @@ describe("asynchronicity", () => {
         process.chdir("preset-plugin-promise");
 
         await expect(babel.transformAsync("")).rejects.toThrow(
-          `[BABEL] unknown: You appear to be using a promise as a plugin, which your current version` +
-            ` of Babel does not support. If you're using a published plugin, you may need to upgrade` +
-            ` your @babel/core version. As an alternative, you can prefix the promise with "await". ` +
-            `(While processing: "${__dirname}/fixtures/async/preset-plugin-promise/preset.js$0")`,
+          `[BABEL] unknown: You appear to be using a promise as a plugin, which your` +
+            ` current version of Babel does not support. If you're using a published` +
+            ` plugin, you may need to upgrade your @babel/core version. As an` +
+            ` alternative, you can prefix the promise with "await". (While processing:` +
+            ` "${path("preset-plugin-promise", "preset.js")}$0")`,
         );
       });
     });
@@ -277,7 +283,7 @@ describe("asynchronicity", () => {
           expect(() => babel.transformSync("")).toThrow(
             `[BABEL]: You appear to be using a native ECMAScript module preset, which is` +
               ` only supported when running Babel asynchronously. (While processing: ` +
-              `${__dirname}/fixtures/async/preset-mjs/preset.mjs)`,
+              `${path("preset-mjs", "preset.mjs")})`,
           );
         });
 
@@ -292,10 +298,8 @@ describe("asynchronicity", () => {
         nodeGte8("must use the 'default' export", async () => {
           process.chdir("preset-mjs-named-exports");
 
-          await expect(
-            babel.transformAsync(""),
-          ).rejects.toThrowErrorMatchingInlineSnapshot(
-            `"Unexpected falsy value: undefined"`,
+          await expect(babel.transformAsync("")).rejects.toThrow(
+            `Unexpected falsy value: undefined`,
           );
         });
       }

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -111,25 +111,18 @@ describe("asynchronicity", () => {
       nodeGte8("called synchronously", () => {
         process.chdir("plugin");
 
-        expect(() =>
-          babel.transformSync(""),
-        ).toThrowErrorMatchingInlineSnapshot(
-          `"[BABEL] unknown: You appear to be using an async plugin, which your current version of Babel` +
-            ` does not support. If you're using a published plugin, you may need to upgrade your` +
-            ` @babel/core version."`,
+        expect(() => babel.transformSync("")).toThrow(
+          `[BABEL] unknown: You appear to be using an async plugin/preset, but Babel has been` +
+            ` called synchronously (While processing: "${__dirname}/fixtures/async/plugin/plugin.js")`,
         );
       });
 
       nodeGte8("called asynchronously", async () => {
         process.chdir("plugin");
 
-        await expect(
-          babel.transformAsync(""),
-        ).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"[BABEL] unknown: You appear to be using an async plugin, which your current version of Babel` +
-            ` does not support. If you're using a published plugin, you may need to upgrade your` +
-            ` @babel/core version."`,
-        );
+        await expect(babel.transformAsync("")).resolves.toMatchObject({
+          code: `"success"`,
+        });
       });
     });
 
@@ -189,24 +182,63 @@ describe("asynchronicity", () => {
       nodeGte8("called synchronously", () => {
         process.chdir("plugin-inherits");
 
-        expect(() =>
-          babel.transformSync(""),
-        ).toThrowErrorMatchingInlineSnapshot(
-          `"[BABEL] unknown: You appear to be using an async plugin, which your current version of Babel` +
-            ` does not support. If you're using a published plugin, you may need to upgrade your` +
-            ` @babel/core version."`,
+        expect(() => babel.transformSync("")).toThrow(
+          `[BABEL] unknown: You appear to be using an async plugin/preset, but Babel has been` +
+            ` called synchronously (While processing: ` +
+            `"${__dirname}/fixtures/async/plugin-inherits/plugin.js$inherits")`,
         );
       });
 
       nodeGte8("called asynchronously", async () => {
         process.chdir("plugin-inherits");
 
-        await expect(
-          babel.transformAsync(""),
-        ).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"[BABEL] unknown: You appear to be using an async plugin, which your current version of Babel` +
-            ` does not support. If you're using a published plugin, you may need to upgrade your` +
-            ` @babel/core version."`,
+        await expect(babel.transformAsync("")).resolves.toMatchObject({
+          code: `"success 2"\n"success"`,
+        });
+      });
+    });
+  });
+
+  describe("preset", () => {
+    describe("factory function", () => {
+      nodeGte8("called synchronously", () => {
+        process.chdir("preset");
+
+        expect(() => babel.transformSync("")).toThrow(
+          `[BABEL] unknown: You appear to be using an async plugin/preset, but Babel has been` +
+            ` called synchronously (While processing: "${__dirname}/fixtures/async/preset/preset.js")`,
+        );
+      });
+
+      nodeGte8("called asynchronously", async () => {
+        process.chdir("preset");
+
+        await expect(babel.transformAsync("")).resolves.toMatchObject({
+          code: `"success"`,
+        });
+      });
+    });
+
+    describe("plugins", () => {
+      nodeGte8("called synchronously", () => {
+        process.chdir("preset-plugin-promise");
+
+        expect(() => babel.transformSync("")).toThrow(
+          `[BABEL] unknown: You appear to be using a promise as a plugin, which your current version` +
+            ` of Babel does not support. If you're using a published plugin, you may need to upgrade` +
+            ` your @babel/core version. As an alternative, you can prefix the promise with "await". ` +
+            `(While processing: "${__dirname}/fixtures/async/preset-plugin-promise/preset.js$0")`,
+        );
+      });
+
+      nodeGte8("called asynchronously", async () => {
+        process.chdir("preset-plugin-promise");
+
+        await expect(babel.transformAsync("")).rejects.toThrow(
+          `[BABEL] unknown: You appear to be using a promise as a plugin, which your current version` +
+            ` of Babel does not support. If you're using a published plugin, you may need to upgrade` +
+            ` your @babel/core version. As an alternative, you can prefix the promise with "await". ` +
+            `(While processing: "${__dirname}/fixtures/async/preset-plugin-promise/preset.js$0")`,
         );
       });
     });

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -16,7 +16,6 @@ async function compileInSpawedProcess(async) {
   // please publish Babel on a modernized node :)
   const { stdout, stderr } = await util.promisify(cp.execFile)(
     require.resolve(`./fixtures/babel-compile-${async ? "async" : "sync"}.mjs`),
-    { env: process.env },
   );
   if (stderr) {
     throw new Error(stderr);

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -197,6 +197,30 @@ describe("asynchronicity", () => {
         });
       });
     });
+
+    describe(".mjs files", () => {
+      if (process.env.IS_PUBLISH) {
+        0;
+      } else {
+        nodeGte8("called synchronously", () => {
+          process.chdir("plugin-mjs");
+
+          expect(() => babel.transformSync("")).toThrow(
+            `[BABEL]: You appear to be using a native ECMAScript module plugin, which is` +
+              ` only supported when running Babel asynchronously. (While processing: ` +
+              `${__dirname}/fixtures/async/plugin-mjs/plugin.mjs)`,
+          );
+        });
+
+        nodeGte8("called asynchronously", async () => {
+          process.chdir("plugin-mjs");
+
+          await expect(babel.transformAsync("")).resolves.toMatchObject({
+            code: `"success"`,
+          });
+        });
+      }
+    });
   });
 
   describe("preset", () => {
@@ -241,6 +265,40 @@ describe("asynchronicity", () => {
             `(While processing: "${__dirname}/fixtures/async/preset-plugin-promise/preset.js$0")`,
         );
       });
+    });
+
+    describe(".mjs files", () => {
+      if (process.env.IS_PUBLISH) {
+        0;
+      } else {
+        nodeGte8("called synchronously", () => {
+          process.chdir("preset-mjs");
+
+          expect(() => babel.transformSync("")).toThrow(
+            `[BABEL]: You appear to be using a native ECMAScript module preset, which is` +
+              ` only supported when running Babel asynchronously. (While processing: ` +
+              `${__dirname}/fixtures/async/preset-mjs/preset.mjs)`,
+          );
+        });
+
+        nodeGte8("called asynchronously", async () => {
+          process.chdir("preset-mjs");
+
+          await expect(babel.transformAsync("")).resolves.toMatchObject({
+            code: `"success"`,
+          });
+        });
+
+        nodeGte8("must use the 'default' export", async () => {
+          process.chdir("preset-mjs-named-exports");
+
+          await expect(
+            babel.transformAsync(""),
+          ).rejects.toThrowErrorMatchingInlineSnapshot(
+            `"Unexpected falsy value: undefined"`,
+          );
+        });
+      }
     });
   });
 });

--- a/packages/babel-core/test/fixtures/async/plugin-mjs-native/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/plugin-mjs-native/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["./plugin.mjs"],
+};

--- a/packages/babel-core/test/fixtures/async/plugin-mjs-native/plugin.mjs
+++ b/packages/babel-core/test/fixtures/async/plugin-mjs-native/plugin.mjs
@@ -1,0 +1,9 @@
+export default function plugin({ types: t }) {
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+}

--- a/packages/babel-core/test/fixtures/async/plugin-mjs/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/plugin-mjs/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["./plugin.mjs"],
+};

--- a/packages/babel-core/test/fixtures/async/plugin-mjs/plugin.mjs
+++ b/packages/babel-core/test/fixtures/async/plugin-mjs/plugin.mjs
@@ -1,0 +1,16 @@
+// Until Jest supports native mjs, we must simulate it 🤷
+module.exports = new Promise(resolve =>
+  resolve({
+    default: function plugin({ types: t }) {
+      return {
+        visitor: {
+          Program(path) {
+            path.pushContainer("body", t.stringLiteral("success"));
+          },
+        },
+      };
+    },
+  })
+);
+
+module.exports.__esModule = true;

--- a/packages/babel-core/test/fixtures/async/preset-mjs-named-exports-native/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/preset-mjs-named-exports-native/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ["./preset.mjs"],
+};

--- a/packages/babel-core/test/fixtures/async/preset-mjs-named-exports-native/plugin.mjs
+++ b/packages/babel-core/test/fixtures/async/preset-mjs-named-exports-native/plugin.mjs
@@ -1,0 +1,9 @@
+export default function plugin({ types: t }) {
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+}

--- a/packages/babel-core/test/fixtures/async/preset-mjs-named-exports-native/preset.mjs
+++ b/packages/babel-core/test/fixtures/async/preset-mjs-named-exports-native/preset.mjs
@@ -1,0 +1,1 @@
+export const plugins = ["./plugin.mjs"];

--- a/packages/babel-core/test/fixtures/async/preset-mjs-named-exports/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/preset-mjs-named-exports/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ["./preset.mjs"],
+};

--- a/packages/babel-core/test/fixtures/async/preset-mjs-named-exports/plugin.mjs
+++ b/packages/babel-core/test/fixtures/async/preset-mjs-named-exports/plugin.mjs
@@ -1,0 +1,16 @@
+// Until Jest supports native mjs, we must simulate it 🤷
+module.exports = new Promise(resolve =>
+  resolve({
+    default: function plugin({ types: t }) {
+      return {
+        visitor: {
+          Program(path) {
+            path.pushContainer("body", t.stringLiteral("success"));
+          },
+        },
+      };
+    },
+  })
+);
+
+module.exports.__esModule = true;

--- a/packages/babel-core/test/fixtures/async/preset-mjs-named-exports/preset.mjs
+++ b/packages/babel-core/test/fixtures/async/preset-mjs-named-exports/preset.mjs
@@ -1,0 +1,8 @@
+// Until Jest supports native mjs, we must simulate it 🤷
+module.exports = new Promise(resolve =>
+  resolve({
+    plugins: ["./plugin.mjs"]
+  })
+);
+
+module.exports.__esModule = true;

--- a/packages/babel-core/test/fixtures/async/preset-mjs-native/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/preset-mjs-native/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ["./preset.mjs"],
+};

--- a/packages/babel-core/test/fixtures/async/preset-mjs-native/plugin.mjs
+++ b/packages/babel-core/test/fixtures/async/preset-mjs-native/plugin.mjs
@@ -1,0 +1,9 @@
+export default function plugin({ types: t }) {
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+}

--- a/packages/babel-core/test/fixtures/async/preset-mjs-native/preset.mjs
+++ b/packages/babel-core/test/fixtures/async/preset-mjs-native/preset.mjs
@@ -1,0 +1,3 @@
+export default () => ({
+  plugins: ["./plugin.mjs"]
+});

--- a/packages/babel-core/test/fixtures/async/preset-mjs/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/preset-mjs/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ["./preset.mjs"],
+};

--- a/packages/babel-core/test/fixtures/async/preset-mjs/plugin.mjs
+++ b/packages/babel-core/test/fixtures/async/preset-mjs/plugin.mjs
@@ -1,0 +1,16 @@
+// Until Jest supports native mjs, we must simulate it 🤷
+module.exports = new Promise(resolve =>
+  resolve({
+    default: function plugin({ types: t }) {
+      return {
+        visitor: {
+          Program(path) {
+            path.pushContainer("body", t.stringLiteral("success"));
+          },
+        },
+      };
+    },
+  })
+);
+
+module.exports.__esModule = true;

--- a/packages/babel-core/test/fixtures/async/preset-mjs/preset.mjs
+++ b/packages/babel-core/test/fixtures/async/preset-mjs/preset.mjs
@@ -1,0 +1,10 @@
+// Until Jest supports native mjs, we must simulate it 🤷
+module.exports = new Promise(resolve =>
+  resolve({
+    default: () => ({
+      plugins: ["./plugin.mjs"]
+    })
+  })
+);
+
+module.exports.__esModule = true;

--- a/packages/babel-core/test/fixtures/async/preset-plugin-promise/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/preset-plugin-promise/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ["./preset"],
+};

--- a/packages/babel-core/test/fixtures/async/preset-plugin-promise/plugin.js
+++ b/packages/babel-core/test/fixtures/async/preset-plugin-promise/plugin.js
@@ -1,0 +1,13 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+module.exports = async function plugin({ types: t }) {
+  await wait(50);
+
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/preset-plugin-promise/preset.js
+++ b/packages/babel-core/test/fixtures/async/preset-plugin-promise/preset.js
@@ -1,0 +1,10 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+// "Dynamic import"
+const import_ = path => Promise.resolve(require(path));
+
+module.exports = function preset(api) {
+  return {
+    plugins: [import_("./plugin")],
+  };
+};

--- a/packages/babel-core/test/fixtures/async/preset/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/preset/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ["./preset"],
+};

--- a/packages/babel-core/test/fixtures/async/preset/plugin.js
+++ b/packages/babel-core/test/fixtures/async/preset/plugin.js
@@ -1,0 +1,13 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+module.exports = async function plugin({ types: t }) {
+  await wait(50);
+
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/preset/preset.js
+++ b/packages/babel-core/test/fixtures/async/preset/preset.js
@@ -1,0 +1,9 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+module.exports = async function preset(api) {
+  await wait(50);
+
+  return {
+    plugins: [require("./plugin")],
+  };
+};

--- a/packages/babel-core/test/fixtures/babel-compile-async.mjs
+++ b/packages/babel-core/test/fixtures/babel-compile-async.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+// Usage:
+// babel-compile-async.js [filename]
+import babel from "../../lib/index.js";
+
+(async () => {
+  process.stdout.write(
+    JSON.stringify(await babel.transformAsync(""))
+  );
+})();

--- a/packages/babel-core/test/fixtures/babel-compile-sync.mjs
+++ b/packages/babel-core/test/fixtures/babel-compile-sync.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+// Usage:
+// babel-compile-async.js [filename]
+import babel from "../../lib/index.js";
+
+process.stdout.write(
+  JSON.stringify(babel.transformSync(""))
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,7 +138,7 @@ __metadata:
     "@babel/types": "workspace:^7.12.1"
     convert-source-map: ^1.7.0
     debug: ^4.1.0
-    gensync: ^1.0.0-beta.1
+    gensync: ^1.0.0-beta.2
     json5: ^2.1.2
     lodash: ^4.17.19
     resolve: ^1.3.2
@@ -7510,10 +7510,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"gensync@npm:^1.0.0-beta.1":
-  version: 1.0.0-beta.1
-  resolution: "gensync@npm:1.0.0-beta.1"
-  checksum: 3d14f7c34fc903dd52c36d0879de2c4afde8315edccd630e97919c365819b32c06d98770ef87f7ba45686ee5d2bd5818354920187659b42828319f7cc3352fdb
+"gensync@npm:^1.0.0-beta.1, gensync@npm:^1.0.0-beta.2":
+  version: 1.0.0-beta.2
+  resolution: "gensync@npm:1.0.0-beta.2"
+  checksum: d523437689c97b3aba9c5cdeca4677d5fff9a29d620db693fea40d852bad63563110f16979d0170248439dbcd2ecee0780fb2533d3f0519f019081aa10767c60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is the first step needed to migrate to native ECMAScript modules: we must support loading `.mjs` plugins and presets :stuck_out_tongue:

- The first commit is mostly needed for third-party presets: many of them directly use `require()` inside the preset factory, and this makes it possible to use `await import()` instead.
- The second commit enables loading `.mjs` plugins/presets. It's mostly functions being converted to generators to work with `gensync`.

While preparing this PR, I noticed that we currently support this kind of presets:
```js
exports.__esModule = true;
exports.plugins = [foo];
```
which is the result of transpiling
```js
export const plugins = [foo];
```

However, we throw an error for
```js
exports.__esModule = true
exports.default = { plugins: [foo] }
```
because presets must export a function, and not a plain object:
```js
exports.__esModule = true
exports.default = function () {
  return { plugins: [foo] };
};
```

Since presets must export a function (so that they can properly configure caching), I didn't implement support for the named exports in `.mjs` files.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12266"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/52e0f20e588e560e184329b521422696585a48be.svg" /></a>

