### PR TITLE
Implement `setPublicClassFields` and `privateFieldsAsProperties` assumptions

### DIFF
--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -340,6 +340,7 @@ export const assumptionsNames = new Set<string>([
   "newableArrowFunctions",
   "noDocumentAll",
   "objectRestNoSymbols",
+  "privateFieldsAsProperties",
   "pureGetters",
   "setClassMethods",
   "setComputedProperties",

--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -366,7 +366,7 @@ export function transformPrivateNamesUsage(
   ref,
   path,
   privateNamesMap,
-  privateFieldsAsProperties,
+  { privateFieldsAsProperties },
   state,
 ) {
   if (!privateNamesMap.size) return;

--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -636,18 +636,12 @@ const thisContextVisitor = traverse.visitors.merge([
   environmentVisitor,
 ]);
 
-function replaceThisContext(
-  path,
-  ref,
-  superRef,
-  file,
-  privateFieldsAsProperties,
-) {
+function replaceThisContext(path, ref, superRef, file, loose) {
   const state = { classRef: ref, needsClassRef: false };
 
   const replacer = new ReplaceSupers({
     methodPath: path,
-    isLoose: privateFieldsAsProperties,
+    isLoose: loose,
     superRef,
     file,
     refToPreserve: ref,
@@ -673,6 +667,7 @@ export function buildFieldsInitNodes(
   state,
   setPublicClassFields,
   privateFieldsAsProperties,
+  loose,
 ) {
   const staticNodes = [];
   const instanceNodes = [];
@@ -689,13 +684,7 @@ export function buildFieldsInitNodes(
     const isMethod = !isField;
 
     if (isStatic || (isMethod && isPrivate)) {
-      const replaced = replaceThisContext(
-        prop,
-        ref,
-        superRef,
-        state,
-        privateFieldsAsProperties,
-      );
+      const replaced = replaceThisContext(prop, ref, superRef, state, loose);
       needsClassRef = needsClassRef || replaced;
     }
 

--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -213,6 +213,7 @@ export function createClassFeaturePlugin({
             state,
             setPublicClassFields ?? loose,
             privateFieldsAsProperties ?? loose,
+            loose,
           ));
         }
 

--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -42,6 +42,31 @@ export function createClassFeaturePlugin({
   const setPublicClassFields = api.assumption("setPublicClassFields");
   const privateFieldsAsProperties = api.assumption("privateFieldsAsProperties");
 
+  if (loose) {
+    const explicit = [];
+
+    if (setPublicClassFields !== undefined) {
+      explicit.push(`"setPublicClassFields"`);
+    }
+    if (privateFieldsAsProperties !== undefined) {
+      explicit.push(`"privateFieldsAsProperties"`);
+    }
+    if (explicit.length !== 0) {
+      console.warn(
+        `[${name}]: You are using the "loose: true" option and you are` +
+          ` explicitly setting a value for the ${explicit.join(" and ")}` +
+          ` assumption${explicit.length > 1 ? "s" : ""}. The "loose" option` +
+          ` can cause incompatibilities with the other class features` +
+          ` plugins, so it's recommended that you replace it with the` +
+          ` following top-level option:\n` +
+          `\t"assumptions": {\n` +
+          `\t\t"setPublicClassFields": true,\n` +
+          `\t\t"privateFieldsAsProperties": true\n` +
+          `\t}`,
+      );
+    }
+  }
+
   return {
     name,
     manipulateOptions,

--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -36,7 +36,11 @@ export function createClassFeaturePlugin({
   feature,
   loose,
   manipulateOptions,
+  // TODO(Babel 8): Remove the default falue
+  api = { assumption: () => {} },
 }) {
+  const setPublicClassFields = api.assumption("setPublicClassFields");
+
   return {
     name,
     manipulateOptions,
@@ -175,7 +179,7 @@ export function createClassFeaturePlugin({
             props,
             privateNamesMap,
             state,
-            loose,
+            setPublicClassFields ?? loose,
           ));
         }
 

--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -40,6 +40,7 @@ export function createClassFeaturePlugin({
   api = { assumption: () => {} },
 }) {
   const setPublicClassFields = api.assumption("setPublicClassFields");
+  const privateFieldsAsProperties = api.assumption("privateFieldsAsProperties");
 
   return {
     name,
@@ -155,11 +156,17 @@ export function createClassFeaturePlugin({
         const privateNamesMap = buildPrivateNamesMap(props);
         const privateNamesNodes = buildPrivateNamesNodes(
           privateNamesMap,
-          loose,
+          privateFieldsAsProperties ?? loose,
           state,
         );
 
-        transformPrivateNamesUsage(ref, path, privateNamesMap, loose, state);
+        transformPrivateNamesUsage(
+          ref,
+          path,
+          privateNamesMap,
+          privateFieldsAsProperties ?? loose,
+          state,
+        );
 
         let keysNodes, staticNodes, instanceNodes, wrapClass;
 
@@ -180,6 +187,7 @@ export function createClassFeaturePlugin({
             privateNamesMap,
             state,
             setPublicClassFields ?? loose,
+            privateFieldsAsProperties ?? loose,
           ));
         }
 

--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -189,7 +189,7 @@ export function createClassFeaturePlugin({
           ref,
           path,
           privateNamesMap,
-          privateFieldsAsProperties ?? loose,
+          { privateFieldsAsProperties: privateFieldsAsProperties ?? loose },
           state,
         );
 

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions/input.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions/input.js
@@ -1,0 +1,3 @@
+class A {
+  foo;
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions/options.json
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions/options.json
@@ -1,0 +1,9 @@
+{
+  "validateLogs": true,
+  "plugins": [
+    ["proposal-class-properties", { "loose": true }]
+  ],
+  "assumptions": {
+    "setPublicClassFields": true
+  }
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions/output.js
@@ -1,0 +1,6 @@
+class A {
+  constructor() {
+    this.foo = void 0;
+  }
+
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions/stderr.txt
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions/stderr.txt
@@ -1,0 +1,5 @@
+[proposal-class-properties]: You are using the "loose: true" option and you are explicitly setting a value for the "setPublicClassFields" assumption. The "loose" option can cause incompatibilities with the other class features plugins, so it's recommended that you replace it with the following top-level option:
+	"assumptions": {
+		"setPublicClassFields": true,
+		"privateFieldsAsProperties": true
+	}

--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -12,6 +12,7 @@ export default declare((api, options) => {
   return createClassFeaturePlugin({
     name: "proposal-class-properties",
 
+    api,
     feature: FEATURES.fields,
     loose: options.loose,
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/computed-initialization-order/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/computed-initialization-order/exec.js
@@ -1,0 +1,38 @@
+const actualOrder = [];
+
+const track = i => {
+  actualOrder.push(i);
+  return i;
+};
+
+class MyClass {
+  static [track(1)] = track(10);
+  [track(2)] = track(13);
+  get [track(3)]() {
+    return "foo";
+  }
+  set [track(4)](value) {
+    this.bar = value;
+  }
+  [track(5)] = track(14);
+  static [track(6)] = track(11);
+  static [track(7)] = track(12);
+  [track(8)]() {}
+  [track(9)] = track(15);
+}
+
+const inst = new MyClass();
+
+const expectedOrder = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+expect(actualOrder).toEqual(expectedOrder);
+
+expect(MyClass[1]).toBe(10);
+expect(inst[2]).toBe(13);
+expect(inst[3]).toBe("foo");
+inst[4] = "baz";
+expect(inst.bar).toBe("baz");
+expect(inst[5]).toBe(14);
+expect(MyClass[6]).toBe(11);
+expect(MyClass[7]).toBe(12);
+expect(typeof inst[8]).toBe("function");
+expect(inst[9]).toBe(15);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/computed/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/computed/input.js
@@ -1,0 +1,25 @@
+const foo = "foo";
+const bar = () => {};
+const four = 4;
+
+class MyClass {
+  static [one()] = "test";
+  static [2 * 4 + 7] = "247";
+  static [2 * four + 7] = "247";
+  static [2 * four + seven] = "247";
+  [null] = "null";
+  [undefined] = "undefined";
+  [void 0] = "void 0";
+  get ["whatever"]() {}
+  set ["whatever"](value) {}
+  get [computed()]() {}
+  set [computed()](value) {}
+  ["test" + one]() {}
+  static [10]() {}
+  [/regex/] = "regex";
+  [foo] = "foo";
+  [bar] = "bar";
+  [baz] = "baz";
+  [`template`] = "template";
+  [`template${expression}`] = "template-with-expression";
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/computed/output.js
@@ -1,0 +1,48 @@
+let _one, _ref, _undefined, _computed, _computed2, _ref2, _ref3, _baz, _ref4;
+
+const foo = "foo";
+
+const bar = () => {};
+
+const four = 4;
+_one = one();
+_ref = 2 * four + seven;
+_undefined = undefined;
+_computed = computed();
+_computed2 = computed();
+_ref2 = "test" + one;
+_ref3 = /regex/;
+_baz = baz;
+_ref4 = `template${expression}`;
+
+class MyClass {
+  constructor() {
+    this[null] = "null";
+    this[_undefined] = "undefined";
+    this[void 0] = "void 0";
+    this[_ref3] = "regex";
+    this[foo] = "foo";
+    this[bar] = "bar";
+    this[_baz] = "baz";
+    this[`template`] = "template";
+    this[_ref4] = "template-with-expression";
+  }
+
+  get ["whatever"]() {}
+
+  set ["whatever"](value) {}
+
+  get [_computed]() {}
+
+  set [_computed2](value) {}
+
+  [_ref2]() {}
+
+  static [10]() {}
+
+}
+
+MyClass[_one] = "test";
+MyClass[2 * 4 + 7] = "247";
+MyClass[2 * four + 7] = "247";
+MyClass[_ref] = "247";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/constructor-collision/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/constructor-collision/input.js
@@ -1,0 +1,11 @@
+var foo = "bar";
+
+class Foo {
+  bar = foo;
+  static bar = baz;
+
+  constructor() {
+    var foo = "foo";
+    var baz = "baz";
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/constructor-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/constructor-collision/output.js
@@ -1,0 +1,12 @@
+var foo = "bar";
+
+class Foo {
+  constructor() {
+    this.bar = foo;
+    var _foo = "foo";
+    var baz = "baz";
+  }
+
+}
+
+Foo.bar = baz;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/derived/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/derived/input.js
@@ -1,0 +1,3 @@
+class Foo extends Bar {
+  bar = "foo";
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/derived/output.js
@@ -1,0 +1,7 @@
+class Foo extends Bar {
+  constructor(...args) {
+    super(...args);
+    this.bar = "foo";
+  }
+
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/foobar/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/foobar/input.js
@@ -1,0 +1,9 @@
+class Child extends Parent {
+    constructor() {
+        super();
+    }
+
+    scopedFunctionWithThis = () => {
+        this.name = {};
+    }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/foobar/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/foobar/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    ["proposal-class-properties", { "loose": true }]
+  ],
+  "presets": ["env"]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/foobar/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/foobar/options.json
@@ -1,7 +1,10 @@
 {
   "plugins": [
     ["external-helpers", { "helperVersion": "7.100.0" }],
-    ["proposal-class-properties", { "loose": true }]
+    "proposal-class-properties"
   ],
-  "presets": ["env"]
+  "presets": ["env"],
+  "assumptions": {
+    "setPublicClassFields": true
+  }
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/foobar/output.js
@@ -1,0 +1,22 @@
+var Child = /*#__PURE__*/function (_Parent) {
+  "use strict";
+
+  babelHelpers.inherits(Child, _Parent);
+
+  var _super = babelHelpers.createSuper(Child);
+
+  function Child() {
+    var _this;
+
+    babelHelpers.classCallCheck(this, Child);
+    _this = _super.call(this);
+
+    _this.scopedFunctionWithThis = function () {
+      _this.name = {};
+    };
+
+    return _this;
+  }
+
+  return Child;
+}(Parent);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance-computed/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance-computed/exec.js
@@ -1,0 +1,13 @@
+function test(x) {
+  class F {
+    [x] = 1;
+    constructor() {}
+  }
+
+  x = 'deadbeef';
+  expect(new F().foo).toBe(1);
+  x = 'wrong';
+  expect(new F().foo).toBe(1);
+}
+
+test('foo');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance-computed/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance-computed/input.js
@@ -1,0 +1,13 @@
+function test(x) {
+  class F {
+    [x] = 1;
+    constructor() {}
+  }
+
+  x = 'deadbeef';
+  expect(new F().foo).toBe(1);
+  x = 'wrong';
+  expect(new F().foo).toBe(1);
+}
+
+test('foo');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance-computed/output.js
@@ -1,0 +1,19 @@
+function test(x) {
+  let _x;
+
+  _x = x;
+
+  class F {
+    constructor() {
+      this[_x] = 1;
+    }
+
+  }
+
+  x = 'deadbeef';
+  expect(new F().foo).toBe(1);
+  x = 'wrong';
+  expect(new F().foo).toBe(1);
+}
+
+test('foo');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance-undefined/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance-undefined/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  bar;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance-undefined/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance-undefined/output.js
@@ -1,0 +1,6 @@
+class Foo {
+  constructor() {
+    this.bar = void 0;
+  }
+
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  bar = "foo";
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/instance/output.js
@@ -1,0 +1,6 @@
+class Foo {
+  constructor() {
+    this.bar = "foo";
+  }
+
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/non-block-arrow-func/input.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/non-block-arrow-func/input.mjs
@@ -1,0 +1,11 @@
+export default param =>
+  class App {
+    static props = {
+      prop1: 'prop1',
+      prop2: 'prop2'
+    }
+
+    getParam() {
+      return param;
+    }
+  }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/non-block-arrow-func/output.mjs
@@ -1,0 +1,13 @@
+export default (param => {
+  var _class, _temp;
+
+  return _temp = _class = class App {
+    getParam() {
+      return param;
+    }
+
+  }, _class.props = {
+    prop1: 'prop1',
+    prop2: 'prop2'
+  }, _temp;
+});

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "proposal-class-properties",
+    "syntax-class-properties"
+  ],
+  "assumptions": {
+    "setPublicClassFields": true
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T2983/input.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T2983/input.mjs
@@ -1,0 +1,7 @@
+call(class {
+  static test = true
+});
+
+export default class {
+  static test = true
+};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T2983/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T2983/output.mjs
@@ -1,0 +1,6 @@
+var _class, _temp;
+
+call((_temp = _class = class {}, _class.test = true, _temp));
+export default class _class2 {}
+_class2.test = true;
+;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T6719/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T6719/input.js
@@ -1,0 +1,14 @@
+function withContext(ComposedComponent) {
+    return class WithContext extends Component {
+
+        static propTypes = {
+            context: PropTypes.shape(
+                {
+                    addCss: PropTypes.func,
+                    setTitle: PropTypes.func,
+                    setMeta: PropTypes.func,
+                }
+            ),
+        };
+    };
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T6719/output.js
@@ -1,0 +1,11 @@
+function withContext(ComposedComponent) {
+  var _class, _temp;
+
+  return _temp = _class = class WithContext extends Component {}, _class.propTypes = {
+    context: PropTypes.shape({
+      addCss: PropTypes.func,
+      setTitle: PropTypes.func,
+      setMeta: PropTypes.func
+    })
+  }, _temp;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T7364/input.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T7364/input.mjs
@@ -1,0 +1,17 @@
+class MyClass {
+  myAsyncMethod = async () => {
+    console.log(this);
+  }
+}
+
+(class MyClass2 {
+  myAsyncMethod = async () => {
+    console.log(this);
+  }
+})
+
+export default class MyClass3 {
+  myAsyncMethod = async () => {
+    console.log(this);
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T7364/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T7364/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    "external-helpers",
+    "transform-async-to-generator",
+    "proposal-class-properties"
+  ],
+  "assumptions": {
+    "setPublicClassFields": true
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T7364/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T7364/output.mjs
@@ -1,0 +1,32 @@
+class MyClass {
+  constructor() {
+    var _this = this;
+
+    this.myAsyncMethod = /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
+      console.log(_this);
+    });
+  }
+
+}
+
+(class MyClass2 {
+  constructor() {
+    var _this2 = this;
+
+    this.myAsyncMethod = /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
+      console.log(_this2);
+    });
+  }
+
+});
+
+export default class MyClass3 {
+  constructor() {
+    var _this3 = this;
+
+    this.myAsyncMethod = /*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
+      console.log(_this3);
+    });
+  }
+
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-export/input.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-export/input.mjs
@@ -1,0 +1,7 @@
+export class MyClass {
+  static property = value;
+}
+
+export default class MyClass2 {
+  static property = value;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-export/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-export/output.mjs
@@ -1,0 +1,4 @@
+export class MyClass {}
+MyClass.property = value;
+export default class MyClass2 {}
+MyClass2.property = value;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-infer-name/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-infer-name/exec.js
@@ -1,0 +1,7 @@
+var Foo = class {
+  static num = 0;
+}
+
+expect(Foo.num).toBe(0);
+expect(Foo.num = 1).toBe(1);
+expect(Foo.name).toBe("Foo");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-infer-name/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-infer-name/input.js
@@ -1,0 +1,3 @@
+var Foo = class {
+  static num = 0;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-infer-name/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-infer-name/output.js
@@ -1,0 +1,3 @@
+var _class, _temp;
+
+var Foo = (_temp = _class = class Foo {}, _class.num = 0, _temp);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super-loose/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super-loose/input.js
@@ -1,0 +1,9 @@
+class A {
+  static prop = 1;
+}
+
+class B extends A {
+  static prop = 2;
+  static propA = super.prop;
+  static getPropA = () => super.prop;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super-loose/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super-loose/options.json
@@ -1,0 +1,11 @@
+{
+  "validateLogs": true,
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    ["proposal-class-properties", { "loose": true }],
+    "syntax-class-properties"
+  ],
+  "assumptions": {
+    "setPublicClassFields": true
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super-loose/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super-loose/output.js
@@ -1,0 +1,10 @@
+class A {}
+
+A.prop = 1;
+
+class B extends A {}
+
+B.prop = 2;
+B.propA = A.prop;
+
+B.getPropA = () => A.prop;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super-loose/stderr.txt
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super-loose/stderr.txt
@@ -1,0 +1,5 @@
+[proposal-class-properties]: You are using the "loose: true" option and you are explicitly setting a value for the "setPublicClassFields" assumption. The "loose" option can cause incompatibilities with the other class features plugins, so it's recommended that you replace it with the following top-level option:
+	"assumptions": {
+		"setPublicClassFields": true,
+		"privateFieldsAsProperties": true
+	}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super/exec.js
@@ -1,0 +1,15 @@
+class A {
+  static prop = 1;
+}
+
+class B extends A {
+  static prop = 2;
+  static propA = super.prop;
+  static getPropA = () => super.prop;
+}
+
+const { prop, propA, getPropA } = B;
+
+expect(prop).toBe(2);
+expect(propA).toBe(1);
+expect(getPropA()).toBe(1);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super/input.js
@@ -1,0 +1,9 @@
+class A {
+  static prop = 1;
+}
+
+class B extends A {
+  static prop = 2;
+  static propA = super.prop;
+  static getPropA = () => super.prop;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super/output.js
@@ -1,0 +1,10 @@
+class A {}
+
+A.prop = 1;
+
+class B extends A {}
+
+B.prop = 2;
+B.propA = A.prop;
+
+B.getPropA = () => A.prop;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-super/output.js
@@ -5,6 +5,6 @@ A.prop = 1;
 class B extends A {}
 
 B.prop = 2;
-B.propA = A.prop;
+B.propA = babelHelpers.get(babelHelpers.getPrototypeOf(B), "prop", B);
 
-B.getPropA = () => A.prop;
+B.getPropA = () => babelHelpers.get(babelHelpers.getPrototypeOf(B), "prop", B);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-this/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-this/exec.js
@@ -1,0 +1,9 @@
+class A {
+  static self = this;
+  static getA = () => this;
+}
+
+const { self, getA } = A;
+
+expect(self).toBe(A);
+expect(getA()).toBe(A);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-this/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-this/input.js
@@ -1,0 +1,4 @@
+class A {
+  static self = this;
+  static getA = () => this;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-this/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-this/output.js
@@ -1,0 +1,5 @@
+class A {}
+
+A.self = A;
+
+A.getA = () => A;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-undefined/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-undefined/exec.js
@@ -1,0 +1,6 @@
+class Foo {
+  static num;
+}
+
+expect("num" in Foo).toBe(true);
+expect(Foo.num).toBeUndefined();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-undefined/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-undefined/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  static bar;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-undefined/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static-undefined/output.js
@@ -1,0 +1,3 @@
+class Foo {}
+
+Foo.bar = void 0;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static/exec.js
@@ -1,0 +1,9 @@
+class Foo {
+  static num = 0;
+  static str = "foo";
+}
+
+expect(Foo.num).toBe(0);
+expect(Foo.num = 1).toBe(1);
+expect(Foo.str).toBe("foo");
+expect(Foo.str = "bar").toBe("bar");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  static bar = "foo";
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/static/output.js
@@ -1,0 +1,3 @@
+class Foo {}
+
+Foo.bar = "foo";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-call/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-call/input.js
@@ -1,0 +1,9 @@
+class A {
+  foo() {
+    return "bar";
+  }
+}
+
+class B extends A {
+  foo = super.foo();
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-call/output.js
@@ -1,0 +1,14 @@
+class A {
+  foo() {
+    return "bar";
+  }
+
+}
+
+class B extends A {
+  constructor(...args) {
+    super(...args);
+    this.foo = super.foo();
+  }
+
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-expression/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-expression/input.js
@@ -1,0 +1,7 @@
+class Foo extends Bar {
+  bar = "foo";
+
+  constructor() {
+    foo(super());
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-expression/output.js
@@ -1,0 +1,8 @@
+class Foo extends Bar {
+  constructor() {
+    var _temp;
+
+    foo((_temp = super(), this.bar = "foo", _temp));
+  }
+
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-statement/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-statement/input.js
@@ -1,0 +1,7 @@
+class Foo extends Bar {
+  bar = "foo";
+
+  constructor() {
+    super();
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-statement/output.js
@@ -1,0 +1,7 @@
+class Foo extends Bar {
+  constructor() {
+    super();
+    this.bar = "foo";
+  }
+
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-with-collision/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-with-collision/input.js
@@ -1,0 +1,6 @@
+class A {
+  force = force;
+  foo = super.method();
+
+  constructor(force) {}
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-with-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/assumption-setPublicClassFields/super-with-collision/output.js
@@ -1,0 +1,7 @@
+class A {
+  constructor(_force) {
+    this.force = force;
+    this.foo = super.method();
+  }
+
+}

--- a/packages/babel-plugin-proposal-decorators/src/index.js
+++ b/packages/babel-plugin-proposal-decorators/src/index.js
@@ -50,6 +50,7 @@ export default declare((api, options) => {
   return createClassFeaturePlugin({
     name: "proposal-decorators",
 
+    api,
     feature: FEATURES.decorators,
     // loose: options.loose, Not supported
 

--- a/packages/babel-plugin-proposal-private-methods/src/index.js
+++ b/packages/babel-plugin-proposal-private-methods/src/index.js
@@ -12,6 +12,7 @@ export default declare((api, options) => {
   return createClassFeaturePlugin({
     name: "proposal-private-methods",
 
+    api,
     feature: FEATURES.privateMethods,
     loose: options.loose,
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/basic/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/basic/exec.js
@@ -1,0 +1,31 @@
+class Cl {
+  #privateField = "top secret string";
+
+  constructor() {
+    this.publicField = "not secret string";
+  }
+
+  get #privateFieldValue() {
+    return this.#privateField;
+  }
+
+  set #privateFieldValue(newValue) {
+    this.#privateField = newValue;
+  }
+
+  publicGetPrivateField() {
+    return this.#privateFieldValue;
+  }
+
+  publicSetPrivateField(newValue) {
+    this.#privateFieldValue = newValue;
+  }
+}
+
+const cl = new Cl();
+
+expect(cl.publicGetPrivateField()).toEqual("top secret string");
+
+cl.publicSetPrivateField("new secret string");
+expect(cl.publicGetPrivateField()).toEqual("new secret string");
+

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/basic/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/basic/input.js
@@ -1,0 +1,23 @@
+class Cl {
+  #privateField = "top secret string";
+
+  constructor() {
+    this.publicField = "not secret string";
+  }
+
+  get #privateFieldValue() {
+    return this.#privateField;
+  }
+
+  set #privateFieldValue(newValue) {
+    this.#privateField = newValue;
+  }
+
+  publicGetPrivateField() {
+    return this.#privateFieldValue;
+  }
+
+  publicSetPrivateField(newValue) {
+    this.#privateFieldValue = newValue;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/basic/output.js
@@ -1,0 +1,34 @@
+var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+
+var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+
+class Cl {
+  constructor() {
+    Object.defineProperty(this, _privateFieldValue, {
+      get: _get_privateFieldValue,
+      set: _set_privateFieldValue
+    });
+    Object.defineProperty(this, _privateField, {
+      writable: true,
+      value: "top secret string"
+    });
+    this.publicField = "not secret string";
+  }
+
+  publicGetPrivateField() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
+  }
+
+  publicSetPrivateField(newValue) {
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = newValue;
+  }
+
+}
+
+var _get_privateFieldValue = function () {
+  return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
+};
+
+var _set_privateFieldValue = function (newValue) {
+  babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = newValue;
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/get-only-setter/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/get-only-setter/exec.js
@@ -1,0 +1,13 @@
+class Cl {
+  #privateField = 0;
+
+  set #privateFieldValue(newValue) {
+    this.#privateField = newValue;
+  }
+
+  constructor() {
+    expect(this.#privateFieldValue).toBeUndefined();
+  }
+}
+
+const cl = new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/get-only-setter/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/get-only-setter/input.js
@@ -1,0 +1,11 @@
+class Cl {
+  #privateField = 0;
+
+  set #privateFieldValue(newValue) {
+    this.#privateField = newValue;
+  }
+
+  constructor() {
+    this.publicField = this.#privateFieldValue;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/get-only-setter/output.js
@@ -1,0 +1,22 @@
+var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+
+var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+
+class Cl {
+  constructor() {
+    Object.defineProperty(this, _privateFieldValue, {
+      get: void 0,
+      set: _set_privateFieldValue
+    });
+    Object.defineProperty(this, _privateField, {
+      writable: true,
+      value: 0
+    });
+    this.publicField = babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
+  }
+
+}
+
+var _set_privateFieldValue = function (newValue) {
+  babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = newValue;
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/helper/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/helper/exec.js
@@ -1,0 +1,11 @@
+let foo;
+class Cl {
+  set #foo(v) { return 1 }
+  test() {
+    foo = this.#foo = 2;
+  }
+}
+
+new Cl().test();
+
+expect(foo).toBe(2);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/options.json
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    ["external-helpers",{ "helperVersion": "7.1000.0" }],
+    "proposal-private-methods",
+    "proposal-class-properties"
+  ],
+  "assumptions": {
+    "privateFieldsAsProperties": true
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/exec.js
@@ -1,0 +1,13 @@
+class Cl {
+  #privateField = 0;
+
+  get #privateFieldValue() {
+    return this.#privateField;
+  }
+
+  constructor() {
+    expect(() => this.#privateFieldValue = 1).toThrow(TypeError);
+  }
+}
+
+const cl = new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/input.js
@@ -1,0 +1,11 @@
+class Cl {
+  #privateField = 0;
+
+  get #privateFieldValue() {
+    return this.#privateField;
+  }
+
+  constructor() {
+    this.#privateFieldValue = 1;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/output.js
@@ -1,0 +1,22 @@
+var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+
+var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+
+class Cl {
+  constructor() {
+    Object.defineProperty(this, _privateFieldValue, {
+      get: _get_privateFieldValue,
+      set: void 0
+    });
+    Object.defineProperty(this, _privateField, {
+      writable: true,
+      value: 0
+    });
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = 1;
+  }
+
+}
+
+var _get_privateFieldValue = function () {
+  return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/updates/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/updates/exec.js
@@ -1,0 +1,50 @@
+class Cl {
+  #privateField = "top secret string";
+
+  constructor() {
+    this.publicField = "not secret string";
+  }
+
+  get #privateFieldValue() {
+    return this.#privateField;
+  }
+
+  set #privateFieldValue(newValue) {
+    this.#privateField = newValue;
+  }
+
+  publicGetPrivateField() {
+    return this.#privateFieldValue;
+  }
+
+  publicSetPrivateField(newValue) {
+    this.#privateFieldValue = newValue;
+  }
+
+  get publicFieldValue() {
+    return this.publicField;
+  }
+
+  set publicFieldValue(newValue) {
+    this.publicField = newValue;
+  }
+
+  testUpdates() {
+    this.#privateField = 0;
+    this.publicField = 0;
+    this.#privateFieldValue = this.#privateFieldValue++;
+    this.publicFieldValue = this.publicFieldValue++;
+    expect(this.#privateField).toEqual(this.publicField);
+
+    ++this.#privateFieldValue;
+    ++this.publicFieldValue;
+    expect(this.#privateField).toEqual(this.publicField);
+
+    this.#privateFieldValue += 1;
+    this.publicFieldValue += 1;
+    expect(this.#privateField).toEqual(this.publicField);
+  }
+}
+
+const cl = new Cl();
+cl.testUpdates();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/updates/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/updates/input.js
@@ -1,0 +1,47 @@
+class Cl {
+  #privateField = "top secret string";
+
+  constructor() {
+    this.publicField = "not secret string";
+  }
+
+  get #privateFieldValue() {
+    return this.#privateField;
+  }
+
+  set #privateFieldValue(newValue) {
+    this.#privateField = newValue;
+  }
+
+  publicGetPrivateField() {
+    return this.#privateFieldValue;
+  }
+
+  publicSetPrivateField(newValue) {
+    this.#privateFieldValue = newValue;
+  }
+
+  get publicFieldValue() {
+    return this.publicField;
+  }
+
+  set publicFieldValue(newValue) {
+    this.publicField = newValue;
+  }
+
+  testUpdates() {
+    this.#privateField = 0;
+    this.publicField = 0;
+    this.#privateFieldValue = this.#privateFieldValue++;
+    this.publicFieldValue = this.publicFieldValue++;
+
+    ++this.#privateFieldValue;
+    ++this.publicFieldValue;
+
+    this.#privateFieldValue += 1;
+    this.publicFieldValue += 1;
+
+    this.#privateFieldValue = -(this.#privateFieldValue ** this.#privateFieldValue);
+    this.publicFieldValue = -(this.publicFieldValue ** this.publicFieldValue);
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/updates/output.js
@@ -1,0 +1,55 @@
+var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+
+var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+
+class Cl {
+  constructor() {
+    Object.defineProperty(this, _privateFieldValue, {
+      get: _get_privateFieldValue,
+      set: _set_privateFieldValue
+    });
+    Object.defineProperty(this, _privateField, {
+      writable: true,
+      value: "top secret string"
+    });
+    this.publicField = "not secret string";
+  }
+
+  publicGetPrivateField() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
+  }
+
+  publicSetPrivateField(newValue) {
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = newValue;
+  }
+
+  get publicFieldValue() {
+    return this.publicField;
+  }
+
+  set publicFieldValue(newValue) {
+    this.publicField = newValue;
+  }
+
+  testUpdates() {
+    babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = 0;
+    this.publicField = 0;
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue]++;
+    this.publicFieldValue = this.publicFieldValue++;
+    ++babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
+    ++this.publicFieldValue;
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] += 1;
+    this.publicFieldValue += 1;
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = -(babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] ** babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue]);
+    this.publicFieldValue = -(this.publicFieldValue ** this.publicFieldValue);
+  }
+
+}
+
+var _get_privateFieldValue = function () {
+  return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
+};
+
+var _set_privateFieldValue = function (newValue) {
+  babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = newValue;
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/assignment/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/assignment/exec.js
@@ -1,0 +1,11 @@
+class Foo {
+    constructor() {
+      this.publicField = this.#privateMethod();
+    }
+
+    #privateMethod() {
+      return 42;
+    }
+  }
+
+  expect((new Foo).publicField).toEqual(42);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/assignment/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/assignment/input.js
@@ -1,0 +1,9 @@
+class Foo {
+  constructor() {
+    this.publicField = this.#privateMethod();
+  }
+
+  #privateMethod() {
+    return 42;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/assignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/assignment/output.js
@@ -1,0 +1,15 @@
+var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+    this.publicField = babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod]();
+  }
+
+}
+
+var _privateMethod2 = function _privateMethod2() {
+  return 42;
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/exec.js
@@ -1,0 +1,13 @@
+class Cl {
+  async #foo() {
+    return 2;
+  }
+
+  test() {
+    return this.#foo();
+  }
+}
+
+return new Cl().test().then(val => {
+  expect(val).toBe(2);
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/input.js
@@ -1,0 +1,9 @@
+class Cl {
+  async #foo() {
+    return 2;
+  }
+
+  test() {
+    return this.#foo();
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/options.json
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/options.json
@@ -1,0 +1,14 @@
+{
+  "minNodeVersion": "8.0.0",
+  "plugins": [
+    ["external-helpers",{ "helperVersion": "7.1000.0" }],
+    "proposal-private-methods",
+    "proposal-class-properties"
+  ],
+  "assumptions": {
+    "privateFieldsAsProperties": true
+  },
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/output.js
@@ -1,0 +1,18 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+class Cl {
+  constructor() {
+    Object.defineProperty(this, _foo, {
+      value: _foo2
+    });
+  }
+
+  test() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
+  }
+
+}
+
+var _foo2 = async function _foo2() {
+  return 2;
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/before-fields/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/before-fields/exec.js
@@ -1,0 +1,16 @@
+class Cl {
+  prop = this.#method(1);
+
+  #priv = this.#method(2);
+
+  #method(x) {
+    return x;
+  }
+
+  getPriv() {
+    return this.#priv;
+  }
+}
+
+expect(new Cl().prop).toBe(1);
+expect(new Cl().getPriv()).toBe(2);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/before-fields/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/before-fields/input.js
@@ -1,0 +1,13 @@
+class Cl {
+  prop = this.#method(1);
+
+  #priv = this.#method(2);
+
+  #method(x) {
+    return x;
+  }
+
+  getPriv() {
+    return this.#priv;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/before-fields/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/before-fields/output.js
@@ -1,0 +1,25 @@
+var _priv = babelHelpers.classPrivateFieldLooseKey("priv");
+
+var _method = babelHelpers.classPrivateFieldLooseKey("method");
+
+class Cl {
+  constructor() {
+    Object.defineProperty(this, _method, {
+      value: _method2
+    });
+    babelHelpers.defineProperty(this, "prop", babelHelpers.classPrivateFieldLooseBase(this, _method)[_method](1));
+    Object.defineProperty(this, _priv, {
+      writable: true,
+      value: babelHelpers.classPrivateFieldLooseBase(this, _method)[_method](2)
+    });
+  }
+
+  getPriv() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _priv)[_priv];
+  }
+
+}
+
+var _method2 = function _method2(x) {
+  return x;
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/context/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/context/exec.js
@@ -1,0 +1,41 @@
+class Foo {
+    constructor(status) {
+      this.status = status;
+      expect(() => this.#getStatus = null).toThrow(TypeError);
+    }
+
+    #getStatus() {
+      return this.status;
+    }
+
+    getCurrentStatus() {
+      return this.#getStatus();
+    }
+
+    setCurrentStatus(newStatus) {
+      this.status = newStatus;
+    }
+
+    getFakeStatus(fakeStatus) {
+      const getStatus = this.#getStatus;
+      return function () {
+        return getStatus.call({ status: fakeStatus });
+      };
+    }
+
+    getFakeStatusFunc() {
+      return {
+        status: 'fake-status',
+        getFakeStatus: this.#getStatus,
+      };
+    }
+  }
+
+  const f = new Foo('inactive');
+  expect(f.getCurrentStatus()).toBe('inactive');
+
+  f.setCurrentStatus('new-status');
+  expect(f.getCurrentStatus()).toBe('new-status');
+
+  expect(f.getFakeStatus('fake')()).toBe('fake');
+  expect(f.getFakeStatusFunc().getFakeStatus()).toBe('fake-status');

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/context/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/context/input.js
@@ -1,0 +1,31 @@
+class Foo {
+  constructor(status) {
+    this.status = status;
+  }
+
+  #getStatus() {
+    return this.status;
+  }
+
+  getCurrentStatus() {
+    return this.#getStatus();
+  }
+
+  setCurrentStatus(newStatus) {
+    this.status = newStatus;
+  }
+
+  getFakeStatus(fakeStatus) {
+    const fakeGetStatus = this.#getStatus;
+    return function() {
+      return fakeGetStatus.call({ status: fakeStatus });
+    };
+  }
+
+  getFakeStatusFunc() {
+    return {
+      status: 'fake-status',
+      getFakeStatus: this.#getStatus,
+    };
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/context/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/context/output.js
@@ -1,0 +1,40 @@
+var _getStatus = babelHelpers.classPrivateFieldLooseKey("getStatus");
+
+class Foo {
+  constructor(status) {
+    Object.defineProperty(this, _getStatus, {
+      value: _getStatus2
+    });
+    this.status = status;
+  }
+
+  getCurrentStatus() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus]();
+  }
+
+  setCurrentStatus(newStatus) {
+    this.status = newStatus;
+  }
+
+  getFakeStatus(fakeStatus) {
+    const fakeGetStatus = babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus];
+
+    return function () {
+      return fakeGetStatus.call({
+        status: fakeStatus
+      });
+    };
+  }
+
+  getFakeStatusFunc() {
+    return {
+      status: 'fake-status',
+      getFakeStatus: babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus]
+    };
+  }
+
+}
+
+var _getStatus2 = function _getStatus2() {
+  return this.status;
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/exfiltrated/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/exfiltrated/exec.js
@@ -1,0 +1,15 @@
+let exfiltrated;
+class Foo {
+    #privateMethod() {}
+
+    constructor() {
+        if (exfiltrated === undefined) {
+            exfiltrated = this.#privateMethod;
+        }
+        expect(exfiltrated).toStrictEqual(this.#privateMethod);
+    }
+}
+
+new Foo();
+// check for private method function object equality
+new Foo();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/exfiltrated/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/exfiltrated/input.js
@@ -1,0 +1,10 @@
+let exfiltrated;
+class Foo {
+    #privateMethod() {}
+
+    constructor() {
+        if (exfiltrated === undefined) {
+            exfiltrated = this.#privateMethod;
+        }
+    }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/exfiltrated/output.js
@@ -1,0 +1,18 @@
+let exfiltrated;
+
+var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
+    if (exfiltrated === undefined) {
+      exfiltrated = babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod];
+    }
+  }
+
+}
+
+var _privateMethod2 = function _privateMethod2() {};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/generator/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/generator/exec.js
@@ -1,0 +1,14 @@
+class Cl {
+  *#foo() {
+    yield 2;
+    return 3;
+  }
+
+  test() {
+    return this.#foo();
+  }
+}
+
+const val = new Cl().test();
+expect(val.next()).toEqual({ value: 2, done: false });
+expect(val.next()).toEqual({ value: 3, done: true });

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/generator/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/generator/input.js
@@ -1,0 +1,10 @@
+class Cl {
+  *#foo() {
+    yield 2;
+    return 3;
+  }
+
+  test() {
+    return this.#foo();
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/generator/output.js
@@ -1,0 +1,19 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+class Cl {
+  constructor() {
+    Object.defineProperty(this, _foo, {
+      value: _foo2
+    });
+  }
+
+  test() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
+  }
+
+}
+
+var _foo2 = function* _foo2() {
+  yield 2;
+  return 3;
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/options.json
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    ["external-helpers",{ "helperVersion": "7.1000.0" }],
+    "proposal-private-methods",
+    "proposal-class-properties"
+  ],
+  "assumptions": {
+    "privateFieldsAsProperties": true
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/exec.js
@@ -1,0 +1,21 @@
+class Base {
+  superMethod() {
+    return 'good';
+  }
+}
+
+class Sub extends Base {
+  superMethod() {
+    return 'bad';
+  }
+
+  #privateMethod() {
+    return super.superMethod();
+  }
+
+  publicMethod() {
+    return this.#privateMethod();
+  }
+}
+
+expect((new Sub()).publicMethod()).toEqual('good');

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/input.js
@@ -1,0 +1,19 @@
+class Base {
+  superMethod() {
+    return 'good';
+  }
+}
+
+class Sub extends Base {
+  superMethod() {
+    return 'bad';
+  }
+
+  #privateMethod() {
+    return super.superMethod();
+  }
+
+  publicMethod() {
+    return this.#privateMethod();
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/output.js
@@ -1,0 +1,30 @@
+class Base {
+  superMethod() {
+    return 'good';
+  }
+
+}
+
+var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+
+class Sub extends Base {
+  constructor(...args) {
+    super(...args);
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+  }
+
+  superMethod() {
+    return 'bad';
+  }
+
+  publicMethod() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod]();
+  }
+
+}
+
+var _privateMethod2 = function _privateMethod2() {
+  return Base.prototype.superMethod.call(this);
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/output.js
@@ -26,5 +26,5 @@ class Sub extends Base {
 }
 
 var _privateMethod2 = function _privateMethod2() {
-  return Base.prototype.superMethod.call(this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(Sub.prototype), "superMethod", this).call(this);
 };

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/async/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/async/input.js
@@ -1,0 +1,13 @@
+class Cl {
+  static async #privateStaticMethod() {
+    return 2;
+  }
+
+  test() {
+    return Cl.#privateStaticMethod();
+  }
+}
+
+return new Cl().test().then(val => {
+  expect(val).toBe(2);
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/async/options.json
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/async/options.json
@@ -1,0 +1,14 @@
+{
+  "minNodeVersion": "8.0.0",
+  "plugins": [
+    ["external-helpers",{ "helperVersion": "7.1000.0" }],
+    "proposal-private-methods",
+    "proposal-class-properties"
+  ],
+  "assumptions": {
+    "privateFieldsAsProperties": true
+  },
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/async/output.js
@@ -1,0 +1,19 @@
+var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+
+class Cl {
+  test() {
+    return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticMethod)[_privateStaticMethod]();
+  }
+
+}
+
+var _privateStaticMethod2 = async function _privateStaticMethod2() {
+  return 2;
+};
+
+Object.defineProperty(Cl, _privateStaticMethod, {
+  value: _privateStaticMethod2
+});
+return new Cl().test().then(val => {
+  expect(val).toBe(2);
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/basic/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/basic/exec.js
@@ -1,0 +1,33 @@
+const privateStaticValue = 1017;
+
+class Cl {
+  static staticMethod2() {
+    return Cl.#privateStaticMethod();
+  }
+
+  static #privateStaticMethod() {
+    return privateStaticValue;
+  }
+
+  static staticMethod() {
+    return Cl.#privateStaticMethod();
+  }
+
+  static privateStaticMethod() {
+    return Cl.#privateStaticMethod();
+  }
+
+  publicMethod() {
+    return Cl.#privateStaticMethod();
+  }
+
+  constructor() {
+    this.instanceField = Cl.#privateStaticMethod();
+  }
+}
+
+expect((new Cl).publicMethod()).toEqual(privateStaticValue);
+// expect((new Cl).instanceField).toEqual(privateStaticValue);
+// expect(Cl.privateStaticMethod()).toEqual(privateStaticValue);
+// expect(Cl.staticMethod()).toEqual(privateStaticValue);
+// expect(Cl.staticMethod2()).toEqual(privateStaticValue);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/basic/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/basic/input.js
@@ -1,0 +1,25 @@
+class Cl {
+  static staticMethod2() {
+    return Cl.#privateStaticMethod();
+  }
+
+  static #privateStaticMethod() {
+    return 1017;
+  }
+
+  static staticMethod() {
+    return Cl.#privateStaticMethod();
+  }
+
+  static privateStaticMethod() {
+    return Cl.#privateStaticMethod();
+  }
+
+  publicMethod() {
+    return Cl.#privateStaticMethod();
+  }
+
+  constructor() {
+    this.instanceField = Cl.#privateStaticMethod();
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/basic/output.js
@@ -1,0 +1,32 @@
+var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+
+class Cl {
+  static staticMethod2() {
+    return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticMethod)[_privateStaticMethod]();
+  }
+
+  static staticMethod() {
+    return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticMethod)[_privateStaticMethod]();
+  }
+
+  static privateStaticMethod() {
+    return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticMethod)[_privateStaticMethod]();
+  }
+
+  publicMethod() {
+    return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticMethod)[_privateStaticMethod]();
+  }
+
+  constructor() {
+    this.instanceField = babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticMethod)[_privateStaticMethod]();
+  }
+
+}
+
+var _privateStaticMethod2 = function _privateStaticMethod2() {
+  return 1017;
+};
+
+Object.defineProperty(Cl, _privateStaticMethod, {
+  value: _privateStaticMethod2
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-check/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-check/exec.js
@@ -1,0 +1,12 @@
+class Cl {
+  static #privateStaticMethod() {
+    return 1017;
+  }
+
+  publicMethod(checked) {
+    return checked.#privateStaticMethod();
+  }
+}
+
+const cl = new Cl();
+expect(cl.publicMethod(Cl)).toBe(1017);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-check/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-check/input.js
@@ -1,0 +1,7 @@
+class Cl {
+  static #privateStaticMethod() { }
+
+  publicMethod(checked) {
+    return checked.#privateStaticMethod();
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-check/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-check/output.js
@@ -1,0 +1,14 @@
+var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+
+class Cl {
+  publicMethod(checked) {
+    return babelHelpers.classPrivateFieldLooseBase(checked, _privateStaticMethod)[_privateStaticMethod]();
+  }
+
+}
+
+var _privateStaticMethod2 = function _privateStaticMethod2() {};
+
+Object.defineProperty(Cl, _privateStaticMethod, {
+  value: _privateStaticMethod2
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/exfiltrated/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/exfiltrated/exec.js
@@ -1,0 +1,20 @@
+let exfiltrated;
+
+class Cl {
+  static #privateStaticMethod() {
+    return 1017;
+  }
+
+  constructor() {
+    if (exfiltrated === undefined) {
+        exfiltrated = Cl.#privateStaticMethod;
+    }
+    expect(exfiltrated).toStrictEqual(Cl.#privateStaticMethod);
+  }
+}
+
+new Cl();
+// check for private method function object equality
+new Cl();
+
+expect(exfiltrated()).toEqual(1017);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/exfiltrated/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/exfiltrated/input.js
@@ -1,0 +1,13 @@
+let exfiltrated;
+
+class Cl {
+  static #privateStaticMethod() {
+    return 1017;
+  }
+
+  constructor() {
+    if (exfiltrated === undefined) {
+        exfiltrated = Cl.#privateStaticMethod;
+    }
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/exfiltrated/output.js
@@ -1,0 +1,20 @@
+let exfiltrated;
+
+var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+
+class Cl {
+  constructor() {
+    if (exfiltrated === undefined) {
+      exfiltrated = babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticMethod)[_privateStaticMethod];
+    }
+  }
+
+}
+
+var _privateStaticMethod2 = function _privateStaticMethod2() {
+  return 1017;
+};
+
+Object.defineProperty(Cl, _privateStaticMethod, {
+  value: _privateStaticMethod2
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/generator/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/generator/exec.js
@@ -1,0 +1,14 @@
+class Cl {
+  static *#foo() {
+    yield 2;
+    return 3;
+  }
+
+  test() {
+    return Cl.#foo();
+  }
+}
+
+const val = new Cl().test();
+expect(val.next()).toEqual({ value: 2, done: false });
+expect(val.next()).toEqual({ value: 3, done: true });

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/generator/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/generator/input.js
@@ -1,0 +1,10 @@
+class Cl {
+  static *#foo() {
+    yield 2;
+    return 3;
+  }
+
+  test() {
+    return Cl.#foo();
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/generator/output.js
@@ -1,0 +1,17 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+class Cl {
+  test() {
+    return babelHelpers.classPrivateFieldLooseBase(Cl, _foo)[_foo]();
+  }
+
+}
+
+var _foo2 = function* _foo2() {
+  yield 2;
+  return 3;
+};
+
+Object.defineProperty(Cl, _foo, {
+  value: _foo2
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/options.json
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    ["external-helpers",{ "helperVersion": "7.1000.0" }],
+    "proposal-private-methods",
+    "proposal-class-properties"
+  ],
+  "assumptions": {
+    "privateFieldsAsProperties": true
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/reassignment/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/reassignment/exec.js
@@ -1,0 +1,9 @@
+class Cl {
+  static #privateStaticMethod() { }
+
+  constructor() {
+    expect(() => Cl.#privateStaticMethod = null).toThrow(TypeError);
+  }
+}
+
+new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/reassignment/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/reassignment/input.js
@@ -1,0 +1,9 @@
+class Cl {
+  static #privateStaticMethod() { }
+
+  constructor() {
+    Cl.#privateStaticMethod = null;
+  }
+}
+
+new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/reassignment/output.js
@@ -1,0 +1,15 @@
+var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+
+class Cl {
+  constructor() {
+    babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticMethod)[_privateStaticMethod] = null;
+  }
+
+}
+
+var _privateStaticMethod2 = function _privateStaticMethod2() {};
+
+Object.defineProperty(Cl, _privateStaticMethod, {
+  value: _privateStaticMethod2
+});
+new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/scopable/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/scopable/exec.js
@@ -1,0 +1,17 @@
+class Cl {
+  static #privateMethodA() {
+    const i = 40;
+    return i;
+  }
+
+  static #privateMethodB() {
+    const i = 2;
+    return i;
+  }
+
+  publicMethod() {
+    return Cl.#privateMethodA() + Cl.#privateMethodB();
+  }
+}
+
+expect((new Cl).publicMethod()).toEqual(42);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/exec.js
@@ -1,0 +1,21 @@
+class Base {
+  static basePublicStaticMethod() {
+    return 'good';
+  }
+}
+
+class Sub extends Base {
+  static basePublicStaticMethod() {
+    return 'bad';
+  }
+
+  static #subStaticPrivateMethod() {
+    return super.basePublicStaticMethod();
+  }
+
+  static check() {
+    return Sub.#subStaticPrivateMethod();
+  }
+}
+
+expect(Sub.check()).toEqual('good');

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/input.js
@@ -1,0 +1,19 @@
+class Base {
+  static basePublicStaticMethod() {
+    return 'good';
+  }
+}
+
+class Sub extends Base {
+  static basePublicStaticMethod() {
+    return 'bad';
+  }
+
+  static #subStaticPrivateMethod() {
+    return super.basePublicStaticMethod();
+  }
+
+  static check() {
+    Sub.#subStaticPrivateMethod();
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/output.js
@@ -1,0 +1,27 @@
+class Base {
+  static basePublicStaticMethod() {
+    return 'good';
+  }
+
+}
+
+var _subStaticPrivateMethod = babelHelpers.classPrivateFieldLooseKey("subStaticPrivateMethod");
+
+class Sub extends Base {
+  static basePublicStaticMethod() {
+    return 'bad';
+  }
+
+  static check() {
+    babelHelpers.classPrivateFieldLooseBase(Sub, _subStaticPrivateMethod)[_subStaticPrivateMethod]();
+  }
+
+}
+
+var _subStaticPrivateMethod2 = function _subStaticPrivateMethod2() {
+  return Base.basePublicStaticMethod.call(this);
+};
+
+Object.defineProperty(Sub, _subStaticPrivateMethod, {
+  value: _subStaticPrivateMethod2
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/output.js
@@ -19,7 +19,7 @@ class Sub extends Base {
 }
 
 var _subStaticPrivateMethod2 = function _subStaticPrivateMethod2() {
-  return Base.basePublicStaticMethod.call(this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(Sub), "basePublicStaticMethod", this).call(this);
 };
 
 Object.defineProperty(Sub, _subStaticPrivateMethod, {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/exec.js
@@ -1,0 +1,18 @@
+class A {
+  static get a() { return 1 }
+}
+
+class B extends A {
+  static get b() { return 2 }
+
+  static #getA() { return super.a }
+  static #getB() { return this.b }
+
+  static extract() {
+    return [this.#getA, this.#getB];
+  }
+}
+
+const [getA, getB] = B.extract();
+expect(getA.call({ a: 3 })).toBe(1);
+expect(getB.call({ b: 4 })).toBe(4);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/input.js
@@ -1,0 +1,16 @@
+class A {
+  static get a() { return 1 }
+}
+
+class B extends A {
+  static get b() { return 2 }
+
+  static #getA() { return super.a }
+  static #getB() { return this.b }
+
+  static extract() {
+    return [this.#getA, this.#getB];
+  }
+}
+
+const [getA, getB] = B.extract();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/output.js
@@ -25,7 +25,7 @@ var _getB2 = function _getB2() {
 };
 
 var _getA2 = function _getA2() {
-  return A.a;
+  return babelHelpers.get(babelHelpers.getPrototypeOf(B), "a", this);
 };
 
 Object.defineProperty(B, _getA, {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/output.js
@@ -1,0 +1,37 @@
+class A {
+  static get a() {
+    return 1;
+  }
+
+}
+
+var _getA = babelHelpers.classPrivateFieldLooseKey("getA");
+
+var _getB = babelHelpers.classPrivateFieldLooseKey("getB");
+
+class B extends A {
+  static get b() {
+    return 2;
+  }
+
+  static extract() {
+    return [babelHelpers.classPrivateFieldLooseBase(this, _getA)[_getA], babelHelpers.classPrivateFieldLooseBase(this, _getB)[_getB]];
+  }
+
+}
+
+var _getB2 = function _getB2() {
+  return this.b;
+};
+
+var _getA2 = function _getA2() {
+  return A.a;
+};
+
+Object.defineProperty(B, _getA, {
+  value: _getA2
+});
+Object.defineProperty(B, _getB, {
+  value: _getB2
+});
+const [getA, getB] = B.extract();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/exec.js
@@ -1,0 +1,23 @@
+class Cl {
+  static #PRIVATE_STATIC_FIELD = "top secret string";
+
+  static get #privateStaticFieldValue() {
+    return Cl.#PRIVATE_STATIC_FIELD;
+  }
+
+  static set #privateStaticFieldValue(newValue) {
+    Cl.#PRIVATE_STATIC_FIELD = `Updated: ${newValue}`;
+  }
+
+  static getValue() {
+    return Cl.#privateStaticFieldValue;
+  }
+
+  static setValue() {
+    Cl.#privateStaticFieldValue = "dank";
+  }
+}
+
+expect(Cl.getValue()).toEqual("top secret string");
+Cl.setValue();
+expect(Cl.getValue()).toEqual("Updated: dank");

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/input.js
@@ -1,0 +1,19 @@
+class Cl {
+  static #PRIVATE_STATIC_FIELD = "top secret string";
+
+  static get #privateStaticFieldValue() {
+    return Cl.#PRIVATE_STATIC_FIELD;
+  }
+
+  static set #privateStaticFieldValue(newValue) {
+    Cl.#PRIVATE_STATIC_FIELD = `Updated: ${newValue}`;
+  }
+
+  static getValue() {
+    return Cl.#privateStaticFieldValue;
+  }
+
+  static setValue() {
+    Cl.#privateStaticFieldValue = "dank";
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/output.js
@@ -1,0 +1,31 @@
+var _PRIVATE_STATIC_FIELD = babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
+
+var _privateStaticFieldValue = babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
+
+class Cl {
+  static getValue() {
+    return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue];
+  }
+
+  static setValue() {
+    babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue] = "dank";
+  }
+
+}
+
+var _set_privateStaticFieldValue = function (newValue) {
+  babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = `Updated: ${newValue}`;
+};
+
+var _get_privateStaticFieldValue = function () {
+  return babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
+};
+
+Object.defineProperty(Cl, _PRIVATE_STATIC_FIELD, {
+  writable: true,
+  value: "top secret string"
+});
+Object.defineProperty(Cl, _privateStaticFieldValue, {
+  get: _get_privateStaticFieldValue,
+  set: _set_privateStaticFieldValue
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/exec.js
@@ -1,0 +1,13 @@
+class Cl {
+  static #PRIVATE_STATIC_FIELD = 0;
+
+  static set #privateStaticFieldValue(newValue) {
+    Cl.#PRIVATE_STATIC_FIELD = newValue;
+  }
+
+  static getPrivateStaticFieldValue() {
+    return Cl.#privateStaticFieldValue;
+  }
+}
+
+expect(Cl.getPrivateStaticFieldValue()).toBeUndefined();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/input.js
@@ -1,0 +1,11 @@
+class Cl {
+  static #PRIVATE_STATIC_FIELD = 0;
+
+  static set #privateStaticFieldValue(newValue) {
+    Cl.#PRIVATE_STATIC_FIELD = newValue;
+  }
+
+  static getPrivateStaticFieldValue() {
+    return Cl.#privateStaticFieldValue;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/output.js
@@ -1,0 +1,23 @@
+var _PRIVATE_STATIC_FIELD = babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
+
+var _privateStaticFieldValue = babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
+
+class Cl {
+  static getPrivateStaticFieldValue() {
+    return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue];
+  }
+
+}
+
+var _set_privateStaticFieldValue = function (newValue) {
+  babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = newValue;
+};
+
+Object.defineProperty(Cl, _PRIVATE_STATIC_FIELD, {
+  writable: true,
+  value: 0
+});
+Object.defineProperty(Cl, _privateStaticFieldValue, {
+  get: void 0,
+  set: _set_privateStaticFieldValue
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/options.json
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    ["external-helpers",{ "helperVersion": "7.1000.0" }],
+    "proposal-private-methods",
+    "proposal-class-properties"
+  ],
+  "assumptions": {
+    "privateFieldsAsProperties": true
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/exec.js
@@ -1,0 +1,13 @@
+class Cl {
+  static #PRIVATE_STATIC_FIELD = 0;
+
+  static get #privateStaticFieldValue() {
+    return Cl.#PRIVATE_STATIC_FIELD;
+  }
+
+  static setPrivateStaticFieldValue() {
+    Cl.#privateStaticFieldValue = 1;
+  }
+}
+
+expect(() => Cl.setPrivateStaticFieldValue()).toThrow(TypeError);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/input.js
@@ -1,0 +1,11 @@
+class Cl {
+  static #PRIVATE_STATIC_FIELD = 0;
+
+  static get #privateStaticFieldValue() {
+    return Cl.#PRIVATE_STATIC_FIELD;
+  }
+
+  static setPrivateStaticFieldValue() {
+    Cl.#privateStaticFieldValue = 1;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/output.js
@@ -1,0 +1,23 @@
+var _PRIVATE_STATIC_FIELD = babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
+
+var _privateStaticFieldValue = babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
+
+class Cl {
+  static setPrivateStaticFieldValue() {
+    babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue] = 1;
+  }
+
+}
+
+var _get_privateStaticFieldValue = function () {
+  return babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
+};
+
+Object.defineProperty(Cl, _PRIVATE_STATIC_FIELD, {
+  writable: true,
+  value: 0
+});
+Object.defineProperty(Cl, _privateStaticFieldValue, {
+  get: _get_privateStaticFieldValue,
+  set: void 0
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/exec.js
@@ -1,0 +1,46 @@
+class Cl {
+  static #privateField = "top secret string";
+  static publicField = "not secret string";
+
+  static get #privateFieldValue() {
+    return Cl.#privateField;
+  }
+
+  static set #privateFieldValue(newValue) {
+    Cl.#privateField = newValue;
+  }
+
+  static publicGetPrivateField() {
+    return Cl.#privateFieldValue;
+  }
+
+  static publicSetPrivateField(newValue) {
+    Cl.#privateFieldValue = newValue;
+  }
+
+  static get publicFieldValue() {
+    return Cl.publicField;
+  }
+
+  static set publicFieldValue(newValue) {
+    Cl.publicField = newValue;
+  }
+
+  static testUpdates() {
+    Cl.#privateField = 0;
+    Cl.publicField = 0;
+    Cl.#privateFieldValue = Cl.#privateFieldValue++;
+    Cl.publicFieldValue = Cl.publicFieldValue++;
+    expect(Cl.#privateField).toEqual(Cl.publicField);
+
+    ++Cl.#privateFieldValue;
+    ++Cl.publicFieldValue;
+    expect(Cl.#privateField).toEqual(Cl.publicField);
+
+    Cl.#privateFieldValue += 1;
+    Cl.publicFieldValue += 1;
+    expect(Cl.#privateField).toEqual(Cl.publicField);
+  }
+}
+
+Cl.testUpdates();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/input.js
@@ -1,0 +1,44 @@
+class Cl {
+  static #privateField = "top secret string";
+  static publicField = "not secret string";
+
+  static get #privateFieldValue() {
+    return Cl.#privateField;
+  }
+
+  static set #privateFieldValue(newValue) {
+    Cl.#privateField = newValue;
+  }
+
+  static publicGetPrivateField() {
+    return Cl.#privateFieldValue;
+  }
+
+  static publicSetPrivateField(newValue) {
+    Cl.#privateFieldValue = newValue;
+  }
+
+  static get publicFieldValue() {
+    return Cl.publicField;
+  }
+
+  static set publicFieldValue(newValue) {
+    Cl.publicField = newValue;
+  }
+
+  static testUpdates() {
+    Cl.#privateField = 0;
+    Cl.publicField = 0;
+    Cl.#privateFieldValue = Cl.#privateFieldValue++;
+    Cl.publicFieldValue = Cl.publicFieldValue++;
+
+    ++Cl.#privateFieldValue;
+    ++Cl.publicFieldValue;
+
+    Cl.#privateFieldValue += 1;
+    Cl.publicFieldValue += 1;
+
+    Cl.#privateFieldValue = -(Cl.#privateFieldValue ** Cl.#privateFieldValue);
+    Cl.publicFieldValue = -(Cl.publicFieldValue ** Cl.publicFieldValue);
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/output.js
@@ -1,0 +1,53 @@
+var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+
+var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+
+class Cl {
+  static publicGetPrivateField() {
+    return babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue];
+  }
+
+  static publicSetPrivateField(newValue) {
+    babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue] = newValue;
+  }
+
+  static get publicFieldValue() {
+    return Cl.publicField;
+  }
+
+  static set publicFieldValue(newValue) {
+    Cl.publicField = newValue;
+  }
+
+  static testUpdates() {
+    babelHelpers.classPrivateFieldLooseBase(Cl, _privateField)[_privateField] = 0;
+    Cl.publicField = 0;
+    babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue] = babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue]++;
+    Cl.publicFieldValue = Cl.publicFieldValue++;
+    ++babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue];
+    ++Cl.publicFieldValue;
+    babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue] += 1;
+    Cl.publicFieldValue += 1;
+    babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue] = -(babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue] ** babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue]);
+    Cl.publicFieldValue = -(Cl.publicFieldValue ** Cl.publicFieldValue);
+  }
+
+}
+
+var _set_privateFieldValue = function (newValue) {
+  babelHelpers.classPrivateFieldLooseBase(Cl, _privateField)[_privateField] = newValue;
+};
+
+var _get_privateFieldValue = function () {
+  return babelHelpers.classPrivateFieldLooseBase(Cl, _privateField)[_privateField];
+};
+
+Object.defineProperty(Cl, _privateField, {
+  writable: true,
+  value: "top secret string"
+});
+babelHelpers.defineProperty(Cl, "publicField", "not secret string");
+Object.defineProperty(Cl, _privateFieldValue, {
+  get: _get_privateFieldValue,
+  set: _set_privateFieldValue
+});

--- a/packages/babel-plugin-proposal-private-property-in-object/src/index.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/src/index.js
@@ -12,6 +12,7 @@ export default declare((api, options) => {
   return createClassFeaturePlugin({
     name: "proposal-class-properties",
 
+    api,
     feature: FEATURES.privateIn,
     loose: options.loose,
 

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/accessor/input.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/accessor/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  get #foo() {}
+
+  test(other) {
+    return #foo in other;
+  }
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/accessor/output.js
@@ -1,0 +1,17 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _foo, {
+      get: _get_foo,
+      set: void 0
+    });
+  }
+
+  test(other) {
+    return Object.prototype.hasOwnProperty.call(other, _foo);
+  }
+
+}
+
+var _get_foo = function () {};

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/compiled-classes/input.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/compiled-classes/input.js
@@ -1,0 +1,12 @@
+class Foo {
+  static #foo = "foo";
+  #bar = "bar";
+
+  static test() {
+    return #foo in Foo;
+  }
+
+  test() {
+    return #bar in this;
+  }
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/compiled-classes/options.json
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/compiled-classes/options.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "proposal-private-property-in-object",
+    "proposal-class-properties",
+    "proposal-private-methods",
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/compiled-classes/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/compiled-classes/output.js
@@ -1,0 +1,33 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+
+let Foo = /*#__PURE__*/function () {
+  "use strict";
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+    Object.defineProperty(this, _bar, {
+      writable: true,
+      value: "bar"
+    });
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "test",
+    value: function test() {
+      return Object.prototype.hasOwnProperty.call(this, _bar);
+    }
+  }], [{
+    key: "test",
+    value: function test() {
+      return Object.prototype.hasOwnProperty.call(Foo, _foo);
+    }
+  }]);
+  return Foo;
+}();
+
+Object.defineProperty(Foo, _foo, {
+  writable: true,
+  value: "foo"
+});

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/field/input.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/field/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  #foo = 1;
+
+  test(other) {
+    return #foo in other;
+  }
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/field/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/field/output.js
@@ -1,0 +1,15 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  test(other) {
+    return Object.prototype.hasOwnProperty.call(other, _foo);
+  }
+
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/input.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  #foo() {}
+
+  test(other) {
+    return #foo in other;
+  }
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/output.js
@@ -1,0 +1,16 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _foo, {
+      value: _foo2
+    });
+  }
+
+  test(other) {
+    return Object.prototype.hasOwnProperty.call(other, _foo);
+  }
+
+}
+
+var _foo2 = function _foo2() {};

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-other-redeclared/input.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-other-redeclared/input.js
@@ -1,0 +1,18 @@
+class Foo {
+  #foo = 1;
+  #bar = 1;
+
+  test() {
+    class Nested {
+      #bar = 2;
+
+      test() {
+        #foo in this;
+        #bar in this;
+      }
+    }
+
+    #foo in this;
+    #bar in this;
+  }
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-other-redeclared/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-other-redeclared/output.js
@@ -1,0 +1,39 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+    Object.defineProperty(this, _bar, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  test() {
+    var _bar2 = babelHelpers.classPrivateFieldLooseKey("bar");
+
+    class Nested {
+      constructor() {
+        Object.defineProperty(this, _bar2, {
+          writable: true,
+          value: 2
+        });
+      }
+
+      test() {
+        Object.prototype.hasOwnProperty.call(this, _foo);
+        Object.prototype.hasOwnProperty.call(this, _bar2);
+      }
+
+    }
+
+    Object.prototype.hasOwnProperty.call(this, _foo);
+    Object.prototype.hasOwnProperty.call(this, _bar);
+  }
+
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-redeclared/input.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-redeclared/input.js
@@ -1,0 +1,15 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      #foo = 2;
+
+      test() {
+        #foo in this;
+      }
+    }
+
+    #foo in this;
+  }
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-redeclared/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-redeclared/output.js
@@ -1,0 +1,31 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  test() {
+    var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+
+    class Nested {
+      constructor() {
+        Object.defineProperty(this, _foo2, {
+          writable: true,
+          value: 2
+        });
+      }
+
+      test() {
+        Object.prototype.hasOwnProperty.call(this, _foo2);
+      }
+
+    }
+
+    Object.prototype.hasOwnProperty.call(this, _foo);
+  }
+
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class/input.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class/input.js
@@ -1,0 +1,13 @@
+class Foo {
+  #foo = 1;
+
+  test() {
+    class Nested {
+      test() {
+        #foo in this;
+      }
+    }
+
+    #foo in this;
+  }
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class/output.js
@@ -1,0 +1,22 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+  }
+
+  test() {
+    class Nested {
+      test() {
+        Object.prototype.hasOwnProperty.call(this, _foo);
+      }
+
+    }
+
+    Object.prototype.hasOwnProperty.call(this, _foo);
+  }
+
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/options.json
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    ["external-helpers",{ "helperVersion": "7.1000.0" }],
+    "proposal-private-property-in-object",
+    "proposal-private-methods",
+    "proposal-class-properties"
+  ],
+  "assumptions": {
+    "privateFieldsAsProperties": true
+  }
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-accessor/input.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-accessor/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  static get #foo() {}
+
+  test(other) {
+    return #foo in other;
+  }
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-accessor/output.js
@@ -1,0 +1,15 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+class Foo {
+  test(other) {
+    return Object.prototype.hasOwnProperty.call(other, _foo);
+  }
+
+}
+
+var _get_foo = function () {};
+
+Object.defineProperty(Foo, _foo, {
+  get: _get_foo,
+  set: void 0
+});

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-field/input.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-field/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  static #foo = 1;
+
+  test(other) {
+    return #foo in other;
+  }
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-field/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-field/output.js
@@ -1,0 +1,13 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+class Foo {
+  test(other) {
+    return Object.prototype.hasOwnProperty.call(other, _foo);
+  }
+
+}
+
+Object.defineProperty(Foo, _foo, {
+  writable: true,
+  value: 1
+});

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-method/input.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-method/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  static #foo() {}
+
+  test(other) {
+    return #foo in other;
+  }
+}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-method/output.js
@@ -1,0 +1,14 @@
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+class Foo {
+  test(other) {
+    return Object.prototype.hasOwnProperty.call(other, _foo);
+  }
+
+}
+
+var _foo2 = function _foo2() {};
+
+Object.defineProperty(Foo, _foo, {
+  value: _foo2
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Main PR: #12219
RFC: babel/rfcs#5

I also introduced a warning when both `loose` and `setPublicClassFields`/`privateFieldsAsProperties` are set (while still maintianing the fallback behavior we have for the other assumptions).
This is because `loose` support for these class features plugins [is a mess](https://github.com/babel/babel/blob/main/packages/babel-helper-create-class-features-plugin/src/features.js#L30-L106) and easily breaks: it was what initially lead me to the `assumptions` RFC. We should encourage users to fully migrate to `assumptions` for these plugins when they start using them, to avoid other possible configuration conflicts caused by the implicit dependencies between them.

The tests are what we already had for `loose`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12497"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/2fce14da240ac1b496a643d9eda826c1f5dee0e8.svg" /></a>

