### PR TITLE
Disallow setting assumptions to `false` in presets

### DIFF
--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -444,6 +444,12 @@ export function assertAssumptions(
     throw new Error(`${msg(loc)} must be an object or undefined.`);
   }
 
+  let root = loc;
+  do {
+    root = root.parent;
+  } while (root.type !== "root");
+  const inPreset = root.source === "preset";
+
   for (const name of Object.keys(value)) {
     const subLoc = access(loc, name);
     if (!assumptionsNames.has(name)) {
@@ -451,6 +457,11 @@ export function assertAssumptions(
     }
     if (typeof value[name] !== "boolean") {
       throw new Error(`${msg(subLoc)} must be a boolean.`);
+    }
+    if (inPreset && value[name] === false) {
+      throw new Error(
+        `${msg(subLoc)} cannot be set to 'false' inside presets.`,
+      );
     }
   }
 

--- a/packages/babel-core/test/assumptions.js
+++ b/packages/babel-core/test/assumptions.js
@@ -47,7 +47,9 @@ describe("assumptions", () => {
       loadOptions({
         presets: [() => ({ assumptions: { mutableTemplateObject: false } })],
       }),
-    ).toThrow();
+    ).toThrow(
+      ` .assumptions["mutableTemplateObject"] cannot be set to 'false' inside presets."`,
+    );
   });
 
   it("can be queried from plugins", () => {

--- a/packages/babel-core/test/assumptions.js
+++ b/packages/babel-core/test/assumptions.js
@@ -28,7 +28,7 @@ describe("assumptions", () => {
     ).not.toThrow();
   });
 
-  it("can be set by presets", () => {
+  it("can be enabled by presets", () => {
     expect(
       loadOptions({
         assumptions: {
@@ -40,6 +40,14 @@ describe("assumptions", () => {
       setPublicClassFields: true,
       mutableTemplateObject: true,
     });
+  });
+
+  it("cannot be disabled by presets", () => {
+    expect(() =>
+      loadOptions({
+        presets: [() => ({ assumptions: { mutableTemplateObject: false } })],
+      }),
+    ).toThrow();
   });
 
   it("can be queried from plugins", () => {

--- a/packages/babel-core/test/assumptions.js
+++ b/packages/babel-core/test/assumptions.js
@@ -48,7 +48,7 @@ describe("assumptions", () => {
         presets: [() => ({ assumptions: { mutableTemplateObject: false } })],
       }),
     ).toThrow(
-      ` .assumptions["mutableTemplateObject"] cannot be set to 'false' inside presets."`,
+      ` .assumptions["mutableTemplateObject"] cannot be set to 'false' inside presets.`,
     );
   });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

While reading the RFC again, I noticed that my previous implementation didn't exactly reflect it.

> To avoid conflicts between assumptions set in presets, they will only be able to _enable_ them (i.e. set them to `true`). The only way to disable an already enabled assumption is to explicitly do it in a configuration file or in programmatic options.

([discussion](https://github.com/babel/rfcs/pull/5#discussion_r507979771) - Sorry I minimized it because I coudn't find the "Mark as resolved" button and now I can't un-minimize them)

This PR needs to be merged before 7.13, otherwise it would be a breaking change.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12498"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/8435f26e635a66751f737cb20f9597e175de6fed.svg" /></a>

