### PR TITLE
refactor: simplify isAwaitAllowed

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -2343,10 +2343,9 @@ export default class ExpressionParser extends LValParser {
   }
 
   isAwaitAllowed(): boolean {
-    if (this.scope.inFunction) return this.prodParam.hasAwait;
-    if (this.options.allowAwaitOutsideFunction) return true;
-    if (this.hasPlugin("topLevelAwait")) {
-      return this.inModule && this.prodParam.hasAwait;
+    if (this.prodParam.hasAwait) return true;
+    if (this.options.allowAwaitOutsideFunction && !this.scope.inFunction) {
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Simplified `parser.isAwaitAllowed` a bit.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12398"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/b9a6e20a427385bd2fbb5d347a8c130c5cd178bc.svg" /></a>

