### PR TITLE
chore: replace resolve with create-require

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -52,11 +52,11 @@
     "@babel/traverse": "workspace:^7.12.9",
     "@babel/types": "workspace:^7.12.7",
     "convert-source-map": "^1.7.0",
+    "create-require": "^1.1.0",
     "debug": "^4.1.0",
     "gensync": "^1.0.0-beta.1",
     "json5": "^2.1.2",
     "lodash": "^4.17.19",
-    "resolve": "^1.3.2",
     "semver": "^5.4.1",
     "source-map": "^0.5.0"
   },

--- a/packages/babel-core/src/config/files/configuration.js
+++ b/packages/babel-core/src/config/files/configuration.js
@@ -15,9 +15,9 @@ import loadCjsOrMjsDefault from "./module-types";
 import pathPatternToRegex from "../pattern-to-regex";
 import type { FilePackageData, RelativeConfig, ConfigFile } from "./types";
 import type { CallerMetadata } from "../validation/options";
+import createRequire from "create-require";
 
 import * as fs from "../../gensync-utils/fs";
-import resolve from "../../gensync-utils/resolve";
 
 const debug = buildDebug("babel:config:loading:files:configuration");
 
@@ -136,7 +136,7 @@ export function* loadConfig(
   envName: string,
   caller: CallerMetadata | void,
 ): Handler<ConfigFile> {
-  const filepath = yield* resolve(name, { basedir: dirname });
+  const filepath = createRequire(dirname).resolve(name);
 
   const conf = yield* readConfig(filepath, envName, caller);
   if (!conf) {

--- a/packages/babel-core/src/config/files/plugins.js
+++ b/packages/babel-core/src/config/files/plugins.js
@@ -5,7 +5,7 @@
  */
 
 import buildDebug from "debug";
-import resolve from "resolve";
+import createRequire from "create-require";
 import path from "path";
 
 const debug = buildDebug("babel:config:loading:files:plugins");
@@ -95,15 +95,17 @@ function resolveStandardizedName(
 ) {
   const standardizedName = standardizeName(type, name);
 
+  const relativeRequire = createRequire(dirname);
+
   try {
-    return resolve.sync(standardizedName, { basedir: dirname });
+    return relativeRequire.resolve(standardizedName);
   } catch (e) {
     if (e.code !== "MODULE_NOT_FOUND") throw e;
 
     if (standardizedName !== name) {
       let resolvedOriginal = false;
       try {
-        resolve.sync(name, { basedir: dirname });
+        relativeRequire.resolve(name);
         resolvedOriginal = true;
       } catch {}
 
@@ -114,9 +116,7 @@ function resolveStandardizedName(
 
     let resolvedBabel = false;
     try {
-      resolve.sync(standardizeName(type, "@babel/" + name), {
-        basedir: dirname,
-      });
+      relativeRequire.resolve(standardizeName(type, "@babel/" + name));
       resolvedBabel = true;
     } catch {}
 
@@ -127,7 +127,7 @@ function resolveStandardizedName(
     let resolvedOppositeType = false;
     const oppositeType = type === "preset" ? "plugin" : "preset";
     try {
-      resolve.sync(standardizeName(oppositeType, name), { basedir: dirname });
+      relativeRequire.resolve(standardizeName(oppositeType, name));
       resolvedOppositeType = true;
     } catch {}
 

--- a/packages/babel-core/src/gensync-utils/resolve.js
+++ b/packages/babel-core/src/gensync-utils/resolve.js
@@ -1,9 +1,0 @@
-// @flow
-
-import resolve from "resolve";
-import gensync from "gensync";
-
-export default gensync<[string, {| basedir: string |}], string>({
-  sync: resolve.sync,
-  errback: resolve,
-});

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -20,10 +20,10 @@
     "@babel/helper-fixtures": "workspace:^7.10.5",
     "@babel/polyfill": "workspace:^7.12.1",
     "babel-check-duplicated-nodes": "^1.0.0",
+    "create-require": "^1.1.0",
     "jest-diff": "^24.8.0",
     "lodash": "^4.17.19",
     "quick-lru": "5.1.0",
-    "resolve": "^1.3.2",
     "source-map": "^0.5.0"
   }
 }

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -7,7 +7,7 @@ import { codeFrameColumns } from "@babel/code-frame";
 import escapeRegExp from "lodash/escapeRegExp";
 import * as helpers from "./helpers";
 import merge from "lodash/merge";
-import resolve from "resolve";
+import createRequire from "create-require";
 import assert from "assert";
 import fs from "fs";
 import path from "path";
@@ -107,9 +107,7 @@ function runModuleInTestContext(
   context: Context,
   moduleCache: Object,
 ) {
-  const filename = resolve.sync(id, {
-    basedir: path.dirname(relativeFilename),
-  });
+  const filename = createRequire(relativeFilename).resolve(id);
 
   // Expose Node-internal modules if the tests want them. Note, this will not execute inside
   // the context's global scope.

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -26,10 +26,10 @@
     "@babel/register": "workspace:^7.12.1",
     "commander": "^4.0.1",
     "core-js": "^3.2.1",
+    "create-require": "^1.1.0",
     "lodash": "^4.17.19",
     "node-environment-flags": "^1.0.5",
     "regenerator-runtime": "^0.13.4",
-    "resolve": "^1.13.1",
     "v8flags": "^3.1.1"
   },
   "peerDependencies": {

--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -8,7 +8,7 @@ import vm from "vm";
 import "core-js/stable";
 import "regenerator-runtime/runtime";
 import register from "@babel/register";
-import resolve from "resolve";
+import createRequire from "create-require";
 
 import pkg from "../package.json";
 
@@ -209,9 +209,7 @@ if (program.eval || program.print) {
 // We have to handle require ourselves, as we want to require it in the context of babel-register
 function requireArgs() {
   if (program.require) {
-    require(resolve.sync(program.require, {
-      basedir: process.cwd(),
-    }));
+    createRequire(process.cwd())(program.require);
   }
 }
 

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/helper-module-imports": "workspace:^7.12.1",
     "@babel/helper-plugin-utils": "workspace:^7.10.4",
-    "resolve": "^1.8.1",
+    "create-require": "^1.1.0",
     "semver": "^5.5.1"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-runtime/src/get-runtime-path/index.js
+++ b/packages/babel-plugin-transform-runtime/src/get-runtime-path/index.js
@@ -1,5 +1,5 @@
 import path from "path";
-import resolve from "resolve";
+import createRequire from "create-require";
 
 export default function (moduleName, dirname, absoluteRuntime) {
   if (absoluteRuntime === false) return moduleName;
@@ -13,7 +13,7 @@ export default function (moduleName, dirname, absoluteRuntime) {
 function resolveAbsoluteRuntime(moduleName: string, dirname: string) {
   try {
     return path
-      .dirname(resolve.sync(`${moduleName}/package.json`, { basedir: dirname }))
+      .dirname(createRequire(dirname).resolve(`${moduleName}/package.json`))
       .replace(/\\/g, "/");
   } catch (err) {
     if (err.code !== "MODULE_NOT_FOUND") throw err;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/output.js
@@ -1,6 +1,6 @@
-var _regeneratorRuntime = require("<CWD>/node_modules/@babel/runtime-corejs3/regenerator");
+var _regeneratorRuntime = require("<CWD>/packages/babel-runtime-corejs3/regenerator");
 
-var _mapInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/instance/map");
+var _mapInstanceProperty = require("<CWD>/packages/babel-runtime-corejs3/core-js/instance/map");
 
 var _marked = /*#__PURE__*/_regeneratorRuntime.mark(makeIterator);
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/output.js
@@ -1,6 +1,6 @@
-var _regeneratorRuntime = require("<CWD>/node_modules/@babel/runtime-corejs3/regenerator");
+var _regeneratorRuntime = require("<CWD>/packages/babel-runtime-corejs3/regenerator");
 
-var _mapInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/instance/map");
+var _mapInstanceProperty = require("<CWD>/packages/babel-runtime-corejs3/core-js-stable/instance/map");
 
 var _marked = /*#__PURE__*/_regeneratorRuntime.mark(makeIterator);
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/output.js
@@ -1,4 +1,4 @@
-var _classCallCheck = require("<CWD>/packages/babel-plugin-transform-runtime/node_modules/@babel/runtime/helpers/classCallCheck");
+var _classCallCheck = require("<CWD>/packages/babel-runtime/helpers/classCallCheck");
 
 let Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/windows/absoluteRuntime/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/windows/absoluteRuntime/output.js
@@ -1,4 +1,4 @@
-var _asyncToGenerator = require("<CWD>/packages/babel-plugin-transform-runtime/node_modules/@babel/runtime/helpers/asyncToGenerator");
+var _asyncToGenerator = require("<CWD>/packages/babel-runtime/helpers/asyncToGenerator");
 
 function test() {
   return _test.apply(this, arguments);

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -27,6 +27,6 @@
     "@babel/runtime": "workspace:*",
     "@babel/runtime-corejs2": "workspace:*",
     "@babel/runtime-corejs3": "workspace:*",
-    "resolve": "^1.15.0"
+    "create-require": "^1.1.0"
   }
 }

--- a/packages/babel-plugin-transform-typeof-symbol/test/helper.spec.js
+++ b/packages/babel-plugin-transform-typeof-symbol/test/helper.spec.js
@@ -1,13 +1,8 @@
 import * as babel from "@babel/core";
-import resolvePath from "resolve";
 import fs from "fs";
 
 import transformTypeofSymbol from "..";
 
-const resolve = path =>
-  new Promise((resolve, reject) =>
-    resolvePath(path, (err, path) => (err ? reject(err) : resolve(path))),
-  );
 const readFile = path =>
   new Promise((resolve, reject) =>
     fs.readFile(path, "utf8", (err, contents) => {
@@ -28,7 +23,7 @@ describe("@babel/plugin-transform-typeof-symbol", () => {
   `(
     "shouldn't transpile the $type $runtime helper",
     async ({ type, runtime }) => {
-      const path = await resolve(
+      const path = require.resolve(
         `${runtime}/helpers${type === "esm" ? "/esm/" : "/"}typeof`,
       );
       const src = await readFile(path);

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,11 +137,11 @@ __metadata:
     "@babel/traverse": "workspace:^7.12.9"
     "@babel/types": "workspace:^7.12.7"
     convert-source-map: ^1.7.0
+    create-require: ^1.1.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.1
     json5: ^2.1.2
     lodash: ^4.17.19
-    resolve: ^1.3.2
     semver: ^5.4.1
     source-map: ^0.5.0
   languageName: unknown
@@ -753,10 +753,10 @@ __metadata:
     "@babel/helper-fixtures": "workspace:^7.10.5"
     "@babel/polyfill": "workspace:^7.12.1"
     babel-check-duplicated-nodes: ^1.0.0
+    create-require: ^1.1.0
     jest-diff: ^24.8.0
     lodash: ^4.17.19
     quick-lru: 5.1.0
-    resolve: ^1.3.2
     source-map: ^0.5.0
   languageName: unknown
   linkType: soft
@@ -867,12 +867,12 @@ __metadata:
     "@babel/runtime": "workspace:*"
     commander: ^4.0.1
     core-js: ^3.2.1
+    create-require: ^1.1.0
     fs-readdir-recursive: ^1.0.0
     lodash: ^4.17.19
     make-dir: ^2.1.0
     node-environment-flags: ^1.0.5
     regenerator-runtime: ^0.13.4
-    resolve: ^1.13.1
     rimraf: ^3.0.0
     v8flags: ^3.1.1
   peerDependencies:
@@ -2664,8 +2664,8 @@ __metadata:
     "@babel/runtime-corejs3": "workspace:*"
     "@babel/template": "workspace:*"
     "@babel/types": "workspace:*"
+    create-require: ^1.1.0
     make-dir: ^2.1.0
-    resolve: ^1.8.1
     semver: ^5.5.1
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -2801,7 +2801,7 @@ __metadata:
     "@babel/runtime": "workspace:*"
     "@babel/runtime-corejs2": "workspace:*"
     "@babel/runtime-corejs3": "workspace:*"
-    resolve: ^1.15.0
+    create-require: ^1.1.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown
@@ -5904,6 +5904,13 @@ __metadata:
     safe-buffer: ^5.0.1
     sha.js: ^2.4.8
   checksum: 98957676a93081678a2a915ae14898d65aac9b5651ffa55b8888484dd9d79c06d3cb3f85b137cd833ab536d87adee17394bb2b0efc591ea0e34110266d5bcd75
+  languageName: node
+  linkType: hard
+
+"create-require@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "create-require@npm:1.1.0"
+  checksum: eee19428ccefdf1a2b28ba50bb12dd5c37c625cdee85478e35239311067022fe1e437d82ecf79235c5eeb03ca319261cd96225d3d0b053c4caf623972765a7bd
   languageName: node
   linkType: hard
 
@@ -11651,7 +11658,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.13.1, resolve@^1.15.0, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1":
+"resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1":
   version: 1.18.1
   resolution: "resolve@npm:1.18.1"
   dependencies:
@@ -11661,7 +11668,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.1.4#builtin<compat/resolve>, resolve@patch:resolve@^1.1.6#builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#builtin<compat/resolve>, resolve@patch:resolve@^1.11.0#builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#builtin<compat/resolve>, resolve@patch:resolve@^1.15.0#builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#builtin<compat/resolve>, resolve@patch:resolve@^1.18.1#builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#builtin<compat/resolve>, resolve@patch:resolve@^1.4.0#builtin<compat/resolve>, resolve@patch:resolve@^1.8.1#builtin<compat/resolve>":
+"resolve@patch:resolve@^1.1.4#builtin<compat/resolve>, resolve@patch:resolve@^1.1.6#builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#builtin<compat/resolve>, resolve@patch:resolve@^1.11.0#builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#builtin<compat/resolve>, resolve@patch:resolve@^1.18.1#builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#builtin<compat/resolve>, resolve@patch:resolve@^1.4.0#builtin<compat/resolve>, resolve@patch:resolve@^1.8.1#builtin<compat/resolve>":
   version: 1.18.1
   resolution: "resolve@patch:resolve@npm%3A1.18.1#builtin<compat/resolve>::version=1.18.1&hash=3388aa"
   dependencies:


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | TBD
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Replaced `resolve` with `create-require`
| License                  | MIT

Babel seems to only need `resolve` because of its `basedir` option, however Node supports using `require.resolve(id, { paths: [baseDir] })` or `createRequire*(baseDir).resolve(id)` for this. Since Babel still supports Node 6, which doesn't have any of these, a polyfill is used for `createRequire`.

`create-require` can be removed in Babel 8 in favour of just using `require.resolve`

The benefit of this change is that PnP support is preserved if someone feels like bundling Babel (https://github.com/vercel/next.js/pull/18768)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12396"><img src="https://gitpod.io/api/apps/github/pbs/github.com/merceyz/babel.git/860dc837171df564eb81244f8cffdeb37d1f263b.svg" /></a>

