### PR TITLE
refactor: move @babel/helper-hoist-variables to ts

### DIFF
--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -13,6 +13,7 @@
     "access": "public"
   },
   "main": "lib/index.js",
+  "TODO": "The @babel/traverse dependency is only needed for the NodePath TS type. After converting @babel/core to TS we can import NodePath from there.",
   "dependencies": {
     "@babel/traverse": "workspace:^7.12.17",
     "@babel/types": "workspace:^7.12.13"

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -14,6 +14,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/traverse": "workspace:^7.12.17",
     "@babel/types": "workspace:^7.12.13"
   }
 }

--- a/packages/babel-helper-hoist-variables/src/index.ts
+++ b/packages/babel-helper-hoist-variables/src/index.ts
@@ -13,6 +13,8 @@ type State = {
   emit: EmitFunction;
 };
 
+type Unpacked<T> = T extends (infer U)[] ? U : T;
+
 const visitor = {
   Scope(path: NodePath, state: State) {
     if (state.kind === "let") path.skip();
@@ -27,9 +29,9 @@ const visitor = {
 
     const nodes = [];
 
-    const declarations: ReadonlyArray<NodePath<
-      VariableDeclaration["declarations"]
-    >> = path.get("declarations");
+    const declarations: ReadonlyArray<
+      NodePath<Unpacked<VariableDeclaration["declarations"]>>
+    > = path.get("declarations");
     let firstId;
 
     for (const declar of declarations) {

--- a/packages/babel-helper-hoist-variables/src/index.ts
+++ b/packages/babel-helper-hoist-variables/src/index.ts
@@ -1,9 +1,8 @@
 import * as t from "@babel/types";
-import type { Identifier, VariableDeclaration } from "@babel/types";
 import type { NodePath } from "@babel/traverse";
 
 export type EmitFunction = (
-  id: Identifier,
+  id: t.Identifier,
   idName: string,
   hasInit: boolean,
 ) => any;
@@ -24,13 +23,13 @@ const visitor = {
     path.skip();
   },
 
-  VariableDeclaration(path: NodePath<VariableDeclaration>, state: State) {
+  VariableDeclaration(path: NodePath<t.VariableDeclaration>, state: State) {
     if (state.kind && path.node.kind !== state.kind) return;
 
     const nodes = [];
 
     const declarations: ReadonlyArray<
-      NodePath<Unpacked<VariableDeclaration["declarations"]>>
+      NodePath<Unpacked<t.VariableDeclaration["declarations"]>>
     > = path.get("declarations");
     let firstId;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,6 +537,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-hoist-variables@workspace:packages/babel-helper-hoist-variables"
   dependencies:
+    "@babel/traverse": "workspace:^7.12.17"
     "@babel/types": "workspace:^7.12.13"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | `@babel/helper-hoist-variables` now depends on `@babel/traverse`, from which it imports `NodePath` type.
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12413"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/3965e6ad83138762ae47c349b866d8fd031475e0.svg" /></a>

