### PR TITLE
Implement `skipForOfIteratorClosing` assumption

### DIFF
--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -337,11 +337,12 @@ export const assumptionsNames = new Set<string>([
   "ignoreToPrimitiveHint",
   "iterableIsArray",
   "mutableTemplateObject",
+  "noDocumentAll",
   "pureGetters",
   "setClassMethods",
   "setComputedProperties",
   "setPublicClassFields",
-  "noDocumentAll",
+  "skipForOfIteratorClosing",
 ]);
 
 function getSource(loc: NestingPath): OptionsSource {

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/identifier/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/identifier/input.js
@@ -1,0 +1,3 @@
+for (i of arr) {
+
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/identifier/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/identifier/output.js
@@ -1,0 +1,3 @@
+for (var _iterator = babelHelpers.createForOfIteratorHelperLoose(arr), _step; !(_step = _iterator()).done;) {
+  i = _step.value;
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/ignore-cases/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/ignore-cases/input.js
@@ -1,0 +1,6 @@
+for (var i of foo) {
+  switch (i) {
+    case 1:
+      break;
+  }
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/ignore-cases/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/ignore-cases/output.js
@@ -1,0 +1,8 @@
+for (var _iterator = babelHelpers.createForOfIteratorHelperLoose(foo), _step; !(_step = _iterator()).done;) {
+  var i = _step.value;
+
+  switch (i) {
+    case 1:
+      break;
+  }
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/let/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/let/input.js
@@ -1,0 +1,3 @@
+for (let i of arr) {
+
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/let/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/let/output.js
@@ -1,0 +1,3 @@
+for (var _iterator = babelHelpers.createForOfIteratorHelperLoose(arr), _step; !(_step = _iterator()).done;) {
+  let i = _step.value;
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/member-expression/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/member-expression/input.js
@@ -1,0 +1,3 @@
+for (obj.prop of arr) {
+
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/member-expression/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/member-expression/output.js
@@ -1,0 +1,3 @@
+for (var _iterator = babelHelpers.createForOfIteratorHelperLoose(arr), _step; !(_step = _iterator()).done;) {
+  obj.prop = _step.value;
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/multiple/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/multiple/input.js
@@ -1,0 +1,7 @@
+for (var i of arr) {
+
+}
+
+for (var i of numbers) {
+
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/multiple/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/multiple/output.js
@@ -1,0 +1,7 @@
+for (var _iterator = babelHelpers.createForOfIteratorHelperLoose(arr), _step; !(_step = _iterator()).done;) {
+  var i = _step.value;
+}
+
+for (var _iterator2 = babelHelpers.createForOfIteratorHelperLoose(numbers), _step2; !(_step2 = _iterator2()).done;) {
+  var i = _step2.value;
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/nested-label-for-of/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/nested-label-for-of/input.js
@@ -1,0 +1,5 @@
+b: for (let c of d()) {
+  for (let e of f()) {
+    continue b;
+  }
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/nested-label-for-of/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/nested-label-for-of/output.js
@@ -1,0 +1,8 @@
+b: for (var _iterator = babelHelpers.createForOfIteratorHelperLoose(d()), _step; !(_step = _iterator()).done;) {
+  let c = _step.value;
+
+  for (var _iterator2 = babelHelpers.createForOfIteratorHelperLoose(f()), _step2; !(_step2 = _iterator2()).done;) {
+    let e = _step2.value;
+    continue b;
+  }
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/options.json
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/options.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "transform-for-of"
+  ],
+  "assumptions": {
+    "skipForOfIteratorClosing": true
+  }
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/var/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/var/input.js
@@ -1,0 +1,3 @@
+for (var i of arr) {
+
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/var/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/assumption-skipForOfIteratorClosing/var/output.js
@@ -1,0 +1,3 @@
+for (var _iterator = babelHelpers.createForOfIteratorHelperLoose(arr), _step; !(_step = _iterator()).done;) {
+  var i = _step.value;
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Main PR: #12219
RFC: babel/rfcs#5

<!-- Describe your changes below in as much detail as possible -->
~This PR includes commits from #12489, only the last one is new.~

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12496"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/ae9fc570e981f22d41100ed1568060ccb8b234fa.svg" /></a>

