### PR TITLE
[babel 8] Remove the `jsonCompatibleStrings` option

### DIFF
--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -205,9 +205,6 @@ export function StringLiteral(node: Object) {
 
   // ensure the output is ASCII-safe
   const opts = this.format.jsescOption;
-  if (this.format.jsonCompatibleStrings) {
-    opts.json = true;
-  }
   const val = jsesc(node.value, opts);
 
   return this.token(val);

--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -204,8 +204,16 @@ export function StringLiteral(node: Object) {
   }
 
   // ensure the output is ASCII-safe
-  const opts = this.format.jsescOption;
-  const val = jsesc(node.value, opts);
+
+  const val = jsesc(
+    node.value,
+    process.env.BABEL_8_BREAKING
+      ? this.format.jsescOption
+      : Object.assign(
+          this.format.jsescOption,
+          this.format.jsonCompatibleStrings && { json: true },
+        ),
+  );
 
   return this.token(val);
 }

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -46,7 +46,6 @@ function normalizeOptions(code, opts): Format {
     compact: opts.compact,
     minified: opts.minified,
     concise: opts.concise,
-    jsonCompatibleStrings: opts.jsonCompatibleStrings,
     indent: {
       adjustMultilineComment: true,
       style: "  ",

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -60,6 +60,10 @@ function normalizeOptions(code, opts): Format {
     recordAndTupleSyntaxType: opts.recordAndTupleSyntaxType,
   };
 
+  if (!process.env.BABEL_8_BREAKING) {
+    format.jsonCompatibleStrings = opts.jsonCompatibleStrings;
+  }
+
   if (format.minified) {
     format.compact = true;
 

--- a/packages/babel-generator/test/fixtures/escapes/jsonEscape-babel-7/input.js
+++ b/packages/babel-generator/test/fixtures/escapes/jsonEscape-babel-7/input.js
@@ -1,0 +1,2 @@
+0; // Not a directive
+"©";

--- a/packages/babel-generator/test/fixtures/escapes/jsonEscape-babel-7/options.json
+++ b/packages/babel-generator/test/fixtures/escapes/jsonEscape-babel-7/options.json
@@ -1,0 +1,5 @@
+{
+  "BABEL_8_BREAKING": false,
+  "minified": true,
+  "jsonCompatibleStrings": true
+}

--- a/packages/babel-generator/test/fixtures/escapes/jsonEscape-babel-7/output.js
+++ b/packages/babel-generator/test/fixtures/escapes/jsonEscape-babel-7/output.js
@@ -1,0 +1,2 @@
+0;// Not a directive
+"\u00A9";

--- a/packages/babel-generator/test/fixtures/escapes/jsonEscape/options.json
+++ b/packages/babel-generator/test/fixtures/escapes/jsonEscape/options.json
@@ -1,4 +1,4 @@
 {
   "minified": true,
-  "jsonCompatibleStrings": true
+  "jsescOption": { "json": true }
 }

--- a/packages/babel-generator/test/fixtures/escapes/jsonEscape/options.json
+++ b/packages/babel-generator/test/fixtures/escapes/jsonEscape/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": true,
   "minified": true,
   "jsescOption": { "json": true }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9943
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Backport of https://github.com/babel/babel/pull/9958

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12477"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/54e783d8866ebbf25ce6534cbdc6a013c2d38455.svg" /></a>

