### PR TITLE
Initialize NodePath context when using `getSibling`

### DIFF
--- a/packages/babel-traverse/src/path/family.js
+++ b/packages/babel-traverse/src/path/family.js
@@ -127,7 +127,7 @@ export function getSibling(key: string): NodePath {
     container: this.container,
     listKey: this.listKey,
     key: key,
-  });
+  }).setContext(this.context);
 }
 
 export function getPrevSibling(): NodePath {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12383
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When the `path` returned by `NodePath.get()` is passed back to plugins code, we must make sure to always initialize the `context` (otherwise it re-uses a possibly wrong cached contex).

I'm marking this PR as `i: regression` even if this bug was already present, because #12331 made it more common (`noScope: true` was almost ignored before that PR, while after that PR it's respected).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12387"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/562b4d60f582de3984b37f48a251cefd131f7947.svg" /></a>

