### PR TITLE
Improve AST node definitions in @babel/types

### DIFF
--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -821,6 +821,7 @@ export interface ExportAllDeclaration extends BaseNode {
   type: "ExportAllDeclaration";
   source: StringLiteral;
   assertions?: ImportAttribute | null;
+  exportKind?: "type" | "value" | null;
 }
 
 export interface ExportDefaultDeclaration extends BaseNode {
@@ -1542,7 +1543,7 @@ export interface ClassPrivateProperty extends BaseNode {
   value?: Expression | null;
   decorators?: Array<Decorator> | null;
   static: any;
-  typeAnnotation: TypeAnnotation | TSTypeAnnotation | Noop | null;
+  typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
 }
 
 export interface ClassPrivateMethod extends BaseNode {

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -1542,6 +1542,7 @@ export interface ClassPrivateProperty extends BaseNode {
   value?: Expression | null;
   decorators?: Array<Decorator> | null;
   static: any;
+  typeAnnotation: TypeAnnotation | TSTypeAnnotation | Noop | null;
 }
 
 export interface ClassPrivateMethod extends BaseNode {

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -1226,6 +1226,7 @@ export interface ObjectTypeProperty extends BaseNode {
   value: FlowType;
   variance?: Variance | null;
   kind: "init" | "get" | "set";
+  method: boolean;
   optional: boolean;
   proto: boolean;
   static: boolean;

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -1336,19 +1336,19 @@ export interface EnumDeclaration extends BaseNode {
 export interface EnumBooleanBody extends BaseNode {
   type: "EnumBooleanBody";
   members: Array<EnumBooleanMember>;
-  explicit: boolean;
+  explicitType: boolean;
 }
 
 export interface EnumNumberBody extends BaseNode {
   type: "EnumNumberBody";
   members: Array<EnumNumberMember>;
-  explicit: boolean;
+  explicitType: boolean;
 }
 
 export interface EnumStringBody extends BaseNode {
   type: "EnumStringBody";
   members: Array<EnumStringMember | EnumDefaultedMember>;
-  explicit: boolean;
+  explicitType: boolean;
 }
 
 export interface EnumSymbolBody extends BaseNode {

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -1399,6 +1399,7 @@ defineType("ExportAllDeclaration", {
     source: {
       validate: assertNodeType("StringLiteral"),
     },
+    exportKind: validateOptional(assertOneOf("type", "value")),
     assertions: {
       optional: true,
       validate: chain(

--- a/packages/babel-types/src/definitions/experimental.ts
+++ b/packages/babel-types/src/definitions/experimental.ts
@@ -117,6 +117,10 @@ defineType("ClassPrivateProperty", {
       validate: assertNodeType("Expression"),
       optional: true,
     },
+    typeAnnotation: {
+      validate: assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
+      optional: true,
+    },
     decorators: {
       validate: chain(
         assertValueType("array"),

--- a/packages/babel-types/src/definitions/flow.ts
+++ b/packages/babel-types/src/definitions/flow.ts
@@ -328,6 +328,7 @@ defineType("ObjectTypeProperty", {
     proto: validate(assertValueType("boolean")),
     optional: validate(assertValueType("boolean")),
     variance: validateOptionalType("Variance"),
+    method: validate(assertValueType("boolean")),
   },
 });
 

--- a/packages/babel-types/src/definitions/flow.ts
+++ b/packages/babel-types/src/definitions/flow.ts
@@ -488,7 +488,7 @@ defineType("EnumBooleanBody", {
   aliases: ["EnumBody"],
   visitor: ["members"],
   fields: {
-    explicit: validate(assertValueType("boolean")),
+    explicitType: validate(assertValueType("boolean")),
     members: validateArrayOfType("EnumBooleanMember"),
   },
 });
@@ -497,7 +497,7 @@ defineType("EnumNumberBody", {
   aliases: ["EnumBody"],
   visitor: ["members"],
   fields: {
-    explicit: validate(assertValueType("boolean")),
+    explicitType: validate(assertValueType("boolean")),
     members: validateArrayOfType("EnumNumberMember"),
   },
 });
@@ -506,7 +506,7 @@ defineType("EnumStringBody", {
   aliases: ["EnumBody"],
   visitor: ["members"],
   fields: {
-    explicit: validate(assertValueType("boolean")),
+    explicitType: validate(assertValueType("boolean")),
     members: validateArrayOfType(["EnumStringMember", "EnumDefaultedMember"]),
   },
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

After adding `node` argument type annotations for @babel/generator (in https://github.com/babel/babel/pull/12487) found some incomplete or not correct AST node definitions - extracted it into separate PR

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12510"><img src="https://gitpod.io/api/apps/github/pbs/github.com/zxbodya/babel.git/06cdbb7dd4bada2d9a9b045e06abaa9a673cbcfe.svg" /></a>

