### PR TITLE
Run e2e tests on GH actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,19 +115,6 @@ jobs:
       - store_test_results: *artifact_test262_xunit
       - save_cache: *save-yarn-cache
 
-  publish-verdaccio:
-    executor: node-executor
-    steps:
-      - checkout
-      - restore_cache: *restore-yarn-cache
-      - run: ./scripts/integration-tests/publish-local.sh
-      - persist_to_workspace:
-          root: /tmp/verdaccio-workspace
-          paths:
-            - storage
-            - htpasswd
-      - save_cache: *save-yarn-cache
-
   publish-verdaccio-babel-8-breaking:
     executor: node-executor
     steps:
@@ -141,15 +128,7 @@ jobs:
             - htpasswd
       - save_cache: *save-yarn-cache
 
-  e2e-babel:
-    executor: node-executor
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/verdaccio-workspace
-      - run: ./scripts/integration-tests/e2e-babel.sh
-
-  e2e-babel-breaking:
+  e2e-breaking-babel:
     executor: node-executor
     steps:
       - checkout
@@ -157,23 +136,15 @@ jobs:
           at: /tmp/verdaccio-workspace
       - run: BABEL_8_BREAKING=true ./scripts/integration-tests/e2e-babel.sh
 
-  e2e-babel-old-version:
+  e2e-breaking-create-react-app:
     executor: node-executor
     steps:
       - checkout
       - attach_workspace:
           at: /tmp/verdaccio-workspace
-      - run: ./scripts/integration-tests/e2e-babel-old-version.sh
+      - run: BABEL_8_BREAKING=true ./scripts/integration-tests/e2e-create-react-app.sh
 
-  e2e-create-react-app:
-    executor: node-executor
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/verdaccio-workspace
-      - run: ./scripts/integration-tests/e2e-create-react-app.sh
-
-  e2e-vue-cli:
+  e2e-breaking-vue-cli:
     executor: node-browsers-executor
     steps:
       - checkout
@@ -183,17 +154,9 @@ jobs:
           # vue-cli uses puppeteer, and it depends on the libXss.so.1 shared library
           name: Install Headless Chrome dependencies
           command: sudo apt-get install -yq libxss1
-      - run: ./scripts/integration-tests/e2e-vue-cli.sh
+      - run: BABEL_8_BREAKING=true ./scripts/integration-tests/e2e-vue-cli.sh
 
-  e2e-jest:
-    executor: node-python-executor
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/verdaccio-workspace
-      - run: ./scripts/integration-tests/e2e-jest.sh
-
-  e2e-jest-breaking:
+  e2e-breaking-jest:
     executor: node-python-executor
     steps:
       - checkout
@@ -238,24 +201,6 @@ workflows:
                 - next-8-dev
                 - next-8-rebased
           context: babel-test262
-  e2e:
-    jobs:
-      - publish-verdaccio
-      - e2e-babel:
-          requires:
-            - publish-verdaccio
-      - e2e-babel-old-version:
-          requires:
-            - publish-verdaccio
-      - e2e-create-react-app:
-          requires:
-            - publish-verdaccio
-      - e2e-vue-cli:
-          requires:
-            - publish-verdaccio
-      - e2e-jest:
-          requires:
-            - publish-verdaccio
 
   e2e-breaking:
     jobs:
@@ -263,16 +208,16 @@ workflows:
           filters:
             branches:
               only: [main, next-8-dev, next-8-rebased]
-      - e2e-babel-breaking:
+      - e2e-breaking-babel:
           requires:
             - publish-verdaccio-babel-8-breaking
-      - e2e-create-react-app:
+      - e2e-breaking-create-react-app:
           requires:
             - publish-verdaccio-babel-8-breaking
-      - e2e-vue-cli:
+      - e2e-breaking-vue-cli:
           requires:
             - publish-verdaccio-babel-8-breaking
-      - e2e-jest-breaking:
+      - e2e-breaking-jest:
           requires:
             - publish-verdaccio-babel-8-breaking
 
@@ -286,16 +231,15 @@ workflows:
       - publish-verdaccio-babel-8-breaking:
           requires:
             - approve-e2e-breaking-run
-      - e2e-babel-breaking:
+      - e2e-breaking-babel:
           requires:
             - publish-verdaccio-babel-8-breaking
