### PR TITLE
refactor: inline `@babel/helper-regex` usage

### DIFF
--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "@babel/helper-annotate-as-pure": "workspace:^7.10.4",
-    "@babel/helper-regex": "workspace:^7.10.4",
     "regexpu-core": "^4.7.1"
   },
   "peerDependencies": {

--- a/packages/babel-helper-create-regexp-features-plugin/src/index.js
+++ b/packages/babel-helper-create-regexp-features-plugin/src/index.js
@@ -10,8 +10,20 @@ import { generateRegexpuOptions } from "./util";
 
 import pkg from "../package.json";
 import { types as t } from "@babel/core";
-import { pullFlag } from "@babel/helper-regex";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
+
+type RegExpFlags = "i" | "g" | "m" | "s" | "u" | "y";
+
+/**
+ * Remove given flag from given RegExpLiteral node
+ *
+ * @param {RegExpLiteral} node
+ * @param {RegExpFlags} flag
+ * @returns {void}
+ */
+function pullFlag(node, flag: RegExpFlags): void {
+  node.flags = node.flags.replace(flag, "");
+}
 
 // Note: Versions are represented as an integer. e.g. 7.1.5 is represented
 //       as 70000100005. This method is easier than using a semver-parsing

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -16,8 +16,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "@babel/helper-plugin-utils": "workspace:^7.10.4",
-    "@babel/helper-regex": "workspace:^7.10.4"
+    "@babel/helper-plugin-utils": "workspace:^7.10.4"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-plugin-transform-sticky-regex/src/index.js
+++ b/packages/babel-plugin-transform-sticky-regex/src/index.js
@@ -1,5 +1,4 @@
 import { declare } from "@babel/helper-plugin-utils";
-import * as regex from "@babel/helper-regex";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
@@ -11,7 +10,7 @@ export default declare(api => {
     visitor: {
       RegExpLiteral(path) {
         const { node } = path;
-        if (!regex.is(node, "y")) return;
+        if (!node.flags.includes("y")) return;
 
         path.replaceWith(
           t.newExpression(t.identifier("RegExp"), [

--- a/yarn.lock
+++ b/yarn.lock
@@ -409,7 +409,6 @@ __metadata:
     "@babel/core": "workspace:*"
     "@babel/helper-annotate-as-pure": "workspace:^7.10.4"
     "@babel/helper-plugin-test-runner": "workspace:*"
-    "@babel/helper-regex": "workspace:^7.10.4"
     regexpu-core: ^4.7.1
   peerDependencies:
     "@babel/core": ^7.0.0
@@ -644,7 +643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-regex@workspace:^7.10.4, @babel/helper-regex@workspace:packages/babel-helper-regex":
+"@babel/helper-regex@workspace:packages/babel-helper-regex":
   version: 0.0.0-use.local
   resolution: "@babel/helper-regex@workspace:packages/babel-helper-regex"
   dependencies:
@@ -2746,7 +2745,6 @@ __metadata:
     "@babel/core": "workspace:*"
     "@babel/helper-plugin-test-runner": "workspace:*"
     "@babel/helper-plugin-utils": "workspace:^7.10.4"
-    "@babel/helper-regex": "workspace:^7.10.4"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | `@babel/helper-regex` is not depended by any package in monorepo
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR inlines `@babel/helper-regex` to our repo. We can archive `@babel/helper-regex` in another PR.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12349"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/d0f1b4ce97e9a047245cbc27ea60bcac5e029b90.svg" /></a>

