### PR TITLE
refactor: move @babel/helper-bindify-decorators to ts

### DIFF
--- a/packages/babel-helper-bindify-decorators/src/index.ts
+++ b/packages/babel-helper-bindify-decorators/src/index.ts
@@ -1,9 +1,10 @@
 import type { NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
+import type { Decorator } from "@babel/types";
 
 export default function bindifyDecorators(
-  decorators: Array<NodePath>,
-): Array<NodePath> {
+  decorators: ReadonlyArray<NodePath<Decorator>>,
+): void {
   for (const decoratorPath of decorators) {
     const decorator = decoratorPath.node;
     const expression = decorator.expression;

--- a/packages/babel-helper-bindify-decorators/src/index.ts
+++ b/packages/babel-helper-bindify-decorators/src/index.ts
@@ -1,9 +1,8 @@
 import type { NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
-import type { Decorator } from "@babel/types";
 
 export default function bindifyDecorators(
-  decorators: ReadonlyArray<NodePath<Decorator>>,
+  decorators: ReadonlyArray<NodePath<t.Decorator>>,
 ): void {
   for (const decoratorPath of decorators) {
     const decorator = decoratorPath.node;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12416"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/315dbd160b75b1c7d7c132aef65b3c375d305e31.svg" /></a>