-      - e2e-create-react-app:
+      - e2e-breaking-create-react-app:
           requires:
             - publish-verdaccio-babel-8-breaking
-      - e2e-vue-cli:
+      - e2e-breaking-vue-cli:
           requires:
             - publish-verdaccio-babel-8-breaking
-      - e2e-jest-breaking:
+      - e2e-breaking-jest:
           requires:
             - publish-verdaccio-babel-8-breaking
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('yarn.lock') }}
+
       - name: Install
         run: yarn install
       - uses: actions/download-artifact@v2
@@ -367,7 +368,7 @@ jobs:
         run: yarn test:runtime:node
 
   e2e-publish:
-    name: Publish to local Verdaccio registry
+    name: Publish to local Verdaccio registry (juan test)
     needs: prepare-yarn-cache
     runs-on: ubuntu-latest
     steps:
@@ -384,16 +385,23 @@ jobs:
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
       - uses: actions/cache@v2
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            /tmp/verdaccio-workspace
+          key: |
+            yarn-${{ hashFiles('yarn.lock') }}
+            ver-${{ hashFiles('yarn.lock') }}
       - name: Publish
         run: ./scripts/integration-tests/publish-local.sh
       - uses: actions/upload-artifact@v2
         with:
           name: verdaccio-workspace
-          path: |
-            /tmp/verdaccio-workspace/storage
-            /tmp/verdaccio-workspace/htpassword
+          path: /tmp/verdaccio-workspace
+
+      - name: Display structure of downloaded files
+        run: ls -R
+      - name: Display workspace
+        run: ls -R /tmp/verdaccio-workspace
 
   e2e-create-react-app:
     name: E2E - create-react-app
@@ -409,5 +417,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: verdaccio-workspace
+          path: /tmp/verdaccio-workspace
+      - name: Display structure of downloaded files
+        run: ls -R
+      - name: Display workspace
+        run: ls -R /tmp/verdaccio-workspace
       - name: Test
         run: ./scripts/integration-tests/e2e-create-react-app.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,24 @@ jobs:
           name: verdaccio-workspace
           path: /tmp/verdaccio-workspace
 
+  e2e-babel:
+    name: E2E - babel
+    needs: e2e-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Use Node.js latest
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: "*"
+      - uses: actions/download-artifact@v2
+        with:
+          name: verdaccio-workspace
+          path: /tmp/verdaccio-workspace
+      - name: Test
+        run: ./scripts/integration-tests/e2e-babel.sh
+
   e2e-create-react-app:
     name: E2E - create-react-app
     needs: e2e-publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [babel, babel-old-version, create-react-app]
+        project: [babel, babel-old-version, create-react-app, vue-cli]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,10 +399,14 @@ jobs:
           name: verdaccio-workspace
           path: /tmp/verdaccio-workspace
 
-  e2e-babel:
-    name: E2E - babel
+  e2e-tests:
+    name: E2E
     needs: e2e-publish
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [babel, babel-old-version, create-react-app]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -415,40 +419,4 @@ jobs:
           name: verdaccio-workspace
           path: /tmp/verdaccio-workspace
       - name: Test
-        run: ./scripts/integration-tests/e2e-babel.sh
-
-  e2e-babel-old-version:
-    name: E2E - babel-old-version
-    needs: e2e-publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Use Node.js latest
-        uses: actions/setup-node@v2-beta
-        with:
-          node-version: "*"
-      - uses: actions/download-artifact@v2
-        with:
-          name: verdaccio-workspace
-          path: /tmp/verdaccio-workspace
-      - name: Test
-        run: ./scripts/integration-tests/e2e-babel-old-version.sh
-
-  e2e-create-react-app:
-    name: E2E - create-react-app
-    needs: e2e-publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Use Node.js latest
-        uses: actions/setup-node@v2-beta
-        with:
-          node-version: "*"
-      - uses: actions/download-artifact@v2
-        with:
-          name: verdaccio-workspace
-          path: /tmp/verdaccio-workspace
-      - name: Test
-        run: ./scripts/integration-tests/e2e-create-react-app.sh
+        run: ./scripts/integration-tests/e2e-${{ matrix.project }}.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('yarn.lock') }}
-      # See https://github.com/babel/babel/pull/12906
+            # See https://github.com/babel/babel/pull/12906
       - name: Workaround yarn bug
         run: |
           echo '{
