### PR TITLE
Fix `t.isReferenced()` for named re-exports

### DIFF
--- a/packages/babel-types/src/validators/isReferenced.js
+++ b/packages/babel-types/src/validators/isReferenced.js
@@ -29,15 +29,6 @@ export default function isReferenced(
     case "ArrowFunctionExpression":
       return parent.body === node;
 
-    // no: export { foo as NODE };
-    // yes: export { NODE as foo };
-    // no: export { NODE as foo } from "foo";
-    case "ExportSpecifier":
-      if (parent.source) {
-        return false;
-      }
-      return parent.local === node;
-
     // no: class { #NODE; }
     // no: class { get #NODE() {} }
     // no: class { #NODE() {} }
@@ -119,6 +110,15 @@ export default function isReferenced(
     case "ExportNamespaceSpecifier":
     case "ExportDefaultSpecifier":
       return false;
+
+    // no: export { foo as NODE };
+    // yes: export { NODE as foo };
+    // no: export { NODE as foo } from "foo";
+    case "ExportSpecifier":
+      if (grandparent?.source) {
+        return false;
+      }
+      return parent.local === node;
 
     // no: import NODE from "foo";
     // no: import * as NODE from "foo";

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -247,6 +247,28 @@ describe("validators", function () {
         expect(t.isReferenced(node, parent)).toBe(false);
       });
     });
+
+    describe("exports", function () {
+      it("returns false for re-exports", function () {
+        const node = t.identifier("foo");
+        const parent = t.exportSpecifier(node, t.identifier("bar"));
+        const grandparent = t.exportNamedDeclaration(
+          null,
+          [parent],
+          t.stringLiteral("library"),
+        );
+
+        expect(t.isReferenced(node, parent, grandparent)).toBe(false);
+      });
+
+      it("returns true for local exports", function () {
+        const node = t.identifier("foo");
+        const parent = t.exportSpecifier(node, t.identifier("bar"));
+        const grandparent = t.exportNamedDeclaration(null, [parent]);
+
+        expect(t.isReferenced(node, parent, grandparent)).toBe(true);
+      });
+    });
   });
 
   describe("isBinding", function () {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel-polyfills/issues/42
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12395"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/f4ed0ec877430de8898c76d7eb348d0fc574f122.svg" /></a>

