### PR TITLE
Test parser with latest test262

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,8 +256,13 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: babel-artifact
+      - name: Download Test262
+        uses: actions/checkout@v2
+        with:
+          repository: tc39/test262
+          path: build/test262
       - name: Download tests
-        run: make -j bootstrap-flow bootstrap-typescript bootstrap-test262
+        run: make -j bootstrap-flow bootstrap-typescript
       - name: Run Test262 Tests
         run: make test-test262
       - name: Run Flow Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,8 @@ jobs:
     name: Third-party Parser Tests
     needs: build
     runs-on: ubuntu-latest
+    env:
+      YARN_NODE_LINKER: pnp
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 FLOW_COMMIT = a1f9a4c709dcebb27a5084acf47755fbae699c25
-TEST262_COMMIT = 36d2d2d348d83e9d6554af59a672fbcd9413914b
 TYPESCRIPT_COMMIT = da8633212023517630de5f3620a23736b63234b1
 
 FORCE_PUBLISH = -f @babel/runtime -f @babel/runtime-corejs2 -f @babel/runtime-corejs3 -f @babel/standalone
@@ -172,8 +171,8 @@ test-typescript-update-allowlist:
 bootstrap-test262:
 	rm -rf build/test262
 	mkdir -p build
-	git clone --single-branch --shallow-since=2019-12-01 https://github.com/tc39/test262.git build/test262
-	cd build/test262 && git checkout -q $(TEST262_COMMIT)
+	git clone --depth 1 https://github.com/tc39/test262.git build/test262
+	cd build/test262
 
 test-test262:
 	$(NODE) scripts/parser-tests/test262


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Babel parser has maintained a clean test262 allowlist since bda759ac3dce548f021ca24e9182b6e6f7c218e3 (8 months ago). Now I feel confident to always test with latest test262 so we don't have to bump the test262 ref from time to time.

We can always add an allowlist item if test262 adds a test that babel parser fails. Before this PR we don't know if fails until we update the test262.

Note that we still need to add mappings from test262 flag to babel plugin names on new language features. By default the tests on new language features could fail if babel parser does not enable / support it. In these cases we can add the required plugin mappings or add to the ignored features in scripts/parser-tests/test262/index.js.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12507"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/11efccdb4b8a92da27e5d3122bf6c0a3f6f807c6.svg" /></a>

