### PR TITLE
[ts]Set `false` to default value of TsTypePredicate.asserts

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -357,6 +357,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const node: N.TsTypePredicate = this.startNodeAtNode(lhs);
       node.parameterName = lhs;
       node.typeAnnotation = this.tsParseTypeAnnotation(/* eatColon */ false);
+      node.asserts = false;
       return this.finishNode(node, "TSTypePredicate");
     }
 

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1262,7 +1262,7 @@ export type TsTypePredicate = TsTypeBase & {
   type: "TSTypePredicate",
   parameterName: Identifier | TsThisType,
   typeAnnotation: TsTypeAnnotation,
-  asserts?: boolean,
+  asserts: boolean,
 };
 
 // `typeof` operator

--- a/packages/babel-parser/test/fixtures/typescript/class/predicate-types/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/predicate-types/output.json
@@ -52,7 +52,8 @@
                       "type": "TSStringKeyword",
                       "start":31,"end":37,"loc":{"start":{"line":2,"column":19},"end":{"line":2,"column":25}}
                     }
-                  }
+                  },
+                  "asserts": false
                 }
               },
               "body": {
@@ -92,7 +93,8 @@
                         "type": "TSStringKeyword",
                         "start":66,"end":72,"loc":{"start":{"line":4,"column":22},"end":{"line":4,"column":28}}
                       }
-                    }
+                    },
+                    "asserts": false
                   }
                 },
                 "id": null,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR has same purpose just as #12167. #12167 isn't enough for `this` type. So this PR sets `false` to default value of  `TSTypePredicate.asserts`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12352"><img src="https://gitpod.io/api/apps/github/pbs/github.com/sosukesuzuki/babel.git/e08a36bf180ca8646473748ade3b12c212ec847a.svg" /></a>

