### PR TITLE
Fix t.arrowFunctionExpression and t.functionExpression builders by adding all fields

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -401,7 +401,15 @@ export const functionDeclarationCommon = {
 };
 
 defineType("FunctionDeclaration", {
-  builder: ["id", "params", "body", "generator", "async"],
+  builder: [
+    "id",
+    "params",
+    "body",
+    "generator",
+    "async",
+    "returnType",
+    "typeParameters",
+  ],
   visitor: ["id", "params", "body", "returnType", "typeParameters"],
   fields: {
     ...functionDeclarationCommon,
@@ -1209,7 +1217,15 @@ defineType("ArrayPattern", {
 });
 
 defineType("ArrowFunctionExpression", {
-  builder: ["params", "body", "async"],
+  builder: [
+    "params",
+    "body",
+    "async",
+    "expression",
+    "generator",
+    "returnType",
+    "typeParameters",
+  ],
   visitor: ["params", "body", "returnType", "typeParameters"],
   aliases: [
     "Scopable",

--- a/packages/babel-types/test/builders/core/__snapshots__/arrowFunctionExpression.js.snap
+++ b/packages/babel-types/test/builders/core/__snapshots__/arrowFunctionExpression.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builders es2015 arrowFunctionExpression accept all parameters 1`] = `
+Object {
+  "async": true,
+  "body": Object {
+    "body": Array [
+      Object {
+        "argument": Object {
+          "type": "ThisExpression",
+        },
+        "type": "ReturnStatement",
+      },
+    ],
+    "directives": Array [],
+    "type": "BlockStatement",
+  },
+  "expression": true,
+  "generator": true,
+  "params": Array [
+    Object {
+      "name": "foo",
+      "type": "Identifier",
+    },
+  ],
+  "returnType": Object {
+    "type": "TSTypeAnnotation",
+    "typeAnnotation": Object {
+      "type": "TSStringKeyword",
+    },
+  },
+  "type": "ArrowFunctionExpression",
+  "typeParameters": Object {
+    "params": Array [
+      Object {
+        "constraint": Object {
+          "type": "TSObjectKeyword",
+        },
+        "default": null,
+        "name": "foo",
+        "type": "TSTypeParameter",
+      },
+    ],
+    "type": "TSTypeParameterDeclaration",
+  },
+}
+`;

--- a/packages/babel-types/test/builders/core/__snapshots__/functionExpression.js.snap
+++ b/packages/babel-types/test/builders/core/__snapshots__/functionExpression.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builders core functionExpression accept all parameters 1`] = `
+Object {
+  "async": true,
+  "body": Object {
+    "body": Array [
+      Object {
+        "argument": Object {
+          "type": "ThisExpression",
+        },
+        "type": "ReturnStatement",
+      },
+    ],
+    "directives": Array [],
+    "type": "BlockStatement",
+  },
+  "generator": true,
+  "id": Object {
+    "name": "foo",
+    "type": "Identifier",
+  },
+  "params": Array [
+    Object {
+      "name": "bar",
+      "type": "Identifier",
+    },
+  ],
+  "returnType": Object {
+    "type": "TSTypeAnnotation",
+    "typeAnnotation": Object {
+      "type": "TSStringKeyword",
+    },
+  },
+  "type": "FunctionExpression",
+  "typeParameters": Object {
+    "params": Array [
+      Object {
+        "constraint": Object {
+          "type": "TSObjectKeyword",
+        },
+        "default": null,
+        "name": "bar",
+        "type": "TSTypeParameter",
+      },
+    ],
+    "type": "TSTypeParameterDeclaration",
+  },
+}
+`;

--- a/packages/babel-types/test/builders/core/arrowFunctionExpression.js
+++ b/packages/babel-types/test/builders/core/arrowFunctionExpression.js
@@ -1,0 +1,22 @@
+import * as t from "@babel/types";
+
+describe("builders", function () {
+  describe("es2015", function () {
+    describe("arrowFunctionExpression", function () {
+      it("accept all parameters", function () {
+        const arrowFunctionExpression = t.arrowFunctionExpression(
+          [t.identifier("foo")],
+          t.blockStatement([t.returnStatement(t.thisExpression())]),
+          true,
+          true,
+          true,
+          t.tsTypeAnnotation(t.tsStringKeyword()),
+          t.tsTypeParameterDeclaration([
+            t.tsTypeParameter(t.tsObjectKeyword(), null, "foo"),
+          ]),
+        );
+        expect(arrowFunctionExpression).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/packages/babel-types/test/builders/core/functionExpression.js
+++ b/packages/babel-types/test/builders/core/functionExpression.js
@@ -1,0 +1,22 @@
+import * as t from "../../..";
+
+describe("builders", function () {
+  describe("core", function () {
+    describe("functionExpression", function () {
+      it("accept all parameters", function () {
+        const functionExpression = t.functionExpression(
+          t.identifier("foo"),
+          [t.identifier("bar")],
+          t.blockStatement([t.returnStatement(t.thisExpression())]),
+          true,
+          true,
+          t.tsTypeAnnotation(t.tsStringKeyword()),
+          t.tsTypeParameterDeclaration([
+            t.tsTypeParameter(t.tsObjectKeyword(), null, "bar"),
+          ]),
+        );
+        expect(functionExpression).toMatchSnapshot();
+      });
+    });
+  });
+});


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12319
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This fix adds the additional fields to the builder arrays for the definitions.
However, this does feel like a workaround, I also found this bug to apply to `assignmentPattern`, and there are probably more.
It looks like defineType in utils.js makes sure to add both builder and visitor fields to a node while the builder function in builder.js only checks the builder values.

Somewhat unrelated, but I can't figure out how to add types to function parameters.
[t.tsParameterProperty](https://babeljs.io/docs/en/babel-types#tsparameterproperty) looks like the wrong type to me, it looks like something you'd add to a class (ie: `readonly property = "value"`).
The closest thing I can find for this is [t.tsPropertySignature](https://babeljs.io/docs/en/babel-types#tspropertysignature), but that looks like some thing for an interface (ie: `key: type;` note the trailing `;`).



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12334"><img src="https://gitpod.io/api/apps/github/pbs/github.com/deificx/babel.git/56aa9b9ef3e625190b540d493dad1b8bf65f0a1d.svg" /></a>

