### PR TITLE
Prepare codebase for inline Babel 8 breaking changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Build babel artifacts
         run: |
           BABEL_ENV=test-legacy make -j build-standalone-ci
+        env:
+          BABEL_8_BREAKING: false
+          STRIP_BABEL_8_FLAG: true
       - uses: actions/upload-artifact@v2
         with:
           name: babel-artifact
@@ -163,6 +166,41 @@ jobs:
         # Remove once `chalk` is bumped to 4.0.
         run: |
           BABEL_ENV=test node ./node_modules/.bin/jest --ci --color
+
+  test-babel-8-breaking:
+    name: Test Babel 8 breaking changes
+    needs: prepare-yarn-cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: 12 # Node.js 12 is the first LTS supported by Babel 8
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-${{ hashFiles('yarn.lock') }}
+      - name: Install and build
+        run: make -j bootstrap
+        env:
+          BABEL_ENV: test
+          BABEL_8_BREAKING: true
+          STRIP_BABEL_8_FLAG: true
+      - name: Test
+        # Hack: --color has supports-color@5 returned true for GitHub CI
+        # Remove once `chalk` is bumped to 4.0.
+        run: |
+          yarn jest --ci --color
+          yarn test:esm
+        env:
+          BABEL_ENV: test
+          BABEL_8_BREAKING: true
+          BABEL_TYPES_8_BREAKING: true
 
   test-windows:
     name: Test on Windows

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -110,7 +110,7 @@ if (process.env.CIRCLE_PR_NUMBER) {
 
 const babelVersion =
   require("./packages/babel-core/package.json").version + versionSuffix;
-function buildRollup(packages) {
+function buildRollup(packages, targetBrowsers) {
   const sourcemap = process.env.NODE_ENV === "production";
   return Promise.all(
     packages.map(async ({ src, format, dest, name, filename }) => {
@@ -166,11 +166,12 @@ function buildRollup(packages) {
             ],
           }),
           rollupJson(),
-          rollupNodePolyfills({
-            sourceMap: sourcemap,
-            include: "**/*.{js,ts}",
-          }),
-        ],
+          targetBrowsers &&
+            rollupNodePolyfills({
+              sourceMap: sourcemap,
+              include: "**/*.{js,ts}",
+            }),
+        ].filter(Boolean),
       });
 
       const outputFile = path.join(src, dest, filename || "index.js");
@@ -235,7 +236,7 @@ const standaloneBundle = [
 ];
 
 gulp.task("build-rollup", () => buildRollup(libBundles));
-gulp.task("build-babel-standalone", () => buildRollup(standaloneBundle));
+gulp.task("build-babel-standalone", () => buildRollup(standaloneBundle, true));
 
 gulp.task("build-babel", () => buildBabel(/* exclude */ libBundles));
 gulp.task("build", gulp.parallel("build-rollup", "build-babel"));

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ clone-license:
 	./scripts/clone-license.sh
 
 prepublish-build: clean-lib clean-runtime-helpers
-	NODE_ENV=production BABEL_ENV=production $(MAKE) build-bundle
+	NODE_ENV=production BABEL_ENV=production STRIP_BABEL_8_FLAG=true $(MAKE) build-bundle
 	$(MAKE) prepublish-build-standalone clone-license
 
 prepublish:

