### PR TITLE
chore: pin stack-utils to 1.0.2 on legacy node tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,10 @@ jobs:
       - name: Downgrade Jest for node <= 8
         if: matrix.node-version == '6' || matrix.node-version == '8'
         run: |
-          yarn remove jest && yarn add --dev jest@24
+          yarn remove jest
+          yarn add --dev jest@24
+          # Pin stack-utils to 1.0.2 https://github.com/tapjs/stack-utils/issues/56
+          yarn set resolution stack-utils@npm:^1.0.1 1.0.2
       - uses: actions/download-artifact@v2
         with:
           name: babel-artifact


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes failing main tests on Node.js 6
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Will mark as ready for review once CI is green.

Closes #12364

Note that this PR does not mean Babel 7 does _not_ support Node.js 6 because `stack-utils` is only used in `jest-message-utils`, it is not in Babel dependencies so we can pin it to a working version.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12365"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/90abf244721da56571d8bd3d2e5337836bf8587f.svg" /></a>

