### PR TITLE
Lazily inject imports to the JSX runtime

### DIFF
--- a/packages/babel-helper-builder-react-jsx-experimental/src/index.js
+++ b/packages/babel-helper-builder-react-jsx-experimental/src/index.js
@@ -209,52 +209,6 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
             );
           }
 
-          type Name = t.MemberExpression | t.Identifier;
-          // eslint-disable-next-line no-inner-declarations
-          function createImportLazily(
-            pass,
-            path,
-            importName,
-            source,
-          ): () => Name {
-            return () => {
-              const actualSource = getSource(source, importName);
-              if (isModule(path)) {
-                let reference = pass.get(
-                  `@babel/plugin-react-jsx/imports/${importName}`,
-                );
-                if (reference) return t.cloneNode(reference);
-
-                reference = addNamed(path, importName, actualSource, {
-                  importedInterop: "uncompiled",
-                });
-                pass.set(
-                  `@babel/plugin-react-jsx/imports/${importName}`,
-                  reference,
-                );
-
-                return reference;
-              } else {
-                let reference = pass.get(
-                  `@babel/plugin-react-jsx/requires/${actualSource}`,
-                );
-                if (reference) {
-                  reference = t.cloneNode(reference);
-                } else {
-                  reference = addNamespace(path, actualSource, {
-                    importedInterop: "uncompiled",
-                  });
-                  pass.set(
-                    `@babel/plugin-react-jsx/requires/${actualSource}`,
-                    reference,
-                  );
-                }
-
-                return t.memberExpression(reference, t.identifier(importName));
-              }
-            };
-          }
-
           state.set(
             "@babel/plugin-react-jsx/jsxIdentifier",
             createImportLazily(
@@ -357,6 +311,42 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
       case "createElement":
         return source;
     }
+  }
+
+  function createImportLazily(pass, path, importName, source) {
+    return () => {
+      const actualSource = getSource(source, importName);
+      if (isModule(path)) {
+        let reference = pass.get(
+          `@babel/plugin-react-jsx/imports/${importName}`,
+        );
+        if (reference) return t.cloneNode(reference);
+
+        reference = addNamed(path, importName, actualSource, {
+          importedInterop: "uncompiled",
+        });
+        pass.set(`@babel/plugin-react-jsx/imports/${importName}`, reference);
+
+        return reference;
+      } else {
+        let reference = pass.get(
+          `@babel/plugin-react-jsx/requires/${actualSource}`,
+        );
+        if (reference) {
+          reference = t.cloneNode(reference);
+        } else {
+          reference = addNamespace(path, actualSource, {
+            importedInterop: "uncompiled",
+          });
+          pass.set(
+            `@babel/plugin-react-jsx/requires/${actualSource}`,
+            reference,
+          );
+        }
+
+        return t.memberExpression(reference, t.identifier(importName));
+      }
+    };
   }
 
   function createIdentifierParser(id) {

--- a/packages/babel-plugin-transform-react-jsx-development/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-development/src/index.js
@@ -26,13 +26,20 @@ export default declare((api, options) => {
         state.pure =
           PURE_ANNOTATION ?? !pass.get("@babel/plugin-react-jsx/pragmaSet");
       } else {
-        state.jsxCallee = pass.get("@babel/plugin-react-jsx/jsxIdentifier")();
-        state.jsxStaticCallee = pass.get(
-          "@babel/plugin-react-jsx/jsxStaticIdentifier",
-        )();
-        state.createElementCallee = pass.get(
-          "@babel/plugin-react-jsx/createElementIdentifier",
-        )();
+        const getter = get => ({ enumerable: true, configurable: true, get });
+
+        // TODO(Babel 8): helper-builder-react-jsx expects those properties to be AST nodes, but we want to
+        // generate them lazily so that we only inject imports when needed.
+        // These should actually be functions.
+        Object.defineProperties(state, {
+          jsxCallee: getter(pass.get("@babel/plugin-react-jsx/jsxIdentifier")),
+          jsxStaticCallee: getter(
+            pass.get("@babel/plugin-react-jsx/jsxStaticIdentifier"),
+          ),
+          createElementCallee: getter(
+            pass.get("@babel/plugin-react-jsx/createElementIdentifier"),
+          ),
+        });
 
         state.pure =
           PURE_ANNOTATION ??

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/auto-import-dev/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/auto-import-dev/output.mjs
@@ -1,6 +1,6 @@
+import { Fragment as _Fragment } from "react/jsx-dev-runtime";
 import { createElement as _createElement } from "react";
 import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
-import { Fragment as _Fragment } from "react/jsx-dev-runtime";
 var _jsxFileName = "<CWD>/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/auto-import-dev/input.js";
 
 var x = /*#__PURE__*/_jsxDEV(_Fragment, {

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/auto-import-dev-windows/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/auto-import-dev-windows/output.mjs
@@ -1,6 +1,6 @@
+import { Fragment as _Fragment } from "react/jsx-dev-runtime";
 import { createElement as _createElement } from "react";
 import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
-import { Fragment as _Fragment } from "react/jsx-dev-runtime";
 var _jsxFileName = "<CWD>\\packages\\babel-plugin-transform-react-jsx-development\\test\\fixtures\\windows\\auto-import-dev-windows\\input.js";
 
 var x = /*#__PURE__*/_jsxDEV(_Fragment, {

--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -27,13 +27,20 @@ export default declare((api, options) => {
         state.pure =
           PURE_ANNOTATION ?? !pass.get("@babel/plugin-react-jsx/pragmaSet");
       } else {
-        state.jsxCallee = pass.get("@babel/plugin-react-jsx/jsxIdentifier")();
-        state.jsxStaticCallee = pass.get(
-          "@babel/plugin-react-jsx/jsxStaticIdentifier",
-        )();
-        state.createElementCallee = pass.get(
-          "@babel/plugin-react-jsx/createElementIdentifier",
-        )();
+        const getter = get => ({ enumerable: true, configurable: true, get });
+
+        // TODO(Babel 8): helper-builder-react-jsx expects those properties to be AST nodes, but we want to
+        // generate them lazily so that we only inject imports when needed.
+        // These should actually be functions.
+        Object.defineProperties(state, {
+          jsxCallee: getter(pass.get("@babel/plugin-react-jsx/jsxIdentifier")),
+          jsxStaticCallee: getter(
+            pass.get("@babel/plugin-react-jsx/jsxStaticIdentifier"),
+          ),
+          createElementCallee: getter(
+            pass.get("@babel/plugin-react-jsx/createElementIdentifier"),
+          ),
+        });
 
         state.pure =
           PURE_ANNOTATION ??

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/autoImport/auto-import-react-source-type-module/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/autoImport/auto-import-react-source-type-module/output.mjs
@@ -1,7 +1,7 @@
-import { createElement as _createElement } from "react";
-import { jsxs as _jsxs } from "react/jsx-runtime";
-import { jsx as _jsx } from "react/jsx-runtime";
 import { Fragment as _Fragment } from "react/jsx-runtime";
+import { jsxs as _jsxs } from "react/jsx-runtime";
+import { createElement as _createElement } from "react";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx(_Fragment, {
   children: /*#__PURE__*/_jsxs("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/autoImport/react-defined/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/autoImport/react-defined/output.mjs
@@ -1,6 +1,6 @@
+import { jsxs as _jsxs } from "react/jsx-runtime";
 import { createElement as _createElement } from "react";
 import { jsx as _jsx } from "react/jsx-runtime";
-import { jsxs as _jsxs } from "react/jsx-runtime";
 import * as react from "react";
 var y = react.createElement("div", {
   foo: 1

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/concatenates-adjacent-string-literals/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/concatenates-adjacent-string-literals/output.mjs
@@ -1,5 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime";
 import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: ["foo", "bar", "baz", /*#__PURE__*/_jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/does-not-add-source-self-automatic/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/does-not-add-source-self-automatic/output.mjs
@@ -1,7 +1,7 @@
-import { createElement as _createElement } from "react";
-import { jsxs as _jsxs } from "react/jsx-runtime";
-import { jsx as _jsx } from "react/jsx-runtime";
 import { Fragment as _Fragment } from "react/jsx-runtime";
+import { jsxs as _jsxs } from "react/jsx-runtime";
+import { createElement as _createElement } from "react";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx(_Fragment, {
   children: /*#__PURE__*/_jsxs("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-fragments/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-fragments/output.mjs
@@ -1,5 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime";
 import { Fragment as _Fragment } from "react/jsx-runtime";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx(_Fragment, {
   children: /*#__PURE__*/_jsx("div", {})

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-static-children/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-static-children/output.mjs
@@ -1,5 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime";
 import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: [/*#__PURE__*/_jsx("span", {}), [/*#__PURE__*/_jsx("span", {}, '0'), /*#__PURE__*/_jsx("span", {}, '1')]]

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-have-correct-comma-in-nested-children/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-have-correct-comma-in-nested-children/output.mjs
@@ -1,5 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime";
 import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: [/*#__PURE__*/_jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-properly-handle-keys/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-properly-handle-keys/output.mjs
@@ -1,5 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime";
 import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: [/*#__PURE__*/_jsx("div", {}, "1"), /*#__PURE__*/_jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/regression/issue-12478-automatic/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/regression/issue-12478-automatic/output.js
@@ -1,1 +1,3 @@
-const foo = /*#__PURE__*/undefined.jsx("p", {});
+var _reactJsxRuntime = require("react/jsx-runtime");
+
+const foo = /*#__PURE__*/_reactJsxRuntime.jsx("p", {});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/12467
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Injecting automatic imports to react on `Program:enter` has a problem: if a plugin later injects some JSX, the automatic imports logic cannot inject the necessary import.

This PR changes the injection to happen when transforming the JSX element, so that it works with injected JSX.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12493"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/e9daba1541b3dd03d101b40d0a69f458e41ece81.svg" /></a>

