### PR TITLE
Final configuration changes in preparation for TS

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,7 +9,6 @@ packages/babel-runtime-corejs2
 packages/babel-runtime-corejs3
 packages/*/node_modules
 packages/*/lib
-packages/*/dts
 packages/*/dist
 packages/*/test/fixtures
 packages/*/test/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -71,9 +71,5 @@ packages/babel-standalone/babel.min.js
 !/packages/babel-eslint-plugin/LICENSE
 /.vscode
 
-/tsconfig.json
-/packages/*/tsconfig.json
-/packages/*/tsconfig.tsbuildinfo
-/packages/*/dts
-/codemods/*/dts
-/eslint/*/dts
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,8 @@
 module.exports = {
   collectCoverageFrom: [
-    "packages/*/src/**/*.mjs",
-    "packages/*/src/**/*.js",
-    "codemods/*/src/**/*.mjs",
-    "codemods/*/src/**/*.js",
-    "eslint/*/src/**/*.mjs",
-    "eslint/*/src/**/*.js",
+    "packages/*/src/**/*.{js,mjs,ts}",
+    "codemods/*/src/**/*.{js,mjs,ts}",
+    "eslint/*/src/**/*.{js,mjs,ts}",
   ],
   // The eslint/* packages use ESLint v6, which has dropped support for Node v6.
   // TODO: Remove this process.version check in Babel 8.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,10 @@
   ],
   "resolutions": {
     "browserslist": "npm:4.14.5",
-    "caniuse-lite": "npm:1.0.30001077"
+    "caniuse-lite": "npm:1.0.30001077",
+    "@types/babel__core": "link:./nope",
+    "@types/babel__traverse": "link:./nope",
+    "@babel/parser/@babel/types": "workspace:*"
   },
   "engines": {
     "node": ">= 6.9.0",

--- a/scripts/utils/formatCode.js
+++ b/scripts/utils/formatCode.js
@@ -15,7 +15,7 @@ if (process.env.CI && parseInt(process.versions.node, 10) < 10) {
     filename = filename || __filename;
     const prettierConfig = prettier.resolveConfig.sync(filename);
     prettierConfig.filepath = filename;
-    prettierConfig.parser = "babel";
+    prettierConfig.parser = filename.endsWith(".ts") ? "babel-ts" : "babel";
 
     return prettier.format(code, prettierConfig);
   };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,8 @@
     "lib": [
       "esnext"
     ],
+    "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "composite": true,
     "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,7 +889,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/parser@npm:^7.0.0, @babel/parser@npm:^7.1.0, @babel/parser@npm:^7.10.4, @babel/parser@npm:^7.12.0, @babel/parser@npm:^7.12.5":
+"@babel/parser@npm:^7.0.0, @babel/parser@npm:^7.10.4, @babel/parser@npm:^7.12.0, @babel/parser@npm:^7.12.5":
   version: 7.12.5
   resolution: "@babel/parser@npm:7.12.5"
   bin:
@@ -3379,7 +3379,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.10.4, @babel/types@npm:^7.10.5, @babel/types@npm:^7.11.0, @babel/types@npm:^7.12.0, @babel/types@npm:^7.12.1, @babel/types@npm:^7.12.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.10.4, @babel/types@npm:^7.10.5, @babel/types@npm:^7.11.0, @babel/types@npm:^7.12.0, @babel/types@npm:^7.12.1, @babel/types@npm:^7.12.5, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.12.6
   resolution: "@babel/types@npm:7.12.6"
   dependencies:
@@ -3807,46 +3807,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__core@npm:^7.0.0, @types/babel__core@npm:^7.1.7":
-  version: 7.1.10
-  resolution: "@types/babel__core@npm:7.1.10"
-  dependencies:
-    "@babel/parser": ^7.1.0
-    "@babel/types": ^7.0.0
-    "@types/babel__generator": "*"
-    "@types/babel__template": "*"
-    "@types/babel__traverse": "*"
-  checksum: fd013086d241527c708844ff379ec5204b31dfb4e50a427bc24e77172af74041f6eab650da16edf1a20f445595052505792ec7fa1978bb5f8f2c191bfc8c767d
+"@types/babel__core@link:./nope::locator=babel%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@types/babel__core@link:./nope::locator=babel%40workspace%3A."
   languageName: node
-  linkType: hard
+  linkType: soft
 
-"@types/babel__generator@npm:*":
-  version: 7.6.0
-  resolution: "@types/babel__generator@npm:7.6.0"
-  dependencies:
-    "@babel/types": ^7.0.0
-  checksum: 97228549b9bba6351d92891b29acfa7eb324a832a6b1d8373042ae8b1bce4e2aa300e9a349e1ec10d06115f597adcd3881635da8dfe7e21724da19e56800fe09
+"@types/babel__traverse@link:./nope::locator=babel%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@types/babel__traverse@link:./nope::locator=babel%40workspace%3A."
   languageName: node
-  linkType: hard
-
-"@types/babel__template@npm:*":
-  version: 7.0.2
-  resolution: "@types/babel__template@npm:7.0.2"
-  dependencies:
-    "@babel/parser": ^7.1.0
-    "@babel/types": ^7.0.0
-  checksum: dd13bcf6f016866dba8310053302ac657de9966d85c67748d07ee385d07bdd8af56930ed4192c426b5118f43db268c17784bc6eb051ba94c5fcd50d5ca2db74f
-  languageName: node
-  linkType: hard
-
-"@types/babel__traverse@npm:*, @types/babel__traverse@npm:^7.0.4, @types/babel__traverse@npm:^7.0.6":
-  version: 7.0.8
-  resolution: "@types/babel__traverse@npm:7.0.8"
-  dependencies:
-    "@babel/types": ^7.3.0
-  checksum: 01ac8f7c1426184330a3d510b7701cc731da0f1778772e7c8c31edd1350b21ea55ee28a8de2e1546dff679cd05c731b03505231965a92ec2422f17dc81800bf9
-  languageName: node
-  linkType: hard
+  linkType: soft
 
 "@types/color-name@npm:^1.1.1":
   version: 1.1.1


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes https://github.com/babel/babel/pull/12342
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR is a trimmed down version of https://github.com/babel/babel/pull/12342, keeping the following changes:
- `.d.ts` files are stored in `lib` instead of `dts`, so that TS can resolved them without using `"types"` in `package.json`
- Yarn workaround to avoid downloading `@types/babel__*` packages that cause conflicts

The differences are:
- Let's only focus the migration on `src` folders for now
- `.d.ts` exclusion from published packages is centralized in `Makefile`, so that it's easy to undo when we decide to publish them and we don't have to update every `.npmignore`.
- Use `@babel/parser` instead of `typescript` for prettier
- While talking with @zxbodya he mentioned that the problem with autogenerated `tsconfig.json` files is that many of them are customized, but I manually checked them and  `tsconfig.json` files need to be manually written in #11578 are:
    - `@babel/standalone`, because it needs DOM typings
    - `@babel/parser`, which doesn't have anything special _per se_ but the parser is so badly typed in Flow that `tsconfig.json` is pointing to the manually-written `.d.ts` definition we already have.

The `tsconfig.json` generation script has easily been updated to allow manually written `tsconfig.json` files (it will not overwrite them), so this problem is solved.
Also, the TS team is looking into automatically inferring `references` from `package.json` (ref: https://github.com/microsoft/TypeScript/issues/25376) and they even create a poc tool similar to our script to automatically generate `tsconfig.json` files in the meantime :slightly_smiling_face: (ref: https://github.com/weswigham/tsautoref)

My goal is to keep the migration as much centralized as possible: the more we can centralize configs (`tsconfig.json`, non-published `.d.ts`), the easier it will be to make changes when we'll start publishing type definitions.

If there will be any package-specific problem, or any possible future concern that doesn't impact the current phase of the migration, let's defer the discussion about it when/if it will actually happen. Same applies for tests: let's keep them JS-based for now (we might want to enable TypeScript `allowJS` option in the future maybe).

I tried applying this PR on top of #11578 in [this branch](https://github.com/nicolo-ribaudo/babel/tree/ts-config-update-check) and you can see on Travis that [it works](https://travis-ci.com/github/nicolo-ribaudo/babel/jobs/434004397). Testing it locally, my editor (vscode) correctly typechecks these files and "go do definition" works! (thanks to https://github.com/babel/babel/pull/12342#discussion_r520942104).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12351"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/36c704459f5eced1d73ad8fd0f6f9bb8adc691f3.svg" /></a>

