### PR TITLE
Continue running tests on GH when Node.js 6 fails (❌ expected)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,12 +97,10 @@ jobs:
     name: Test on Node.js # GitHub will add ${{ matrix.node-version }} to this title
     needs: build
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.node-version == 6 }}
     strategy:
       matrix:
         node-version: [14, 12, 10, 8, 6]
-        include:
-          - node-version: 6
-            continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
     strategy:
       matrix:
         node-version: [14, 12, 10, 8, 6]
+        include:
+          - node-version: 6
+            continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

https://github.com/tapjs/stack-utils/issues/56 is currently making the tests on Node.js 6 fail, and when a job fails GH aborts all the other ones.

With this PR, the overall status will still be :x:, but at least the other jobs can finish and we can see if there is an actual problem.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12364"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/ffb93b2c0fc7cf516f031ff718ec69a867000f7d.svg" /></a>

