### PR TITLE
chore: fix broken REPL link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -20,8 +20,7 @@ assignees: ''
 **Current behavior**
 <!-- A clear and concise description of the behavior. -->
 
-- [REPL](https://babel.dev/repl), [Codesandbox](https://codesandbox.io/s/babel-repl-custom-plugin-7s08o?file=/src/index.js), or GitHub Repo may increase
-triaging priority!
+- [REPL](https://babel.dev/repl), [Codesandbox](https://codesandbox.io/s/babel-repl-custom-plugin-7s08o?file=/src/index.js), or GitHub Repo may increase triaging priority!
 
 **Input Code**
 

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -20,7 +20,8 @@ assignees: ''
 **Current behavior**
 <!-- A clear and concise description of the behavior. -->
 
-- [REPL](babeljs.io/repl), [Codesandbox](https://codesandbox.io/s/babel-repl-custom-plugin-7s08o?file=/src/index.js), or GitHub Repo helps!
+- [REPL](https://babel.dev/repl), [Codesandbox](https://codesandbox.io/s/babel-repl-custom-plugin-7s08o?file=/src/index.js), or GitHub Repo may increase
+triaging priority!
 
 **Input Code**
 
@@ -45,11 +46,11 @@ var your => (code) => here;
 ```
 
 ```
-- Babel version(s): [e.g. v6.0.0, v7.0.0-beta.34]
-- Node/npm version: [e.g. Node 8/npm 5]
-- OS: [e.g. OSX 10.13.4, Windows 10]
+- Babel version(s): [e.g. v7.12.0]
+- Node/npm version: [e.g. Node 12/npm 7]
+- OS: [e.g. macOS 10.15.4, Windows 10]
 - Monorepo: [e.g. yes/no/Lerna]
-- How you are using Babel: [e.g. `cli`, `register`, `loader`]
+- How you are using Babel: [e.g. `webpack`, `rollup`, `parcel`, `babel-register`]
 
 **Possible Solution**
 <!--- If you have suggestions on a fix for the bug -->


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Context: People feel confused about the REPL link when filing a bug report: https://github.com/babel/babel/issues/12456#issuecomment-740812931, also rephrase a bit.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12459"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/d92b7d474f0be9ab4f11c1c944047e5ea7371466.svg" /></a>

