### PR TITLE
chore: always check yarn lock and dedupe during update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,16 @@ jobs:
           key: yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             yarn-
-      - name: Update Yarn cache
+      - name: Check Yarn dedupe
         if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: |
+          yarn dedupe --check
+      - name: Check or update Yarn cache
         env:
           YARN_ENABLE_SCRIPTS: false # disable post-install scripts
           YARN_NODE_LINKER: pnp # use pnp linker for better performance: it's meant to update yarn cache only
         run: |
-          yarn dedupe --check
-          yarn install --immutable
+          yarn install --immutable --skip-builds
 
   test-coverage:
     name: Test on Node.js Latest

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,6 +77,7 @@ __metadata:
   resolution: "@babel/code-frame@workspace:packages/babel-code-frame"
   dependencies:
     "@babel/highlight": "workspace:^7.10.4"
+    "@types/chalk": ^2.0.0
     chalk: ^2.0.0
     strip-ansi: ^4.0.0
   languageName: unknown
@@ -3804,6 +3805,15 @@ __metadata:
   languageName: node
   linkType: soft
 
+"@types/chalk@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "@types/chalk@npm:2.2.0"
+  dependencies:
+    chalk: "*"
+  checksum: 9cded9031f180268be59010fc1e13c7b4384e51f0ca8b75bc7a40bdd46f5f3c4859953525fb53663287e5bb25ca5df59396c276ce5c09e1a83aa7a2aec6a9f59
+  languageName: node
+  linkType: hard
+
 "@types/color-name@npm:^1.1.1":
   version: 1.1.1
   resolution: "@types/color-name@npm:1.1.1"
@@ -5360,6 +5370,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:*, chalk@npm:^4.0.0, chalk@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "chalk@npm:4.1.0"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: f860285b419f9e925c2db0f45ffa88aa8794c14b80cc5d01ff30930bcfc384996606362706f0829cf557f6d36152a5fb2d227ad63c4bc90e2ec9e9dbed4a3c07
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^1.0.0, chalk@npm:^1.1.3":
   version: 1.1.3
   resolution: "chalk@npm:1.1.3"
@@ -5381,16 +5401,6 @@ __metadata:
     escape-string-regexp: ^1.0.5
     supports-color: ^5.3.0
   checksum: 22c7b7b5bc761c882bb6516454a1a671923f1c53ff972860065aa0b28a195f230163c1d46ee88bcc7a03e5539177d896457d8bc727de7f244c6e87032743038e
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "chalk@npm:4.1.0"
-  dependencies:
-    ansi-styles: ^4.1.0
-    supports-color: ^7.1.0
-  checksum: f860285b419f9e925c2db0f45ffa88aa8794c14b80cc5d01ff30930bcfc384996606362706f0829cf557f6d36152a5fb2d227ad63c4bc90e2ec9e9dbed4a3c07
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | CI does not bail when `yarn.lock` needs to be updated
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Context: In #12433 we modified the package.json of `@babel/code-frame` but forgot to commit Yarn lock changes. The CI does not bail because the install check is skipped when CI has yarn cache for the `yarn.lock`. This PR refines the CI step so that it always check whether `yarn.lock` need to be modified. I catch this issue when my fork fails: https://github.com/JLHwung/babel/runs/1557682750

The CI now bails as expected: https://github.com/babel/babel/runs/1557842082 

The following commit fixes this error.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12508"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/ef4e92ba64218359ed77d5cc052b8765fb02250b.svg" /></a>