### PR TITLE
babel-types update OptionalCallExpression to support ArgumentPlaceholder

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -1998,7 +1998,12 @@ defineType("OptionalCallExpression", {
       validate: chain(
         assertValueType("array"),
         assertEach(
-          assertNodeType("Expression", "SpreadElement", "JSXNamespacedName"),
+          assertNodeType(
+            "Expression",
+            "SpreadElement",
+            "JSXNamespacedName",
+            "ArgumentPlaceholder",
+          ),
         ),
       ),
     },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Adding support for `ArgumentPlaceholder` in `OptionalCallExpression` to align it with `CallExpression`.

Found this while rebasing #11578 

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12418"><img src="https://gitpod.io/api/apps/github/pbs/github.com/zxbodya/babel.git/b15a5d30097272ccc660c3f4ec1df5e88f66af23.svg" /></a>

