### PR TITLE
Generate class ref ID for anonymous class only

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -138,7 +138,7 @@ export function createClassFeaturePlugin({
 
         let ref;
 
-        if (path.isClassExpression() || !path.node.id) {
+        if (!path.node.id) {
           nameFunction(path);
           ref = path.scope.generateUidIdentifier("class");
         } else {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/non-block-arrow-func/output.mjs
@@ -1,12 +1,12 @@
 export default (param => {
-  var _class, _props, _temp;
+  var App, _props, _temp;
 
-  return _temp = (_props = babelHelpers.classPrivateFieldLooseKey("props"), _class = class App {
+  return _temp = (_props = babelHelpers.classPrivateFieldLooseKey("props"), App = class App {
     getParam() {
       return param;
     }
 
-  }), Object.defineProperty(_class, _props, {
+  }), Object.defineProperty(App, _props, {
     writable: true,
     value: {
       prop1: 'prop1',

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reevaluated/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reevaluated/output.js
@@ -1,7 +1,7 @@
 function classFactory() {
-  var _class, _foo, _bar, _temp;
+  var Foo, _foo, _bar, _temp;
 
-  return _temp = (_foo = babelHelpers.classPrivateFieldLooseKey("foo"), _bar = babelHelpers.classPrivateFieldLooseKey("bar"), _class = class Foo {
+  return _temp = (_foo = babelHelpers.classPrivateFieldLooseKey("foo"), _bar = babelHelpers.classPrivateFieldLooseKey("bar"), Foo = class Foo {
     constructor() {
       Object.defineProperty(this, _foo, {
         writable: true,
@@ -25,7 +25,7 @@ function classFactory() {
       return babelHelpers.classPrivateFieldLooseBase(Foo, _bar)[_bar];
     }
 
-  }), Object.defineProperty(_class, _bar, {
+  }), Object.defineProperty(Foo, _bar, {
     writable: true,
     value: "bar"
   }), _temp;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-init-has-class-ref/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-init-has-class-ref/exec.js
@@ -1,0 +1,7 @@
+const X = class B {
+  static #a = 0;
+  static #b = B.#a;
+  static c = B.#b;
+}
+
+expect(X.c).toBe(0);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-init-has-class-ref/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-init-has-class-ref/input.js
@@ -1,0 +1,5 @@
+const X = class B {
+  static #a = 0;
+  static #b = B.#a;
+  static c = B.#b;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-init-has-class-ref/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-init-has-class-ref/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    ["proposal-class-properties", { "loose": true }]
+  ]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-init-has-class-ref/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-init-has-class-ref/output.js
@@ -1,0 +1,9 @@
+var B, _a, _b, _temp;
+
+const X = (_temp = (_a = babelHelpers.classPrivateFieldLooseKey("a"), _b = babelHelpers.classPrivateFieldLooseKey("b"), B = class B {}), Object.defineProperty(B, _a, {
+  writable: true,
+  value: 0
+}), Object.defineProperty(B, _b, {
+  writable: true,
+  value: babelHelpers.classPrivateFieldLooseBase(B, _a)[_a]
+}), B.c = babelHelpers.classPrivateFieldLooseBase(B, _b)[_b], _temp);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/non-block-arrow-func/output.mjs
@@ -1,7 +1,7 @@
 export default (param => {
-  var _class, _temp, _props;
+  var App, _temp, _props;
 
-  return _temp = _class = class App {
+  return _temp = App = class App {
     getParam() {
       return param;
     }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reevaluated/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reevaluated/output.js
@@ -1,7 +1,7 @@
 function classFactory() {
-  var _class, _foo, _temp, _bar;
+  var Foo, _foo, _temp, _bar;
 
-  return _temp = (_foo = new WeakMap(), _class = class Foo {
+  return _temp = (_foo = new WeakMap(), Foo = class Foo {
     constructor() {
       _foo.set(this, {
         writable: true,
@@ -14,7 +14,7 @@ function classFactory() {
     }
 
     static() {
-      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, _class, _bar);
+      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _bar);
     }
 
     static instance(inst) {
@@ -22,7 +22,7 @@ function classFactory() {
     }
 
     static static() {
-      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, _class, _bar);
+      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _bar);
     }
 
   }), _bar = {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T6719/output.js
@@ -1,7 +1,7 @@
 function withContext(ComposedComponent) {
-  var _class, _temp, _propTypes;
+  var WithContext, _temp, _propTypes;
 
-  return _temp = _class = class WithContext extends Component {}, _propTypes = {
+  return _temp = WithContext = class WithContext extends Component {}, _propTypes = {
     writable: true,
     value: {
       context: PropTypes.shape({

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-init-has-class-ref/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-init-has-class-ref/exec.js
@@ -1,0 +1,7 @@
+const X = class B {
+  static #a = 0;
+  static #b = B.#a;
+  static c = B.#b;
+}
+
+expect(X.c).toBe(0);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-init-has-class-ref/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-init-has-class-ref/input.js
@@ -1,0 +1,5 @@
+const X = class B {
+  static #a = 0;
+  static #b = B.#a;
+  static c = B.#b;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-init-has-class-ref/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-init-has-class-ref/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "proposal-class-properties"
+  ]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-init-has-class-ref/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-init-has-class-ref/output.js
@@ -1,0 +1,9 @@
+var B, _temp, _a, _b;
+
+const X = (_temp = B = class B {}, _a = {
+  writable: true,
+  value: 0
+}, _b = {
+  writable: true,
+  value: babelHelpers.classStaticPrivateFieldSpecGet(B, B, _a)
+}, babelHelpers.defineProperty(B, "c", babelHelpers.classStaticPrivateFieldSpecGet(B, B, _b)), _temp);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/non-block-arrow-func/output.mjs
@@ -1,7 +1,7 @@
 export default (param => {
-  var _class, _temp;
+  var App, _temp;
 
-  return _temp = _class = /*#__PURE__*/function () {
+  return _temp = App = /*#__PURE__*/function () {
     function App() {
       babelHelpers.classCallCheck(this, App);
     }
@@ -13,7 +13,7 @@ export default (param => {
       }
     }]);
     return App;
-  }(), _class.props = {
+  }(), App.props = {
     prop1: 'prop1',
     prop2: 'prop2'
   }, _temp;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T6719/output.js
@@ -1,7 +1,7 @@
 function withContext(ComposedComponent) {
-  var _class, _temp;
+  var WithContext, _temp;
 
-  return _temp = _class = /*#__PURE__*/function (_Component) {
+  return _temp = WithContext = /*#__PURE__*/function (_Component) {
     "use strict";
 
     babelHelpers.inherits(WithContext, _Component);
@@ -14,7 +14,7 @@ function withContext(ComposedComponent) {
     }
 
     return WithContext;
-  }(Component), _class.propTypes = {
+  }(Component), WithContext.propTypes = {
     context: PropTypes.shape({
       addCss: PropTypes.func,
       setTitle: PropTypes.func,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-init-has-class-ref/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-init-has-class-ref/exec.js
@@ -1,0 +1,6 @@
+const X = class B {
+  static a = 0;
+  static b = B.a;
+}
+
+expect(X.b).toBe(0);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-init-has-class-ref/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-init-has-class-ref/input.js
@@ -1,0 +1,4 @@
+const X = class B {
+  static a = 0;
+  static b = B.a;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-init-has-class-ref/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-init-has-class-ref/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    ["proposal-class-properties", { "loose": true }]
+  ]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-init-has-class-ref/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-init-has-class-ref/output.js
@@ -1,0 +1,3 @@
+var B, _temp;
+
+const X = (_temp = B = class B {}, B.a = 0, B.b = B.a, _temp);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/non-block-arrow-func/output.mjs
@@ -1,7 +1,7 @@
 export default (param => {
-  var _class, _temp;
+  var App, _temp;
 
-  return _temp = _class = /*#__PURE__*/function () {
+  return _temp = App = /*#__PURE__*/function () {
     function App() {
       babelHelpers.classCallCheck(this, App);
     }
@@ -13,7 +13,7 @@ export default (param => {
       }
     }]);
     return App;
-  }(), babelHelpers.defineProperty(_class, "props", {
+  }(), babelHelpers.defineProperty(App, "props", {
     prop1: 'prop1',
     prop2: 'prop2'
   }), _temp;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T6719/output.js
@@ -1,7 +1,7 @@
 function withContext(ComposedComponent) {
-  var _class, _temp;
+  var WithContext, _temp;
 
-  return _temp = _class = /*#__PURE__*/function (_Component) {
+  return _temp = WithContext = /*#__PURE__*/function (_Component) {
     "use strict";
 
     babelHelpers.inherits(WithContext, _Component);
@@ -14,7 +14,7 @@ function withContext(ComposedComponent) {
     }
 
     return WithContext;
-  }(Component), babelHelpers.defineProperty(_class, "propTypes", {
+  }(Component), babelHelpers.defineProperty(WithContext, "propTypes", {
     context: PropTypes.shape({
       addCss: PropTypes.func,
       setTitle: PropTypes.func,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-init-has-class-ref/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-init-has-class-ref/exec.js
@@ -1,0 +1,6 @@
+const X = class B {
+  static a = 0;
+  static b = B.a;
+}
+
+expect(X.b).toBe(0);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-init-has-class-ref/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-init-has-class-ref/input.js
@@ -1,0 +1,4 @@
+const X = class B {
+  static a = 0;
+  static b = B.a;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-init-has-class-ref/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-init-has-class-ref/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "proposal-class-properties"
+  ]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-init-has-class-ref/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-init-has-class-ref/output.js
@@ -1,0 +1,3 @@
+var B, _temp;
+
+const X = (_temp = B = class B {}, babelHelpers.defineProperty(B, "a", 0), babelHelpers.defineProperty(B, "b", B.a), _temp);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6153/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6153/output.js
@@ -16,9 +16,9 @@
 });
 
 (function () {
-  var _class, _temp;
+  var Bar, _temp;
 
-  return _temp = _class = class Bar {
+  return _temp = Bar = class Bar {
     constructor() {
       var _this2 = this;
 
@@ -27,8 +27,8 @@
       });
     }
 
-  }, babelHelpers.defineProperty(_class, "fn", function () {
-    return console.log(_class);
+  }, babelHelpers.defineProperty(Bar, "fn", function () {
+    return console.log(Bar);
   }), _temp;
 });
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/8882/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/8882/output.js
@@ -1,11 +1,11 @@
 const classes = [];
 
 for (let i = 0; i <= 10; ++i) {
-  var _class, _bar, _temp;
+  var A, _bar, _temp;
 
   let _i;
 
-  classes.push((_temp = (_bar = new WeakMap(), _i = i, _class = class A {
+  classes.push((_temp = (_bar = new WeakMap(), _i = i, A = class A {
     constructor() {
       babelHelpers.defineProperty(this, _i, `computed field ${i}`);
 
@@ -19,5 +19,5 @@ for (let i = 0; i <= 10; ++i) {
       return babelHelpers.classPrivateFieldGet(this, _bar);
     }
 
-  }), babelHelpers.defineProperty(_class, "foo", `static field ${i}`), _temp));
+  }), babelHelpers.defineProperty(A, "foo", `static field ${i}`), _temp));
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T6719/output.js
@@ -1,7 +1,7 @@
 function withContext(ComposedComponent) {
-  var _class, _temp;
+  var WithContext, _temp;
 
-  return _temp = _class = /*#__PURE__*/function (_Component) {
+  return _temp = WithContext = /*#__PURE__*/function (_Component) {
     "use strict";
 
     babelHelpers.inherits(WithContext, _Component);
@@ -14,7 +14,7 @@ function withContext(ComposedComponent) {
     }
 
     return WithContext;
-  }(Component), _class.propTypes = {
+  }(Component), WithContext.propTypes = {
     context: PropTypes.shape({
       addCss: PropTypes.func,
       setTitle: PropTypes.func,

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/in-class-heritage/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/in-class-heritage/output.js
@@ -1,11 +1,11 @@
-var _class, _2, _temp, _class2, _3, _temp2;
+var _class, _2, _temp, Base, _3, _temp2;
 
 var _ = babelHelpers.classPrivateFieldLooseKey("_");
 
-class Foo extends (_temp = (_2 = babelHelpers.classPrivateFieldLooseKey("_"), _class = class extends (_temp2 = (_3 = babelHelpers.classPrivateFieldLooseKey("_"), _class2 = class Base {}), Object.defineProperty(_class2, _3, {
+class Foo extends (_temp = (_2 = babelHelpers.classPrivateFieldLooseKey("_"), _class = class extends (_temp2 = (_3 = babelHelpers.classPrivateFieldLooseKey("_"), Base = class Base {}), Object.defineProperty(Base, _3, {
   writable: true,
   value: (() => {
-    _class2.qux = 21;
+    Base.qux = 21;
   })()
 }), _temp2) {}), Object.defineProperty(_class, _2, {
   writable: true,

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/in-class-heritage/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/in-class-heritage/output.js
@@ -1,9 +1,9 @@
-var _class, _temp, _2, _class2, _temp2, _3;
+var _class, _temp, _2, Base, _temp2, _3;
 
-class Foo extends (_temp = _class = class extends (_temp2 = _class2 = class Base {}, _3 = {
+class Foo extends (_temp = _class = class extends (_temp2 = Base = class Base {}, _3 = {
   writable: true,
   value: (() => {
-    _class2.qux = 21;
+    Base.qux = 21;
   })()
 }, _temp2) {}, _2 = {
   writable: true,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11990 
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
A named class expression can be referenced in the field initializers, e.g.
```js
const x = class B {
  static b = B.name
}
```
before this PR we generated `_class` reference to `B` but did not replace `B.name` to `_class.name`.
```js
const x = (_temp = _class = class B {}, _defineProperty(_class, "b", B.name), _temp);
```

I assume that we are safe to produce `(X = class X {})` as the following cases are invalid
```js
(a) => { a = 1; return class a {} };
const a = class a {};
```
so this PR clones the class binding identifier when it exists, since it could be referenced in field initializers.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12403"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/dc3a666070bf52b065664eddd0071ef4198f77d5.svg" /></a>

