### PR TITLE
Implement `pureGetters` assumption

### DIFF
--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -335,6 +335,7 @@ export const assumptionsNames = new Set<string>([
   "ignoreFunctionLength",
   "ignoreToPrimitiveHint",
   "mutableTemplateObject",
+  "pureGetters",
   "setClassMethods",
   "setComputedProperties",
   "setPublicClassFields",

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -17,6 +17,7 @@ export default declare((api, options) => {
 
   const { loose = false } = options;
   const noDocumentAll = api.assumption("noDocumentAll") ?? loose;
+  const pureGetters = api.assumption("pureGetters") ?? loose;
 
   function isSimpleMemberExpression(expression) {
     expression = skipTransparentExprWrappers(expression);
@@ -131,8 +132,8 @@ export default declare((api, options) => {
             check = ref = chain;
             // `eval?.()` is an indirect eval call transformed to `(0,eval)()`
             node[replaceKey] = t.sequenceExpression([t.numericLiteral(0), ref]);
-          } else if (loose && isCall && isSimpleMemberExpression(chain)) {
-            // If we are using a loose transform (avoiding a Function#call) and we are at the call,
+          } else if (pureGetters && isCall && isSimpleMemberExpression(chain)) {
+            // If we assume getters are pure (avoiding a Function#call) and we are at the call,
             // we can avoid a needless memoize. We only do this if the callee is a simple member
             // expression, to avoid multiple calls to nested call expressions.
             check = ref = chainWithTypes;
@@ -157,7 +158,7 @@ export default declare((api, options) => {
           // Ensure call expressions have the proper `this`
           // `foo.bar()` has context `foo`.
           if (isCall && t.isMemberExpression(chain)) {
-            if (loose && isSimpleMemberExpression(chain)) {
+            if (pureGetters && isSimpleMemberExpression(chain)) {
               // To avoid a Function#call, we can instead re-grab the property from the context object.
               // `a.?b.?()` translates roughly to `_a.b != null && _a.b()`
               node.callee = chainWithTypes;
@@ -192,8 +193,9 @@ export default declare((api, options) => {
               replacementPath.get("object"),
             ).node;
             let baseRef;
-            if (!loose || !isSimpleMemberExpression(object)) {
-              // memoize the context object in non-loose mode
+            if (!pureGetters || !isSimpleMemberExpression(object)) {
+              // memoize the context object when getters are not always pure
+              // or the object is not a simple member expression
               // `(a?.b.c)()` to `(a == null ? undefined : (_a$b = a.b).c.bind(_a$b))()`
               baseRef = scope.maybeGenerateMemoised(object);
               if (baseRef) {

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/function-call/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/function-call/input.js
@@ -1,0 +1,19 @@
+foo?.(foo);
+
+foo?.bar()
+
+foo.bar?.(foo.bar, false)
+
+foo?.bar?.(foo.bar, true)
+
+foo?.().bar
+
+foo?.()?.bar
+
+foo.bar?.().baz
+
+foo.bar?.()?.baz
+
+foo?.bar?.().baz
+
+foo?.bar?.()?.baz

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/function-call/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/function-call/output.js
@@ -1,0 +1,12 @@
+var _foo, _foo2, _foo3, _foo$bar, _foo4, _foo5, _foo5$bar;
+
+foo === null || foo === void 0 ? void 0 : foo(foo);
+(_foo = foo) === null || _foo === void 0 ? void 0 : _foo.bar();
+foo.bar === null || foo.bar === void 0 ? void 0 : foo.bar(foo.bar, false);
+(_foo2 = foo) === null || _foo2 === void 0 ? void 0 : _foo2.bar === null || _foo2.bar === void 0 ? void 0 : _foo2.bar(foo.bar, true);
+foo === null || foo === void 0 ? void 0 : foo().bar;
+foo === null || foo === void 0 ? void 0 : (_foo3 = foo()) === null || _foo3 === void 0 ? void 0 : _foo3.bar;
+foo.bar === null || foo.bar === void 0 ? void 0 : foo.bar().baz;
+foo.bar === null || foo.bar === void 0 ? void 0 : (_foo$bar = foo.bar()) === null || _foo$bar === void 0 ? void 0 : _foo$bar.baz;
+(_foo4 = foo) === null || _foo4 === void 0 ? void 0 : _foo4.bar === null || _foo4.bar === void 0 ? void 0 : _foo4.bar().baz;
+(_foo5 = foo) === null || _foo5 === void 0 ? void 0 : _foo5.bar === null || _foo5.bar === void 0 ? void 0 : (_foo5$bar = _foo5.bar()) === null || _foo5$bar === void 0 ? void 0 : _foo5$bar.baz;

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/memoize/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/memoize/input.js
@@ -1,0 +1,29 @@
+function test(foo) {
+  foo?.bar;
+
+  foo?.bar?.baz;
+
+  foo?.(foo);
+
+  foo?.bar()
+
+  foo.get(bar)?.()
+
+  foo.bar()?.()
+  foo[bar]()?.()
+
+  foo.bar().baz?.()
+  foo[bar]().baz?.()
+
+  foo.bar?.(foo.bar, false)
+
+  foo?.bar?.(foo.bar, true)
+
+  foo.bar?.baz(foo.bar, false)
+
+  foo?.bar?.baz(foo.bar, true)
+
+  foo.bar?.baz?.(foo.bar, false)
+
+  foo?.bar?.baz?.(foo.bar, true)
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/memoize/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/memoize/output.js
@@ -1,0 +1,19 @@
+function test(foo) {
+  var _foo$bar, _foo$get, _foo$bar2, _foo$bar3, _foo$bar$baz, _foo$bar4, _foo$bar$baz2, _foo$bar5, _foo$bar6, _foo$bar7, _foo$bar8, _foo$bar9;
+
+  foo === null || foo === void 0 ? void 0 : foo.bar;
+  foo === null || foo === void 0 ? void 0 : (_foo$bar = foo.bar) === null || _foo$bar === void 0 ? void 0 : _foo$bar.baz;
+  foo === null || foo === void 0 ? void 0 : foo(foo);
+  foo === null || foo === void 0 ? void 0 : foo.bar();
+  (_foo$get = foo.get(bar)) === null || _foo$get === void 0 ? void 0 : _foo$get();
+  (_foo$bar2 = foo.bar()) === null || _foo$bar2 === void 0 ? void 0 : _foo$bar2();
+  (_foo$bar3 = foo[bar]()) === null || _foo$bar3 === void 0 ? void 0 : _foo$bar3();
+  (_foo$bar$baz = (_foo$bar4 = foo.bar()).baz) === null || _foo$bar$baz === void 0 ? void 0 : _foo$bar$baz.call(_foo$bar4);
+  (_foo$bar$baz2 = (_foo$bar5 = foo[bar]()).baz) === null || _foo$bar$baz2 === void 0 ? void 0 : _foo$bar$baz2.call(_foo$bar5);
+  foo.bar === null || foo.bar === void 0 ? void 0 : foo.bar(foo.bar, false);
+  foo === null || foo === void 0 ? void 0 : foo.bar === null || foo.bar === void 0 ? void 0 : foo.bar(foo.bar, true);
+  (_foo$bar6 = foo.bar) === null || _foo$bar6 === void 0 ? void 0 : _foo$bar6.baz(foo.bar, false);
+  foo === null || foo === void 0 ? void 0 : (_foo$bar7 = foo.bar) === null || _foo$bar7 === void 0 ? void 0 : _foo$bar7.baz(foo.bar, true);
+  (_foo$bar8 = foo.bar) === null || _foo$bar8 === void 0 ? void 0 : _foo$bar8.baz === null || _foo$bar8.baz === void 0 ? void 0 : _foo$bar8.baz(foo.bar, false);
+  foo === null || foo === void 0 ? void 0 : (_foo$bar9 = foo.bar) === null || _foo$bar9 === void 0 ? void 0 : _foo$bar9.baz === null || _foo$bar9.baz === void 0 ? void 0 : _foo$bar9.baz(foo.bar, true);
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/options.json
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["proposal-optional-chaining"],
+  "assumptions": {
+    "pureGetters": true
+  }
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/super-method-call/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/super-method-call/input.js
@@ -1,0 +1,12 @@
+"use strict";
+class Base {
+  method() {
+    return 'Hello!';
+  }
+}
+
+class Derived extends Base {
+    method() {
+        return super.method?.()
+    }
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/super-method-call/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/assumption-pureGetters/super-method-call/output.js
@@ -1,0 +1,15 @@
+"use strict";
+
+class Base {
+  method() {
+    return 'Hello!';
+  }
+
+}
+
+class Derived extends Base {
+  method() {
+    return super.method === null || super.method === void 0 ? void 0 : super.method();
+  }
+
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Can confirm that after this PR optional-chaining does not have `loose` in conditions.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12504"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/24e5187698f5794bbe7e45143bc9017f5c77096c.svg" /></a>

