### PR TITLE
babel-node: support require flag in repl mode

### DIFF
--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -187,12 +187,7 @@ if (program.eval || program.print) {
     });
     args = args.slice(i);
 
-    // We have to handle require ourselves, as we want to require it in the context of babel-register
-    if (program.require) {
-      require(resolve.sync(program.require, {
-        basedir: process.cwd(),
-      }));
-    }
+    requireArgs();
 
     // make the filename absolute
     const filename = args[0];
@@ -206,7 +201,17 @@ if (program.eval || program.print) {
 
     Module.runMain();
   } else {
+    requireArgs();
     replStart();
+  }
+}
+
+// We have to handle require ourselves, as we want to require it in the context of babel-register
+function requireArgs() {
+  if (program.require) {
+    require(resolve.sync(program.require, {
+      basedir: process.cwd(),
+    }));
   }
 }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Replicated the behavior `node -r my-module` by calling the existing require logic before spinning up a repl.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12297"><img src="https://gitpod.io/api/apps/github/pbs/github.com/markshlick/babel.git/c869c411f93b60e847188a16cc4204b5f5eb59b9.svg" /></a>

