### PR TITLE
Update pathCache in `NodePath#_replaceWith`

### DIFF
--- a/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/input.ts
@@ -1,0 +1,2 @@
+const a = 1;
+const b = () => a?.b?.c!.d;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-typescript", "proposal-optional-chaining"]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/variable-declaration/non-null-in-optional-chain/output.js
@@ -1,0 +1,7 @@
+const a = 1;
+
+const b = () => {
+  var _a$b;
+
+  return a === null || a === void 0 ? void 0 : (_a$b = a.b) === null || _a$b === void 0 ? void 0 : _a$b.c.d;
+};

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -50,7 +50,7 @@ export function replaceWithMultiple(nodes: Array<Object>) {
   nodes = this._verifyNodeList(nodes);
   t.inheritLeadingComments(nodes[0], this.node);
   t.inheritTrailingComments(nodes[nodes.length - 1], this.node);
-  pathCache.get(this.parent).delete(this.node);
+  pathCache.get(this.parent)?.delete(this.node);
   this.node = this.container[this.key] = null;
   const paths = this.insertAfter(nodes);
 

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -199,11 +199,7 @@ export function _replaceWith(node) {
   }
 
   this.debug(`Replace with ${node?.type}`);
-  const cache = pathCache.get(this.parent);
-  if (cache) {
-    cache.set(node, this);
-    cache.delete(this.node);
-  }
+  pathCache.get(this.parent)?.set(node, this).delete(this.node);
 
   this.node = this.container[this.key] = node;
 }

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -199,6 +199,11 @@ export function _replaceWith(node) {
   }
 
   this.debug(`Replace with ${node?.type}`);
+  const cache = pathCache.get(this.parent);
+  if (cache) {
+    cache.set(node, this);
+    cache.delete(this.node);
+  }
 
   this.node = this.container[this.key] = node;
 }

--- a/packages/babel-traverse/test/conversion.js
+++ b/packages/babel-traverse/test/conversion.js
@@ -51,6 +51,14 @@ describe("conversion", function () {
       expect(generateCode(rootPath)).toBe("() => {\n  return false;\n};");
     });
 
+    it("preserves arrow function body's context", function () {
+      const rootPath = getPath("() => true").get("expression");
+      const body = rootPath.get("body");
+      rootPath.ensureBlock();
+      body.replaceWithMultiple([t.booleanLiteral(false), t.emptyStatement()]);
+      expect(generateCode(rootPath)).toBe("() => {\n  return false;\n};");
+    });
+
     it("converts for loop with statement body to block", function () {
       const rootPath = getPath("for (;;) true;");
       rootPath.ensureBlock();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12386 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes a regression introduced in #12302, where we replaced the `pathCache` to `Node`-indexed Map. Before that PR, the `pathCache` is searched by comparing `NodePath.node === targetNode`, where `targetNode` is defined by `container[key]`. After we replaced it with `Node`-indexed map, whenever we assign new value to `this.container[this.key]`, i.e. in [`replaceWithMultiple`](https://github.com/babel/babel/blob/8ab668beee32a0f7c9bd983e8542edf4278f1eca/packages/babel-traverse/src/path/replacement.js#L54), we should also update the `pathCache` otherwise if we query the replaced node in `pathCache`, we lost the access of previously cached NodePath. Why? Because when we update `this.node` and `this.container[this.key]`, we only update the _values_ of the map-backed `pathCache`, which is analogous to the exact array-backed `pathCache` before #12302. Now that we replaced `pathCache` to a Map, we should also update the _keys_ so that the replaced node points to the hosting NodePath.

Note that the second commit of #12302 https://github.com/babel/babel/pull/12302/commits/3a365bf24f9c56369ddb50b738b2f1398914b797 is exactly for such purpose, to remove `this.node` from the cache since we assign `null` to `this.container[this.key]`. Since we assign `replacement` to `this.container[this.key]` in [`NodePath#_replaceWith`](https://github.com/babel/babel/blob/8ab668beee32a0f7c9bd983e8542edf4278f1eca/packages/babel-traverse/src/path/replacement.js#L203) we should apply similar routine here. So we set a new cache for `replacement` and removed the old node cache entries.

As a summary, the side-effect introduced in #12302 is: whenever we update the targetNode (`this.container[this.key]`) of a created NodePath, we should also update the `pathCache`. I searched `this.container[this.key] =` usage in the codebase, it seems that there are only two of them so this fix seems to be complete.


Todo:

- [x] add tests to `@babel/traverse`. (I will be appreciated if you come up with such test and push to this branch, so we can merge 😄)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12391"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/307b003de7385fe21458d36f6bb46a24e1a25205.svg" /></a>

