### PR TITLE
Use `require.resolve` instead of the `resolve` package

### DIFF
--- a/lib/third-party-libs.js.flow
+++ b/lib/third-party-libs.js.flow
@@ -6,12 +6,11 @@ declare module "debug" {
   declare export default (namespace: string) => (formatter: string, ...args: any[]) => void;
 }
 
-declare module "resolve" {
-  declare export default {
-    (string, {| basedir: string |}, (err: ?Error, res: string) => void): void;
-    sync: (string, {| basedir: string |}) => string;
-  };
-}
+declare var require: {
+  resolve(specifier: string, opts?: {
+    paths: string[]
+  }): string,
+};
 
 declare module "json5" {
   declare export default {

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -56,7 +56,6 @@
     "gensync": "^1.0.0-beta.1",
     "json5": "^2.1.2",
     "lodash": "^4.17.19",
-    "resolve": "^1.3.2",
     "semver": "^5.4.1",
     "source-map": "^0.5.0"
   },

--- a/packages/babel-core/src/config/files/configuration.js
+++ b/packages/babel-core/src/config/files/configuration.js
@@ -17,7 +17,6 @@ import type { FilePackageData, RelativeConfig, ConfigFile } from "./types";
 import type { CallerMetadata } from "../validation/options";
 
 import * as fs from "../../gensync-utils/fs";
-import resolve from "../../gensync-utils/resolve";
 
 const debug = buildDebug("babel:config:loading:files:configuration");
 
@@ -136,7 +135,7 @@ export function* loadConfig(
   envName: string,
   caller: CallerMetadata | void,
 ): Handler<ConfigFile> {
-  const filepath = yield* resolve(name, { basedir: dirname });
+  const filepath = require.resolve(name, { paths: [dirname] });
 
   const conf = yield* readConfig(filepath, envName, caller);
   if (!conf) {

--- a/packages/babel-core/src/config/files/plugins.js
+++ b/packages/babel-core/src/config/files/plugins.js
@@ -5,7 +5,6 @@
  */
 
 import buildDebug from "debug";
-import resolve from "resolve";
 import path from "path";
 
 const debug = buildDebug("babel:config:loading:files:plugins");
@@ -96,14 +95,18 @@ function resolveStandardizedName(
   const standardizedName = standardizeName(type, name);
 
   try {
-    return resolve.sync(standardizedName, { basedir: dirname });
+    return require.resolve(standardizedName, {
+      paths: [dirname],
+    });
   } catch (e) {
     if (e.code !== "MODULE_NOT_FOUND") throw e;
 
     if (standardizedName !== name) {
       let resolvedOriginal = false;
       try {
-        resolve.sync(name, { basedir: dirname });
+        require.resolve(name, {
+          paths: [dirname],
+        });
         resolvedOriginal = true;
       } catch {}
 
@@ -114,8 +117,8 @@ function resolveStandardizedName(
 
     let resolvedBabel = false;
     try {
-      resolve.sync(standardizeName(type, "@babel/" + name), {
-        basedir: dirname,
+      require.resolve(standardizeName(type, "@babel/" + name), {
+        paths: [dirname],
       });
       resolvedBabel = true;
     } catch {}
@@ -127,7 +130,9 @@ function resolveStandardizedName(
     let resolvedOppositeType = false;
     const oppositeType = type === "preset" ? "plugin" : "preset";
     try {
-      resolve.sync(standardizeName(oppositeType, name), { basedir: dirname });
+      require.resolve(standardizeName(oppositeType, name), {
+        paths: [dirname],
+      });
       resolvedOppositeType = true;
     } catch {}
 

--- a/packages/babel-core/src/gensync-utils/resolve.js
+++ b/packages/babel-core/src/gensync-utils/resolve.js
@@ -1,9 +1,0 @@
-// @flow
-
-import resolve from "resolve";
-import gensync from "gensync";
-
-export default gensync<[string, {| basedir: string |}], string>({
-  sync: resolve.sync,
-  errback: resolve,
-});

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -144,13 +144,13 @@ describe("parser and generator options", function () {
 describe("api", function () {
   it("exposes the resolvePlugin method", function () {
     expect(() => babel.resolvePlugin("nonexistent-plugin")).toThrow(
-      /Cannot find module 'babel-plugin-nonexistent-plugin'/,
+      /Cannot resolve module 'babel-plugin-nonexistent-plugin'/,
     );
   });
 
   it("exposes the resolvePreset method", function () {
     expect(() => babel.resolvePreset("nonexistent-preset")).toThrow(
-      /Cannot find module 'babel-preset-nonexistent-preset'/,
+      /Cannot resolve module 'babel-preset-nonexistent-preset'/,
     );
   });
 

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -344,7 +344,7 @@ describe("addon resolution", function () {
         presets: ["foo"],
       });
     }).toThrow(
-      /Cannot find module 'babel-preset-foo'.*\n- If you want to resolve "foo", use "module:foo"/,
+      /Cannot resolve module 'babel-preset-foo'.*\n- If you want to resolve "foo", use "module:foo"/,
     );
   });
 
@@ -358,7 +358,7 @@ describe("addon resolution", function () {
         plugins: ["foo"],
       });
     }).toThrow(
-      /Cannot find module 'babel-plugin-foo'.*\n- If you want to resolve "foo", use "module:foo"/,
+      /Cannot resolve module 'babel-plugin-foo'.*\n- If you want to resolve "foo", use "module:foo"/,
     );
   });
 
@@ -372,7 +372,7 @@ describe("addon resolution", function () {
         presets: ["foo"],
       });
     }).toThrow(
-      /Cannot find module 'babel-preset-foo'.*\n- Did you mean "@babel\/foo"\?/,
+      /Cannot resolve module 'babel-preset-foo'.*\n- Did you mean "@babel\/foo"\?/,
     );
   });
 
@@ -386,7 +386,7 @@ describe("addon resolution", function () {
         plugins: ["foo"],
       });
     }).toThrow(
-      /Cannot find module 'babel-plugin-foo'.*\n- Did you mean "@babel\/foo"\?/,
+      /Cannot resolve module 'babel-plugin-foo'.*\n- Did you mean "@babel\/foo"\?/,
     );
   });
 
