### PR TITLE
Fix: correctly transform `this.#m?.(...arguments)`

### DIFF
--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -14,5 +14,9 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/types": "workspace:^7.10.4"
+  },
+  "devDependencies": {
+    "@babel/generator": "workspace:*",
+    "@babel/parser": "workspace:*"
   }
 }

--- a/packages/babel-helper-optimise-call-expression/src/index.js
+++ b/packages/babel-helper-optimise-call-expression/src/index.js
@@ -22,6 +22,14 @@ export default function (
     t.isSpreadElement(args[0]) &&
     t.isIdentifier(args[0].argument, { name: "arguments" })
   ) {
+    // a.b?.(...arguments);
+    if (optional) {
+      return t.optionalCallExpression(
+        t.optionalMemberExpression(callee, t.identifier("apply"), false, true),
+        [thisNode, args[0].argument],
+        false,
+      );
+    }
     // a.b(...arguments);
     return t.callExpression(t.memberExpression(callee, t.identifier("apply")), [
       thisNode,

--- a/packages/babel-helper-optimise-call-expression/src/index.js
+++ b/packages/babel-helper-optimise-call-expression/src/index.js
@@ -1,17 +1,34 @@
 import * as t from "@babel/types";
 
-export default function (callee, thisNode, args, optional) {
+/**
+ * A helper function that generates a new call expression with given thisNode.
+ It will also optimize `(...arguments)` to `.apply(arguments)`
+ *
+ * @export
+ * @param {Node} callee The callee of call expression
+ * @param {Node} thisNode The desired this of call expression
+ * @param {Node[]} args The arguments of call expression
+ * @param {boolean} optional Whether the call expression is optional
+ * @returns {CallExpression | OptionalCallExpression} The generated new call expression
+ */
+export default function (
+  callee: Node,
+  thisNode: Node,
+  args: Node[],
+  optional: boolean,
+): CallExpression | OptionalCallExpression {
   if (
     args.length === 1 &&
     t.isSpreadElement(args[0]) &&
     t.isIdentifier(args[0].argument, { name: "arguments" })
   ) {
-    // eg. super(...arguments);
+    // a.b(...arguments);
     return t.callExpression(t.memberExpression(callee, t.identifier("apply")), [
       thisNode,
       args[0].argument,
     ]);
   } else {
+    // a.b?.(arg1, arg2)
     if (optional) {
       return t.optionalCallExpression(
         t.optionalMemberExpression(callee, t.identifier("call"), false, true),
@@ -19,6 +36,7 @@ export default function (callee, thisNode, args, optional) {
         false,
       );
     }
+    // a.b(arg1, arg2)
     return t.callExpression(t.memberExpression(callee, t.identifier("call")), [
       thisNode,
       ...args,

--- a/packages/babel-helper-optimise-call-expression/test/index.js
+++ b/packages/babel-helper-optimise-call-expression/test/index.js
@@ -27,10 +27,10 @@ describe("@babel/helper-optimise-call-expression", () => {
       `"a[b].apply(a, arguments)"`,
     );
     expect(transformInput("a.b?.(...arguments)")).toMatchInlineSnapshot(
-      `"a.b.apply(a, arguments)"`,
+      `"a.b?.apply(a, arguments)"`,
     );
     expect(transformInput("a[b]?.(...arguments)")).toMatchInlineSnapshot(
-      `"a[b].apply(a, arguments)"`,
+      `"a[b]?.apply(a, arguments)"`,
     );
 
     expect(transformInput("a.b(...args)")).toMatchInlineSnapshot(
@@ -68,10 +68,10 @@ describe("@babel/helper-optimise-call-expression", () => {
       `"a[b].apply(c, arguments)"`,
     );
     expect(transformInput("a.b?.(...arguments)", "c")).toMatchInlineSnapshot(
-      `"a.b.apply(c, arguments)"`,
+      `"a.b?.apply(c, arguments)"`,
     );
     expect(transformInput("a[b]?.(...arguments)", "c")).toMatchInlineSnapshot(
-      `"a[b].apply(c, arguments)"`,
+      `"a[b]?.apply(c, arguments)"`,
     );
 
     expect(transformInput("a.b(...args)", "c")).toMatchInlineSnapshot(

--- a/packages/babel-helper-optimise-call-expression/test/index.js
+++ b/packages/babel-helper-optimise-call-expression/test/index.js
@@ -1,0 +1,103 @@
+import { parse } from "@babel/parser";
+import generator from "@babel/generator";
+import * as t from "@babel/types";
+import optimizeCallExpression from "..";
+
+function transformInput(input, thisIdentifier) {
+  const ast = parse(input);
+  const callExpression = ast.program.body[0].expression;
+  return generator(
+    optimizeCallExpression(
+      callExpression.callee,
+      thisIdentifier
+        ? t.identifier(thisIdentifier)
+        : callExpression.callee.object,
+      callExpression.arguments,
+      callExpression.type === "OptionalCallExpression",
+    ),
+  ).code;
+}
+
+describe("@babel/helper-optimise-call-expression", () => {
+  test("optimizeCallExpression should work when thisNode is implied from callee", () => {
+    expect(transformInput("a.b(...arguments)")).toMatchInlineSnapshot(
+      `"a.b.apply(a, arguments)"`,
+    );
+    expect(transformInput("a[b](...arguments)")).toMatchInlineSnapshot(
+      `"a[b].apply(a, arguments)"`,
+    );
+    expect(transformInput("a.b?.(...arguments)")).toMatchInlineSnapshot(
+      `"a.b.apply(a, arguments)"`,
+    );
+    expect(transformInput("a[b]?.(...arguments)")).toMatchInlineSnapshot(
+      `"a[b].apply(a, arguments)"`,
+    );
+
+    expect(transformInput("a.b(...args)")).toMatchInlineSnapshot(
+      `"a.b.call(a, ...args)"`,
+    );
+    expect(transformInput("a[b](...args)")).toMatchInlineSnapshot(
+      `"a[b].call(a, ...args)"`,
+    );
+    expect(transformInput("a.b?.(...args)")).toMatchInlineSnapshot(
+      `"a.b?.call(a, ...args)"`,
+    );
+    expect(transformInput("a[b]?.(...args)")).toMatchInlineSnapshot(
+      `"a[b]?.call(a, ...args)"`,
+    );
+
+    expect(transformInput("a.b(arg1, arg2)")).toMatchInlineSnapshot(
+      `"a.b.call(a, arg1, arg2)"`,
+    );
+    expect(transformInput("a[b](arg1, arg2)")).toMatchInlineSnapshot(
+      `"a[b].call(a, arg1, arg2)"`,
+    );
+    expect(transformInput("a.b?.(arg1, arg2)")).toMatchInlineSnapshot(
+      `"a.b?.call(a, arg1, arg2)"`,
+    );
+    expect(transformInput("a[b]?.(arg1, arg2)")).toMatchInlineSnapshot(
+      `"a[b]?.call(a, arg1, arg2)"`,
+    );
+  });
+
+  test("optimizeCallExpression should work when thisNode is provided", () => {
+    expect(transformInput("a.b(...arguments)", "c")).toMatchInlineSnapshot(
+      `"a.b.apply(c, arguments)"`,
+    );
+    expect(transformInput("a[b](...arguments)", "c")).toMatchInlineSnapshot(
+      `"a[b].apply(c, arguments)"`,
+    );
+    expect(transformInput("a.b?.(...arguments)", "c")).toMatchInlineSnapshot(
+      `"a.b.apply(c, arguments)"`,
+    );
+    expect(transformInput("a[b]?.(...arguments)", "c")).toMatchInlineSnapshot(
+      `"a[b].apply(c, arguments)"`,
+    );
+
+    expect(transformInput("a.b(...args)", "c")).toMatchInlineSnapshot(
+      `"a.b.call(c, ...args)"`,
+    );
+    expect(transformInput("a[b](...args)", "c")).toMatchInlineSnapshot(
+      `"a[b].call(c, ...args)"`,
+    );
+    expect(transformInput("a.b?.(...args)", "c")).toMatchInlineSnapshot(
+      `"a.b?.call(c, ...args)"`,
+    );
+    expect(transformInput("a[b]?.(...args)", "c")).toMatchInlineSnapshot(
+      `"a[b]?.call(c, ...args)"`,
+    );
+
+    expect(transformInput("a.b(arg1, arg2)", "c")).toMatchInlineSnapshot(
+      `"a.b.call(c, arg1, arg2)"`,
+    );
+    expect(transformInput("a[b](arg1, arg2)", "c")).toMatchInlineSnapshot(
+      `"a[b].call(c, arg1, arg2)"`,
+    );
+    expect(transformInput("a.b?.(arg1, arg2)", "c")).toMatchInlineSnapshot(
+      `"a.b?.call(c, arg1, arg2)"`,
+    );
+    expect(transformInput("a[b]?.(arg1, arg2)", "c")).toMatchInlineSnapshot(
+      `"a[b]?.call(c, arg1, arg2)"`,
+    );
+  });
+});

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-spread-arguments/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-spread-arguments/exec.js
@@ -1,0 +1,19 @@
+class Foo {
+  #m;
+  init() {
+    this.#m = (...args) => args;
+  }
+  static test() {
+    const f = new Foo();
+    f.init();
+    return f.#m?.(...arguments);
+  }
+
+  static testNull() {
+    const f = new Foo();
+    return f.#m?.(...arguments);
+  }
+}
+
+expect(Foo.test(1, 2)).toEqual([1, 2]);
+expect(Foo.testNull(1, 2)).toBe(undefined);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-spread-arguments/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-spread-arguments/input.js
@@ -1,0 +1,16 @@
+class Foo {
+  #m;
+  init() {
+    this.#m = (...args) => args;
+  }
+  static test() {
+    const f = new Foo();
+    f.init();
+    return f.#m?.(...arguments);
+  }
+
+  static testNull() {
+    const f = new Foo();
+    return f.#m?.(...arguments);
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-spread-arguments/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-spread-arguments/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": [["proposal-class-properties", { "loose": true }]],
+  "minNodeVersion": "14.0.0"
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-spread-arguments/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-spread-arguments/output.js
@@ -1,0 +1,32 @@
+function _classPrivateFieldLooseBase(receiver, privateKey) { if (!Object.prototype.hasOwnProperty.call(receiver, privateKey)) { throw new TypeError("attempted to use private field on non-instance"); } return receiver; }
+
+var id = 0;
+
+function _classPrivateFieldLooseKey(name) { return "__private_" + id++ + "_" + name; }
+
+var _m = _classPrivateFieldLooseKey("m");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _m, {
+      writable: true,
+      value: void 0
+    });
+  }
+
+  init() {
+    _classPrivateFieldLooseBase(this, _m)[_m] = (...args) => args;
+  }
+
+  static test() {
+    const f = new Foo();
+    f.init();
+    return _classPrivateFieldLooseBase(f, _m)[_m]?.(...arguments);
+  }
+
+  static testNull() {
+    const f = new Foo();
+    return _classPrivateFieldLooseBase(f, _m)[_m]?.(...arguments);
+  }
+
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-member-optional-call-spread-arguments/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-member-optional-call-spread-arguments/exec.js
@@ -1,0 +1,19 @@
+class Foo {
+  #m;
+  init() {
+    this.#m = (...args) => args;
+  }
+  static test() {
+    const f = new Foo();
+    f.init();
+    return f.#m?.(...arguments);
+  }
+
+  static testNull() {
+    const f = new Foo();
+    return f.#m?.(...arguments);
+  }
+}
+
+expect(Foo.test(1, 2)).toEqual([1, 2]);
+expect(Foo.testNull(1, 2)).toBe(undefined);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-member-optional-call-spread-arguments/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-member-optional-call-spread-arguments/input.js
@@ -1,0 +1,16 @@
+class Foo {
+  #m;
+  init() {
+    this.#m = (...args) => args;
+  }
+  static test() {
+    const f = new Foo();
+    f.init();
+    return f.#m?.(...arguments);
+  }
+
+  static testNull() {
+    const f = new Foo();
+    return f.#m?.(...arguments);
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-member-optional-call-spread-arguments/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-member-optional-call-spread-arguments/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["proposal-class-properties"],
+  "minNodeVersion": "14.0.0"
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-member-optional-call-spread-arguments/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-member-optional-call-spread-arguments/output.js
@@ -1,0 +1,30 @@
+function _classPrivateFieldGet(receiver, privateMap) { var descriptor = privateMap.get(receiver); if (!descriptor) { throw new TypeError("attempted to get private field on non-instance"); } if (descriptor.get) { return descriptor.get.call(receiver); } return descriptor.value; }
+
+function _classPrivateFieldSet(receiver, privateMap, value) { var descriptor = privateMap.get(receiver); if (!descriptor) { throw new TypeError("attempted to set private field on non-instance"); } if (descriptor.set) { descriptor.set.call(receiver, value); } else { if (!descriptor.writable) { throw new TypeError("attempted to set read only private field"); } descriptor.value = value; } return value; }
+
+var _m = new WeakMap();
+
+class Foo {
+  constructor() {
+    _m.set(this, {
+      writable: true,
+      value: void 0
+    });
+  }
+
+  init() {
+    _classPrivateFieldSet(this, _m, (...args) => args);
+  }
+
+  static test() {
+    const f = new Foo();
+    f.init();
+    return _classPrivateFieldGet(f, _m)?.apply(f, arguments);
+  }
+
+  static testNull() {
+    const f = new Foo();
+    return _classPrivateFieldGet(f, _m)?.apply(f, arguments);
+  }
+
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,6 +610,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-optimise-call-expression@workspace:packages/babel-helper-optimise-call-expression"
   dependencies:
+    "@babel/generator": "workspace:*"
+    "@babel/parser": "workspace:*"
     "@babel/types": "workspace:^7.10.4"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The transpiled output of `new class { #m; constructor() { this.#m?.(...arguments) } }` throws ([REPL](https://babel.dev/repl#?browsers=chrome%208&build=&builtIns=false&spec=false&loose=false&code_lz=HYUw7gBAxgNghgZwRA3gKAhAxAWwNwbQD2wCALgE4CuUZRFAFAJSqGZkAWAlggHS4B-Xg16i4FAOZUcIYGQRNCAXzRKgA&debug=false&forceAllTransforms=false&shippedProposals=true&circleciRepo=&evaluate=true&fileSize=false&timeTravel=false&sourceType=module&lineWrap=false&presets=env%2Creact%2Cstage-2%2Cflow&prettier=false&targets=&version=7.12.3&externalPlugins=))
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Also added a Jest powered fixture tester for helpers. It will be great if the fixture test runner could support inlining input/output/options.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12350"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/b783079aecf1b9dd77263f96ef1210b807caa108.svg" /></a>

