### PR TITLE
Make babelrcRoots only match exact directories

### DIFF
--- a/packages/babel-core/src/config/config-chain.js
+++ b/packages/babel-core/src/config/config-chain.js
@@ -316,7 +316,7 @@ function babelrcLoadEnabled(
 
   return babelrcPatterns.some(pat => {
     if (typeof pat === "string") {
-      pat = pathPatternToRegex(pat, babelrcRootsDirectory);
+      pat = pathPatternToRegex(pat, babelrcRootsDirectory, false);
     }
 
     return pkgData.directories.some(directory => {

--- a/packages/babel-core/src/config/pattern-to-regex.js
+++ b/packages/babel-core/src/config/pattern-to-regex.js
@@ -21,6 +21,7 @@ const starStarPatLast = `${starPat}*?${starPatLast}?`;
 export default function pathToPattern(
   pattern: string,
   dirname: string,
+  matchPrefix: boolean = true,
 ): RegExp {
   const parts = path.resolve(dirname, pattern).split(path.sep);
 
@@ -46,6 +47,7 @@ export default function pathToPattern(
         // Otherwise match the pattern text.
         return escapeRegExp(part) + (last ? endSep : sep);
       }),
+      matchPrefix ? "" : "$",
     ].join(""),
   );
 }

--- a/packages/babel-core/test/pattern-to-regex.js
+++ b/packages/babel-core/test/pattern-to-regex.js
@@ -1,0 +1,31 @@
+import path from "path";
+import patternToRegex from "../lib/config/pattern-to-regex";
+
+describe("patternToRegex", function () {
+  const dirname = process.cwd();
+
+  it.each([
+    [dirname, ".", true],
+    [dirname + path.sep, ".", true],
+    [path.resolve(dirname, "node_modules", "my-package"), ".", true],
+    [dirname, ".", false],
+    [dirname + path.sep, ".", false],
+  ])(`%s matches pattern %s when matchPrefix is %s`, function (
+    test,
+    pattern,
+    matchPrefix,
+  ) {
+    const regex = patternToRegex(pattern, dirname, matchPrefix);
+
+    expect(test).toMatch(regex);
+  });
+
+  it.each([[path.join(dirname, "node_modules", "my-package"), ".", false]])(
+    `%s does not match pattern %s when matchPrefix is %s`,
+    function (test, pattern, matchPrefix) {
+      const regex = patternToRegex(pattern, dirname, matchPrefix);
+
+      expect(test).not.toMatch(regex);
+    },
+  );
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12314 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 👍
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Previously any path with a prefix of the directories specified would match, causing false positives, particularly in the case where the babelrcRoots included `"."`, since then all subdirectories are considered babelrc roots.

This introduces a new parameter, `matchPrefix`, to `patternToRegex` that specifies whether a prefix or exact match is required. This flag is then disabled when matching in `babelrcLoadEnabled`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12315"><img src="https://gitpod.io/api/apps/github/pbs/github.com/cameron-martin/babel.git/e56c3db2c8aee6ad8043e891ac44068f7ba0ff04.svg" /></a>

