### PR TITLE
Adding includes fix for plugin-proposal-numeric-separator

### DIFF
--- a/packages/babel-plugin-proposal-numeric-separator/src/index.js
+++ b/packages/babel-plugin-proposal-numeric-separator/src/index.js
@@ -9,7 +9,7 @@ import syntaxNumericSeparator from "@babel/plugin-syntax-numeric-separator";
  */
 function remover({ node }: NodePath<BigIntLiteral | NumericLiteral>) {
   const { extra } = node;
-  if (extra && extra.raw.includes("_")) {
+  if (extra?.raw?.includes("_")) {
     extra.raw = extra.raw.replace(/_/g, "");
   }
 }


### PR DESCRIPTION


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | "Fixes #12310" <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Fixing array lookup for `extra.raw` that was breaking when `raw` in some cases is `undefined`

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12311"><img src="https://gitpod.io/api/apps/github/pbs/github.com/fraywing/babel.git/837ae56c9bc63e6d5bcbe66ccf0c60fc01a98fcd.svg" /></a>