@@ -400,7 +400,7 @@ describe("addon resolution", function () {
         presets: ["testplugin"],
       });
     }).toThrow(
-      /Cannot find module 'babel-preset-testplugin'.*\n- Did you accidentally pass a plugin as a preset\?/,
+      /Cannot resolve module 'babel-preset-testplugin'.*\n- Did you accidentally pass a plugin as a preset\?/,
     );
   });
 
@@ -414,7 +414,7 @@ describe("addon resolution", function () {
         plugins: ["testpreset"],
       });
     }).toThrow(
-      /Cannot find module 'babel-plugin-testpreset'.*\n- Did you accidentally pass a preset as a plugin\?/,
+      /Cannot resolve module 'babel-plugin-testpreset'.*\n- Did you accidentally pass a preset as a plugin\?/,
     );
   });
 
@@ -427,7 +427,7 @@ describe("addon resolution", function () {
         babelrc: false,
         presets: ["foo"],
       });
-    }).toThrow(/Cannot find module 'babel-preset-foo'/);
+    }).toThrow(/Cannot resolve module 'babel-preset-foo'/);
   });
 
   it("should throw about missing plugins", function () {
@@ -439,6 +439,6 @@ describe("addon resolution", function () {
         babelrc: false,
         plugins: ["foo"],
       });
-    }).toThrow(/Cannot find module 'babel-plugin-foo'/);
+    }).toThrow(/Cannot resolve module 'babel-plugin-foo'/);
   });
 });

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -23,7 +23,6 @@
     "jest-diff": "^24.8.0",
     "lodash": "^4.17.19",
     "quick-lru": "5.1.0",
-    "resolve": "^1.3.2",
     "source-map": "^0.5.0"
   }
 }

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -7,7 +7,6 @@ import { codeFrameColumns } from "@babel/code-frame";
 import escapeRegExp from "lodash/escapeRegExp";
 import * as helpers from "./helpers";
 import merge from "lodash/merge";
-import resolve from "resolve";
 import assert from "assert";
 import fs from "fs";
 import path from "path";
