### PR TITLE
Use new CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,12 +163,7 @@ jobs:
           # Copied from https://circleci.com/developer/orbs/orb/threetreeslight/puppeteer
           name: Install Headless Chrome dependencies
           command: |
-            sudo apt-get install -yq \
-            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
-            libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+            sudo apt-get install -yq libxss1
       - run: ./scripts/integration-tests/e2e-vue-cli.sh
 
   e2e-jest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,17 @@ aliases:
 executors:
   node-executor:
     docker:
-      - image: circleci/node:latest
+      - image: cimg/node:current
     working_directory: ~/babel
   # e2e-vue-cli test requires chromium
   node-browsers-executor:
     docker:
-      - image: circleci/node:latest-browsers
+      - image: cimg/node:current-browsers
+    working_directory: ~/babel
+  # e2e-jest test requires python
+  node-python-executor:
+    docker:
+      - image: cimg/python:3.9-node
     working_directory: ~/babel
 
 jobs:
@@ -153,10 +158,21 @@ jobs:
       - checkout
       - attach_workspace:
           at: /tmp/verdaccio-workspace
+      - run:
+          # vue-cli uses puppeteer
+          # Copied from https://circleci.com/developer/orbs/orb/threetreeslight/puppeteer
+          name: Install Headless Chrome dependencies
+          command: |
+            sudo apt-get install -yq \
+            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
+            libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
+            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
       - run: ./scripts/integration-tests/e2e-vue-cli.sh
 
   e2e-jest:
-    executor: node-executor
+    executor: node-python-executor
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,11 +159,9 @@ jobs:
       - attach_workspace:
           at: /tmp/verdaccio-workspace
       - run:
-          # vue-cli uses puppeteer
-          # Copied from https://circleci.com/developer/orbs/orb/threetreeslight/puppeteer
+          # vue-cli uses puppeteer, and it depends on the libXss.so.1 shared library
           name: Install Headless Chrome dependencies
-          command: |
-            sudo apt-get install -yq libxss1
+          command: sudo apt-get install -yq libxss1
       - run: ./scripts/integration-tests/e2e-vue-cli.sh
 
   e2e-jest:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

CRA e2e tests started failing today with this error:
```
Husky requires Git >=2.13.0. Got v2.11.0.
```

The only change I could find is that they updated Docker from 18.09.6 to 19.03.13. I'm not sure how this affected the Git version, but maybe the [new images](https://circleci.com/developer/images/image/cimg/node) work :shrug:

I already tried updating the images at https://github.com/babel/babel/pull/12243 and gave up due to this error, but I think I found a fix:
```
error while loading shared libraries: libXss.so.1: cannot open shared object file: No such file or directory
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12450"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/cfb817e48e4ca5295a26caf03fa30f138223142f.svg" /></a>

