### PR TITLE
Implement `noDocumentAll` assumption

### DIFF
--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -338,6 +338,7 @@ export const assumptionsNames = new Set<string>([
   "setClassMethods",
   "setComputedProperties",
   "setPublicClassFields",
+  "noDocumentAll",
 ]);
 
 function getSource(loc: NestingPath): OptionsSource {

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.js
@@ -4,6 +4,7 @@ import { types as t, template } from "@babel/core";
 
 export default declare((api, { loose = false }) => {
   api.assertVersion(7);
+  const noDocumentAll = api.assumption("noDocumentAll") ?? loose;
 
   return {
     name: "proposal-nullish-coalescing-operator",
@@ -38,7 +39,7 @@ export default declare((api, { loose = false }) => {
           t.conditionalExpression(
             // We cannot use `!= null` in spec mode because
             // `document.all == null` and `document.all` is not "nullish".
-            loose
+            noDocumentAll
               ? t.binaryExpression("!=", assignment, t.nullLiteral())
               : t.logicalExpression(
                   "&&",

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/options.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["proposal-nullish-coalescing-operator"],
+  "assumptions": {
+    "noDocumentAll": true
+  }
+}

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/runtime-semantics/exec.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/runtime-semantics/exec.js
@@ -1,0 +1,19 @@
+expect(null ?? undefined).toBeUndefined(undefined);
+expect(undefined ?? null).toBeNull();
+expect(false ?? true).toBe(false);
+expect(0 ?? 1).toBe(0);
+expect("" ?? "foo").toBe("");
+
+var obj = { exists: true };
+expect(obj.exists ?? false).toBe(true);
+expect(obj.doesNotExist ?? "foo").toBe("foo");
+
+var counter = 0;
+function sideEffect() { return counter++; }
+expect(sideEffect() ?? -1).toBe(0);
+
+var counter2 = 0;
+var obj2 = {
+    get foo() { return counter2++; }
+};
+expect(obj2.foo ?? -1).toBe(0);

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-default-destructuring/input.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-default-destructuring/input.js
@@ -1,0 +1,1 @@
+var { qux = foo.bar ?? "qux" } = {};

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-default-destructuring/output.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-default-destructuring/output.js
@@ -1,0 +1,5 @@
+var _foo$bar;
+
+var {
+  qux = (_foo$bar = foo.bar) != null ? _foo$bar : "qux"
+} = {};

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-default-param/input.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-default-param/input.js
@@ -1,0 +1,3 @@
+function foo(foo, qux = foo.bar ?? "qux") {}
+
+function bar(bar, qux = bar ?? "qux") {}

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-default-param/output.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-default-param/output.js
@@ -1,0 +1,7 @@
+function foo(foo, qux = (() => {
+  var _foo$bar;
+
+  return (_foo$bar = foo.bar) != null ? _foo$bar : "qux";
+})()) {}
+
+function bar(bar, qux = bar != null ? bar : "qux") {}

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-function/input.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-function/input.js
@@ -1,0 +1,3 @@
+function foo(opts) {
+  var foo = opts.foo ?? "default";
+}

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-function/output.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-function/output.js
@@ -1,0 +1,5 @@
+function foo(opts) {
+  var _opts$foo;
+
+  var foo = (_opts$foo = opts.foo) != null ? _opts$foo : "default";
+}

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-static-refs-in-default/input.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-static-refs-in-default/input.js
@@ -1,0 +1,1 @@
+function foo(foo, bar = foo ?? "bar") {}

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-static-refs-in-default/output.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-static-refs-in-default/output.js
@@ -1,0 +1,1 @@
+function foo(foo, bar = foo != null ? foo : "bar") {}

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-static-refs-in-function/input.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-static-refs-in-function/input.js
@@ -1,0 +1,3 @@
+function foo() {
+  var foo = this ?? {};
+}

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-static-refs-in-function/output.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-static-refs-in-function/output.js
@@ -1,0 +1,3 @@
+function foo() {
+  var foo = this != null ? this : {};
+}

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform/input.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform/input.js
@@ -1,0 +1,3 @@
+function foo(opts) {
+  var foo = opts.foo ?? "default";
+}

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform/output.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform/output.js
@@ -1,0 +1,5 @@
+function foo(opts) {
+  var _opts$foo;
+
+  var foo = (_opts$foo = opts.foo) != null ? _opts$foo : "default";
+}

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -16,6 +16,7 @@ export default declare((api, options) => {
   api.assertVersion(7);
 
   const { loose = false } = options;
+  const noDocumentAll = api.assumption("noDocumentAll") ?? loose;
 
   function isSimpleMemberExpression(expression) {
     expression = skipTransparentExprWrappers(expression);
@@ -213,7 +214,7 @@ export default declare((api, options) => {
             // `if (a?.b) {}` transformed to `if (a != null && a.b) {}`
             // we don't need to return `void 0` because the returned value will
             // eveutally cast to boolean.
-            const nonNullishCheck = loose
+            const nonNullishCheck = noDocumentAll
               ? ast`${t.cloneNode(check)} != null`
               : ast`
             ${t.cloneNode(check)} !== null && ${t.cloneNode(ref)} !== void 0`;
@@ -224,7 +225,7 @@ export default declare((api, options) => {
               replacementPath.get("right"),
             );
           } else {
-            const nullishCheck = loose
+            const nullishCheck = noDocumentAll
               ? ast`${t.cloneNode(check)} == null`
               : ast`
             ${t.cloneNode(check)} === null || ${t.cloneNode(ref)} === void 0`;

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/assignment/exec.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/assignment/exec.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const obj = {
+  a: {
+    b: {
+      c: {
+        d: 2,
+      },
+    },
+  },
+};
+
+const a = obj?.a;
+expect(a).toBe(obj.a);
+
+const b = obj?.a?.b;
+expect(b).toBe(obj.a.b);
+
+const bad = obj?.b?.b;
+expect(bad).toBeUndefined();
+
+let val;
+val = obj?.a?.b;
+expect(val).toBe(obj.a.b);
+
+expect(() => {
+  const bad = obj?.b.b;
+}).toThrow();

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/assignment/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/assignment/input.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const obj = {
+  a: {
+    b: {
+      c: {
+        d: 2,
+      },
+    },
+  },
+};
+
+const a = obj?.a;
+
+const b = obj?.a?.b;
+
+const bad = obj?.b?.b;
+
+let val;
+val = obj?.a?.b;

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/assignment/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/assignment/output.js
@@ -1,0 +1,18 @@
+"use strict";
+
+var _obj$a, _obj$b, _obj$a2;
+
+const obj = {
+  a: {
+    b: {
+      c: {
+        d: 2
+      }
+    }
+  }
+};
+const a = obj == null ? void 0 : obj.a;
+const b = obj == null ? void 0 : (_obj$a = obj.a) == null ? void 0 : _obj$a.b;
+const bad = obj == null ? void 0 : (_obj$b = obj.b) == null ? void 0 : _obj$b.b;
+let val;
+val = obj == null ? void 0 : (_obj$a2 = obj.a) == null ? void 0 : _obj$a2.b;

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/cast-to-boolean/exec.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/cast-to-boolean/exec.js
@@ -1,0 +1,120 @@
+class C {
+  static testIf(o) {
+    if (o?.a.b.c.d) {
+      return true;
+    }
+    return false;
+  }
+  static testConditional(o) {
+    return o?.a.b?.c.d ? true : false;
+  }
+  static testLoop(o) {
+    while (o?.a.b.c.d) {
+      for (; o?.a.b.c?.d; ) {
+        let i = 0;
+        do {
+          i++;
+          if (i === 2) {
+            return true;
+          }
+        } while (o?.a.b?.c.d);
+      }
+    }
+    return false;
+  }
+  static testNegate(o) {
+    return !!o?.a.b?.c.d;
+  }
+  static testIfDeep(o) {
+    if (o.obj?.a.b?.c.d) {
+      return true;
+    }
+    return false;
+  }
+  static testConditionalDeep(o) {
+    return o.obj?.a.b?.c.d ? true : false;
+  }
+  static testLoopDeep(o) {
+    while (o.obj?.a.b.c.d) {
+      for (; o.obj?.a.b.c?.d; ) {
+        let i = 0;
+        do {
+          i++;
+          if (i === 2) {
+            return true;
+          }
+        } while (o.obj?.a.b?.c.d);
+      }
+    }
+    return false;
+  }
+  static testNegateDeep(o) {
+    return !!o.obj?.a.b?.c.d;
+  }
+
+  static testLogicalInIf(o) {
+    if (o?.a.b?.c.d && o?.a?.b.c.d) {
+      return true;
+    }
+    return false;
+  }
+
+  static testLogicalInReturn(o) {
+    return o?.a.b?.c.d && o?.a?.b.c.d;
+  }
+
+  static testNullishCoalescing(o) {
+    if (o?.a.b?.c.non_existent ?? o?.a.b?.c.d) {
+      return o?.a.b?.c.non_existent ?? o?.a.b?.c.d;
+    }
+    return o?.a.b?.c.non_existent ?? o;
+  }
+
+  static test() {
+    const c = {
+      a: {
+        b: {
+          c: {
+            d: 2,
+          },
+        },
+      },
+    };
+    expect(C.testIf(c)).toBe(true);
+    expect(C.testConditional(c)).toBe(true);
+    expect(C.testLoop(c)).toBe(true);
+    expect(C.testNegate(c)).toBe(true);
+
+    expect(C.testIfDeep({ obj: c })).toBe(true);
+    expect(C.testConditionalDeep({ obj: c })).toBe(true);
+    expect(C.testLoopDeep({ obj: c })).toBe(true);
+    expect(C.testNegateDeep({ obj: c })).toBe(true);
+
+    expect(C.testLogicalInIf(c)).toBe(true);
+    expect(C.testLogicalInReturn(c)).toBe(2);
+
+    expect(C.testNullishCoalescing(c)).toBe(2);
+  }
+
+  static testNullish() {
+    for (const n of [null, undefined]) {
+      expect(C.testIf(n)).toBe(false);
+      expect(C.testConditional(n)).toBe(false);
+      expect(C.testLoop(n)).toBe(false);
+      expect(C.testNegate(n)).toBe(false);
+
+      expect(C.testIfDeep({ obj: n })).toBe(false);
+      expect(C.testConditionalDeep({ obj: n })).toBe(false);
+      expect(C.testLoopDeep({ obj: n })).toBe(false);
+      expect(C.testNegateDeep({ obj: n })).toBe(false);
+
+      expect(C.testLogicalInIf(n)).toBe(false);
+      expect(C.testLogicalInReturn(n)).toBe(undefined);
+
+      expect(C.testNullishCoalescing(n)).toBe(n);
+    }
+  }
+}
+
+C.test();
+C.testNullish();

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/cast-to-boolean/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/cast-to-boolean/input.js
@@ -1,0 +1,75 @@
+class C {
+  static testIf(o) {
+    if (o?.a.b.c.d) {
+      return true;
+    }
+    return false;
+  }
+  static testConditional(o) {
+    return o?.a.b?.c.d ? true : false;
+  }
+  static testLoop(o) {
+    while (o?.a.b.c.d) {
+      for (; o?.a.b.c?.d; ) {
+        let i = 0;
+        do {
+          i++;
+          if (i === 2) {
+            return true;
+          }
+        } while (o?.a.b?.c.d);
+      }
+    }
+    return false;
+  }
+  static testNegate(o) {
+    return !!o?.a.b?.c.d;
+  }
+  static testIfDeep(o) {
+    if (o.obj?.a.b?.c.d) {
+      return true;
+    }
+    return false;
+  }
+  static testConditionalDeep(o) {
+    return o.obj?.a.b?.c.d ? true : false;
+  }
+  static testLoopDeep(o) {
+    while (o.obj?.a.b.c.d) {
+      for (; o.obj?.a.b.c?.d; ) {
+        let i = 0;
+        do {
+          i++;
+          if (i === 2) {
+            return true;
+          }
+        } while (o.obj?.a.b?.c.d);
+      }
+    }
+    return false;
+  }
+  static testNegateDeep(o) {
+    return !!o.obj?.a.b?.c.d;
+  }
+
+  static testLogicalInIf(o) {
+    if (o?.a.b?.c.d && o?.a?.b.c.d) {
+      return true;
+    }
+    return false;
+  }
+
+  static testLogicalInReturn(o) {
+    return o?.a.b?.c.d && o?.a?.b.c.d;
+  }
+
+  static testNullishCoalescing(o) {
+    if (o?.a.b?.c.non_existent ?? o?.a.b?.c.d) {
+      return o?.a.b?.c.non_existent ?? o?.a.b?.c.d;
+    }
+    return o?.a.b?.c.non_existent ?? o;
+  }
+}
+
+C.test();
+C.testNullish();

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/cast-to-boolean/options.json
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/cast-to-boolean/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["proposal-optional-chaining", "proposal-nullish-coalescing-operator"]
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/cast-to-boolean/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/cast-to-boolean/output.js
@@ -1,0 +1,121 @@
+class C {
+  static testIf(o) {
+    if (o != null && o.a.b.c.d) {
+      return true;
+    }
+
+    return false;
+  }
+
+  static testConditional(o) {
+    var _o$a$b;
+
+    return o != null && (_o$a$b = o.a.b) != null && _o$a$b.c.d ? true : false;
+  }
+
+  static testLoop(o) {
+    while (o != null && o.a.b.c.d) {
+      for (; o != null && (_o$a$b$c = o.a.b.c) != null && _o$a$b$c.d;) {
+        var _o$a$b$c;
+
+        let i = 0;
+
+        do {
+          var _o$a$b2;
+
+          i++;
+
+          if (i === 2) {
+            return true;
+          }
+        } while (o != null && (_o$a$b2 = o.a.b) != null && _o$a$b2.c.d);
+      }
+    }
+
+    return false;
+  }
+
+  static testNegate(o) {
+    var _o$a$b3;
+
+    return !!(o != null && (_o$a$b3 = o.a.b) != null && _o$a$b3.c.d);
+  }
+
+  static testIfDeep(o) {
+    var _o$obj, _o$obj$a$b;
+
+    if ((_o$obj = o.obj) != null && (_o$obj$a$b = _o$obj.a.b) != null && _o$obj$a$b.c.d) {
+      return true;
+    }
+
+    return false;
+  }
+
+  static testConditionalDeep(o) {
+    var _o$obj2, _o$obj2$a$b;
+
+    return (_o$obj2 = o.obj) != null && (_o$obj2$a$b = _o$obj2.a.b) != null && _o$obj2$a$b.c.d ? true : false;
+  }
+
+  static testLoopDeep(o) {
+    while ((_o$obj3 = o.obj) != null && _o$obj3.a.b.c.d) {
+      var _o$obj3;
+
+      for (; (_o$obj4 = o.obj) != null && (_o$obj4$a$b$c = _o$obj4.a.b.c) != null && _o$obj4$a$b$c.d;) {
+        var _o$obj4, _o$obj4$a$b$c;
+
+        let i = 0;
+
+        do {
+          var _o$obj5, _o$obj5$a$b;
+
+          i++;
+
+          if (i === 2) {
+            return true;
+          }
+        } while ((_o$obj5 = o.obj) != null && (_o$obj5$a$b = _o$obj5.a.b) != null && _o$obj5$a$b.c.d);
+      }
+    }
+
+    return false;
+  }
+
+  static testNegateDeep(o) {
+    var _o$obj6, _o$obj6$a$b;
+
+    return !!((_o$obj6 = o.obj) != null && (_o$obj6$a$b = _o$obj6.a.b) != null && _o$obj6$a$b.c.d);
+  }
+
+  static testLogicalInIf(o) {
+    var _o$a$b4, _o$a;
+
+    if (o != null && (_o$a$b4 = o.a.b) != null && _o$a$b4.c.d && o != null && (_o$a = o.a) != null && _o$a.b.c.d) {
+      return true;
+    }
+
+    return false;
+  }
+
+  static testLogicalInReturn(o) {
+    var _o$a$b5, _o$a2;
+
+    return (o == null ? void 0 : (_o$a$b5 = o.a.b) == null ? void 0 : _o$a$b5.c.d) && (o == null ? void 0 : (_o$a2 = o.a) == null ? void 0 : _o$a2.b.c.d);
+  }
+
+  static testNullishCoalescing(o) {
+    var _o$a$b$c$non_existent, _o$a$b6, _o$a$b7, _o$a$b$c$non_existent3, _o$a$b10;
+
+    if ((_o$a$b$c$non_existent = o == null ? void 0 : (_o$a$b6 = o.a.b) == null ? void 0 : _o$a$b6.c.non_existent) != null ? _o$a$b$c$non_existent : o == null ? void 0 : (_o$a$b7 = o.a.b) == null ? void 0 : _o$a$b7.c.d) {
+      var _o$a$b$c$non_existent2, _o$a$b8, _o$a$b9;
+
+      return (_o$a$b$c$non_existent2 = o == null ? void 0 : (_o$a$b8 = o.a.b) == null ? void 0 : _o$a$b8.c.non_existent) != null ? _o$a$b$c$non_existent2 : o == null ? void 0 : (_o$a$b9 = o.a.b) == null ? void 0 : _o$a$b9.c.d;
+    }
+
+    return (_o$a$b$c$non_existent3 = o == null ? void 0 : (_o$a$b10 = o.a.b) == null ? void 0 : _o$a$b10.c.non_existent) != null ? _o$a$b$c$non_existent3 : o;
+  }
+
+}
+
+C.test();
+C.testNullish();

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/in-function-params/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/in-function-params/input.js
@@ -1,0 +1,9 @@
+function f(a = x?.y) {}
+
+function g({ a, b = a?.c }) {}
+
+function h(a, { b = a.b?.c?.d.e }) {}
+
+function i(a, { b = (a.b?.c?.d).e }) {}
+
+function j(a, { b = a?.b?.c().d.e }) {}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/in-function-params/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/in-function-params/output.js
@@ -1,0 +1,34 @@
+function f(a = (() => {
+  var _x;
+
+  return (_x = x) == null ? void 0 : _x.y;
+})()) {}
+
+function g({
+  a,
+  b = a == null ? void 0 : a.c
+}) {}
+
+function h(a, {
+  b = (() => {
+    var _a$b, _a$b$c;
+
+    return (_a$b = a.b) == null ? void 0 : (_a$b$c = _a$b.c) == null ? void 0 : _a$b$c.d.e;
+  })()
+}) {}
+
+function i(a, {
+  b = (() => {
+    var _a$b2, _a$b2$c;
+
+    return (_a$b2 = a.b) == null ? void 0 : (_a$b2$c = _a$b2.c) == null ? void 0 : _a$b2$c.d;
+  })().e
+}) {}
+
+function j(a, {
+  b = (() => {
+    var _a$b3;
+
+    return a == null ? void 0 : (_a$b3 = a.b) == null ? void 0 : _a$b3.c().d.e;
+  })()
+}) {}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/memoize/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/memoize/input.js
@@ -1,0 +1,29 @@
+function test(foo) {
+  foo?.bar;
+
+  foo?.bar?.baz;
+
+  foo?.(foo);
+
+  foo?.bar()
+
+  foo.get(bar)?.()
+
+  foo.bar()?.()
+  foo[bar]()?.()
+
+  foo.bar().baz?.()
+  foo[bar]().baz?.()
+
+  foo.bar?.(foo.bar, false)
+
+  foo?.bar?.(foo.bar, true)
+
+  foo.bar?.baz(foo.bar, false)
+
+  foo?.bar?.baz(foo.bar, true)
+
+  foo.bar?.baz?.(foo.bar, false)
+
+  foo?.bar?.baz?.(foo.bar, true)
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/memoize/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/memoize/output.js
@@ -1,0 +1,19 @@
+function test(foo) {
+  var _foo$bar, _foo$get, _foo$bar2, _foo$bar3, _foo$bar$baz, _foo$bar4, _foo$bar$baz2, _foo$bar5, _foo$bar6, _foo$bar7, _foo$bar8, _foo$bar9, _foo$bar10, _foo$bar10$baz, _foo$bar11, _foo$bar11$baz;
+
+  foo == null ? void 0 : foo.bar;
+  foo == null ? void 0 : (_foo$bar = foo.bar) == null ? void 0 : _foo$bar.baz;
+  foo == null ? void 0 : foo(foo);
+  foo == null ? void 0 : foo.bar();
+  (_foo$get = foo.get(bar)) == null ? void 0 : _foo$get();
+  (_foo$bar2 = foo.bar()) == null ? void 0 : _foo$bar2();
+  (_foo$bar3 = foo[bar]()) == null ? void 0 : _foo$bar3();
+  (_foo$bar$baz = (_foo$bar4 = foo.bar()).baz) == null ? void 0 : _foo$bar$baz.call(_foo$bar4);
+  (_foo$bar$baz2 = (_foo$bar5 = foo[bar]()).baz) == null ? void 0 : _foo$bar$baz2.call(_foo$bar5);
+  (_foo$bar6 = foo.bar) == null ? void 0 : _foo$bar6.call(foo, foo.bar, false);
+  foo == null ? void 0 : (_foo$bar7 = foo.bar) == null ? void 0 : _foo$bar7.call(foo, foo.bar, true);
+  (_foo$bar8 = foo.bar) == null ? void 0 : _foo$bar8.baz(foo.bar, false);
+  foo == null ? void 0 : (_foo$bar9 = foo.bar) == null ? void 0 : _foo$bar9.baz(foo.bar, true);
+  (_foo$bar10 = foo.bar) == null ? void 0 : (_foo$bar10$baz = _foo$bar10.baz) == null ? void 0 : _foo$bar10$baz.call(_foo$bar10, foo.bar, false);
+  foo == null ? void 0 : (_foo$bar11 = foo.bar) == null ? void 0 : (_foo$bar11$baz = _foo$bar11.baz) == null ? void 0 : _foo$bar11$baz.call(_foo$bar11, foo.bar, true);
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/optional-eval-call/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/optional-eval-call/input.js
@@ -1,0 +1,22 @@
+var foo;
+
+/* indirect eval calls */
+eval?.(foo);
+
+(eval)?.(foo);
+
+eval?.()();
+
+eval?.().foo;
+
+/* direct eval calls */
+
+eval()?.();
+
+eval()?.foo;
+
+/* plain function calls */
+
+foo.eval?.(foo);
+
+eval.foo?.(foo);

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/optional-eval-call/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/optional-eval-call/output.js
@@ -1,0 +1,17 @@
+var _eval, _eval2, _foo$eval, _eval$foo;
+
+var foo;
+/* indirect eval calls */
+
+eval == null ? void 0 : (0, eval)(foo);
+eval == null ? void 0 : (0, eval)(foo);
+eval == null ? void 0 : (0, eval)()();
+eval == null ? void 0 : (0, eval)().foo;
+/* direct eval calls */
+
+(_eval = eval()) == null ? void 0 : _eval();
+(_eval2 = eval()) == null ? void 0 : _eval2.foo;
+/* plain function calls */
+
+(_foo$eval = foo.eval) == null ? void 0 : _foo$eval.call(foo, foo);
+(_eval$foo = eval.foo) == null ? void 0 : _eval$foo.call(eval, foo);

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/options.json
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["proposal-optional-chaining"],
+  "assumptions": {
+    "noDocumentAll": true
+  }
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/parenthesized-expression-member-call/exec.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/parenthesized-expression-member-call/exec.js
@@ -1,0 +1,51 @@
+class Foo {
+  constructor() {
+    this.x = 1;
+    this.self = this;
+  }
+  m() { return this.x; };
+  getSelf() { return this }
+
+  test() {
+    const Foo = this;
+    const o = { Foo: Foo };
+    const fn = function () {
+      return o;
+    };
+
+    expect((Foo?.["m"])()).toEqual(1);
+    expect((Foo?.["m"])().toString).toEqual(1..toString);
+    expect((Foo?.["m"])().toString()).toEqual('1');
+
+    expect(((Foo?.["m"]))()).toEqual(1);
+    expect(((Foo?.["m"]))().toString).toEqual(1..toString);
+    expect(((Foo?.["m"]))().toString()).toEqual('1');
+
+    expect((o?.Foo.m)()).toEqual(1);
+    expect((o?.Foo.m)().toString).toEqual(1..toString);
+    expect((o?.Foo.m)().toString()).toEqual('1');
+
+    expect((((o.Foo?.self.getSelf)())?.m)()).toEqual(1);
+    expect((((o.Foo.self?.getSelf)())?.m)()).toEqual(1);
+
+    expect((((fn()?.Foo?.self.getSelf)())?.m)()).toEqual(1);
+    expect((((fn?.().Foo.self?.getSelf)())?.m)()).toEqual(1);
+  }
+
+  testNull() {
+    const o = null;
+
+    expect(() => { (o?.Foo.m)() }).toThrow();
+    expect(() => { (o?.Foo.m)().toString }).toThrow();
+    expect(() => { (o?.Foo.m)().toString() }).toThrow();
+
+    expect(() => { (((o.Foo?.self.getSelf)())?.m)() }).toThrow();
+    expect(() => { (((o.Foo.self?.getSelf)())?.m)() }).toThrow();
+
+    expect(() => (((fn()?.Foo?.self.getSelf)())?.m)()).toThrow();
+    expect(() => (((fn?.().Foo.self?.getSelf)())?.m)()).toThrow();
+  }
+}
+
+(new Foo).test();
+(new Foo).testNull();

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/parenthesized-expression-member-call/options.json
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/parenthesized-expression-member-call/options.json
@@ -1,0 +1,5 @@
+{
+  "parserOpts": {
+    "createParenthesizedExpressions": true
+  }
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/super-method-call/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/super-method-call/input.js
@@ -1,0 +1,12 @@
+"use strict";
+class Base {
+  method() {
+    return 'Hello!';
+  }
+}
+
+class Derived extends Base {
+    method() {
+        return super.method?.()
+    }
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/super-method-call/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-noDocumentAll/super-method-call/output.js
@@ -1,0 +1,17 @@
+"use strict";
+
+class Base {
+  method() {
+    return 'Hello!';
+  }
+
+}
+
+class Derived extends Base {
+  method() {
+    var _super$method;
+
+    return (_super$method = super.method) == null ? void 0 : _super$method.call(this);
+  }
+
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Note that this PR only add supports to optional-chaining and nullish-coalescing. Support of `this.#x ??= 1` and `this?.#x` is deferred because it will depend on other class properties assumptions implementation.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12481"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/e83ae87f7015515daea32bb287d1304a3cef68d2.svg" /></a>

