### PR TITLE
@babel/parser: read inputSourceMap

### DIFF
--- a/packages/babel-parser/src/options.js
+++ b/packages/babel-parser/src/options.js
@@ -72,13 +72,15 @@ export const defaultOptions: Options = {
 
 // Interpret and default an options object
 
-export function getOptions(opts: ?Options): Options {
+export function getOptions(opts: ?Options, input: string): Options {
   const options: any = {};
   for (const key of Object.keys(defaultOptions)) {
     options[key] = opts && opts[key] != null ? opts[key] : defaultOptions[key];
   }
-  if(options.inputSourceMap) {
+  if(typeof options.inputSourceMap === 'object') {
     options.inputSourceMap = new sourcemap.SourceMapConsumer(options.inputSourceMap);
+  } else if(options.inputSourceMap === true){
+    throw new Error("not implemented")
   }
   return options;
 }

--- a/packages/babel-parser/src/options.js
+++ b/packages/babel-parser/src/options.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { PluginList } from "./plugin-utils";
+import sourcemap from "source-map";
 
 // A second optional argument can be given to further configure
 // the parser process. These options are recognized:
@@ -66,6 +67,7 @@ export const defaultOptions: Options = {
   // When enabled, errors are attached to the AST instead of being directly thrown.
   // Some errors will still throw, because @babel/parser can't always recover.
   errorRecovery: false,
+  inputSourceMap: undefined,
 };
 
 // Interpret and default an options object
@@ -74,6 +76,9 @@ export function getOptions(opts: ?Options): Options {
   const options: any = {};
   for (const key of Object.keys(defaultOptions)) {
     options[key] = opts && opts[key] != null ? opts[key] : defaultOptions[key];
+  }
+  if(options.inputSourceMap) {
+    options.inputSourceMap = new sourcemap.SourceMapConsumer(options.inputSourceMap);
   }
   return options;
 }

--- a/packages/babel-parser/src/parser/index.js
+++ b/packages/babel-parser/src/parser/index.js
@@ -25,7 +25,7 @@ export default class Parser extends StatementParser {
   */
 
   constructor(options: ?Options, input: string) {
-    options = getOptions(options);
+    options = getOptions(options, input);
     super(options, input);
 
     const ScopeHandler = this.getScopeHandler();

--- a/x.js
+++ b/x.js
@@ -1,0 +1,28 @@
+const BUNDLE_PATH =
+  __dirname +
+  "/../parcel/packages/core/integration-tests/test/integration/sourcemap-existing/sum.js";
+const MAP_PATH =
+  __dirname +
+  "/../parcel/packages/core/integration-tests/test/integration/sourcemap-existing/sum.map";
+
+const fs = require("fs");
+const convertSourceMap = require("convert-source-map");
+const { parse } = require("@babel/parser");
+
+const BUNDLE = fs.readFileSync(BUNDLE_PATH, "utf8");
+const MAP = JSON.parse(fs.readFileSync(MAP_PATH, "utf8"));
+
+const ast = parse(BUNDLE, { inputSourceMap: MAP });
+
+// Should be:
+//
+// SourceLocation {
+//   start: Position { line: 1, column: 27 },
+//   end: Position { line: 1, column: 31 },
+//   filename: 'sum.coffee',
+//   identifierName: null
+// }
+console.log(
+  ast.program.body[0].expression.callee.object.body.body[0].expression.right
+    .callee.body.body[0].argument.body.body[0].argument.loc
+);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #11960
| Patch: Bug Fix?          |
| Major: Breaking Change?  | 
| Minor: New Feature?      | 👍
| Tests Added + Pass?      |  TODO
| Documentation PR Link    | TODO
| Any Dependency Changes?  | No
| License                  | MIT

This makes the parser read a previous sourcemap and reflect the changes in `node.loc`.
Does this make sense/is this reasonable?

Todo:
- [ ] Tests
- [ ] (Maybe: refactor sourcemap loading function into utility that is userd by core and parser)