### PR TITLE
[babel 8] Remove the `Noop` node type

### DIFF
--- a/packages/babel-generator/src/generators/base.ts
+++ b/packages/babel-generator/src/generators/base.ts
@@ -46,8 +46,6 @@ export function BlockStatement(this: Printer, node: t.BlockStatement) {
   }
 }
 
-export function Noop(this: Printer) {}
-
 export function Directive(this: Printer, node: t.Directive) {
   this.print(node.value, node);
   this.semicolon();

--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -56,7 +56,7 @@ export function DeclareFunction(
   this.word("function");
   this.space();
   this.print(node.id, node);
-  // @ts-expect-error todo(flow->ts) typeAnnotation does not exist on Noop
+  // @ts-ignore TODO(Babel 8) Remove this comment, since we'll remove the Noop node
   this.print(node.id.typeAnnotation.typeAnnotation, node);
 
   if (node.predicate) {

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -680,6 +680,11 @@ class Printer {
 // Expose the node type functions and helpers on the prototype for easy usage.
 Object.assign(Printer.prototype, generatorFunctions);
 
+if (!process.env.BABEL_8_BREAKING) {
+  // @ts-ignore
+  Printer.prototype.Noop = function Noop(this: Printer) {};
+}
+
 type GeneratorFunctions = typeof generatorFunctions;
 interface Printer extends GeneratorFunctions {}
 export default Printer;

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -373,15 +373,19 @@ export const functionCommon = {
 
 export const functionTypeAnnotationCommon = {
   returnType: {
-    validate: assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
+    validate: process.env.BABEL_8_BREAKING
+      ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
+      : assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
     optional: true,
   },
   typeParameters: {
-    validate: assertNodeType(
-      "TypeParameterDeclaration",
-      "TSTypeParameterDeclaration",
-      "Noop",
-    ),
+    validate: process.env.BABEL_8_BREAKING
+      ? assertNodeType("TypeParameterDeclaration", "TSTypeParameterDeclaration")
+      : assertNodeType(
+          "TypeParameterDeclaration",
+          "TSTypeParameterDeclaration",
+          "Noop",
+        ),
     optional: true,
   },
 };
@@ -455,8 +459,9 @@ defineType("FunctionExpression", {
 
 export const patternLikeCommon = {
   typeAnnotation: {
-    // TODO: @babel/plugin-transform-flow-comments puts a Noop here, is there a better way?
-    validate: assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
+    validate: process.env.BABEL_8_BREAKING
+      ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
+      : assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
     optional: true,
   },
   decorators: {
@@ -1272,11 +1277,16 @@ defineType("ClassExpression", {
       optional: true,
     },
     typeParameters: {
-      validate: assertNodeType(
-        "TypeParameterDeclaration",
-        "TSTypeParameterDeclaration",
-        "Noop",
-      ),
+      validate: process.env.BABEL_8_BREAKING
+        ? assertNodeType(
+            "TypeParameterDeclaration",
+            "TSTypeParameterDeclaration",
+          )
+        : assertNodeType(
+            "TypeParameterDeclaration",
+            "TSTypeParameterDeclaration",
+            "Noop",
+          ),
       optional: true,
     },
     body: {
@@ -1324,11 +1334,16 @@ defineType("ClassDeclaration", {
       validate: assertNodeType("Identifier"),
     },
     typeParameters: {
-      validate: assertNodeType(
-        "TypeParameterDeclaration",
-        "TSTypeParameterDeclaration",
-        "Noop",
-      ),
+      validate: process.env.BABEL_8_BREAKING
+        ? assertNodeType(
+            "TypeParameterDeclaration",
+            "TSTypeParameterDeclaration",
+          )
+        : assertNodeType(
+            "TypeParameterDeclaration",
+            "TSTypeParameterDeclaration",
+            "Noop",
+          ),
       optional: true,
     },
     body: {

--- a/packages/babel-types/src/definitions/experimental.ts
+++ b/packages/babel-types/src/definitions/experimental.ts
@@ -60,7 +60,9 @@ defineType("ClassProperty", {
       optional: true,
     },
     typeAnnotation: {
-      validate: assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
+      validate: process.env.BABEL_8_BREAKING
+        ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
+        : assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
       optional: true,
     },
     decorators: {
@@ -118,7 +120,9 @@ defineType("ClassPrivateProperty", {
       optional: true,
     },
     typeAnnotation: {
-      validate: assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
+      validate: process.env.BABEL_8_BREAKING
+        ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
+        : assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
       optional: true,
     },
     decorators: {

--- a/packages/babel-types/src/definitions/misc.ts
+++ b/packages/babel-types/src/definitions/misc.ts
@@ -5,9 +5,11 @@ import defineType, {
 } from "./utils";
 import { PLACEHOLDERS } from "./placeholders";
 
-defineType("Noop", {
-  visitor: [],
-});
+if (!process.env.BABEL_8_BREAKING) {
+  defineType("Noop", {
+    visitor: [],
+  });
+}
 
 defineType("Placeholder", {
   visitor: [],

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -20,11 +20,15 @@ const bool = assertValueType("boolean");
 
 const tSFunctionTypeAnnotationCommon = {
   returnType: {
-    validate: assertNodeType("TSTypeAnnotation", "Noop"),
+    validate: process.env.BABEL_8_BREAKING
+      ? assertNodeType("TSTypeAnnotation")
+      : assertNodeType("TSTypeAnnotation", "Noop"),
     optional: true,
   },
   typeParameters: {
-    validate: assertNodeType("TSTypeParameterDeclaration", "Noop"),
+    validate: process.env.BABEL_8_BREAKING
+      ? assertNodeType("TSTypeParameterDeclaration")
+      : assertNodeType("TSTypeParameterDeclaration", "Noop"),
     optional: true,
   },
 };

--- a/scripts/integration-tests/e2e-jest.sh
+++ b/scripts/integration-tests/e2e-jest.sh
@@ -37,14 +37,18 @@ python --version
 #                                   TEST                                       #
 #==============================================================================#
 
-if [ "$BABEL_8_BREAKING" = true ] ; then
-  # This option is removed in Babel 8
-  sed -i 's/allowDeclareFields: true,\?/\/* allowDeclareFields: true *\//g' babel.config.js
-fi
-
 startLocalRegistry "$root"/verdaccio-config.yml
 yarn install
 yarn dedupe '@babel/*'
+
+if [ "$BABEL_8_BREAKING" = true ] ; then
+  # This option is removed in Babel 8
+  sed -i 's/allowDeclareFields: true,\?/\/* allowDeclareFields: true *\//g' babel.config.js
+
+  # Jest depends on @types/babel__traverse for Babel 7, and they contain the removed Noop node
+  sed -i 's/t.Noop/any/g' node_modules/@types/babel__traverse/index.d.ts
+fi
+
 yarn build
 
 # The full test suite takes about 20mins on CircleCI. We run only a few of them


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12355  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes, behind `BABEL_8_BREAKING`
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12361"><img src="https://gitpod.io/api/apps/github/pbs/github.com/sidntrivedi012/babel.git/9952ab443fef9e867331a3f145ed50dfbdc957fc.svg" /></a>

