### PR TITLE
Fix packages documentation README links.

### DIFF
--- a/packages/babel-cli/README.md
+++ b/packages/babel-cli/README.md
@@ -2,7 +2,7 @@
 
 > Babel command line.
 
-See our website [@babel/cli](https://babeljs.io/docs/en/next/babel-cli.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20cli%22+is%3Aopen) associated with this package.
+See our website [@babel/cli](https://babeljs.io/docs/en/babel-cli) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20cli%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-code-frame/README.md
+++ b/packages/babel-code-frame/README.md
@@ -2,7 +2,7 @@
 
 > Generate errors that contain a code frame that point to source locations.
 
-See our website [@babel/code-frame](https://babeljs.io/docs/en/next/babel-code-frame.html) for more information.
+See our website [@babel/code-frame](https://babeljs.io/docs/en/babel-code-frame) for more information.
 
 ## Install
 

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -2,7 +2,7 @@
 
 > Babel compiler core.
 
-See our website [@babel/core](https://babeljs.io/docs/en/next/babel-core.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20core%22+is%3Aopen) associated with this package.
+See our website [@babel/core](https://babeljs.io/docs/en/babel-core) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20core%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-generator/README.md
+++ b/packages/babel-generator/README.md
@@ -2,7 +2,7 @@
 
 > Turns an AST into code.
 
-See our website [@babel/generator](https://babeljs.io/docs/en/next/babel-generator.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20generator%22+is%3Aopen) associated with this package.
+See our website [@babel/generator](https://babeljs.io/docs/en/babel-generator) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20generator%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-helper-annotate-as-pure/README.md
+++ b/packages/babel-helper-annotate-as-pure/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to annotate paths and nodes with #__PURE__ comment
 
-See our website [@babel/helper-annotate-as-pure](https://babeljs.io/docs/en/next/babel-helper-annotate-as-pure.html) for more information.
+See our website [@babel/helper-annotate-as-pure](https://babeljs.io/docs/en/babel-helper-annotate-as-pure) for more information.
 
 ## Install
 

--- a/packages/babel-helper-bindify-decorators/README.md
+++ b/packages/babel-helper-bindify-decorators/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to bindify decorators
 
-See our website [@babel/helper-bindify-decorators](https://babeljs.io/docs/en/next/babel-helper-bindify-decorators.html) for more information.
+See our website [@babel/helper-bindify-decorators](https://babeljs.io/docs/en/babel-helper-bindify-decorators) for more information.
 
 ## Install
 

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/README.md
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to build binary assignment operator visitors
 
-See our website [@babel/helper-builder-binary-assignment-operator-visitor](https://babeljs.io/docs/en/next/babel-helper-builder-binary-assignment-operator-visitor.html) for more information.
+See our website [@babel/helper-builder-binary-assignment-operator-visitor](https://babeljs.io/docs/en/babel-helper-builder-binary-assignment-operator-visitor) for more information.
 
 ## Install
 

--- a/packages/babel-helper-builder-react-jsx/README.md
+++ b/packages/babel-helper-builder-react-jsx/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to build react jsx
 
-See our website [@babel/helper-builder-react-jsx](https://babeljs.io/docs/en/next/babel-helper-builder-react-jsx.html) for more information.
+See our website [@babel/helper-builder-react-jsx](https://babeljs.io/docs/en/babel-helper-builder-react-jsx) for more information.
 
 ## Install
 

--- a/packages/babel-helper-call-delegate/README.md
+++ b/packages/babel-helper-call-delegate/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to call delegate
 
-See our website [@babel/helper-call-delegate](https://babeljs.io/docs/en/next/babel-helper-call-delegate.html) for more information.
+See our website [@babel/helper-call-delegate](https://babeljs.io/docs/en/babel-helper-call-delegate) for more information.
 
 ## Install
 

--- a/packages/babel-helper-create-class-features-plugin/README.md
+++ b/packages/babel-helper-create-class-features-plugin/README.md
@@ -2,7 +2,7 @@
 
 > Compile class public and private fields, private methods and decorators to ES6
 
-See our website [@babel/helper-create-class-features-plugin](https://babeljs.io/docs/en/next/babel-helper-create-class-features-plugin.html) for more information.
+See our website [@babel/helper-create-class-features-plugin](https://babeljs.io/docs/en/babel-helper-create-class-features-plugin) for more information.
 
 ## Install
 

--- a/packages/babel-helper-create-regexp-features-plugin/README.md
+++ b/packages/babel-helper-create-regexp-features-plugin/README.md
@@ -2,7 +2,7 @@
 
 > Compile ESNext Regular Expressions to ES5
 
-See our website [@babel/helper-create-regexp-features-plugin](https://babeljs.io/docs/en/next/babel-helper-create-regexp-features-plugin.html) for more information.
+See our website [@babel/helper-create-regexp-features-plugin](https://babeljs.io/docs/en/babel-helper-create-regexp-features-plugin) for more information.
 
 ## Install
 

--- a/packages/babel-helper-define-map/README.md
+++ b/packages/babel-helper-define-map/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to define a map
 
-See our website [@babel/helper-define-map](https://babeljs.io/docs/en/next/babel-helper-define-map.html) for more information.
+See our website [@babel/helper-define-map](https://babeljs.io/docs/en/babel-helper-define-map) for more information.
 
 ## Install
 

--- a/packages/babel-helper-explode-assignable-expression/README.md
+++ b/packages/babel-helper-explode-assignable-expression/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to explode an assignable expression
 
-See our website [@babel/helper-explode-assignable-expression](https://babeljs.io/docs/en/next/babel-helper-explode-assignable-expression.html) for more information.
+See our website [@babel/helper-explode-assignable-expression](https://babeljs.io/docs/en/babel-helper-explode-assignable-expression) for more information.
 
 ## Install
 

--- a/packages/babel-helper-explode-class/README.md
+++ b/packages/babel-helper-explode-class/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to explode class
 
-See our website [@babel/helper-explode-class](https://babeljs.io/docs/en/next/babel-helper-explode-class.html) for more information.
+See our website [@babel/helper-explode-class](https://babeljs.io/docs/en/babel-helper-explode-class) for more information.
 
 ## Install
 

--- a/packages/babel-helper-fixtures/README.md
+++ b/packages/babel-helper-fixtures/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to support fixtures
 
-See our website [@babel/helper-fixtures](https://babeljs.io/docs/en/next/babel-helper-fixtures.html) for more information.
+See our website [@babel/helper-fixtures](https://babeljs.io/docs/en/babel-helper-fixtures) for more information.
 
 ## Install
 

--- a/packages/babel-helper-function-name/README.md
+++ b/packages/babel-helper-function-name/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to change the property 'name' of every function
 
-See our website [@babel/helper-function-name](https://babeljs.io/docs/en/next/babel-helper-function-name.html) for more information.
+See our website [@babel/helper-function-name](https://babeljs.io/docs/en/babel-helper-function-name) for more information.
 
 ## Install
 

--- a/packages/babel-helper-get-function-arity/README.md
+++ b/packages/babel-helper-get-function-arity/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to get function arity
 
-See our website [@babel/helper-get-function-arity](https://babeljs.io/docs/en/next/babel-helper-get-function-arity.html) for more information.
+See our website [@babel/helper-get-function-arity](https://babeljs.io/docs/en/babel-helper-get-function-arity) for more information.
 
 ## Install
 

--- a/packages/babel-helper-hoist-variables/README.md
+++ b/packages/babel-helper-hoist-variables/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to hoist variables
 
-See our website [@babel/helper-hoist-variables](https://babeljs.io/docs/en/next/babel-helper-hoist-variables.html) for more information.
+See our website [@babel/helper-hoist-variables](https://babeljs.io/docs/en/babel-helper-hoist-variables) for more information.
 
 ## Install
 

--- a/packages/babel-helper-member-expression-to-functions/README.md
+++ b/packages/babel-helper-member-expression-to-functions/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to replace certain member expressions with function calls
 
-See our website [@babel/helper-member-expression-to-functions](https://babeljs.io/docs/en/next/babel-helper-member-expression-to-functions.html) for more information.
+See our website [@babel/helper-member-expression-to-functions](https://babeljs.io/docs/en/babel-helper-member-expression-to-functions) for more information.
 
 ## Install
 

--- a/packages/babel-helper-module-imports/README.md
+++ b/packages/babel-helper-module-imports/README.md
@@ -2,7 +2,7 @@
 
 > Babel helper functions for inserting module loads
 
-See our website [@babel/helper-module-imports](https://babeljs.io/docs/en/next/babel-helper-module-imports.html) for more information.
+See our website [@babel/helper-module-imports](https://babeljs.io/docs/en/babel-helper-module-imports) for more information.
 
 ## Install
 

--- a/packages/babel-helper-module-transforms/README.md
+++ b/packages/babel-helper-module-transforms/README.md
@@ -2,7 +2,7 @@
 
 > Babel helper functions for implementing ES6 module transformations
 
-See our website [@babel/helper-module-transforms](https://babeljs.io/docs/en/next/babel-helper-module-transforms.html) for more information.
+See our website [@babel/helper-module-transforms](https://babeljs.io/docs/en/babel-helper-module-transforms) for more information.
 
 ## Install
 

--- a/packages/babel-helper-optimise-call-expression/README.md
+++ b/packages/babel-helper-optimise-call-expression/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to optimise call expression
 
-See our website [@babel/helper-optimise-call-expression](https://babeljs.io/docs/en/next/babel-helper-optimise-call-expression.html) for more information.
+See our website [@babel/helper-optimise-call-expression](https://babeljs.io/docs/en/babel-helper-optimise-call-expression) for more information.
 
 ## Install
 

--- a/packages/babel-helper-plugin-test-runner/README.md
+++ b/packages/babel-helper-plugin-test-runner/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to support test runner
 
-See our website [@babel/helper-plugin-test-runner](https://babeljs.io/docs/en/next/babel-helper-plugin-test-runner.html) for more information.
+See our website [@babel/helper-plugin-test-runner](https://babeljs.io/docs/en/babel-helper-plugin-test-runner) for more information.
 
 ## Install
 

--- a/packages/babel-helper-plugin-utils/README.md
+++ b/packages/babel-helper-plugin-utils/README.md
@@ -2,7 +2,7 @@
 
 > General utilities for plugins to use
 
-See our website [@babel/helper-plugin-utils](https://babeljs.io/docs/en/next/babel-helper-plugin-utils.html) for more information.
+See our website [@babel/helper-plugin-utils](https://babeljs.io/docs/en/babel-helper-plugin-utils) for more information.
 
 ## Install
 

--- a/packages/babel-helper-regex/README.md
+++ b/packages/babel-helper-regex/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to check for literal RegEx
 
-See our website [@babel/helper-regex](https://babeljs.io/docs/en/next/babel-helper-regex.html) for more information.
+See our website [@babel/helper-regex](https://babeljs.io/docs/en/babel-helper-regex) for more information.
 
 ## Install
 

--- a/packages/babel-helper-remap-async-to-generator/README.md
+++ b/packages/babel-helper-remap-async-to-generator/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to remap async functions to generators
 
-See our website [@babel/helper-remap-async-to-generator](https://babeljs.io/docs/en/next/babel-helper-remap-async-to-generator.html) for more information.
+See our website [@babel/helper-remap-async-to-generator](https://babeljs.io/docs/en/babel-helper-remap-async-to-generator) for more information.
 
 ## Install
 

--- a/packages/babel-helper-replace-supers/README.md
+++ b/packages/babel-helper-replace-supers/README.md
@@ -2,7 +2,7 @@
 
 > Helper function to replace supers
 
-See our website [@babel/helper-replace-supers](https://babeljs.io/docs/en/next/babel-helper-replace-supers.html) for more information.
+See our website [@babel/helper-replace-supers](https://babeljs.io/docs/en/babel-helper-replace-supers) for more information.
 
 ## Install
 

--- a/packages/babel-helper-simple-access/README.md
+++ b/packages/babel-helper-simple-access/README.md
@@ -2,7 +2,7 @@
 
 > Babel helper for ensuring that access to a given value is performed through simple accesses
 
-See our website [@babel/helper-simple-access](https://babeljs.io/docs/en/next/babel-helper-simple-access.html) for more information.
+See our website [@babel/helper-simple-access](https://babeljs.io/docs/en/babel-helper-simple-access) for more information.
 
 ## Install
 

--- a/packages/babel-helper-skip-transparent-expression-wrappers/README.md
+++ b/packages/babel-helper-skip-transparent-expression-wrappers/README.md
@@ -2,6 +2,8 @@
 
 > Helper which skips types and parentheses
 
+See our website [@babel/helper-skip-transparent-expression-wrappers](https://babeljs.io/docs/en/babel-helper-skip-transparent-expression-wrappers) for more information.
+
 ## Install
 
 Using npm:

--- a/packages/babel-helper-split-export-declaration/README.md
+++ b/packages/babel-helper-split-export-declaration/README.md
@@ -2,7 +2,7 @@
 
 > 
 
-See our website [@babel/helper-split-export-declaration](https://babeljs.io/docs/en/next/babel-helper-split-export-declaration.html) for more information.
+See our website [@babel/helper-split-export-declaration](https://babeljs.io/docs/en/babel-helper-split-export-declaration) for more information.
 
 ## Install
 

--- a/packages/babel-helper-transform-fixture-test-runner/README.md
+++ b/packages/babel-helper-transform-fixture-test-runner/README.md
@@ -2,7 +2,7 @@
 
 > Transform test runner for @babel/helper-fixtures module
 
-See our website [@babel/helper-transform-fixture-test-runner](https://babeljs.io/docs/en/next/babel-helper-transform-fixture-test-runner.html) for more information.
+See our website [@babel/helper-transform-fixture-test-runner](https://babeljs.io/docs/en/babel-helper-transform-fixture-test-runner) for more information.
 
 ## Install
 

--- a/packages/babel-helper-validator-identifier/README.md
+++ b/packages/babel-helper-validator-identifier/README.md
@@ -2,7 +2,7 @@
 
 > Validate identifier/keywords name
 
-See our website [@babel/helper-validator-identifier](https://babeljs.io/docs/en/next/babel-helper-validator-identifier.html) for more information.
+See our website [@babel/helper-validator-identifier](https://babeljs.io/docs/en/babel-helper-validator-identifier) for more information.
 
 ## Install
 

--- a/packages/babel-helper-validator-option/README.md
+++ b/packages/babel-helper-validator-option/README.md
@@ -2,7 +2,7 @@
 
 > Validate plugin/preset options
 
-See our website [@babel/helper-validator-option](https://babeljs.io/docs/en/next/babel-helper-validator-option.html) for more information.
+See our website [@babel/helper-validator-option](https://babeljs.io/docs/en/babel-helper-validator-option) for more information.
 
 ## Install
 

--- a/packages/babel-helper-wrap-function/README.md
+++ b/packages/babel-helper-wrap-function/README.md
@@ -2,7 +2,7 @@
 
 > Helper to wrap functions inside a function call.
 
-See our website [@babel/helper-wrap-function](https://babeljs.io/docs/en/next/babel-helper-wrap-function.html) for more information.
+See our website [@babel/helper-wrap-function](https://babeljs.io/docs/en/babel-helper-wrap-function) for more information.
 
 ## Install
 

--- a/packages/babel-helpers/README.md
+++ b/packages/babel-helpers/README.md
@@ -2,7 +2,7 @@
 
 > Collection of helper functions used by Babel transforms.
 
-See our website [@babel/helpers](https://babeljs.io/docs/en/next/babel-helpers.html) for more information.
+See our website [@babel/helpers](https://babeljs.io/docs/en/babel-helpers) for more information.
 
 ## Install
 

--- a/packages/babel-highlight/README.md
+++ b/packages/babel-highlight/README.md
@@ -2,7 +2,7 @@
 
 > Syntax highlight JavaScript strings for output in terminals.
 
-See our website [@babel/highlight](https://babeljs.io/docs/en/next/babel-highlight.html) for more information.
+See our website [@babel/highlight](https://babeljs.io/docs/en/babel-highlight) for more information.
 
 ## Install
 

--- a/packages/babel-node/README.md
+++ b/packages/babel-node/README.md
@@ -2,7 +2,7 @@
 
 > Babel command line
 
-See our website [@babel/node](https://babeljs.io/docs/en/next/babel-node.html) for more information.
+See our website [@babel/node](https://babeljs.io/docs/en/babel-node) for more information.
 
 ## Install
 

--- a/packages/babel-parser/README.md
+++ b/packages/babel-parser/README.md
@@ -2,7 +2,7 @@
 
 > A JavaScript parser
 
-See our website [@babel/parser](https://babeljs.io/docs/en/next/babel-parser.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A+parser+%28babylon%29%22+is%3Aopen) associated with this package.
+See our website [@babel/parser](https://babeljs.io/docs/en/babel-parser) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20parser%20(babylon)%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-plugin-external-helpers/README.md
+++ b/packages/babel-plugin-external-helpers/README.md
@@ -2,7 +2,7 @@
 
 > This plugin contains helper functions that’ll be placed at the top of the generated code
 
-See our website [@babel/plugin-external-helpers](https://babeljs.io/docs/en/next/babel-plugin-external-helpers.html) for more information.
+See our website [@babel/plugin-external-helpers](https://babeljs.io/docs/en/babel-plugin-external-helpers) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-async-generator-functions/README.md
+++ b/packages/babel-plugin-proposal-async-generator-functions/README.md
@@ -2,7 +2,7 @@
 
 > Turn async generator functions into ES2015 generators
 
-See our website [@babel/plugin-proposal-async-generator-functions](https://babeljs.io/docs/en/next/babel-plugin-proposal-async-generator-functions.html) for more information.
+See our website [@babel/plugin-proposal-async-generator-functions](https://babeljs.io/docs/en/babel-plugin-proposal-async-generator-functions) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-class-properties/README.md
+++ b/packages/babel-plugin-proposal-class-properties/README.md
@@ -2,7 +2,7 @@
 
 > This plugin transforms static class properties as well as properties declared with the property initializer syntax
 
-See our website [@babel/plugin-proposal-class-properties](https://babeljs.io/docs/en/next/babel-plugin-proposal-class-properties.html) for more information.
+See our website [@babel/plugin-proposal-class-properties](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-class-static-block/README.md
+++ b/packages/babel-plugin-proposal-class-static-block/README.md
@@ -1,8 +1,8 @@
 # @babel/plugin-proposal-class-static-block
 
-> Allow transforming of class static blocks
+> Allow parsing of class static blocks
 
-See our website [@babel/plugin-proposal-class-static-block](https://babeljs.io/docs/en/next/babel-plugin-proposal-class-static-block.html) for more information.
+See our website [@babel/plugin-proposal-class-static-block](https://babeljs.io/docs/en/babel-plugin-proposal-class-static-block) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-decorators/README.md
+++ b/packages/babel-plugin-proposal-decorators/README.md
@@ -2,7 +2,7 @@
 
 > Compile class and object decorators to ES5
 
-See our website [@babel/plugin-proposal-decorators](https://babeljs.io/docs/en/next/babel-plugin-proposal-decorators.html) for more information.
+See our website [@babel/plugin-proposal-decorators](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-do-expressions/README.md
+++ b/packages/babel-plugin-proposal-do-expressions/README.md
@@ -2,7 +2,7 @@
 
 > Compile do expressions to ES5
 
-See our website [@babel/plugin-proposal-do-expressions](https://babeljs.io/docs/en/next/babel-plugin-proposal-do-expressions.html) for more information.
+See our website [@babel/plugin-proposal-do-expressions](https://babeljs.io/docs/en/babel-plugin-proposal-do-expressions) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-dynamic-import/README.md
+++ b/packages/babel-plugin-proposal-dynamic-import/README.md
@@ -2,7 +2,7 @@
 
 > Transform import() expressions
 
-See our website [@babel/plugin-proposal-dynamic-import](https://babeljs.io/docs/en/next/babel-plugin-proposal-dynamic-import.html) for more information.
+See our website [@babel/plugin-proposal-dynamic-import](https://babeljs.io/docs/en/babel-plugin-proposal-dynamic-import) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-export-default-from/README.md
+++ b/packages/babel-plugin-proposal-export-default-from/README.md
@@ -2,7 +2,7 @@
 
 > Compile export default to ES2015
 
-See our website [@babel/plugin-proposal-export-default-from](https://babeljs.io/docs/en/next/babel-plugin-proposal-export-default-from.html) for more information.
+See our website [@babel/plugin-proposal-export-default-from](https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-export-namespace-from/README.md
+++ b/packages/babel-plugin-proposal-export-namespace-from/README.md
@@ -2,7 +2,7 @@
 
 > Compile export namespace to ES2015
 
-See our website [@babel/plugin-proposal-export-namespace-from](https://babeljs.io/docs/en/next/babel-plugin-proposal-export-namespace-from.html) for more information.
+See our website [@babel/plugin-proposal-export-namespace-from](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-function-bind/README.md
+++ b/packages/babel-plugin-proposal-function-bind/README.md
@@ -2,7 +2,7 @@
 
 > Compile function bind operator to ES5
 
-See our website [@babel/plugin-proposal-function-bind](https://babeljs.io/docs/en/next/babel-plugin-proposal-function-bind.html) for more information.
+See our website [@babel/plugin-proposal-function-bind](https://babeljs.io/docs/en/babel-plugin-proposal-function-bind) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-function-sent/README.md
+++ b/packages/babel-plugin-proposal-function-sent/README.md
@@ -2,7 +2,7 @@
 
 > Compile the function.sent meta property to valid ES2015 code
 
-See our website [@babel/plugin-proposal-function-sent](https://babeljs.io/docs/en/next/babel-plugin-proposal-function-sent.html) for more information.
+See our website [@babel/plugin-proposal-function-sent](https://babeljs.io/docs/en/babel-plugin-proposal-function-sent) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-json-strings/README.md
+++ b/packages/babel-plugin-proposal-json-strings/README.md
@@ -2,7 +2,7 @@
 
 > Escape U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR in JS strings
 
-See our website [@babel/plugin-proposal-json-strings](https://babeljs.io/docs/en/next/babel-plugin-proposal-json-strings.html) for more information.
+See our website [@babel/plugin-proposal-json-strings](https://babeljs.io/docs/en/babel-plugin-proposal-json-strings) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-logical-assignment-operators/README.md
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/README.md
@@ -2,7 +2,7 @@
 
 > Transforms logical assignment operators into short-circuited assignments
 
-See our website [@babel/plugin-proposal-logical-assignment-operators](https://babeljs.io/docs/en/next/babel-plugin-proposal-logical-assignment-operators.html) for more information.
+See our website [@babel/plugin-proposal-logical-assignment-operators](https://babeljs.io/docs/en/babel-plugin-proposal-logical-assignment-operators) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/README.md
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/README.md
@@ -2,7 +2,7 @@
 
 > Remove nullish coalescing operator
 
-See our website [@babel/plugin-proposal-nullish-coalescing-operator](https://babeljs.io/docs/en/next/babel-plugin-proposal-nullish-coalescing-operator.html) for more information.
+See our website [@babel/plugin-proposal-nullish-coalescing-operator](https://babeljs.io/docs/en/babel-plugin-proposal-nullish-coalescing-operator) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-numeric-separator/README.md
+++ b/packages/babel-plugin-proposal-numeric-separator/README.md
@@ -2,7 +2,7 @@
 
 > Remove numeric separators from Decimal, Binary, Hex and Octal literals
 
-See our website [@babel/plugin-proposal-numeric-separator](https://babeljs.io/docs/en/next/babel-plugin-proposal-numeric-separator.html) for more information.
+See our website [@babel/plugin-proposal-numeric-separator](https://babeljs.io/docs/en/babel-plugin-proposal-numeric-separator) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-object-rest-spread/README.md
+++ b/packages/babel-plugin-proposal-object-rest-spread/README.md
@@ -2,7 +2,7 @@
 
 > Compile object rest and spread to ES5
 
-See our website [@babel/plugin-proposal-object-rest-spread](https://babeljs.io/docs/en/next/babel-plugin-proposal-object-rest-spread.html) for more information.
+See our website [@babel/plugin-proposal-object-rest-spread](https://babeljs.io/docs/en/babel-plugin-proposal-object-rest-spread) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-optional-catch-binding/README.md
+++ b/packages/babel-plugin-proposal-optional-catch-binding/README.md
@@ -2,7 +2,7 @@
 
 > Compile optional catch bindings
 
-See our website [@babel/plugin-proposal-optional-catch-binding](https://babeljs.io/docs/en/next/babel-plugin-proposal-optional-catch-binding.html) for more information.
+See our website [@babel/plugin-proposal-optional-catch-binding](https://babeljs.io/docs/en/babel-plugin-proposal-optional-catch-binding) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-optional-chaining/README.md
+++ b/packages/babel-plugin-proposal-optional-chaining/README.md
@@ -2,7 +2,7 @@
 
 > Transform optional chaining operators into a series of nil checks
 
-See our website [@babel/plugin-proposal-optional-chaining](https://babeljs.io/docs/en/next/babel-plugin-proposal-optional-chaining.html) for more information.
+See our website [@babel/plugin-proposal-optional-chaining](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-partial-application/README.md
+++ b/packages/babel-plugin-proposal-partial-application/README.md
@@ -2,7 +2,7 @@
 
 > Introduces a new ? token in an argument list which allows for partially applying an argument list to a call expression
 
-See our website [@babel/plugin-proposal-partial-application](https://babeljs.io/docs/en/next/babel-plugin-proposal-partial-application.html) for more information.
+See our website [@babel/plugin-proposal-partial-application](https://babeljs.io/docs/en/babel-plugin-proposal-partial-application) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-pipeline-operator/README.md
+++ b/packages/babel-plugin-proposal-pipeline-operator/README.md
@@ -2,7 +2,7 @@
 
 > Transform pipeline operator into call expressions
 
-See our website [@babel/plugin-proposal-pipeline-operator](https://babeljs.io/docs/en/next/babel-plugin-proposal-pipeline-operator.html) for more information.
+See our website [@babel/plugin-proposal-pipeline-operator](https://babeljs.io/docs/en/babel-plugin-proposal-pipeline-operator) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-private-methods/README.md
+++ b/packages/babel-plugin-proposal-private-methods/README.md
@@ -2,7 +2,7 @@
 
 > This plugin transforms private class methods
 
-See our website [@babel/plugin-proposal-private-methods](https://babeljs.io/docs/en/next/babel-plugin-proposal-private-methods.html) for more information.
+See our website [@babel/plugin-proposal-private-methods](https://babeljs.io/docs/en/babel-plugin-proposal-private-methods) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-private-property-in-object/README.md
+++ b/packages/babel-plugin-proposal-private-property-in-object/README.md
@@ -2,15 +2,14 @@
 
 > This plugin transforms checks for a private property in an object
 
-See our website [@babel/plugin-proposal-private-property-in-object](https://babeljs.io/docs/en/next/babel-plugin-proposal-private-property-in-object.html) for more information.
+See our website [@babel/plugin-proposal-private-property-in-object](https://babeljs.io/docs/en/babel-plugin-proposal-private-property-in-object) for more information.
 
 ## Install
 
 Using npm:
 
 ```sh
-npm install --save-dev
-@babel/plugin-proposal-private-property-in-object
+npm install --save-dev @babel/plugin-proposal-private-property-in-object
 ```
 
 or using yarn:

--- a/packages/babel-plugin-proposal-throw-expressions/README.md
+++ b/packages/babel-plugin-proposal-throw-expressions/README.md
@@ -2,7 +2,7 @@
 
 > Wraps Throw Expressions in an IIFE
 
-See our website [@babel/plugin-proposal-throw-expressions](https://babeljs.io/docs/en/next/babel-plugin-proposal-throw-expressions.html) for more information.
+See our website [@babel/plugin-proposal-throw-expressions](https://babeljs.io/docs/en/babel-plugin-proposal-throw-expressions) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-proposal-unicode-property-regex/README.md
+++ b/packages/babel-plugin-proposal-unicode-property-regex/README.md
@@ -2,7 +2,7 @@
 
 > Compile Unicode property escapes in Unicode regular expressions to ES5.
 
-See our website [@babel/plugin-proposal-unicode-property-regex](https://babeljs.io/docs/en/next/babel-plugin-proposal-unicode-property-regex.html) for more information.
+See our website [@babel/plugin-proposal-unicode-property-regex](https://babeljs.io/docs/en/babel-plugin-proposal-unicode-property-regex) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-class-properties/README.md
+++ b/packages/babel-plugin-syntax-class-properties/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of class properties
 
-See our website [@babel/plugin-syntax-class-properties](https://babeljs.io/docs/en/next/babel-plugin-syntax-class-properties.html) for more information.
+See our website [@babel/plugin-syntax-class-properties](https://babeljs.io/docs/en/babel-plugin-syntax-class-properties) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-class-static-block/README.md
+++ b/packages/babel-plugin-syntax-class-static-block/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of class static blocks
 
-See our website [@babel/plugin-syntax-class-static-block](https://babeljs.io/docs/en/next/babel-plugin-syntax-class-static-block.html) for more information.
+See our website [@babel/plugin-syntax-class-static-block](https://babeljs.io/docs/en/babel-plugin-syntax-class-static-block) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-decimal/README.md
+++ b/packages/babel-plugin-syntax-decimal/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of decimal
 
-See our website [@babel/plugin-syntax-decimal](https://babeljs.io/docs/en/next/babel-plugin-syntax-decimal.html) for more information.
+See our website [@babel/plugin-syntax-decimal](https://babeljs.io/docs/en/babel-plugin-syntax-decimal) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-decorators/README.md
+++ b/packages/babel-plugin-syntax-decorators/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of decorators
 
-See our website [@babel/plugin-syntax-decorators](https://babeljs.io/docs/en/next/babel-plugin-syntax-decorators.html) for more information.
+See our website [@babel/plugin-syntax-decorators](https://babeljs.io/docs/en/babel-plugin-syntax-decorators) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-do-expressions/README.md
+++ b/packages/babel-plugin-syntax-do-expressions/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of do expressions
 
-See our website [@babel/plugin-syntax-do-expressions](https://babeljs.io/docs/en/next/babel-plugin-syntax-do-expressions.html) for more information.
+See our website [@babel/plugin-syntax-do-expressions](https://babeljs.io/docs/en/babel-plugin-syntax-do-expressions) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-export-default-from/README.md
+++ b/packages/babel-plugin-syntax-export-default-from/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of export default from
 
-See our website [@babel/plugin-syntax-export-default-from](https://babeljs.io/docs/en/next/babel-plugin-syntax-export-default-from.html) for more information.
+See our website [@babel/plugin-syntax-export-default-from](https://babeljs.io/docs/en/babel-plugin-syntax-export-default-from) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-flow/README.md
+++ b/packages/babel-plugin-syntax-flow/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of the flow syntax
 
-See our website [@babel/plugin-syntax-flow](https://babeljs.io/docs/en/next/babel-plugin-syntax-flow.html) for more information.
+See our website [@babel/plugin-syntax-flow](https://babeljs.io/docs/en/babel-plugin-syntax-flow) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-function-bind/README.md
+++ b/packages/babel-plugin-syntax-function-bind/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of function bind
 
-See our website [@babel/plugin-syntax-function-bind](https://babeljs.io/docs/en/next/babel-plugin-syntax-function-bind.html) for more information.
+See our website [@babel/plugin-syntax-function-bind](https://babeljs.io/docs/en/babel-plugin-syntax-function-bind) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-function-sent/README.md
+++ b/packages/babel-plugin-syntax-function-sent/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of the function.sent meta property
 
-See our website [@babel/plugin-syntax-function-sent](https://babeljs.io/docs/en/next/babel-plugin-syntax-function-sent.html) for more information.
+See our website [@babel/plugin-syntax-function-sent](https://babeljs.io/docs/en/babel-plugin-syntax-function-sent) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-import-assertions/README.md
+++ b/packages/babel-plugin-syntax-import-assertions/README.md
@@ -1,8 +1,8 @@
 # @babel/plugin-syntax-import-assertions
 
-> Allow parsing of the module assertion attributes in the import statements
+> Allow parsing of the module assertion attributes in the import statement
 
-See our website [@babel/plugin-syntax-import-assertions](https://babeljs.io/docs/en/next/babel-plugin-syntax-import-assertions.html) for more information.
+See our website [@babel/plugin-syntax-import-assertions](https://babeljs.io/docs/en/babel-plugin-syntax-import-assertions) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-jsx/README.md
+++ b/packages/babel-plugin-syntax-jsx/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of jsx
 
-See our website [@babel/plugin-syntax-jsx](https://babeljs.io/docs/en/next/babel-plugin-syntax-jsx.html) for more information.
+See our website [@babel/plugin-syntax-jsx](https://babeljs.io/docs/en/babel-plugin-syntax-jsx) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-module-string-names/README.md
+++ b/packages/babel-plugin-syntax-module-string-names/README.md
@@ -1,8 +1,8 @@
 # @babel/plugin-syntax-module-string-names
 
-> Allow parsing `import { 'any unicode' as bar }` and `export { foo as 'any unicode' }`"
+> Allow parsing `import { 'any unicode' as bar }` and `export { foo as 'any unicode' }`
 
-See our website [@babel/plugin-syntax-module-string-names](https://babeljs.io/docs/en/next/babel-plugin-syntax-module-string-names.html) for more information.
+See our website [@babel/plugin-syntax-module-string-names](https://babeljs.io/docs/en/babel-plugin-syntax-module-string-names) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-partial-application/README.md
+++ b/packages/babel-plugin-syntax-partial-application/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of partial application syntax
 
-See our website [@babel/plugin-syntax-partial-application](https://babeljs.io/docs/en/next/babel-plugin-syntax-partial-application.html) for more information.
+See our website [@babel/plugin-syntax-partial-application](https://babeljs.io/docs/en/babel-plugin-syntax-partial-application) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-pipeline-operator/README.md
+++ b/packages/babel-plugin-syntax-pipeline-operator/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of the pipeline operator
 
-See our website [@babel/plugin-syntax-pipeline-operator](https://babeljs.io/docs/en/next/babel-plugin-syntax-pipeline-operator.html) for more information.
+See our website [@babel/plugin-syntax-pipeline-operator](https://babeljs.io/docs/en/babel-plugin-syntax-pipeline-operator) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-record-and-tuple/README.md
+++ b/packages/babel-plugin-syntax-record-and-tuple/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of records and tuples.
 
-See our website [@babel/plugin-syntax-record-and-tuple](https://babeljs.io/docs/en/next/babel-plugin-syntax-record-and-tuple.html) for more information.
+See our website [@babel/plugin-syntax-record-and-tuple](https://babeljs.io/docs/en/babel-plugin-syntax-record-and-tuple) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-throw-expressions/README.md
+++ b/packages/babel-plugin-syntax-throw-expressions/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of Throw Expressions
 
-See our website [@babel/plugin-syntax-throw-expressions](https://babeljs.io/docs/en/next/babel-plugin-syntax-throw-expressions.html) for more information.
+See our website [@babel/plugin-syntax-throw-expressions](https://babeljs.io/docs/en/babel-plugin-syntax-throw-expressions) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-top-level-await/README.md
+++ b/packages/babel-plugin-syntax-top-level-await/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of top-level await in modules
 
-See our website [@babel/plugin-syntax-top-level-await](https://babeljs.io/docs/en/next/babel-plugin-syntax-top-level-await.html) for more information.
+See our website [@babel/plugin-syntax-top-level-await](https://babeljs.io/docs/en/babel-plugin-syntax-top-level-await) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-typescript/README.md
+++ b/packages/babel-plugin-syntax-typescript/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of TypeScript syntax
 
-See our website [@babel/plugin-syntax-typescript](https://babeljs.io/docs/en/next/babel-plugin-syntax-typescript.html) for more information.
+See our website [@babel/plugin-syntax-typescript](https://babeljs.io/docs/en/babel-plugin-syntax-typescript) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-arrow-functions/README.md
+++ b/packages/babel-plugin-transform-arrow-functions/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 arrow functions to ES5
 
-See our website [@babel/plugin-transform-arrow-functions](https://babeljs.io/docs/en/next/babel-plugin-transform-arrow-functions.html) for more information.
+See our website [@babel/plugin-transform-arrow-functions](https://babeljs.io/docs/en/babel-plugin-transform-arrow-functions) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-async-to-generator/README.md
+++ b/packages/babel-plugin-transform-async-to-generator/README.md
@@ -2,7 +2,7 @@
 
 > Turn async functions into ES2015 generators
 
-See our website [@babel/plugin-transform-async-to-generator](https://babeljs.io/docs/en/next/babel-plugin-transform-async-to-generator.html) for more information.
+See our website [@babel/plugin-transform-async-to-generator](https://babeljs.io/docs/en/babel-plugin-transform-async-to-generator) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-block-scoped-functions/README.md
+++ b/packages/babel-plugin-transform-block-scoped-functions/README.md
@@ -2,7 +2,7 @@
 
 > Babel plugin to ensure function declarations at the block level are block scoped
 
-See our website [@babel/plugin-transform-block-scoped-functions](https://babeljs.io/docs/en/next/babel-plugin-transform-block-scoped-functions.html) for more information.
+See our website [@babel/plugin-transform-block-scoped-functions](https://babeljs.io/docs/en/babel-plugin-transform-block-scoped-functions) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-block-scoping/README.md
+++ b/packages/babel-plugin-transform-block-scoping/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 block scoping (const and let) to ES5
 
-See our website [@babel/plugin-transform-block-scoping](https://babeljs.io/docs/en/next/babel-plugin-transform-block-scoping.html) for more information.
+See our website [@babel/plugin-transform-block-scoping](https://babeljs.io/docs/en/babel-plugin-transform-block-scoping) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-classes/README.md
+++ b/packages/babel-plugin-transform-classes/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 classes to ES5
 
-See our website [@babel/plugin-transform-classes](https://babeljs.io/docs/en/next/babel-plugin-transform-classes.html) for more information.
+See our website [@babel/plugin-transform-classes](https://babeljs.io/docs/en/babel-plugin-transform-classes) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-computed-properties/README.md
+++ b/packages/babel-plugin-transform-computed-properties/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 computed properties to ES5
 
-See our website [@babel/plugin-transform-computed-properties](https://babeljs.io/docs/en/next/babel-plugin-transform-computed-properties.html) for more information.
+See our website [@babel/plugin-transform-computed-properties](https://babeljs.io/docs/en/babel-plugin-transform-computed-properties) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-destructuring/README.md
+++ b/packages/babel-plugin-transform-destructuring/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 destructuring to ES5
 
-See our website [@babel/plugin-transform-destructuring](https://babeljs.io/docs/en/next/babel-plugin-transform-destructuring.html) for more information.
+See our website [@babel/plugin-transform-destructuring](https://babeljs.io/docs/en/babel-plugin-transform-destructuring) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-dotall-regex/README.md
+++ b/packages/babel-plugin-transform-dotall-regex/README.md
@@ -2,7 +2,7 @@
 
 > Compile regular expressions using the `s` (`dotAll`) flag to ES5.
 
-See our website [@babel/plugin-transform-dotall-regex](https://babeljs.io/docs/en/next/babel-plugin-transform-dotall-regex.html) for more information.
+See our website [@babel/plugin-transform-dotall-regex](https://babeljs.io/docs/en/babel-plugin-transform-dotall-regex) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-duplicate-keys/README.md
+++ b/packages/babel-plugin-transform-duplicate-keys/README.md
@@ -2,7 +2,7 @@
 
 > Compile objects with duplicate keys to valid strict ES5
 
-See our website [@babel/plugin-transform-duplicate-keys](https://babeljs.io/docs/en/next/babel-plugin-transform-duplicate-keys.html) for more information.
+See our website [@babel/plugin-transform-duplicate-keys](https://babeljs.io/docs/en/babel-plugin-transform-duplicate-keys) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-exponentiation-operator/README.md
+++ b/packages/babel-plugin-transform-exponentiation-operator/README.md
@@ -2,7 +2,7 @@
 
 > Compile exponentiation operator to ES5
 
-See our website [@babel/plugin-transform-exponentiation-operator](https://babeljs.io/docs/en/next/babel-plugin-transform-exponentiation-operator.html) for more information.
+See our website [@babel/plugin-transform-exponentiation-operator](https://babeljs.io/docs/en/babel-plugin-transform-exponentiation-operator) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-flow-comments/README.md
+++ b/packages/babel-plugin-transform-flow-comments/README.md
@@ -2,7 +2,7 @@
 
 > Turn flow type annotations into comments
 
-See our website [@babel/plugin-transform-flow-comments](https://babeljs.io/docs/en/next/babel-plugin-transform-flow-comments.html) for more information.
+See our website [@babel/plugin-transform-flow-comments](https://babeljs.io/docs/en/babel-plugin-transform-flow-comments) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-flow-strip-types/README.md
+++ b/packages/babel-plugin-transform-flow-strip-types/README.md
@@ -2,7 +2,7 @@
 
 > Strip flow type annotations from your output code.
 
-See our website [@babel/plugin-transform-flow-strip-types](https://babeljs.io/docs/en/next/babel-plugin-transform-flow-strip-types.html) for more information.
+See our website [@babel/plugin-transform-flow-strip-types](https://babeljs.io/docs/en/babel-plugin-transform-flow-strip-types) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-for-of/README.md
+++ b/packages/babel-plugin-transform-for-of/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 for...of to ES5
 
-See our website [@babel/plugin-transform-for-of](https://babeljs.io/docs/en/next/babel-plugin-transform-for-of.html) for more information.
+See our website [@babel/plugin-transform-for-of](https://babeljs.io/docs/en/babel-plugin-transform-for-of) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-function-name/README.md
+++ b/packages/babel-plugin-transform-function-name/README.md
@@ -2,7 +2,7 @@
 
 > Apply ES2015 function.name semantics to all functions
 
-See our website [@babel/plugin-transform-function-name](https://babeljs.io/docs/en/next/babel-plugin-transform-function-name.html) for more information.
+See our website [@babel/plugin-transform-function-name](https://babeljs.io/docs/en/babel-plugin-transform-function-name) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-instanceof/README.md
+++ b/packages/babel-plugin-transform-instanceof/README.md
@@ -2,7 +2,7 @@
 
 > This plugin transforms all the ES2015 'instanceof' methods
 
-See our website [@babel/plugin-transform-instanceof](https://babeljs.io/docs/en/next/babel-plugin-transform-instanceof.html) for more information.
+See our website [@babel/plugin-transform-instanceof](https://babeljs.io/docs/en/babel-plugin-transform-instanceof) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-jscript/README.md
+++ b/packages/babel-plugin-transform-jscript/README.md
@@ -2,7 +2,7 @@
 
 > Babel plugin to fix buggy JScript named function expressions
 
-See our website [@babel/plugin-transform-jscript](https://babeljs.io/docs/en/next/babel-plugin-transform-jscript.html) for more information.
+See our website [@babel/plugin-transform-jscript](https://babeljs.io/docs/en/babel-plugin-transform-jscript) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-literals/README.md
+++ b/packages/babel-plugin-transform-literals/README.md
@@ -1,8 +1,8 @@
 # @babel/plugin-transform-literals
 
-> Compile ES2015 Unicode string and number literals to ES5
+> Compile ES2015 unicode string and number literals to ES5
 
-See our website [@babel/plugin-transform-literals](https://babeljs.io/docs/en/next/babel-plugin-transform-literals.html) for more information.
+See our website [@babel/plugin-transform-literals](https://babeljs.io/docs/en/babel-plugin-transform-literals) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-member-expression-literals/README.md
+++ b/packages/babel-plugin-transform-member-expression-literals/README.md
@@ -2,7 +2,7 @@
 
 > Ensure that reserved words are quoted in property accesses
 
-See our website [@babel/plugin-transform-member-expression-literals](https://babeljs.io/docs/en/next/babel-plugin-transform-member-expression-literals.html) for more information.
+See our website [@babel/plugin-transform-member-expression-literals](https://babeljs.io/docs/en/babel-plugin-transform-member-expression-literals) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-modules-amd/README.md
+++ b/packages/babel-plugin-transform-modules-amd/README.md
@@ -2,7 +2,7 @@
 
 > This plugin transforms ES2015 modules to AMD
 
-See our website [@babel/plugin-transform-modules-amd](https://babeljs.io/docs/en/next/babel-plugin-transform-modules-amd.html) for more information.
+See our website [@babel/plugin-transform-modules-amd](https://babeljs.io/docs/en/babel-plugin-transform-modules-amd) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-modules-commonjs/README.md
+++ b/packages/babel-plugin-transform-modules-commonjs/README.md
@@ -2,7 +2,7 @@
 
 > This plugin transforms ES2015 modules to CommonJS
 
-See our website [@babel/plugin-transform-modules-commonjs](https://babeljs.io/docs/en/next/babel-plugin-transform-modules-commonjs.html) for more information.
+See our website [@babel/plugin-transform-modules-commonjs](https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-modules-systemjs/README.md
+++ b/packages/babel-plugin-transform-modules-systemjs/README.md
@@ -2,7 +2,7 @@
 
 > This plugin transforms ES2015 modules to SystemJS
 
-See our website [@babel/plugin-transform-modules-systemjs](https://babeljs.io/docs/en/next/babel-plugin-transform-modules-systemjs.html) for more information.
+See our website [@babel/plugin-transform-modules-systemjs](https://babeljs.io/docs/en/babel-plugin-transform-modules-systemjs) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-modules-umd/README.md
+++ b/packages/babel-plugin-transform-modules-umd/README.md
@@ -2,7 +2,7 @@
 
 > This plugin transforms ES2015 modules to UMD
 
-See our website [@babel/plugin-transform-modules-umd](https://babeljs.io/docs/en/next/babel-plugin-transform-modules-umd.html) for more information.
+See our website [@babel/plugin-transform-modules-umd](https://babeljs.io/docs/en/babel-plugin-transform-modules-umd) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/README.md
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/README.md
@@ -2,7 +2,7 @@
 
 > Compile regular expressions using named groups to ES5.
 
-See our website [@babel/plugin-transform-named-capturing-groups-regex](https://babeljs.io/docs/en/next/babel-plugin-transform-named-capturing-groups-regex.html) for more information.
+See our website [@babel/plugin-transform-named-capturing-groups-regex](https://babeljs.io/docs/en/babel-plugin-transform-named-capturing-groups-regex) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-new-target/README.md
+++ b/packages/babel-plugin-transform-new-target/README.md
@@ -2,7 +2,7 @@
 
 > Transforms new.target meta property
 
-See our website [@babel/plugin-transform-new-target](https://babeljs.io/docs/en/next/babel-plugin-transform-new-target.html) for more information.
+See our website [@babel/plugin-transform-new-target](https://babeljs.io/docs/en/babel-plugin-transform-new-target) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-object-assign/README.md
+++ b/packages/babel-plugin-transform-object-assign/README.md
@@ -2,7 +2,7 @@
 
 > Replace Object.assign with an inline helper
 
-See our website [@babel/plugin-transform-object-assign](https://babeljs.io/docs/en/next/babel-plugin-transform-object-assign.html) for more information.
+See our website [@babel/plugin-transform-object-assign](https://babeljs.io/docs/en/babel-plugin-transform-object-assign) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/README.md
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/README.md
@@ -2,7 +2,7 @@
 
 > Turn Object.setPrototypeOf to assignments
 
-See our website [@babel/plugin-transform-object-set-prototype-of-to-assign](https://babeljs.io/docs/en/next/babel-plugin-transform-object-set-prototype-of-to-assign.html) for more information.
+See our website [@babel/plugin-transform-object-set-prototype-of-to-assign](https://babeljs.io/docs/en/babel-plugin-transform-object-set-prototype-of-to-assign) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-object-super/README.md
+++ b/packages/babel-plugin-transform-object-super/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 object super to ES5
 
-See our website [@babel/plugin-transform-object-super](https://babeljs.io/docs/en/next/babel-plugin-transform-object-super.html) for more information.
+See our website [@babel/plugin-transform-object-super](https://babeljs.io/docs/en/babel-plugin-transform-object-super) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-parameters/README.md
+++ b/packages/babel-plugin-transform-parameters/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 default and rest parameters to ES5
 
-See our website [@babel/plugin-transform-parameters](https://babeljs.io/docs/en/next/babel-plugin-transform-parameters.html) for more information.
+See our website [@babel/plugin-transform-parameters](https://babeljs.io/docs/en/babel-plugin-transform-parameters) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-property-literals/README.md
+++ b/packages/babel-plugin-transform-property-literals/README.md
@@ -2,7 +2,7 @@
 
 > Ensure that reserved words are quoted in object property keys
 
-See our website [@babel/plugin-transform-property-literals](https://babeljs.io/docs/en/next/babel-plugin-transform-property-literals.html) for more information.
+See our website [@babel/plugin-transform-property-literals](https://babeljs.io/docs/en/babel-plugin-transform-property-literals) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-property-mutators/README.md
+++ b/packages/babel-plugin-transform-property-mutators/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES5 property mutator shorthand syntax to Object.defineProperty
 
-See our website [@babel/plugin-transform-property-mutators](https://babeljs.io/docs/en/next/babel-plugin-transform-property-mutators.html) for more information.
+See our website [@babel/plugin-transform-property-mutators](https://babeljs.io/docs/en/babel-plugin-transform-property-mutators) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-proto-to-assign/README.md
+++ b/packages/babel-plugin-transform-proto-to-assign/README.md
@@ -2,7 +2,7 @@
 
 > Babel plugin for turning __proto__ into a shallow property clone
 
-See our website [@babel/plugin-transform-proto-to-assign](https://babeljs.io/docs/en/next/babel-plugin-transform-proto-to-assign.html) for more information.
+See our website [@babel/plugin-transform-proto-to-assign](https://babeljs.io/docs/en/babel-plugin-transform-proto-to-assign) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-react-constant-elements/README.md
+++ b/packages/babel-plugin-transform-react-constant-elements/README.md
@@ -2,7 +2,7 @@
 
 > Treat React JSX elements as value types and hoist them to the highest scope
 
-See our website [@babel/plugin-transform-react-constant-elements](https://babeljs.io/docs/en/next/babel-plugin-transform-react-constant-elements.html) for more information.
+See our website [@babel/plugin-transform-react-constant-elements](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-react-display-name/README.md
+++ b/packages/babel-plugin-transform-react-display-name/README.md
@@ -2,7 +2,7 @@
 
 > Add displayName to React.createClass calls
 
-See our website [@babel/plugin-transform-react-display-name](https://babeljs.io/docs/en/next/babel-plugin-transform-react-display-name.html) for more information.
+See our website [@babel/plugin-transform-react-display-name](https://babeljs.io/docs/en/babel-plugin-transform-react-display-name) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-react-inline-elements/README.md
+++ b/packages/babel-plugin-transform-react-inline-elements/README.md
@@ -2,7 +2,7 @@
 
 > Turn JSX elements into exploded React objects
 
-See our website [@babel/plugin-transform-react-inline-elements](https://babeljs.io/docs/en/next/babel-plugin-transform-react-inline-elements.html) for more information.
+See our website [@babel/plugin-transform-react-inline-elements](https://babeljs.io/docs/en/babel-plugin-transform-react-inline-elements) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-react-jsx-compat/README.md
+++ b/packages/babel-plugin-transform-react-jsx-compat/README.md
@@ -2,7 +2,7 @@
 
 > Turn JSX into React Pre-0.12 function calls
 
-See our website [@babel/plugin-transform-react-jsx-compat](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx-compat.html) for more information.
+See our website [@babel/plugin-transform-react-jsx-compat](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx-compat) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-react-jsx-self/README.md
+++ b/packages/babel-plugin-transform-react-jsx-self/README.md
@@ -2,7 +2,7 @@
 
 > Add a __self prop to all JSX Elements
 
-See our website [@babel/plugin-transform-react-jsx-self](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx-self.html) for more information.
+See our website [@babel/plugin-transform-react-jsx-self](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx-self) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-react-jsx-source/README.md
+++ b/packages/babel-plugin-transform-react-jsx-source/README.md
@@ -2,7 +2,7 @@
 
 > Add a __source prop to all JSX Elements
 
-See our website [@babel/plugin-transform-react-jsx-source](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx-source.html) for more information.
+See our website [@babel/plugin-transform-react-jsx-source](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx-source) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-react-jsx/README.md
+++ b/packages/babel-plugin-transform-react-jsx/README.md
@@ -2,7 +2,7 @@
 
 > Turn JSX into React function calls
 
-See our website [@babel/plugin-transform-react-jsx](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx.html) for more information.
+See our website [@babel/plugin-transform-react-jsx](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-regenerator/README.md
+++ b/packages/babel-plugin-transform-regenerator/README.md
@@ -2,7 +2,7 @@
 
 > Explode async and generator functions into a state machine.
 
-See our website [@babel/plugin-transform-regenerator](https://babeljs.io/docs/en/next/babel-plugin-transform-regenerator.html) for more information.
+See our website [@babel/plugin-transform-regenerator](https://babeljs.io/docs/en/babel-plugin-transform-regenerator) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-reserved-words/README.md
+++ b/packages/babel-plugin-transform-reserved-words/README.md
@@ -2,7 +2,7 @@
 
 > Ensure that no reserved words are used.
 
-See our website [@babel/plugin-transform-reserved-words](https://babeljs.io/docs/en/next/babel-plugin-transform-reserved-words.html) for more information.
+See our website [@babel/plugin-transform-reserved-words](https://babeljs.io/docs/en/babel-plugin-transform-reserved-words) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-runtime/README.md
+++ b/packages/babel-plugin-transform-runtime/README.md
@@ -2,7 +2,7 @@
 
 > Externalise references to helpers and builtins, automatically polyfilling your code without polluting globals
 
-See our website [@babel/plugin-transform-runtime](https://babeljs.io/docs/en/next/babel-plugin-transform-runtime.html) for more information.
+See our website [@babel/plugin-transform-runtime](https://babeljs.io/docs/en/babel-plugin-transform-runtime) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-shorthand-properties/README.md
+++ b/packages/babel-plugin-transform-shorthand-properties/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 shorthand properties to ES5
 
-See our website [@babel/plugin-transform-shorthand-properties](https://babeljs.io/docs/en/next/babel-plugin-transform-shorthand-properties.html) for more information.
+See our website [@babel/plugin-transform-shorthand-properties](https://babeljs.io/docs/en/babel-plugin-transform-shorthand-properties) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-spread/README.md
+++ b/packages/babel-plugin-transform-spread/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 spread to ES5
 
-See our website [@babel/plugin-transform-spread](https://babeljs.io/docs/en/next/babel-plugin-transform-spread.html) for more information.
+See our website [@babel/plugin-transform-spread](https://babeljs.io/docs/en/babel-plugin-transform-spread) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-sticky-regex/README.md
+++ b/packages/babel-plugin-transform-sticky-regex/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 sticky regex to an ES5 RegExp constructor
 
-See our website [@babel/plugin-transform-sticky-regex](https://babeljs.io/docs/en/next/babel-plugin-transform-sticky-regex.html) for more information.
+See our website [@babel/plugin-transform-sticky-regex](https://babeljs.io/docs/en/babel-plugin-transform-sticky-regex) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-strict-mode/README.md
+++ b/packages/babel-plugin-transform-strict-mode/README.md
@@ -2,7 +2,7 @@
 
 > This plugin places a 'use strict'; directive at the top of all files to enable strict mode
 
-See our website [@babel/plugin-transform-strict-mode](https://babeljs.io/docs/en/next/babel-plugin-transform-strict-mode.html) for more information.
+See our website [@babel/plugin-transform-strict-mode](https://babeljs.io/docs/en/babel-plugin-transform-strict-mode) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-template-literals/README.md
+++ b/packages/babel-plugin-transform-template-literals/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 template literals to ES5
 
-See our website [@babel/plugin-transform-template-literals](https://babeljs.io/docs/en/next/babel-plugin-transform-template-literals.html) for more information.
+See our website [@babel/plugin-transform-template-literals](https://babeljs.io/docs/en/babel-plugin-transform-template-literals) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-typeof-symbol/README.md
+++ b/packages/babel-plugin-transform-typeof-symbol/README.md
@@ -2,7 +2,7 @@
 
 > This transformer wraps all typeof expressions with a method that replicates native behaviour. (ie. returning “symbol” for symbols)
 
-See our website [@babel/plugin-transform-typeof-symbol](https://babeljs.io/docs/en/next/babel-plugin-transform-typeof-symbol.html) for more information.
+See our website [@babel/plugin-transform-typeof-symbol](https://babeljs.io/docs/en/babel-plugin-transform-typeof-symbol) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-typescript/README.md
+++ b/packages/babel-plugin-transform-typescript/README.md
@@ -2,7 +2,7 @@
 
 > Transform TypeScript into ES.next
 
-See our website [@babel/plugin-transform-typescript](https://babeljs.io/docs/en/next/babel-plugin-transform-typescript.html) for more information.
+See our website [@babel/plugin-transform-typescript](https://babeljs.io/docs/en/babel-plugin-transform-typescript) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-unicode-escapes/README.md
+++ b/packages/babel-plugin-transform-unicode-escapes/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 Unicode escapes to ES5
 
-See our website [@babel/plugin-transform-unicode-escapes](https://babeljs.io/docs/en/next/babel-plugin-transform-unicode-escapes.html) for more information.
+See our website [@babel/plugin-transform-unicode-escapes](https://babeljs.io/docs/en/babel-plugin-transform-unicode-escapes) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-transform-unicode-regex/README.md
+++ b/packages/babel-plugin-transform-unicode-regex/README.md
@@ -2,7 +2,7 @@
 
 > Compile ES2015 Unicode regex to ES5
 
-See our website [@babel/plugin-transform-unicode-regex](https://babeljs.io/docs/en/next/babel-plugin-transform-unicode-regex.html) for more information.
+See our website [@babel/plugin-transform-unicode-regex](https://babeljs.io/docs/en/babel-plugin-transform-unicode-regex) for more information.
 
 ## Install
 

--- a/packages/babel-polyfill/README.md
+++ b/packages/babel-polyfill/README.md
@@ -2,10 +2,7 @@
 
 > Provides polyfills necessary for a full ES2015+ environment
 
-
-**This package has been deprecated in favor of separate inclusion of required parts of [`core-js`](https://github.com/zloirock/core-js) and [`regenerator-runtime`](https://www.npmjs.com/package/regenerator-runtime). See our website [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill.html) for more information.**
-
-See our website [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20polyfill%22+is%3Aopen) associated with this package.
+See our website [@babel/polyfill](https://babeljs.io/docs/en/babel-polyfill) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20polyfill%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -2,7 +2,7 @@
 
 > A Babel preset for each environment.
 
-See our website [@babel/preset-env](https://babeljs.io/docs/en/next/babel-preset-env.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20preset-env%22+is%3Aopen) associated with this package.
+See our website [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20preset-env%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-preset-flow/README.md
+++ b/packages/babel-preset-flow/README.md
@@ -2,7 +2,7 @@
 
 > Babel preset for all Flow plugins.
 
-See our website [@babel/preset-flow](https://babeljs.io/docs/en/next/babel-preset-flow.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22area%3A%20flow%22+is%3Aopen) associated with this package.
+See our website [@babel/preset-flow](https://babeljs.io/docs/en/babel-preset-flow) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22area%3A%20flow%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-preset-react/README.md
+++ b/packages/babel-preset-react/README.md
@@ -2,7 +2,7 @@
 
 > Babel preset for all React plugins.
 
-See our website [@babel/preset-react](https://babeljs.io/docs/en/next/babel-preset-react.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22area%3A%20react%22+is%3Aopen) associated with this package.
+See our website [@babel/preset-react](https://babeljs.io/docs/en/babel-preset-react) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22area%3A%20react%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-preset-typescript/README.md
+++ b/packages/babel-preset-typescript/README.md
@@ -2,7 +2,7 @@
 
 > Babel preset for TypeScript.
 
-See our website [@babel/preset-typescript](https://babeljs.io/docs/en/next/babel-preset-typescript.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22area%3A%20typescript%22+is%3Aopen) associated with this package.
+See our website [@babel/preset-typescript](https://babeljs.io/docs/en/babel-preset-typescript) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22area%3A%20typescript%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -2,7 +2,7 @@
 
 > babel require hook
 
-See our website [@babel/register](https://babeljs.io/docs/en/next/babel-register.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20register%22+is%3Aopen) associated with this package.
+See our website [@babel/register](https://babeljs.io/docs/en/babel-register) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20register%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-runtime-corejs2/README.md
+++ b/packages/babel-runtime-corejs2/README.md
@@ -2,7 +2,7 @@
 
 > babel's modular runtime helpers with core-js@2 polyfilling
 
-See our website [@babel/runtime-corejs2](https://babeljs.io/docs/en/next/babel-runtime-corejs2.html) for more information.
+See our website [@babel/runtime-corejs2](https://babeljs.io/docs/en/babel-runtime-corejs2) for more information.
 
 ## Install
 

--- a/packages/babel-runtime-corejs3/README.md
+++ b/packages/babel-runtime-corejs3/README.md
@@ -2,6 +2,8 @@
 
 > babel's modular runtime helpers with core-js@3 polyfilling
 
+See our website [@babel/runtime-corejs3](https://babeljs.io/docs/en/babel-runtime-corejs3) for more information.
+
 ## Install
 
 Using npm:

--- a/packages/babel-runtime/README.md
+++ b/packages/babel-runtime/README.md
@@ -2,7 +2,7 @@
 
 > babel's modular runtime helpers
 
-See our website [@babel/runtime](https://babeljs.io/docs/en/next/babel-runtime.html) for more information.
+See our website [@babel/runtime](https://babeljs.io/docs/en/babel-runtime) for more information.
 
 ## Install
 

--- a/packages/babel-template/README.md
+++ b/packages/babel-template/README.md
@@ -2,7 +2,7 @@
 
 > Generate an AST from a string template.
 
-See our website [@babel/template](https://babeljs.io/docs/en/next/babel-template.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20template%22+is%3Aopen) associated with this package.
+See our website [@babel/template](https://babeljs.io/docs/en/babel-template) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20template%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-traverse/README.md
+++ b/packages/babel-traverse/README.md
@@ -2,7 +2,7 @@
 
 > The Babel Traverse module maintains the overall tree state, and is responsible for replacing, removing, and adding nodes
 
-See our website [@babel/traverse](https://babeljs.io/docs/en/next/babel-traverse.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20traverse%22+is%3Aopen) associated with this package.
+See our website [@babel/traverse](https://babeljs.io/docs/en/babel-traverse) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20traverse%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -2,7 +2,7 @@
 
 > Babel Types is a Lodash-esque utility library for AST nodes
 
-See our website [@babel/types](https://babeljs.io/docs/en/next/babel-types.html) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20types%22+is%3Aopen) associated with this package.
+See our website [@babel/types](https://babeljs.io/docs/en/babel-types) for more information or the [issues](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20types%22+is%3Aopen) associated with this package.
 
 ## Install
 

--- a/scripts/generators/readmes.js
+++ b/scripts/generators/readmes.js
@@ -14,7 +14,7 @@ const packageDir = join(cwd, "packages");
 
 const packages = readdirSync(packageDir);
 const packagesInstalledToDep = ["@babel/polyfill", "@babel/runtime"];
-const getWebsiteLink = n => `https://babeljs.io/docs/en/next/${n}.html`;
+const getWebsiteLink = n => `https://babeljs.io/docs/en/${n}`;
 const getPackageJson = pkg => require(join(packageDir, pkg, "package.json"));
 const getIssueLabelLink = l =>
   `https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22${encodeURIComponent(


### PR DESCRIPTION
Packages README links pointing to documentation are redirecting to Babel documentation index page. I've updated the READMEs generator script and regenerated all README for packages that was including their `README.md`, so packages that doesn't have a README still are without them.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12289"><img src="https://gitpod.io/api/apps/github/pbs/github.com/mondeja/babel.git/4c78386eff2d359161123cbc2b41ac9e377b12f6.svg" /></a>