@@ -365,3 +365,49 @@ jobs:
           node-version: 14.2
       - name: Test Node.js 14.2
         run: yarn test:runtime:node
+
+  e2e-publish:
+    name: Publish to local Verdaccio registry
+    needs: prepare-yarn-cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Node.js latest
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: "*"
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-${{ hashFiles('yarn.lock') }}
+      - name: Publish
+        run: ./scripts/integration-tests/publish-local.sh
+      - uses: actions/upload-artifact@v2
+        with:
+          name: verdaccio-workspace
+          path: |
+            /tmp/verdaccio-workspace/storage
+            /tmp/verdaccio-workspace/htpassword
+
+  e2e-create-react-app:
+    name: E2E - create-react-app
+    needs: e2e-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Use Node.js latest
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: "*"
+      - uses: actions/download-artifact@v2
+        with:
+          name: verdaccio-workspace
+      - name: Test
+        run: ./scripts/integration-tests/e2e-create-react-app.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,11 +387,6 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('yarn.lock') }}
-      - name: Setup Verdaccio cache
-        uses: actions/cache@v2
-        with:
-          path: /tmp/verdaccio-workspace
-          key: verdaccio-${{ hashFiles('yarn.lock') }}
       - name: Publish
         run: ./scripts/integration-tests/publish-local.sh
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,6 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('yarn.lock') }}
-
       - name: Install
         run: yarn install
       - uses: actions/download-artifact@v2
@@ -289,8 +288,8 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('yarn.lock') }}
-            # See https://github.com/babel/babel/pull/12906
-      - name: Workaround yarn bug
+      # See https://github.com/babel/babel/pull/12906
+      - name: Support self-references on old Node.js
         run: |
           echo '{
             "private": true,
@@ -368,7 +367,7 @@ jobs:
         run: yarn test:runtime:node
 
   e2e-publish:
-    name: Publish to local Verdaccio registry (juan test)
+    name: Publish to local Verdaccio registry
     needs: prepare-yarn-cache
     runs-on: ubuntu-latest
     steps:
@@ -383,25 +382,22 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-      - uses: actions/cache@v2
+      - name: Setup Yarn cache
+        uses: actions/cache@v2
         with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            /tmp/verdaccio-workspace
