### PR TITLE
chore: bump chokidar in glob-watcher to ^3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   "resolutions": {
     "browserslist": "npm:4.14.5",
     "caniuse-lite": "npm:1.0.30001158",
+    "glob-watcher/chokidar": "npm:^3.4.0",
     "@types/babel__core": "link:./nope",
     "@types/babel__traverse": "link:./nope",
     "@babel/parser/@babel/types": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5408,29 +5408,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^2.0.0":
-  version: 2.1.8
-  resolution: "chokidar@npm:2.1.8"
-  dependencies:
-    anymatch: ^2.0.0
-    async-each: ^1.0.1
-    braces: ^2.3.2
-    fsevents: ^1.2.7
-    glob-parent: ^3.1.0
-    inherits: ^2.0.3
-    is-binary-path: ^1.0.0
-    is-glob: ^4.0.0
-    normalize-path: ^3.0.0
-    path-is-absolute: ^1.0.0
-    readdirp: ^2.2.1
-    upath: ^1.1.1
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: 0758dcc7c6c7ace5924cf3c68088210932d391ab41026376b0adb8e07013ac87232e029f13468dfc9ca4dd59adae62a2b7eaedebb6c4e4f0ba92cbf3ac9e3721
-  languageName: node
-  linkType: hard
-
 "chokidar@npm:^3.4.0":
   version: 3.4.2
   resolution: "chokidar@npm:3.4.2"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | CPU usage can hit 10% when running `make watch` for a long time 
| Any Dependency Changes?  | Bump `glob-watcher/chokidar` to v3
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Looks good on my local machine. The CPU usage is improved as expected. Since we are shipping `chokidar@3` in `@babel/cli`, it makes sense to dog fooding for our own infra.

Context: https://github.com/gulpjs/glob-watcher/issues/55

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12397"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/e0f4d6cf8984221a80730fa4a94bb6e252f6bb1d.svg" /></a>

