### PR TITLE
Set correct `path.context` un `push/unshiftContainer`

### DIFF
--- a/packages/babel-traverse/src/context.js
+++ b/packages/babel-traverse/src/context.js
@@ -42,6 +42,8 @@ export default class TraversalContext {
   }
 
   create(node, obj, key, listKey): NodePath {
+    // We don't need to `.setContext()` here, since `.visitQueue()` already
+    // calls `.pushContext`.
     return NodePath.get({
       parentPath: this.parentPath,
       parent: node,

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -217,7 +217,7 @@ export function unshiftContainer(listKey, nodes) {
     container: this.node[listKey],
     listKey,
     key: 0,
-  });
+  }).setContext(this.context);
 
   return path._containerInsertBefore(nodes);
 }
@@ -237,7 +237,7 @@ export function pushContainer(listKey, nodes) {
     container: container,
     listKey,
     key: container.length,
-  });
+  }).setContext(this.context);
 
   return path.replaceWithMultiple(nodes);
 }

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -49,6 +49,26 @@ describe("modification", function () {
         },
       });
     });
+
+    it("should set the correct path.context", function () {
+      expect.assertions(2);
+
+      const ast = parse("[b];");
+      traverse(ast, {
+        skipKeys: ["consequent"],
+        ExpressionStatement(path) {
+          path.traverse({ Identifier() {}, skipKeys: [] });
+
+          const arr = path.get("expression");
+          const x = arr.pushContainer("elements", [
+            { type: "Identifier", name: "x" },
+          ])[0];
+
+          expect(x.node.name).toBe("x");
+          expect(x.opts.skipKeys).toEqual(["consequent"]);
+        },
+      });
+    });
   });
   describe("unshiftContainer", function () {
     it("unshifts identifier into params", function () {
@@ -75,6 +95,26 @@ describe("modification", function () {
           expect(generateCode(path)).toBe("foo(d, a, b);");
           path.unshiftContainer("arguments", t.stringLiteral("s"));
           expect(generateCode(path)).toBe(`foo("s", d, a, b);`);
+        },
+      });
+    });
+
+    it("should set the correct path.context", function () {
+      expect.assertions(2);
+
+      const ast = parse("[b];");
+      traverse(ast, {
+        skipKeys: ["consequent"],
+        ExpressionStatement(path) {
+          path.traverse({ Identifier() {}, skipKeys: [] });
+
+          const arr = path.get("expression");
+          const x = arr.unshiftContainer("elements", [
+            { type: "Identifier", name: "x" },
+          ])[0];
+
+          expect(x.node.name).toBe("x");
+          expect(x.opts.skipKeys).toEqual(["consequent"]);
         },
       });
     });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Both the test cases in this PR are failing without the `.setContext()` calls. The first one with "cannot read `.skipKeys` of `null` (because `pushContianer` uses a `NodePath` not in the cache) and the second one with `["consequent"] != []` (because it re-uses the options from the inner traversal).

`path.opts` in this PR is a direct side effect of not having the correct `context`, and it can cause problem when requeuing (since paths could be requeued in an "inactive" context of a nested `path.traverse` finished call).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12394"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/bdb738cf0a04560eaa53d1bff8cb203a9ae8c69e.svg" /></a>

