### PR TITLE
Reduce linear search on list traversing

### DIFF
--- a/packages/babel-traverse/src/context.js
+++ b/packages/babel-traverse/src/context.js
@@ -95,7 +95,7 @@ export default class TraversalContext {
     this.queue = queue;
     this.priorityQueue = [];
 
-    const visited = [];
+    const visited = new WeakSet();
     let stop = false;
 
     // visit the queue
@@ -120,8 +120,9 @@ export default class TraversalContext {
       }
 
       // ensure we don't visit the same node twice
-      if (visited.indexOf(path.node) >= 0) continue;
-      visited.push(path.node);
+      const { node } = path;
+      if (visited.has(node)) continue;
+      if (node) visited.add(node);
 
       if (path.visit()) {
         stop = true;

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -67,24 +67,16 @@ export default class NodePath {
 
     const targetNode = container[key];
 
-    const paths = pathCache.get(parent) || [];
-    if (!pathCache.has(parent)) {
+    let paths = pathCache.get(parent);
+    if (!paths) {
+      paths = new Map();
       pathCache.set(parent, paths);
     }
 
-    let path;
-
-    for (let i = 0; i < paths.length; i++) {
-      const pathCheck = paths[i];
-      if (pathCheck.node === targetNode) {
-        path = pathCheck;
-        break;
-      }
-    }
-
+    let path = paths.get(targetNode);
     if (!path) {
       path = new NodePath(hub, parent);
-      paths.push(path);
+      if (targetNode) paths.set(targetNode, path);
     }
 
     path.setup(parentPath, container, listKey, key);

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -163,8 +163,7 @@ export function updateSiblingKeys(fromIndex, incrementBy) {
   if (!this.parent) return;
 
   const paths = pathCache.get(this.parent);
-  for (let i = 0; i < paths.length; i++) {
-    const path = paths[i];
+  for (const [, path] of paths) {
     if (path.key >= fromIndex) {
       path.key += incrementBy;
     }

--- a/packages/babel-traverse/src/path/removal.js
+++ b/packages/babel-traverse/src/path/removal.js
@@ -1,6 +1,7 @@
 // This file contains methods responsible for removing a node.
 
 import { hooks } from "./lib/removal-hooks";
+import { path as pathCache } from "../cache";
 import { REMOVED, SHOULD_SKIP } from "./index";
 
 export function remove() {
@@ -44,6 +45,7 @@ export function _remove() {
 export function _markRemoved() {
   // this.shouldSkip = true; this.removed = true;
   this._traverseFlags |= SHOULD_SKIP | REMOVED;
+  if (this.parent) pathCache.get(this.parent).delete(this.node);
   this.node = null;
 }
 

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -3,6 +3,7 @@
 import { codeFrameColumns } from "@babel/code-frame";
 import traverse from "../index";
 import NodePath from "./index";
+import { path as pathCache } from "../cache";
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
 
@@ -49,6 +50,7 @@ export function replaceWithMultiple(nodes: Array<Object>) {
   nodes = this._verifyNodeList(nodes);
   t.inheritLeadingComments(nodes[0], this.node);
   t.inheritTrailingComments(nodes[nodes.length - 1], this.node);
+  pathCache.get(this.parent).delete(this.node);
   this.node = this.container[this.key] = null;
   const paths = this.insertAfter(nodes);
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11527 
| Tests Added + Pass?      | No, see below
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Checkout this branch, build Babel and run https://gist.github.com/robmcl4/080bf388c95de3b2761307b39d6f895a

The output on my local machine is attached here for reference
<details>
  <summary>Current main</summary>

```
2,0.049
4,0.037
8,0.017
16,0.018
32,0.028
64,0.057
128,0.114
256,0.306
512,0.900
1024,3.106
2048,11.738
4096,45.160
```
</details>

<details>
  <summary>This PR</summary>

```
2,0.046
4,0.043
8,0.022
16,0.020
32,0.028
64,0.053
128,0.083
256,0.164
512,0.336
1024,0.658
2048,1.343
4096,2.764
```
</details>

In other words, traversing an ArrayLiteral of 4096 elements can be up to 16x faster. The execution time also looks linear.

Note that this issue is not limited to ArrayLiteral, I can reproduce it on any list-style AST structures: e.g. Program, ObjectLiteral, BlockStatement, etc. Although it is uncommon that an array literal may contain 4096 elements, a Program/BlockStatement, especially bundled, could contain thousands of statements as their list children.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12302"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/3a365bf24f9c56369ddb50b738b2f1398914b797.svg" /></a>

