### PR TITLE
chore: remove Node.js 13 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 13, 12, 10, 8, 6]
+        node-version: [14, 12, 10, 8, 6]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Per https://github.com/nodejs/Release, Node.js 13 reached EOL in 2020-06-01. Remove it from our CI for less carbon footprint.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12328"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/e41eab15ffafbbb4f97edadb417f6efb8ab695e8.svg" /></a>