-          key: |
-            yarn-${{ hashFiles('yarn.lock') }}
-            ver-${{ hashFiles('yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-${{ hashFiles('yarn.lock') }}
+      - name: Setup Verdaccio cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/verdaccio-workspace
+          key: verdaccio-${{ hashFiles('yarn.lock') }}
       - name: Publish
         run: ./scripts/integration-tests/publish-local.sh
       - uses: actions/upload-artifact@v2
         with:
           name: verdaccio-workspace
           path: /tmp/verdaccio-workspace
-
-      - name: Display structure of downloaded files
-        run: ls -R
-      - name: Display workspace
-        run: ls -R /tmp/verdaccio-workspace
 
   e2e-create-react-app:
     name: E2E - create-react-app
@@ -418,9 +414,5 @@ jobs:
         with:
           name: verdaccio-workspace
           path: /tmp/verdaccio-workspace
-      - name: Display structure of downloaded files
-        run: ls -R
-      - name: Display workspace
-        run: ls -R /tmp/verdaccio-workspace
       - name: Test
         run: ./scripts/integration-tests/e2e-create-react-app.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,6 +417,24 @@ jobs:
       - name: Test
         run: ./scripts/integration-tests/e2e-babel.sh
 
+  e2e-babel-old-version:
+    name: E2E - babel-old-version
+    needs: e2e-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Use Node.js latest
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: "*"
+      - uses: actions/download-artifact@v2
+        with:
+          name: verdaccio-workspace
+          path: /tmp/verdaccio-workspace
+      - name: Test
+        run: ./scripts/integration-tests/e2e-babel-old-version.sh
+
   e2e-create-react-app:
     name: E2E - create-react-app
     needs: e2e-publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [babel, babel-old-version, create-react-app, vue-cli]
+        project: [babel, babel-old-version, create-react-app, vue-cli, jest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/scripts/integration-tests/e2e-babel-old-version.sh
+++ b/scripts/integration-tests/e2e-babel-old-version.sh
@@ -23,10 +23,13 @@ cd ../..
 startLocalRegistry "$PWD"/scripts/integration-tests/verdaccio-config.yml
 
 node "$PWD"/scripts/integration-tests/utils/bump-babel-dependencies.js
+
 (
-  yarn why @babel/core | grep -o "@babel/core@npm:.* (via npm:.*)";
-  yarn why @babel/helpers | grep -o "@babel/helpers@npm:.* (via npm:.*)";
-  yarn why @babel/traverse | grep -o "@babel/traverse@npm:.* (via npm:.*)"
+  # Yarn prints colors on GH actions even if it's piped, unless explicitly disabled
+  # https://github.com/yarnpkg/berry/pull/659
+  YARN_ENABLE_COLORS=0 yarn why @babel/core | grep -o "@babel/core@npm:.* (via npm:.*)";
+  YARN_ENABLE_COLORS=0 yarn why @babel/helpers | grep -o "@babel/helpers@npm:.* (via npm:.*)";
+  YARN_ENABLE_COLORS=0 yarn why @babel/traverse | grep -o "@babel/traverse@npm:.* (via npm:.*)"
 ) | uniq | node -e "
   var pkg = require('./package.json');
   var packages = fs.readFileSync(0, 'utf8').trim().split('\n');

--- a/scripts/integration-tests/e2e-create-react-app.sh
+++ b/scripts/integration-tests/e2e-create-react-app.sh
@@ -39,7 +39,7 @@ done
 export YARN_IGNORE_PATH=1
 
 startLocalRegistry "$PWD"/../../verdaccio-config.yml
-yarn install
+yarn install --verbose --registry http://localhost:4873
 
 # Test
 CI=true yarn test

--- a/scripts/integration-tests/e2e-create-react-app.sh
+++ b/scripts/integration-tests/e2e-create-react-app.sh
@@ -39,7 +39,7 @@ done
 export YARN_IGNORE_PATH=1
 
 startLocalRegistry "$PWD"/../../verdaccio-config.yml
-yarn install --verbose --registry http://localhost:4873
+yarn install
 
 # Test
 CI=true yarn test

--- a/scripts/integration-tests/publish-local.sh
+++ b/scripts/integration-tests/publish-local.sh
@@ -31,7 +31,7 @@ loginLocalRegistry
 # This script gets the last @babel/standalone version (because it's always published),
 # and then increases by one the patch number
 VERSION=$(
-  node -p "'$(npm view @babel/standalone version)'.replace(/(?<=\\d+\\.\\d+\\.)\\d+/, x => ++x)"
+  node -p "require('./package.json').version.replace(/(?<=\\d+\\.\\d+\\.)\\d+/, x => ++x)"
 )
 
 I_AM_USING_VERDACCIO=I_AM_SURE VERSION="$VERSION" make publish-test

--- a/scripts/integration-tests/publish-local.sh
+++ b/scripts/integration-tests/publish-local.sh
@@ -28,7 +28,7 @@ yarn
 startLocalRegistry "$PWD"/scripts/integration-tests/verdaccio-config.yml
 loginLocalRegistry
 
-# This script gets the last @babel/standalone version (because it's always published),
+# This script gets the last root package.json version,
 # and then increases by one the patch number
 VERSION=$(
   node -p "require('./package.json').version.replace(/(?<=\\d+\\.\\d+\\.)\\d+/, x => ++x)"

--- a/scripts/integration-tests/utils/local-registry.sh
+++ b/scripts/integration-tests/utils/local-registry.sh
@@ -3,14 +3,14 @@
 # Copied from https://github.com/facebook/create-react-app/blob/053f9774d3f592c17741d2a86de66a7ca58f90c0/tasks/local-registry.sh
 
 custom_registry_url=http://localhost:4873
-default_verdaccio_package=verdaccio@~4.10.0
+default_verdaccio_package=verdaccio@~4.11.1
 
 function startLocalRegistry {
   # Start local registry
   tmp_registry_log=`mktemp`
   echo "Registry output file: $tmp_registry_log"
   (cd && nohup npx ${VERDACCIO_PACKAGE:-$default_verdaccio_package} -c $1 &>$tmp_registry_log &)
-  npm install --global verdaccio-memory
+  npm install --global verdaccio-memory@~9.7.2
   # Wait for Verdaccio to boot
   grep -q "http address" <(tail -f $tmp_registry_log)
 

--- a/scripts/integration-tests/utils/local-registry.sh
+++ b/scripts/integration-tests/utils/local-registry.sh
@@ -3,16 +3,17 @@
 # Copied from https://github.com/facebook/create-react-app/blob/053f9774d3f592c17741d2a86de66a7ca58f90c0/tasks/local-registry.sh
 
 custom_registry_url=http://localhost:4873
-default_verdaccio_package=verdaccio@~4.3.3
+default_verdaccio_package=verdaccio@~4.10.0
 
 function startLocalRegistry {
   # Start local registry
   tmp_registry_log=`mktemp`
   echo "Registry output file: $tmp_registry_log"
   (cd && nohup npx ${VERDACCIO_PACKAGE:-$default_verdaccio_package} -c $1 &>$tmp_registry_log &)
-
+  npm install --global verdaccio-memory
   # Wait for Verdaccio to boot
   grep -q "http address" <(tail -f $tmp_registry_log)
+  tail -f $tmp_registry_log &
 
   # Set registry to local registry
   export NPM_CONFIG_REGISTRY="$custom_registry_url"

--- a/scripts/integration-tests/utils/local-registry.sh
+++ b/scripts/integration-tests/utils/local-registry.sh
@@ -10,7 +10,7 @@ function startLocalRegistry {
   tmp_registry_log=`mktemp`
   echo "Registry output file: $tmp_registry_log"
   (cd && nohup npx ${VERDACCIO_PACKAGE:-$default_verdaccio_package} -c $1 &>$tmp_registry_log &)
-  npm install --global verdaccio-memory@~9.7.2
+  yarn global add verdaccio-memory@~9.7.2
   # Wait for Verdaccio to boot
   grep -q "http address" <(tail -f $tmp_registry_log)
 

--- a/scripts/integration-tests/utils/local-registry.sh
+++ b/scripts/integration-tests/utils/local-registry.sh
@@ -13,7 +13,6 @@ function startLocalRegistry {
   npm install --global verdaccio-memory
   # Wait for Verdaccio to boot
   grep -q "http address" <(tail -f $tmp_registry_log)
-  tail -f $tmp_registry_log &
 
   # Set registry to local registry
   export NPM_CONFIG_REGISTRY="$custom_registry_url"

--- a/scripts/integration-tests/verdaccio-config.yml
+++ b/scripts/integration-tests/verdaccio-config.yml
@@ -20,6 +20,10 @@ auth:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
+    agent_options:
+      keepAlive: true
+      maxSockets: 40
+      maxFreeSockets: 10
 
 packages:
   '@*/*':
@@ -54,7 +58,7 @@ middlewares:
 
 # log settings
 logs:
-  - { type: stdout, format: pretty, level: http }
+  - { type: stdout, format: pretty, level: trace }
   #- {type: file, path: verdaccio.log, level: info}
 #experiments:
 #  # support for npm token command

--- a/scripts/integration-tests/verdaccio-config.yml
+++ b/scripts/integration-tests/verdaccio-config.yml
@@ -20,20 +20,16 @@ auth:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
-    agent_options:
-      keepAlive: true
-      maxSockets: 40
-      maxFreeSockets: 10
 
 packages:
-  '@*/*':
+  "@*/*":
     # scoped packages
     access: $all
     publish: $all
     unpublish: $all
     proxy: npmjs
 
-  '**':
+  "**":
     # allow all users (including non-authenticated users) to read and
     # publish all packages
     #
@@ -58,7 +54,7 @@ middlewares:
 
 # log settings
 logs:
-  - { type: stdout, format: pretty, level: trace }
+  - { type: stdout, format: pretty, level: warn }
   #- {type: file, path: verdaccio.log, level: info}
 #experiments:
 #  # support for npm token command


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

CircleCI is quite slow because there is a low concurrency limit (I think it's 1 job at time?) so it gets overloaded easily and sometimes jobs are queued for hours. Even when they are not, it happens quite often that they wait for ~30 mins before running.

This PR moves the Babel 7 e2e tests to GitHub actions, where the concurrency limit is 16 parallel jobs, to speed it up a bit.

I'm not moving _everything_ to GH actions to avoid hitting the concurrency limit. CircleCI will still run:
- `build-standalone` on PRs and `main`
- `e2e-breaking` on `main` (it's opt-in on PRs)
- `test262` on `main` (it's opt-in on PRs)

Thanks @juanpicado for the help!

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12517"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/caf0a43abf3101f7f096e64d65e44163a4d8c226.svg" /></a>

