### PR TITLE
Fix printing BigIntLiterals/DecimalLiterals with compact option

### DIFF
--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -216,19 +216,19 @@ export function StringLiteral(node: Object) {
 export function BigIntLiteral(node: Object) {
   const raw = this.getPossibleRaw(node);
   if (!this.format.minified && raw != null) {
-    this.token(raw);
+    this.word(raw);
     return;
   }
-  this.token(node.value + "n");
+  this.word(node.value + "n");
 }
 
 export function DecimalLiteral(node: Object) {
   const raw = this.getPossibleRaw(node);
   if (!this.format.minified && raw != null) {
-    this.token(raw);
+    this.word(raw);
     return;
   }
-  this.token(node.value + "m");
+  this.word(node.value + "m");
 }
 
 export function PipelineTopicExpression(node: Object) {

--- a/packages/babel-generator/test/fixtures/types/BigIntLiteral-compact/input.js
+++ b/packages/babel-generator/test/fixtures/types/BigIntLiteral-compact/input.js
@@ -1,0 +1,5 @@
+function a() { return 100n; }
+function b() { return 9223372036854775807n; }
+function c() { return 0o16432n; }
+function d() { return 0xFFF123n; }
+function e() { return 0b101011101n; }

--- a/packages/babel-generator/test/fixtures/types/BigIntLiteral-compact/options.json
+++ b/packages/babel-generator/test/fixtures/types/BigIntLiteral-compact/options.json
@@ -1,0 +1,3 @@
+{
+  "compact": true
+}

--- a/packages/babel-generator/test/fixtures/types/BigIntLiteral-compact/output.js
+++ b/packages/babel-generator/test/fixtures/types/BigIntLiteral-compact/output.js
@@ -1,0 +1,1 @@
+function a(){return 100n;}function b(){return 9223372036854775807n;}function c(){return 0o16432n;}function d(){return 0xFFF123n;}function e(){return 0b101011101n;}

--- a/packages/babel-generator/test/fixtures/types/DecimalLiteral-compact/input.js
+++ b/packages/babel-generator/test/fixtures/types/DecimalLiteral-compact/input.js
@@ -1,0 +1,5 @@
+function a() { return 100m; }
+function b() { return 9223372036854775807m; }
+function c() { return 0.m; }
+function d() { return 3.1415926535897932m; }
+function e() { return 100.000m; }

--- a/packages/babel-generator/test/fixtures/types/DecimalLiteral-compact/options.json
+++ b/packages/babel-generator/test/fixtures/types/DecimalLiteral-compact/options.json
@@ -1,0 +1,4 @@
+{
+  "compact": true,
+  "plugins": ["decimal"]
+}

--- a/packages/babel-generator/test/fixtures/types/DecimalLiteral-compact/output.js
+++ b/packages/babel-generator/test/fixtures/types/DecimalLiteral-compact/output.js
@@ -1,0 +1,1 @@
+function a(){return 100m;}function b(){return 9223372036854775807m;}function c(){return 0.m;}function d(){return 3.1415926535897932m;}function e(){return 100.000m;}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12423 
| Patch: Bug Fix?          | Y
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12424"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/84fb9a101f3701678067a8e678fc17774d6f58e1.svg" /></a>

