### PR TITLE
test: add tests about behaviour of replaceWithMultiple

### DIFF
--- a/packages/babel-traverse/test/replacement.js
+++ b/packages/babel-traverse/test/replacement.js
@@ -112,5 +112,20 @@ describe("path/replacement", function () {
       });
       expect(generate(ast).code).toBe("<div><p></p><h></h></div>;");
     });
+    it("does not revisit one of new nodes if it is the node being replaced", () => {
+      // packages/babel-plugin-transform-block-scoping/src/index.js relies on this behaviour
+      const ast = parse(`var x;`);
+      let visitCounter = 0;
+      traverse(ast, {
+        VariableDeclaration(path) {
+          visitCounter++;
+          if (visitCounter > 2) {
+            return true;
+          }
+          path.replaceWithMultiple([path.node, t.emptyStatement()]);
+        },
+      });
+      expect(visitCounter).toBe(1);
+    });
   });
 });

--- a/packages/babel-traverse/test/replacement.js
+++ b/packages/babel-traverse/test/replacement.js
@@ -97,6 +97,21 @@ describe("path/replacement", function () {
         /You passed `path\.replaceWith\(\)` a falsy node, use `path\.remove\(\)` instead/,
       );
     });
+
+    it("does not revisit the replaced node if it is the node being replaced", () => {
+      const ast = parse(`var x;`);
+      let visitCounter = 0;
+      traverse(ast, {
+        VariableDeclaration(path) {
+          visitCounter++;
+          if (visitCounter > 1) {
+            return true;
+          }
+          path.replaceWith(path.node);
+        },
+      });
+      expect(visitCounter).toBe(1);
+    });
   });
   describe("replaceWithMultiple", () => {
     it("does not add extra parentheses for a JSXElement with a JSXElement parent", () => {
@@ -112,17 +127,32 @@ describe("path/replacement", function () {
       });
       expect(generate(ast).code).toBe("<div><p></p><h></h></div>;");
     });
-    it("does not revisit one of new nodes if it is the node being replaced", () => {
+    it("does not revisit one of new nodes if it is the node being replaced and is the head of nodes", () => {
       // packages/babel-plugin-transform-block-scoping/src/index.js relies on this behaviour
       const ast = parse(`var x;`);
       let visitCounter = 0;
       traverse(ast, {
         VariableDeclaration(path) {
           visitCounter++;
-          if (visitCounter > 2) {
+          if (visitCounter > 1) {
             return true;
           }
           path.replaceWithMultiple([path.node, t.emptyStatement()]);
+        },
+      });
+      expect(visitCounter).toBe(1);
+    });
+    it("does not revisit one of new nodes if it is the node being replaced and is the tail of nodes", () => {
+      // packages/babel-plugin-transform-block-scoping/src/index.js relies on this behaviour
+      const ast = parse(`var x;`);
+      let visitCounter = 0;
+      traverse(ast, {
+        VariableDeclaration(path) {
+          visitCounter++;
+          if (visitCounter > 1) {
+            return true;
+          }
+          path.replaceWithMultiple([t.emptyStatement(), path.node]);
         },
       });
       expect(visitCounter).toBe(1);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Add a test on the `NodePath#replaceWithMultiple` behaviour when one of node is the replaced node. This tests is required by #12302, I feel it should be landed separately.

This behaviour is not intuitive to me. It is _not_ visited because in https://github.com/babel/babel/blob/12c6db6fae54ea7ffe6481ffe7e610b8cf4146ae/packages/babel-traverse/src/path/replacement.js#L46-L52, 

when we clear `this.node` (we denote `this.node` by `n`, w.l.o.g. we assume `nodes[0] === n`), we don't update the `pathCache` of its parent. 

https://github.com/babel/babel/blob/12c6db6fae54ea7ffe6481ffe7e610b8cf4146ae/packages/babel-traverse/src/path/index.js#L70

Since the `pathCache` holds a NodePath which has a reference to the `n`, it implicitly copy `n` to a new memory address. Now when the `n` is queried against `pathCache`

https://github.com/babel/babel/blob/12c6db6fae54ea7ffe6481ffe7e610b8cf4146ae/packages/babel-traverse/src/path/index.js#L79

The `pathCache` is missed because the NodePath is referencing a shallow copy of `n`, so a new NodePath instance is created for `n` and `this.node` is always `null` during

https://github.com/babel/babel/blob/12c6db6fae54ea7ffe6481ffe7e610b8cf4146ae/packages/babel-traverse/src/path/replacement.js#L53-L59

then it is removed instead of `requeue` so this node is never visited after replaced.

I think intuitively all nodes in the argument of `replaceWithMultiple` should be revisited. But the suggested behaviour is a breaking change, e.g. breaking TDZ implementation.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12309"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/0eb52146e1b4fb20db2902523833542cc5f2f009.svg" /></a>