### PR TITLE
Add `@babel/traverse` tests for re-exported bindings

### DIFF
--- a/packages/babel-traverse/test/fixtures/rename/re-export/input.mjs
+++ b/packages/babel-traverse/test/fixtures/rename/re-export/input.mjs
@@ -1,0 +1,7 @@
+// https://github.com/babel/babel/issues/9266
+
+export function x() {
+  return "YES";
+}
+
+export { x as someFunction } from './lib2.js'

--- a/packages/babel-traverse/test/fixtures/rename/re-export/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/re-export/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/re-export/output.mjs
+++ b/packages/babel-traverse/test/fixtures/rename/re-export/output.mjs
@@ -1,0 +1,7 @@
+// https://github.com/babel/babel/issues/9266
+function a() {
+  return "YES";
+}
+
+export { a as x };
+export { x as someFunction } from './lib2.js';

--- a/packages/babel-traverse/test/fixtures/rename/re-export/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/re-export/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      Function(path) {
+        path.scope.rename("x", "a");
+      }
+    }
+  };
+}

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -351,6 +351,13 @@ describe("scope", () => {
 
       expect(path.scope.generateUid("Cls")).toBe("_Cls2");
     });
+
+    it("re-exports are not references", () => {
+      const path = getPath("export { x } from 'y'", {
+        sourceType: "module",
+      });
+      expect(path.scope.hasGlobal("x")).toBe(false);
+    });
   });
 
   describe("duplicate bindings", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9266, fixes #12406
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

These two issues where actually fixed by https://github.com/babel/babel/pull/12395, but since they are on a completely different level I added two tests to make sure that they were actually fixed (since it's not obvious by looking at #12395)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12429"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/15cc8b75bbede4784be0bcfc58e1e72932ae8d32.svg" /></a>

