### PR TITLE
Fix arrow transformation when `arguments` is defined as variable

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2364/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2364/output.js
@@ -1,9 +1,7 @@
 function wrapper(fn) {
   return function () {
-    var _arguments = arguments;
-
     var _loop = function () {
-      var val = fn(..._arguments);
+      var val = fn(...arguments);
       return {
         v: val.test(function () {
           console.log(val);

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2364/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2364/output.js
@@ -1,7 +1,9 @@
 function wrapper(fn) {
   return function () {
+    var _arguments = arguments;
+
     var _loop = function () {
-      var val = fn(...arguments);
+      var val = fn(..._arguments);
       return {
         v: val.test(function () {
           console.log(val);

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments-global-undeclared/input.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments-global-undeclared/input.js
@@ -1,0 +1,9 @@
+function fn() {
+  var foo = () => {
+    return arguments;
+  };
+}
+
+var bar = () => arguments;
+
+var baz = () => () => arguments;

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments-global-undeclared/output.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments-global-undeclared/output.js
@@ -1,0 +1,19 @@
+var _arguments2 = typeof arguments === "undefined" ? void 0 : arguments;
+
+function fn() {
+  var _arguments = arguments;
+
+  var foo = function () {
+    return _arguments;
+  };
+}
+
+var bar = function () {
+  return _arguments2;
+};
+
+var baz = function () {
+  return function () {
+    return _arguments2;
+  };
+};

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments-global-var/input.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments-global-var/input.js
@@ -1,0 +1,10 @@
+var arguments = 1;
+function fn() {
+  var foo = () => {
+    return arguments;
+  };
+}
+
+var bar = () => arguments;
+
+var baz = () => () => arguments;

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments-global-var/output.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments-global-var/output.js
@@ -1,0 +1,19 @@
+var _arguments2 = 1;
+
+function fn() {
+  var _arguments = _arguments2;
+
+  var foo = function () {
+    return _arguments;
+  };
+}
+
+var bar = function () {
+  return _arguments2;
+};
+
+var baz = function () {
+  return function () {
+    return _arguments2;
+  };
+};

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments/input.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments/input.js
@@ -64,14 +64,6 @@ function nine() {
 }
 nine();
 
-var arguments = 1;
-function ten() {
-  var foo = () => {
-    return arguments;
-  };
-}
-ten();
-
 var eleven = () => {
   var arguments = 2;
   return function () {

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments/input.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments/input.js
@@ -43,3 +43,47 @@ function six(obj) {
   return fn();
 }
 six();
+
+var seven = () => {
+    var arguments = 1;
+    return arguments;
+};
+seven();
+
+var eight = () => {
+    var arguments = 1;
+    return () => arguments;
+};
+eight();
+
+function nine() {
+    var arguments = 1;
+    var foo = () => {
+      return arguments;
+    };
+}
+nine();
+
+var arguments = 1;
+function ten() {
+  var foo = () => {
+    return arguments;
+  };
+}
+ten();
+
+var eleven = () => {
+  var arguments = 2;
+  return function () {
+    return () => arguments;
+  }
+};
+eleven()(1,2,3)();
+
+var twelve = () => {
+  var arguments = 2;
+  return class {
+    m() { return () => arguments; }
+  }
+};
+twelve();

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments/output.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments/output.js
@@ -1,10 +1,8 @@
-var _arguments4 = arguments;
-
 function one() {
-  var _arguments2 = arguments;
+  var _arguments = arguments;
 
   var inner = function () {
-    return _arguments2;
+    return _arguments;
   };
 
   return [].slice.call(inner());
@@ -13,13 +11,17 @@ function one() {
 one(1, 2);
 
 function two() {
+  var _arguments2 = arguments;
+
   var inner = function () {
-    return _arguments;
+    return _arguments2;
   };
 
   var another = function () {
+    var _arguments3 = arguments;
+
     var inner2 = function () {
-      return _arguments;
+      return _arguments3;
     };
   };
 
@@ -29,8 +31,10 @@ function two() {
 two(1, 2);
 
 function three() {
+  var _arguments4 = arguments;
+
   var fn = function () {
-    return _arguments[0] + "bar";
+    return _arguments4[0] + "bar";
   };
 
   return fn();
@@ -39,8 +43,10 @@ function three() {
 three("foo");
 
 function four() {
+  var _arguments5 = arguments;
+
   var fn = function () {
-    return _arguments[0].foo + "bar";
+    return _arguments5[0].foo + "bar";
   };
 
   return fn();
@@ -65,7 +71,7 @@ five({
 function six(obj) {
   var fn = function () {
     var fn2 = function () {
-      return _arguments[0];
+      return arguments[0];
     };
 
     return fn2("foobar");
@@ -77,47 +83,37 @@ function six(obj) {
 six();
 
 var seven = function () {
-  var arguments = 1;
-  return arguments;
+  var _arguments6 = 1;
+  return _arguments6;
 };
 
 seven();
 
 var eight = function () {
-  var _arguments3 = 1;
+  var _arguments7 = 1;
   return function () {
-    return _arguments4;
+    return _arguments7;
   };
 };
 
 eight();
 
 function nine() {
-  var _arguments6 = arguments;
-  var _arguments5 = 1;
+  var _arguments8 = 1;
 
   var foo = function () {
-    return _arguments6;
+    return _arguments8;
   };
 }
 
 nine();
-var _arguments = 1;
-
-function ten() {
-  var foo = function () {
-    return _arguments;
-  };
-}
-
-ten();
 
 var eleven = function () {
-  var _arguments7 = 2;
+  var arguments = 2;
   return function () {
-    var _arguments8 = arguments;
+    var _arguments9 = arguments;
     return function () {
-      return _arguments8;
+      return _arguments9;
     };
   };
 };
@@ -125,7 +121,7 @@ var eleven = function () {
 eleven()(1, 2, 3)();
 
 var twelve = function () {
-  var _arguments9 = 2;
+  var arguments = 2;
   return class {
     m() {
       var _arguments10 = arguments;

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments/output.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/arguments/output.js
@@ -1,8 +1,10 @@
+var _arguments4 = arguments;
+
 function one() {
-  var _arguments = arguments;
+  var _arguments2 = arguments;
 
   var inner = function () {
-    return _arguments;
+    return _arguments2;
   };
 
   return [].slice.call(inner());
@@ -11,17 +13,13 @@ function one() {
 one(1, 2);
 
 function two() {
-  var _arguments2 = arguments;
-
   var inner = function () {
-    return _arguments2;
+    return _arguments;
   };
 
   var another = function () {
-    var _arguments3 = arguments;
-
     var inner2 = function () {
-      return _arguments3;
+      return _arguments;
     };
   };
 
@@ -31,10 +29,8 @@ function two() {
 two(1, 2);
 
 function three() {
-  var _arguments4 = arguments;
-
   var fn = function () {
-    return _arguments4[0] + "bar";
+    return _arguments[0] + "bar";
   };
 
   return fn();
@@ -43,10 +39,8 @@ function three() {
 three("foo");
 
 function four() {
-  var _arguments5 = arguments;
-
   var fn = function () {
-    return _arguments5[0].foo + "bar";
+    return _arguments[0].foo + "bar";
   };
 
   return fn();
@@ -71,7 +65,7 @@ five({
 function six(obj) {
   var fn = function () {
     var fn2 = function () {
-      return arguments[0];
+      return _arguments[0];
     };
 
     return fn2("foobar");
@@ -81,3 +75,66 @@ function six(obj) {
 }
 
 six();
+
+var seven = function () {
+  var arguments = 1;
+  return arguments;
+};
+
+seven();
+
+var eight = function () {
+  var _arguments3 = 1;
+  return function () {
+    return _arguments4;
+  };
+};
+
+eight();
+
+function nine() {
+  var _arguments6 = arguments;
+  var _arguments5 = 1;
+
+  var foo = function () {
+    return _arguments6;
+  };
+}
+
+nine();
+var _arguments = 1;
+
+function ten() {
+  var foo = function () {
+    return _arguments;
+  };
+}
+
+ten();
+
+var eleven = function () {
+  var _arguments7 = 2;
+  return function () {
+    var _arguments8 = arguments;
+    return function () {
+      return _arguments8;
+    };
+  };
+};
+
+eleven()(1, 2, 3)();
+
+var twelve = function () {
+  var _arguments9 = 2;
+  return class {
+    m() {
+      var _arguments10 = arguments;
+      return function () {
+        return _arguments10;
+      };
+    }
+
+  };
+};
+
+twelve();

--- a/packages/babel-traverse/src/path/conversion.ts
+++ b/packages/babel-traverse/src/path/conversion.ts
@@ -236,20 +236,10 @@ function hoistFunctionEnvironment(
     );
 
     argumentsPaths.forEach(argumentsChild => {
-      let currentScope = argumentsChild.scope;
-      do {
-        if (
-          !currentScope.hasOwnBinding("arguments") &&
-          !(
-            currentScope.path.isFunction() &&
-            !currentScope.path.isArrowFunctionExpression()
-          )
-        ) {
-          const argsRef = t.identifier(argumentsBinding);
-          argsRef.loc = argumentsChild.node.loc;
-          argumentsChild.replaceWith(argsRef);
-        }
-      } while ((currentScope = currentScope.parent));
+      const argsRef = t.identifier(argumentsBinding);
+      argsRef.loc = argumentsChild.node.loc;
+
+      argumentsChild.replaceWith(argsRef);
     });
   }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes https://github.com/babel/babel/issues/11385, fixes #7673  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Fixes https://github.com/babel/babel/issues/11385


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12344"><img src="https://gitpod.io/api/apps/github/pbs/github.com/snitin315/babel.git/98e71543f05faaffd7350c6bfbd9bfe7dae2b7d5.svg" /></a>



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12344"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

