### PR TITLE
Fix README link in 'babel-preset-env'.

### DIFF
--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -2,7 +2,7 @@
 
 > A Babel preset for each environment.
 
-See our website [@babel/preset-env](https://babeljs.io/docs/en/next/babel-preset-env.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20preset-env%22+is%3Aopen) associated with this package.
+See our website [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20preset-env%22+is%3Aopen) associated with this package.
 
 ## Install
 


### PR DESCRIPTION
`babel-preset-env` README link (https://babeljs.io/docs/en/next/babel-preset-env.html) is redirecting to Babel documentation index page. I've update it to point to `@babel/preset-env` documentation page (https://babeljs.io/docs/en/babel-preset-env).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12287"><img src="https://gitpod.io/api/apps/github/pbs/github.com/mondeja/babel.git/4bc7d4e154be1bfb31441d9b12c464578014d3af.svg" /></a>

