### PR TITLE
Fixed issue with skipping over self & source generated by another instance

### DIFF
--- a/packages/babel-helper-builder-react-jsx-experimental/src/index.js
+++ b/packages/babel-helper-builder-react-jsx-experimental/src/index.js
@@ -837,7 +837,6 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
         if (name === "__source" || name === "__self") {
           if (found[name]) throw sourceSelfError(path, name);
           found[name] = true;
-          if (!options.development) continue;
         }
 
         props.push(convertAttribute(attr));
@@ -850,15 +849,6 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
     const objs = [];
 
     for (const attr of attribs) {
-      const name =
-        t.isJSXAttribute(attr) &&
-        t.isJSXIdentifier(attr.name) &&
-        attr.name.name;
-
-      if (!options.development && (name === "__source" || name === "__self")) {
-        continue;
-      }
-
       if (useSpread || !t.isJSXSpreadAttribute(attr)) {
         props.push(convertAttribute(attr));
       } else {

--- a/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/emotion-css-prop-preset.js
+++ b/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/emotion-css-prop-preset.js
@@ -1,0 +1,3 @@
+module.exports = () => ({
+  plugins: [["@babel/plugin-transform-react-jsx", { pragma: "___EmotionJSX" }]],
+});

--- a/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/input.mjs
+++ b/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/input.mjs
@@ -1,0 +1,5 @@
+import * as React from "react";
+
+export default function Foo() {
+  return <div />;
+}

--- a/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/options.json
+++ b/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/options.json
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    ["@babel/preset-react", { "development": true }],
+    "./emotion-css-prop-preset.js"
+  ],
+  "os": ["linux", "darwin"]
+}

--- a/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/output.mjs
+++ b/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/output.mjs
@@ -1,0 +1,12 @@
+var _jsxFileName = "<CWD>/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/input.mjs";
+import * as React from "react";
+export default function Foo() {
+  return ___EmotionJSX("div", {
+    __self: this,
+    __source: {
+      fileName: _jsxFileName,
+      lineNumber: 4,
+      columnNumber: 10
+    }
+  });
+}


### PR DESCRIPTION
Fixes the issue reported here https://github.com/babel/babel/pull/12253#issuecomment-743464107 and here https://github.com/emotion-js/emotion/issues/2173

Basically the issue is that its fairly easy to add the same plugin with different options through presets and in this case the React preset has been adding those props but thr Emotion preset has started skipping over them because it was not configured with a development flag - this was a behavioral change after switching to the -experimental builder completely

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12495"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/6a59e4ca474f0e001e6180f92bb670949870bea7.svg" /></a>