--- a/packages/babel-helper-fixtures/src/index.js
+++ b/packages/babel-helper-fixtures/src/index.js
@@ -122,7 +122,11 @@ function pushTask(taskName, taskDir, suite, suiteName) {
   const test = {
     optionsDir: taskOptsLoc ? path.dirname(taskOptsLoc) : null,
     title: humanize(taskName, true),
-    disabled: taskName[0] === ".",
+    disabled:
+      taskName[0] === "." ||
+      (process.env.BABEL_8_BREAKING
+        ? taskOpts.BABEL_8_BREAKING === false
+        : taskOpts.BABEL_8_BREAKING === true),
     options: taskOpts,
     validateLogs: taskOpts.validateLogs,
     ignoreOutput: taskOpts.ignoreOutput,

--- a/packages/babel-types/test/regressions.js
+++ b/packages/babel-types/test/regressions.js
@@ -1,7 +1,9 @@
 import * as t from "../lib";
 
 describe("regressions", () => {
-  it("jest .toMatchInlineSnapshot used 'Line' for comments", () => {
+  const babel7 = process.env.BABEL_TYPES_8_BREAKING ? it.skip : it;
+
+  babel7("jest .toMatchInlineSnapshot used 'Line' for comments", () => {
     expect(() => {
       t.file(t.program([]), [{ type: "Line" }]);
     }).not.toThrow();


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The current process for working on Babel 8 features is:
- We have a `next-8-dev` branch, that we target with breaking PRs
- We have a `next-8-rebased` branch, which is a "clean" branch for Babel 8. We can rewrite the history of this branch when we need to remove a commit because it's not needed anymore after a change in Babel 7.
- We regularly merge `main` in `next-8-dev`
- We regularly rebase `next-8-rebased` on `main`

Merges/rebases often take a lot of time (a few hours at least), especially when there is a big number of merge conflicts. Also, the risk of introducing bugs is high (as an example, both the branches for Babel 8 are failing on CI).

With this PR, it would be possible to inline many breaking changes (everything except for dependency updates) directly in `main`, stripping them at build time when publishing by specifying `STRIP_BABEL_8_FLAG=true`.

<details>

<summary>There are currently 29 commits in <code>next-8-rebased</code>, and most of them could be moved to <code>main</code>. What can't be moved are mostly depenencies updates</summary>

(:x: = "cannot be moved", :heavy_check_mark: = "can be moved", :grey_question: = "needs investigation"/"not applicable")

- :x: `1ee144c69c` Replace lodash 'escapeRegExp' with escape-string-regexp library (#11842)
- :heavy_check_mark: `5ae8ab2579` Make automatic runtime the default for JSX compilation (#11436)
- :grey_question: `6b3f1fdaf4` chore: lint-js-ci depends on build-bundle
- :grey_question: `9ec4ab43d6` chore: fix yarn warnings
- :heavy_check_mark: `034981d0c3` Drop core-js 2 support (#11751)
- :heavy_check_mark: `f50f7aa4fe` Enable the `BABEL_TYPES_8_BREAKING` flag in `@babel/types` (#11172)
- :heavy_check_mark: `5a44a83c51` breaking: remove useSpread and useBuiltIns option (#11141)
- :heavy_check_mark: `6b0be825e5` add rejects assertion to fixture-test-runner (#11740)
- :heavy_check_mark: `5535630633` Better file extension handling for TypeScript and Flow presets (#11316)
- :grey_question: `f7ab3749a3` Update transform-unicode-escapes test to output minimal strings (#11721)
- :heavy_check_mark: `ee5d2ed479` Remove backward compatibility for union types (#11468)
- :heavy_check_mark:/:x:`1727d26062` Improve syntax highlighting (#11413)
- :grey_question: `cb4917510e` Disable e2e-babel-old-version test (#11477)
- :grey_question: `8406b10005` Update failing test on Windows (#11454)
- :heavy_check_mark: `d9c65dbe6b` Output minimal strings by default (#11384)
- :heavy_check_mark: `cd0c303894` Remove error plugin name mappings of removed parser plugins (#11234)
- :grey_question: `e1f91da012` Remove config hack for old Node compatibility (#11199)
- :heavy_check_mark: `cd41cc9165` Remove jsonCompatibleStrings option (#9958)
- :grey_question: `0881dd8629` Use require.resolve instead of the "resolve" package (#11125) (:warning: Backported in https://github.com/babel/babel/pull/12439)
- :heavy_check_mark: `7217f71c57` Remove the allowDeclareFields TS option and make it the default behavior (#11114)
- :heavy_check_mark: `635c7fd6a9` Avoid removing uninitialized class fields with flow (#10120)
- :x: `2eeb3497b0` Bump dependencies (#10747)
- :x: `5e4757c3e7` Remove polyfills and minNodeVersion for old Node.js (#10747)
- :x: `ef1edc1416` Drop Node.js <10.13 support (#10747)
- :heavy_check_mark: `94431e4daf` Remove `uglify` target support in preset-env (#10895)
- :heavy_check_mark: `13fa535e59` Remove functions present only for backwards-compatibility (#11095)
- :heavy_check_mark: `129149ed4c` breaking: remove parserOpts.objectRestSpread from typescript (#10915)
- :heavy_check_mark: `524080265e` feat(babel-parser): throw syntax error for `}` and `>` in JSX… (#11046)
- :heavy_check_mark: `3b1404991f` jsx: fix sequence expression at JSXAttributeValue (#8787)

</details>

We would still need a separate branch for dependency updates, but it would be way easier to merge/rebase since the changes would be mostly isolated in `package.json` files.

When we'll release a Babel 8 alpha/beta/RC, we will have to:
- Create a new branch from `main`
- Apply the "dependency update" commits on top of it
- Release with `BABEL_8_BREAKING=true`

This PR also introduces a new flag in our fixutres options, `BABEL_8_BREAKING: boolean`, and when it is specified the test is only run if Babel has been built with the corresponding breaking changes.

This is an example of a backport from `next-8-rebased` to `main`: https://github.com/nicolo-ribaudo/babel/compare/prepare-for-breaking-changes...nicolo-ribaudo:breaking/disallow-sequence-expression-in-jsx

What do you think about this approach?

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12440"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/1e31f387334f9774021ca85fa342dee43fbb4cdd.svg" /></a>

