### PR TITLE
Make sure estree test should not throw if babel parser does not throw

### DIFF
--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -61,7 +61,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         directiveLiteral.loc.start,
       );
 
-      expression.value = directiveLiteral.value;
+      expression.value = directiveLiteral.extra.expressionValue;
       expression.raw = directiveLiteral.extra.raw;
 
       stmt.expression = this.finishNodeAt(
@@ -118,9 +118,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const directive = super.stmtToDirective(stmt);
       const value = stmt.expression.value;
 
-      // Reset value to the actual value as in estree mode we want
-      // the stmt to have the real value and not the raw value
-      directive.value.value = value;
+      // Record the expression value as in estree mode we want
+      // the stmt to have the real value e.g. ("use strict") and
+      // not the raw value e.g. ("use\\x20strict")
+      this.addExtra(directive.value, "expressionValue", value);
 
       return directive;
     }

--- a/packages/babel-parser/test/helpers/runFixtureTests.js
+++ b/packages/babel-parser/test/helpers/runFixtureTests.js
@@ -83,14 +83,6 @@ export function runThrowTestsWithEstree(fixturesPath, parseFunction) {
   Object.keys(fixtures).forEach(function (name) {
     fixtures[name].forEach(function (testSuite) {
       testSuite.tests.forEach(function (task) {
-        if (!task.options.throws) {
-          const hasErrors =
-            !task.disabled && "errors" in JSON.parse(task.expect.code);
-          if (!hasErrors) {
-            return;
-          }
-        }
-
         task.options.plugins = task.options.plugins || [];
         task.options.plugins.push("estree");
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | When `estree` is enabled, Babel parser incorrectly throws for valid `"use\x20strict"; with (a) {}`, [astexplorer](https://astexplorer.net/#/gist/925537686e3e1c3f26c93265bb042e9c/175c6fdc9bcff323fc38975cdad0fcd41c1c09b7), [CI Failure](https://github.com/babel/babel/pull/12443/checks?check_run_id=1495321345#step:11:390) reported by the new test runner.
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This first commit is to enable `estree` test to be run on those test cases that does not expect `errors`. The second commit is to fix the issue detected by the new test runner.

This PR is a follow-up to https://github.com/babel/babel/pull/12375.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12443"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/65f333e847dfd15fe55d1b3bf28a0ed0a4bca492.svg" /></a>

