### PR TITLE
refactor: use option-validator in preset-typescript

### DIFF
--- a/packages/babel-preset-react/src/index.js
+++ b/packages/babel-preset-react/src/index.js
@@ -29,12 +29,6 @@ export default declare((api, opts) => {
   const development = !!opts.development;
   const useBuiltIns = !!opts.useBuiltIns;
 
-  if (typeof development !== "boolean") {
-    throw new Error(
-      "@babel/preset-react 'development' option must be a boolean.",
-    );
-  }
-
   const transformReactJSXPlugin =
     runtime === "automatic" && development
       ? transformReactJSXDevelopment

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -18,6 +18,7 @@
   ],
   "dependencies": {
     "@babel/helper-plugin-utils": "workspace:^7.10.4",
+    "@babel/helper-validator-option": "workspace:^7.12.1",
     "@babel/plugin-transform-typescript": "workspace:^7.12.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3134,6 +3134,7 @@ __metadata:
     "@babel/core": "workspace:*"
     "@babel/helper-plugin-test-runner": "workspace:*"
     "@babel/helper-plugin-utils": "workspace:^7.10.4"
+    "@babel/helper-validator-option": "workspace:^7.12.1"
     "@babel/plugin-transform-typescript": "workspace:^7.12.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | `@babel/preset-typescript` now depends on `@babel/helper-validator-option`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is extracted from #10927. It targets to current `main`.

In another PR, I plan to re-introduce #10927 behind a flag (tentatively named as `BABEL_8_PRESET_OPTION_CHECK`) like we did in #11172, so it is non-breaking change (not if you randomly assign `BABEL_8_*` env in your CI) and we can merge without holding off for a long while.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12347"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/4c023d8d9bc6c602bfe001c15e696f881251a7ea.svg" /></a>

