### PR TITLE
Revert "Mark `ThisExpression` and `Super` as `Purish`"

### DIFF
--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -232,19 +232,6 @@ describe("scope", () => {
       expect(
         getPath("String.raw`foo`").get("body")[0].get("expression").isPure(),
       ).toBeTruthy();
-      expect(getPath("this").get("body.0.expression").isPure()).toBeTruthy();
-      expect(getPath("this.foo").get("body.0.expression").isPure()).toBeFalsy();
-      expect(
-        getPath("({ m() { super.foo } })")
-          .get("body.0.expression.properties.0.body.body.0.expression")
-          .isPure(),
-      ).toBeFalsy();
-      expect(
-        // This only tests "super", not "super.foo"
-        getPath("({ m() { super.foo } })")
-          .get("body.0.expression.properties.0.body.body.0.expression.object")
-          .isPure(),
-      ).toBeTruthy();
     });
 
     test("label", function () {

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -980,7 +980,7 @@ defineType("SwitchStatement", {
 });
 
 defineType("ThisExpression", {
-  aliases: ["Expression", "Pureish"],
+  aliases: ["Expression"],
 });
 
 defineType("ThrowStatement", {
@@ -1806,7 +1806,7 @@ defineType("SpreadElement", {
 });
 
 defineType("Super", {
-  aliases: ["Expression", "Pureish"],
+  aliases: ["Expression"],
 });
 
 defineType("TaggedTemplateExpression", {

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -3965,9 +3965,7 @@ export function isPureish(node: ?Object, opts?: Object): boolean {
     "NullLiteral" === nodeType ||
     "BooleanLiteral" === nodeType ||
     "RegExpLiteral" === nodeType ||
-    "ThisExpression" === nodeType ||
     "ArrowFunctionExpression" === nodeType ||
-    "Super" === nodeType ||
     "BigIntLiteral" === nodeType ||
     "DecimalLiteral" === nodeType ||
     (nodeType === "Placeholder" && "StringLiteral" === node.expectedNode)


### PR DESCRIPTION
Reverts babel/babel#12251

Fixes https://github.com/babel/babel/issues/12306

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12307"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/1404aedc3d67dd98877988b6493464467c8b16fd.svg" /></a>