@@ -107,8 +106,8 @@ function runModuleInTestContext(
   context: Context,
   moduleCache: Object,
 ) {
-  const filename = resolve.sync(id, {
-    basedir: path.dirname(relativeFilename),
+  const filename = require.resolve(id, {
+    paths: [path.dirname(relativeFilename)],
   });
 
   // Expose Node-internal modules if the tests want them. Note, this will not execute inside

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -29,7 +29,6 @@
     "lodash": "^4.17.19",
     "node-environment-flags": "^1.0.5",
     "regenerator-runtime": "^0.13.4",
-    "resolve": "^1.13.1",
     "v8flags": "^3.1.1"
   },
   "peerDependencies": {

--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -8,7 +8,6 @@ import vm from "vm";
 import "core-js/stable";
 import "regenerator-runtime/runtime";
 import register from "@babel/register";
-import resolve from "resolve";
 
 import pkg from "../package.json";
 
@@ -209,8 +208,8 @@ if (program.eval || program.print) {
 // We have to handle require ourselves, as we want to require it in the context of babel-register
 function requireArgs() {
   if (program.require) {
-    require(resolve.sync(program.require, {
-      basedir: process.cwd(),
+    require(require.resolve(program.require, {
+      paths: [process.cwd()],
     }));
   }
 }

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/exec.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/exec.js
@@ -15,7 +15,7 @@ let functionPath;
 transform(code, {
   configFile: false,
   plugins: [
-    "../../../../lib",
+    __dirname + "/../../../../lib",
     {
       post({ path }) {
         programPath = path;

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@babel/helper-module-imports": "workspace:^7.12.1",
     "@babel/helper-plugin-utils": "workspace:^7.10.4",
-    "resolve": "^1.8.1",
     "semver": "^5.5.1"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-runtime/src/get-runtime-path/index.js
+++ b/packages/babel-plugin-transform-runtime/src/get-runtime-path/index.js
@@ -1,5 +1,4 @@
 import path from "path";
-import resolve from "resolve";
 
 export default function (moduleName, dirname, absoluteRuntime) {
   if (absoluteRuntime === false) return moduleName;
@@ -13,7 +12,9 @@ export default function (moduleName, dirname, absoluteRuntime) {
 function resolveAbsoluteRuntime(moduleName: string, dirname: string) {
   try {
     return path
-      .dirname(resolve.sync(`${moduleName}/package.json`, { basedir: dirname }))
+      .dirname(
+        require.resolve(`${moduleName}/package.json`, { paths: [dirname] }),
+      )
       .replace(/\\/g, "/");
   } catch (err) {
     if (err.code !== "MODULE_NOT_FOUND") throw err;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-proposals/output.js
@@ -1,6 +1,6 @@
-var _regeneratorRuntime = require("<CWD>/node_modules/@babel/runtime-corejs3/regenerator");
+var _regeneratorRuntime = require("<CWD>/packages/babel-runtime-corejs3/regenerator");
 
-var _mapInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js/instance/map");
+var _mapInstanceProperty = require("<CWD>/packages/babel-runtime-corejs3/core-js/instance/map");
 
 var _marked = /*#__PURE__*/_regeneratorRuntime.mark(makeIterator);
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-corejs3-stable/output.js
@@ -1,6 +1,6 @@
-var _regeneratorRuntime = require("<CWD>/node_modules/@babel/runtime-corejs3/regenerator");
+var _regeneratorRuntime = require("<CWD>/packages/babel-runtime-corejs3/regenerator");
 
-var _mapInstanceProperty = require("<CWD>/node_modules/@babel/runtime-corejs3/core-js-stable/instance/map");
+var _mapInstanceProperty = require("<CWD>/packages/babel-runtime-corejs3/core-js-stable/instance/map");
 
 var _marked = /*#__PURE__*/_regeneratorRuntime.mark(makeIterator);
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/output.js
@@ -1,4 +1,4 @@
-var _classCallCheck = require("<CWD>/packages/babel-plugin-transform-runtime/node_modules/@babel/runtime/helpers/classCallCheck");
+var _classCallCheck = require("<CWD>/packages/babel-runtime/helpers/classCallCheck");
 
 let Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/windows/absoluteRuntime/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/windows/absoluteRuntime/output.js
@@ -1,4 +1,4 @@
-var _asyncToGenerator = require("<CWD>/packages/babel-plugin-transform-runtime/node_modules/@babel/runtime/helpers/asyncToGenerator");
+var _asyncToGenerator = require("<CWD>/packages/babel-runtime/helpers/asyncToGenerator");
 
 function test() {
   return _test.apply(this, arguments);

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -26,7 +26,6 @@
     "@babel/helper-plugin-test-runner": "workspace:*",
     "@babel/runtime": "workspace:*",
     "@babel/runtime-corejs2": "workspace:*",
-    "@babel/runtime-corejs3": "workspace:*",
-    "resolve": "^1.15.0"
+    "@babel/runtime-corejs3": "workspace:*"
   }
 }

--- a/packages/babel-plugin-transform-typeof-symbol/test/helper.spec.js
+++ b/packages/babel-plugin-transform-typeof-symbol/test/helper.spec.js
@@ -1,13 +1,8 @@
 import * as babel from "@babel/core";
-import resolvePath from "resolve";
 import fs from "fs";
 
 import transformTypeofSymbol from "..";
 
-const resolve = path =>
-  new Promise((resolve, reject) =>
-    resolvePath(path, (err, path) => (err ? reject(err) : resolve(path))),
-  );
 const readFile = path =>
   new Promise((resolve, reject) =>
     fs.readFile(path, "utf8", (err, contents) => {
@@ -28,7 +23,7 @@ describe("@babel/plugin-transform-typeof-symbol", () => {
   `(
     "shouldn't transpile the $type $runtime helper",
     async ({ type, runtime }) => {
-      const path = await resolve(
+      const path = require.resolve(
         `${runtime}/helpers${type === "esm" ? "/esm/" : "/"}typeof`,
       );
       const src = await readFile(path);

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,7 +141,6 @@ __metadata:
     gensync: ^1.0.0-beta.1
     json5: ^2.1.2
     lodash: ^4.17.19
-    resolve: ^1.3.2
     semver: ^5.4.1
     source-map: ^0.5.0
   languageName: unknown
@@ -756,7 +755,6 @@ __metadata:
     jest-diff: ^24.8.0
     lodash: ^4.17.19
     quick-lru: 5.1.0
-    resolve: ^1.3.2
     source-map: ^0.5.0
   languageName: unknown
   linkType: soft
@@ -872,7 +870,6 @@ __metadata:
     make-dir: ^2.1.0
     node-environment-flags: ^1.0.5
     regenerator-runtime: ^0.13.4
-    resolve: ^1.13.1
     rimraf: ^3.0.0
     v8flags: ^3.1.1
   peerDependencies:
@@ -2665,7 +2662,6 @@ __metadata:
     "@babel/template": "workspace:*"
     "@babel/types": "workspace:*"
     make-dir: ^2.1.0
-    resolve: ^1.8.1
     semver: ^5.5.1
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -2801,7 +2797,6 @@ __metadata:
     "@babel/runtime": "workspace:*"
     "@babel/runtime-corejs2": "workspace:*"
     "@babel/runtime-corejs3": "workspace:*"
-    resolve: ^1.15.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown
@@ -11628,7 +11623,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.13.1, resolve@^1.15.0, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1":
+"resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1":
   version: 1.18.1
   resolution: "resolve@npm:1.18.1"
   dependencies:
@@ -11638,7 +11633,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.1.4#builtin<compat/resolve>, resolve@patch:resolve@^1.1.6#builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#builtin<compat/resolve>, resolve@patch:resolve@^1.11.0#builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#builtin<compat/resolve>, resolve@patch:resolve@^1.15.0#builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#builtin<compat/resolve>, resolve@patch:resolve@^1.18.1#builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#builtin<compat/resolve>, resolve@patch:resolve@^1.4.0#builtin<compat/resolve>, resolve@patch:resolve@^1.8.1#builtin<compat/resolve>":
+"resolve@patch:resolve@^1.1.4#builtin<compat/resolve>, resolve@patch:resolve@^1.1.6#builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#builtin<compat/resolve>, resolve@patch:resolve@^1.11.0#builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#builtin<compat/resolve>, resolve@patch:resolve@^1.18.1#builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#builtin<compat/resolve>, resolve@patch:resolve@^1.4.0#builtin<compat/resolve>, resolve@patch:resolve@^1.8.1#builtin<compat/resolve>":
   version: 1.18.1
   resolution: "resolve@patch:resolve@npm%3A1.18.1#builtin<compat/resolve>::version=1.18.1&hash=3388aa"
   dependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes https://github.com/babel/babel/pull/12396, fixes https://github.com/vercel/next.js/issues/19334
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Removed `resolve`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR fixes an incompatibility between Babel, PnP and Next.js.

The problem is that Next.js bundles Babel, and thus it bundles our `resolve` dependency. `resolve` doesn't support PnP, but Yarn patches `resolve` at install time so that it works with PnP: this doesn't work if `resolve` is inside of a bundle, because Yarn cannot detect it.
(context: https://github.com/babel/babel/pull/12396)

This PR drops `"resolve"`, in favor or `require.resolve` (when supported) or a custom small polyfill when it's not.
The other possible fix is that `resolve` supports PnP natively (rather than being patched at build-time), but it won't likely be implemented because it would unnecessarly ship a lot of code to consumers not using PnP (ref: https://github.com/browserify/resolve/issues/199).

- The first commit is exactly https://github.com/babel/babel/pull/11125, that we already merged in the Babel 8 branch.
- The second commit modifies our `babel.config.js` so that when building for Node.js 6 (and for releases) it inlines a small polyfill. The polyfill is the smallest I could think of, based on https://github.com/nodejs/node/blob/f223bba539c8dab131e443225a8695eba0fd5521/lib/module.js#L462 where `_resolveLookupPaths` has been replaced by what fits our usage.

By doing so,
- we avoid the new dependency (which was proposed in https://github.com/babel/babel/pull/12396)
- we only have to delete that Babel plugin in Babel 8
- we use the native `require.resolve` when it supports the `paths` option.

Note that customizing our build process to support older Node.js versions is something we already did: for example, before https://github.com/babel/babel/pull/12288 we were using a custom plugin to fix resolution of dynamic import paths in some Node.js versions.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12439"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/d5b2aee61429f6a9175206a92f7b47e113b8ef7f.svg" /></a>

