### PR TITLE
Don't compile `import()` in development

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,11 +14,9 @@ module.exports = function (api) {
   const envOptsNoTargets = {
     loose: true,
     shippedProposals: true,
+    modules: false,
   };
   const envOpts = Object.assign({}, envOptsNoTargets);
-
-  const compileDynamicImport =
-    env === "test" || env === "development" || env === "test-legacy";
 
   let convertESM = true;
   let ignoreLib = true;
@@ -111,9 +109,8 @@ module.exports = function (api) {
         "@babel/proposal-object-rest-spread",
         { useBuiltIns: true, loose: true },
       ],
-      compileDynamicImport ? dynamicImportUrlToPath : null,
-      compileDynamicImport ? "@babel/plugin-proposal-dynamic-import" : null,
 
+      convertESM ? "@babel/proposal-export-namespace-from" : null,
       convertESM ? "@babel/transform-modules-commonjs" : null,
     ].filter(Boolean),
     overrides: [
@@ -159,45 +156,3 @@ module.exports = function (api) {
 
   return config;
 };
-
-// !!! WARNING !!! Hacks are coming
-
-// import() uses file:// URLs for absolute imports, while require() uses
-// file paths.
-// Since this isn't handled by @babel/plugin-transform-modules-commonjs,
-// we must handle it here.
-// However, fileURLToPath is only supported starting from Node.js 10.
-// In older versions, we can remove the pathToFileURL call so that it keeps
-// the original absolute path.
-// NOTE: This plugin must run before @babel/plugin-transform-modules-commonjs,
-// and assumes that the target is the current node version.
-function dynamicImportUrlToPath({ template, env }) {
-  const currentNodeSupportsURL =
-    !!require("url").pathToFileURL && env() !== "test-legacy"; // test-legacy is run on legacy node versions without pathToFileURL support
-  if (currentNodeSupportsURL) {
-    return {
-      visitor: {
-        CallExpression(path) {
-          if (path.get("callee").isImport()) {
-            path.get("arguments.0").replaceWith(
-              template.expression.ast`
-              require("url").fileURLToPath(${path.node.arguments[0]})
-            `
-            );
-          }
-        },
-      },
-    };
-  } else {
-    // TODO: Remove in Babel 8 (it's not needed when using Node 10)
-    return {
-      visitor: {
-        CallExpression(path) {
-          if (path.get("callee").isIdentifier({ name: "pathToFileURL" })) {
-            path.replaceWith(path.get("arguments.0"));
-          }
-        },
-      },
-    };
-  }
-}

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -1,5 +1,4 @@
 import path from "path";
-import { pathToFileURL } from "url";
 import escope from "eslint-scope";
 import unpad from "dedent";
 import { parseForESLint } from "../src";
@@ -80,7 +79,7 @@ describe("Babel and Espree", () => {
       paths: [path.dirname(require.resolve("eslint"))],
     });
 
-    espree = await import(pathToFileURL(espreePath));
+    espree = require(espreePath);
   });
 
   describe("compatibility", () => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/eslint-parser": "workspace:*",
     "@babel/eslint-plugin-development": "workspace:*",
     "@babel/eslint-plugin-development-internal": "workspace:*",
-    "@babel/plugin-proposal-dynamic-import": "^7.10.4",
+    "@babel/plugin-proposal-export-namespace-from": "^7.12.1",
     "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
     "@babel/plugin-transform-for-of": "^7.10.4",
     "@babel/plugin-transform-modules-commonjs": "^7.10.4",

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -87,7 +87,10 @@ async function loadOptionsAsyncInSpawedProcess({ filename, cwd }) {
       env: process.env,
     },
   );
