### PR TITLE
Bump core-js-compat to version 3.8.0

### DIFF
--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -79,7 +79,7 @@
     "@babel/plugin-transform-unicode-regex": "workspace:^7.12.1",
     "@babel/preset-modules": "^0.1.3",
     "@babel/types": "workspace:^7.12.7",
-    "core-js-compat": "^3.7.0",
+    "core-js-compat": "^3.8.0",
     "semver": "^5.5.0"
   },
   "peerDependencies": {

--- a/packages/babel-preset-env/test/fixtures/corejs3/entry-entries-proposals/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs3/entry-entries-proposals/output.mjs
@@ -1,3 +1,4 @@
+import "core-js/modules/es.map";
 import "core-js/modules/esnext.aggregate-error";
 import "core-js/modules/esnext.array.last-index";
 import "core-js/modules/esnext.array.last-item";

--- a/packages/babel-preset-env/test/fixtures/corejs3/entry-entries-stage/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs3/entry-entries-stage/output.mjs
@@ -1,3 +1,4 @@
+import "core-js/modules/es.map";
 import "core-js/modules/esnext.aggregate-error";
 import "core-js/modules/esnext.array.last-index";
 import "core-js/modules/esnext.array.last-item";

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/input.mjs] Replaced core-js entries with the following polyfills:
+  es.map {}
   esnext.aggregate-error {}
   esnext.array.last-index {}
   esnext.array.last-item {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/input.mjs] Replaced core-js entries with the following polyfills:
+  es.map {}
   esnext.aggregate-error {}
   esnext.array.last-index {}
   esnext.array.last-item {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3042,7 +3042,7 @@ __metadata:
     "@babel/plugin-transform-unicode-regex": "workspace:^7.12.1"
     "@babel/preset-modules": ^0.1.3
     "@babel/types": "workspace:^7.12.7"
-    core-js-compat: ^3.7.0
+    core-js-compat: ^3.8.0
     semver: ^5.5.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -5797,13 +5797,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.6.2, core-js-compat@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "core-js-compat@npm:3.7.0"
+"core-js-compat@npm:^3.6.2, core-js-compat@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "core-js-compat@npm:3.8.0"
   dependencies:
-    browserslist: ^4.14.6
+    browserslist: ^4.14.7
     semver: 7.0.0
-  checksum: 4194aaeb0da4cd584aa493069f322b3f6310d22207fae965bda476d4469283e76f4f8857920222b58c083b0e57e1c4199ac039d5337e76bdeb60b793f2a05f3b
+  checksum: e0278c0e64334bdd5a7e13cc49830585dd194d0d4f84322c9fe3cb30ab7f23396374cf499fe02f8e4817470b51e3b35d533e67045a0f67ed391995f013f17a83
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Bumped `core-js-compat` to 3.8.0
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12399"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/8b30e43fec02444219e82e5c958d6ae553865a8e.svg" /></a>

