### PR TITLE
Requeue parent path after processing optionals

### DIFF
--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -111,6 +111,9 @@ export default declare((api, options) => {
           replacementPath = parentPath;
           isDeleteOperation = true;
         }
+
+        let needsRequeue = false;
+
         for (let i = optionals.length - 1; i >= 0; i--) {
           const node = optionals[i];
 
@@ -237,6 +240,15 @@ export default declare((api, options) => {
               replacementPath.get("alternate"),
             );
           }
+
+          needsRequeue = true;
+        }
+
+        // TODO(bng): Continue investigating why changes in https://github.com/babel/babel/pull/12302
+        // now need this requeue (and also why this _specific_ requeue,
+        // replacementPath.requeue() doesn't work).
+        if (needsRequeue) {
+          parentPath.requeue();
         }
       },
     },

--- a/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/input.ts
@@ -1,0 +1,2 @@
+const a = 1;
+const b = () => a?.b?.c!.d;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-typescript", "proposal-optional-chaining"]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/output.js
@@ -1,0 +1,7 @@
+const a = 1;
+
+const b = () => {
+  var _a$b;
+
+  return a === null || a === void 0 ? void 0 : (_a$b = a.b) === null || _a$b === void 0 ? void 0 : _a$b.c.d;
+};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12386 
| Patch: Bug Fix?          | Y
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12389"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/26c522ed157bb55c91e43d3d3559736339dfd382.svg" /></a>