-  if (stderr) {
+
+  const EXPERIMENTAL_WARNING = /\(node:\d+\) ExperimentalWarning: The ESM module loader is experimental\./;
+
+  if (stderr.replace(EXPERIMENTAL_WARNING, "").trim()) {
     throw new Error(
       "error is thrown in babel-load-options-async.mjs: stdout\n" +
         stdout +

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -14,7 +14,7 @@ const isMJS = file => file.slice(-4) === ".mjs";
 const skipUnsupportedESM = (esm, name) => {
   if (esm && !supportsESM) {
     console.warn(
-      `Skipping ${name} because native ECMAScript modules are not supported.`,
+      `Skipping "${name}" because native ECMAScript modules are not supported.`,
     );
     return true;
   }

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -18,6 +18,12 @@ const skipUnsupportedESM = (esm, name) => {
     );
     return true;
   }
+  if (esm && process.platform === "win32") {
+    console.warn(
+      `Skipping "${name}" because the ESM runner cannot be spawned on Windows.`,
+    );
+    return true;
+  }
   return false;
 };
 

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -6,6 +6,21 @@ import util from "util";
 import escapeRegExp from "lodash/escapeRegExp";
 import * as babel from "../lib";
 
+// "minNodeVersion": "10.0.0" <-- For Ctrl+F when dropping node 10
+const supportsESM = parseInt(process.versions.node) >= 12;
+
+const isMJS = file => file.slice(-4) === ".mjs";
+
+const skipUnsupportedESM = (esm, name) => {
+  if (esm && !supportsESM) {
+    console.warn(
+      `Skipping ${name} because native ECMAScript modules are not supported.`,
+    );
+    return true;
+  }
+  return false;
+};
+
 // TODO: In Babel 8, we can directly uses fs.promises which is supported by
 // node 8+
 const pfs =
@@ -49,8 +64,13 @@ function loadOptions(opts) {
   return babel.loadOptions({ cwd: __dirname, ...opts });
 }
 
-function loadOptionsAsync(opts) {
-  return babel.loadOptionsAsync({ cwd: __dirname, ...opts });
+function loadOptionsAsync({ filename, cwd = __dirname }, mjs) {
+  if (mjs) {
+    // import() crashes with jest
+    return loadOptionsAsyncInSpawedProcess({ filename, cwd });
+  }
+
+  return babel.loadOptionsAsync({ filename, cwd });
 }
 
 async function loadOptionsAsyncInSpawedProcess({ filename, cwd }) {
@@ -88,10 +108,11 @@ function pairs(items) {
   return pairs;
 }
 
-async function getTemp(name, fixtureFolder = "config-files-templates") {
+async function getTemp(name) {
   const cwd = await pfs.mkdtemp(os.tmpdir() + path.sep + name);
   const tmp = name => path.join(cwd, name);
-  const config = name => pfs.copyFile(fixture(fixtureFolder, name), tmp(name));
+  const config = name =>
+    pfs.copyFile(fixture("config-files-templates", name), tmp(name));
   return { cwd, tmp, config };
 }
 
@@ -1060,16 +1081,17 @@ describe("buildConfigChain", function () {
         );
       });
 
-      test.each(
-        [
-          "babel.config.json",
-          "babel.config.js",
-          "babel.config.cjs",
-          // We can't transpile import() while publishing, and it isn't supported
-          // by jest.
-          process.env.IS_PUBLISH ? "" : "babel.config.mjs",
-        ].filter(Boolean),
-      )("should load %s asynchronously", async name => {
+      test.each([
+        "babel.config.json",
+        "babel.config.js",
+        "babel.config.cjs",
+        "babel.config.mjs",
+      ])("should load %s asynchronously", async name => {
+        const esm = isMJS(name);
+        if (skipUnsupportedESM(esm, `should load ${name} asynchronously`)) {
+          return;
+        }
+
         const { cwd, tmp, config } = await getTemp(
           `babel-test-load-config-async-${name}`,
         );
@@ -1077,13 +1099,15 @@ describe("buildConfigChain", function () {
 
         await config(name);
 
-        expect(await loadOptionsAsync({ filename, cwd })).toEqual({
-          ...getDefaults(),
-          filename,
-          cwd,
-          root: cwd,
-          comments: true,
-        });
+        await expect(loadOptionsAsync({ filename, cwd }, esm)).resolves.toEqual(
+          {
+            ...getDefaults(),
+            filename,
+            cwd,
+            root: cwd,
+            comments: true,
+          },
+        );
       });
 
       test.each(
@@ -1094,48 +1118,26 @@ describe("buildConfigChain", function () {
           "babel.config.mjs",
         ]),
       )("should throw if both %s and %s are used", async (name1, name2) => {
-        const { cwd, tmp, config } = await getTemp(
-          `babel-test-dup-config-${name1}-${name2}`,
-        );
-
-        // We can't transpile import() while publishing, and it isn't supported
-        // by jest.
+        const esm = isMJS(name1) || isMJS(name2);
         if (
-          process.env.IS_PUBLISH &&
-          (name1 === "babel.config.mjs" || name2 === "babel.config.mjs")
+          skipUnsupportedESM(
+            esm,
+            `should throw if both ${name1} and ${name2} are used`,
+          )
         ) {
           return;
         }
 
+        const { cwd, tmp, config } = await getTemp(
+          `babel-test-dup-config-${name1}-${name2}`,
+        );
+
         await Promise.all([config(name1), config(name2)]);
 
         await expect(
-          loadOptionsAsync({ filename: tmp("src.js"), cwd }),
+          loadOptionsAsync({ filename: tmp("src.js"), cwd }, esm),
         ).rejects.toThrow(/Multiple configuration files found/);
       });
-
-      if (process.env.IS_PUBLISH) {
-        test.each(["babel.config.mjs", ".babelrc.mjs"])(
-          "should load %s asynchronously",
-          async name => {
-            const { cwd, tmp, config } = await getTemp(
-              `babel-test-load-config-async-prepublish-${name}`,
-              "config-files-templates-prepublish",
-            );
-            const filename = tmp("src.js");
-            await config(name);
-            expect(
-              await loadOptionsAsyncInSpawedProcess({ filename, cwd }),
-            ).toEqual({
-              ...getDefaults(),
-              filename,
-              cwd,
-              root: cwd,
-              comments: true,
-            });
-          },
-        );
-      }
     });
 
     describe("relative", () => {
@@ -1181,11 +1183,14 @@ describe("buildConfigChain", function () {
           ".babelrc",
           ".babelrc.js",
           ".babelrc.cjs",
-          // We can't transpile import() while publishing, and it isn't supported
-          // by jest.
-          process.env.IS_PUBLISH ? "" : "babel.config.mjs",
+          ".babelrc.mjs",
         ].filter(Boolean),
       )("should load %s asynchronously", async name => {
+        const esm = isMJS(name);
+        if (skipUnsupportedESM(esm, `should load ${name} asynchronously`)) {
+          return;
+        }
+
         const { cwd, tmp, config } = await getTemp(
           `babel-test-load-config-${name}`,
         );
@@ -1193,13 +1198,15 @@ describe("buildConfigChain", function () {
 
         await config(name);
 
-        expect(await loadOptionsAsync({ filename, cwd })).toEqual({
-          ...getDefaults(),
-          filename,
-          cwd,
-          root: cwd,
-          comments: true,
-        });
+        await expect(loadOptionsAsync({ filename, cwd }, esm)).resolves.toEqual(
+          {
+            ...getDefaults(),
+            filename,
+            cwd,
+            root: cwd,
+            comments: true,
+          },
+        );
       });
 
       it("should load .babelignore", () => {
@@ -1220,23 +1227,24 @@ describe("buildConfigChain", function () {
           ".babelrc.json",
         ]),
       )("should throw if both %s and %s are used", async (name1, name2) => {
-        const { cwd, tmp, config } = await getTemp(
-          `babel-test-dup-config-${name1}-${name2}`,
-        );
-
-        // We can't transpile import() while publishing, and it isn't supported
-        // by jest.
+        const esm = isMJS(name1) || isMJS(name2);
         if (
-          process.env.IS_PUBLISH &&
-          (name1 === ".babelrc.mjs" || name2 === ".babelrc.mjs")
+          skipUnsupportedESM(
+            esm,
+            `should throw if both ${name1} and ${name2} are used`,
+          )
         ) {
           return;
         }
 
+        const { cwd, tmp, config } = await getTemp(
+          `babel-test-dup-config-${name1}-${name2}`,
+        );
+
         await Promise.all([config(name1), config(name2)]);
 
         await expect(
-          loadOptionsAsync({ filename: tmp("src.js"), cwd }),
+          loadOptionsAsync({ filename: tmp("src.js"), cwd }, esm),
         ).rejects.toThrow(/Multiple configuration files found/);
       });
 
@@ -1260,17 +1268,23 @@ describe("buildConfigChain", function () {
         ${".babelrc.cjs"}  | ${"babelrc-cjs-error"}  | ${/Babelrc threw an error/}
         ${".babelrc.mjs"}  | ${"babelrc-mjs-error"}  | ${/Babelrc threw an error/}
         ${"package.json"}  | ${"pkg-error"}          | ${/Error while parsing JSON - /}
-      `("should show helpful errors for $config", async ({ dir, error }) => {
-        const filename = fixture("config-files", dir, "src.js");
+      `(
+        "should show helpful errors for $config",
+        async ({ config, dir, error }) => {
+          const esm = isMJS(config);
+          if (
+            skipUnsupportedESM(esm, `should show helpful errors for ${config}`)
+          ) {
+            return;
+          }
 
-        // We can't transpile import() while publishing, and it isn't supported
-        // by jest.
-        if (process.env.IS_PUBLISH && dir === "babelrc-mjs-error") return;
+          const filename = fixture("config-files", dir, "src.js");
 
-        await expect(
-          loadOptionsAsync({ filename, cwd: path.dirname(filename) }),
-        ).rejects.toThrow(error);
-      });
+          await expect(
+            loadOptionsAsync({ filename, cwd: path.dirname(filename) }, esm),
+          ).rejects.toThrow(error);
+        },
+      );
 
       it("loadPartialConfig should return a list of files that were extended", () => {
         const filename = fixture("config-files", "babelrc-extended", "src.js");

--- a/packages/babel-core/test/fixtures/config/config-files-templates-prepublish/.babelrc.mjs
+++ b/packages/babel-core/test/fixtures/config/config-files-templates-prepublish/.babelrc.mjs
@@ -1,3 +1,0 @@
-export default {
-  comments: true,
-};

--- a/packages/babel-core/test/fixtures/config/config-files-templates-prepublish/babel.config.mjs
+++ b/packages/babel-core/test/fixtures/config/config-files-templates-prepublish/babel.config.mjs
@@ -1,3 +1,0 @@
-export default {
-  comments: true,
-};

--- a/packages/babel-core/test/fixtures/config/config-files-templates/.babelrc.mjs
+++ b/packages/babel-core/test/fixtures/config/config-files-templates/.babelrc.mjs
@@ -1,8 +1,3 @@
-// Until Jest supports native mjs, we must simulate it 🤷
-
-module.exports = new Promise(resolve => resolve({
-  default: {
-    comments: true
-  }
-}));
-module.exports.__esModule = true;
+export default {
+  comments: true,
+};

--- a/packages/babel-core/test/fixtures/config/config-files-templates/babel.config.mjs
+++ b/packages/babel-core/test/fixtures/config/config-files-templates/babel.config.mjs
@@ -1,8 +1,3 @@
-// Until Jest supports native mjs, we must simulate it 🤷
-
-module.exports = new Promise(resolve => resolve({
-  default: {
-    comments: true
-  }
-}));
-module.exports.__esModule = true;
+export default {
+  comments: true,
+};

--- a/packages/babel-core/test/fixtures/config/config-files/babelrc-mjs-error/.babelrc.mjs
+++ b/packages/babel-core/test/fixtures/config/config-files/babelrc-mjs-error/.babelrc.mjs
@@ -1,8 +1,1 @@
-// Until Jest supports native mjs, we must simulate it 🤷
-
-module.exports = new Promise(resolve => resolve({
-  default: function () {
-    throw new Error("Babelrc threw an error");
-  }
-}));
-module.exports.__esModule = true;
+throw new Error("Babelrc threw an error");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,6 +1089,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-export-namespace-from@npm:^7.12.1":
+  version: 7.12.1
+  resolution: "@babel/plugin-proposal-export-namespace-from@npm:7.12.1"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: ae5317ca008cc9eb2890b1f238156fbb990e5030fd1b7f123a5d11d89f8617a867b11db129aeafe51ef3bb4dddc4059e8172ddf99e8cdc42cbfa2a45dce1a16b
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-export-namespace-from@workspace:*, @babel/plugin-proposal-export-namespace-from@workspace:^7.12.1, @babel/plugin-proposal-export-namespace-from@workspace:packages/babel-plugin-proposal-export-namespace-from":
   version: 0.0.0-use.local
   resolution: "@babel/plugin-proposal-export-namespace-from@workspace:packages/babel-plugin-proposal-export-namespace-from"
@@ -4696,7 +4708,7 @@ __metadata:
     "@babel/eslint-parser": "workspace:*"
     "@babel/eslint-plugin-development": "workspace:*"
     "@babel/eslint-plugin-development-internal": "workspace:*"
-    "@babel/plugin-proposal-dynamic-import": ^7.10.4
+    "@babel/plugin-proposal-export-namespace-from": ^7.12.1
     "@babel/plugin-proposal-object-rest-spread": ^7.11.0
     "@babel/plugin-transform-for-of": ^7.10.4
     "@babel/plugin-transform-modules-commonjs": ^7.10.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,19 +1077,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/plugin-proposal-export-namespace-from@npm:^7.12.0":
-  version: 7.12.0
-  resolution: "@babel/plugin-proposal-export-namespace-from@npm:7.12.0"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.10.4
-    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 371d59486a28445f51352b498d22c372de6b8ae59f44a0d62de626498f162372b596430bedbc869e1ea6c0397aa1cb33dc806e7872da6d67625316fb8a019023
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-proposal-export-namespace-from@npm:^7.12.1":
+"@babel/plugin-proposal-export-namespace-from@npm:^7.12.0, @babel/plugin-proposal-export-namespace-from@npm:^7.12.1":
   version: 7.12.1
   resolution: "@babel/plugin-proposal-export-namespace-from@npm:7.12.1"
   dependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

With this PR, we:
1. Stop compiling `import()` to require in development
2. Align prepublish tests with "normal" tests
3. Always test the native `import()` when it's supported, and skip those tests in older Node.js versions

I wanted to use the native Jest support for `import()`, but I'm getting some segmentation faults so this PR doesn't remove the `loadOptionsAsyncInSpawedProcess` hack.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12288"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/c12b4135286ba3675d2bc188a22fe54fba4b8adb.svg" /></a>

