### PR TITLE
Fixed incorrectly implemented tests for loadOptions

### DIFF
--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -62,7 +62,7 @@ describe("option-manager", () => {
     });
 
     it("should not throw when a preset string followed by valid preset object", () => {
-      const { plugin } = makePlugin("my-plugin");
+      const { plugin } = makePlugin();
       expect(
         loadOptions({
           presets: [
@@ -73,8 +73,8 @@ describe("option-manager", () => {
       ).toBeTruthy();
     });
 
-    it("should throw if a plugin is repeated, with information about the repeated plugin", () => {
-      const { calls, plugin } = makePlugin("my-plugin");
+    it("should throw if a plugin name is repeated, with information about the repeated plugin", () => {
+      const { calls, plugin } = makePlugin();
 
       expect(() => {
         loadOptions({
@@ -101,17 +101,15 @@ describe("option-manager", () => {
     });
 
     it("should not throw if a repeated plugin has a different name", () => {
-      const { calls: calls1, plugin: plugin1 } = makePlugin();
-      const { calls: calls2, plugin: plugin2 } = makePlugin();
+      const { calls, plugin } = makePlugin();
 
       loadOptions({
         plugins: [
-          [plugin1, { arg: 1 }],
-          [plugin2, { arg: 2 }, "some-name"],
+          [plugin, { arg: 1 }],
+          [plugin, { arg: 2 }, "some-name"],
         ],
       });
-      expect(calls1).toEqual([{ arg: 1 }]);
-      expect(calls2).toEqual([{ arg: 2 }]);
+      expect(calls).toEqual([{ arg: 1 }, { arg: 2 }]);
     });
 
     it("should merge .env[] plugins with parent presets", () => {
@@ -146,17 +144,15 @@ describe("option-manager", () => {
     });
 
     it("should not throw if a repeated preset has a different name", () => {
-      const { calls: calls1, plugin: preset1 } = makePlugin();
-      const { calls: calls2, plugin: preset2 } = makePlugin();
+      const { calls, plugin: preset } = makePlugin();
 
       loadOptions({
         presets: [
-          [preset1, { arg: 1 }],
-          [preset2, { arg: 2 }, "some-name"],
+          [preset, { arg: 1 }],
+          [preset, { arg: 2 }, "some-name"],
         ],
       });
-      expect(calls1).toEqual([{ arg: 1 }]);
-      expect(calls2).toEqual([{ arg: 2 }]);
+      expect(calls).toEqual([{ arg: 1 }, { arg: 2 }]);
     });
     it("should merge .env[] presets with parent presets", () => {
       const { calls: calls1, plugin: preset1 } = makePlugin();


### PR DESCRIPTION
Those tests were not actually testing what they were supposed to test. `makePlugin` returns a fresh instance of a plugin each time so those tests were passing regardless of a name being configured per plugin or not. I've fixed this by actually reusing a plugin instance for those tests.

| Q                        | A 
| ------------------------ | ---
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12301"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/4b77cc4b1fc7d1ac5d708d0de87966ae642d27db.svg" /></a>

