### PR TITLE
Fix Node version check

### DIFF
--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -117,7 +117,7 @@ process.on("uncaughtException", function (err) {
 export function requireChokidar(): Object {
   try {
     // todo(babel 8): revert `@nicolo-ribaudo/chokidar-2` hack
-    return parseInt(process.version) >= 8
+    return parseInt(process.versions.node) >= 8
       ? require("chokidar")
       : require("@nicolo-ribaudo/chokidar-2");
   } catch (err) {


### PR DESCRIPTION
`process.version` always starts with `v`, so `parseInt(process.version)` always evaluates to `NaN`. See https://nodejs.org/api/process.html#process_process_version

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12382"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Hypnosphi/babel.git/687171f781aad5694a09054463945ed94a0d14c6.svg" /></a>

