### PR TITLE
Raise recoverable error for await expressions in sync functions

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -538,12 +538,14 @@ export default class ExpressionParser extends LValParser {
       ? this.state.type.startsExpr
       : this.state.type.startsExpr && !this.match(tt.modulo);
     if (isAwait && startsExpr && !this.isAmbiguousAwait()) {
-      this.raise(
-        startPos,
-        this.hasPlugin("topLevelAwait")
-          ? Errors.AwaitNotInAsyncContext
-          : Errors.AwaitNotInAsyncFunction,
-      );
+      if (!this.state.invalidAwaitErrors.has(startPos)) {
+        this.raise(
+          startPos,
+          this.hasPlugin("topLevelAwait")
+            ? Errors.AwaitNotInAsyncContext
+            : Errors.AwaitNotInAsyncFunction,
+        );
+      }
       return this.parseAwait(startPos, startLoc);
     }
 
@@ -2353,6 +2355,7 @@ export default class ExpressionParser extends LValParser {
             ? Errors.AwaitNotInAsyncContext
             : Errors.AwaitNotInAsyncFunction,
         );
+        this.state.invalidAwaitErrors.add(startLoc);
       } else {
         this.raise(startLoc, Errors.UnexpectedReservedWord, word);
       }

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -544,7 +544,12 @@ export default class ExpressionParser extends LValParser {
       (this.scope.inFunction ||
         (this.hasPlugin("topLevelAwait") && !this.inModule))
     ) {
-      this.raise(startPos, Errors.AwaitNotInAsyncContext);
+      this.raise(
+        startPos,
+        this.hasPlugin("topLevelAwait")
+          ? Errors.AwaitNotInAsyncContext
+          : Errors.AwaitNotInAsyncFunction,
+      );
       return this.parseAwait(startPos, startLoc);
     }
 

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -534,11 +534,15 @@ export default class ExpressionParser extends LValParser {
 
     const expr = this.parseUpdate(node, update, refExpressionErrors);
 
+    const startsExpr = this.hasPlugin("v8intrinsic")
+      ? this.state.type.startsExpr
+      : this.state.type.startsExpr && !this.match(tt.modulo);
     if (
       isAwait &&
-      this.scope.inFunction &&
-      this.state.type.startsExpr &&
-      !this.isAmbiguousAwait()
+      startsExpr &&
+      !this.isAmbiguousAwait() &&
+      (this.scope.inFunction ||
+        (this.hasPlugin("topLevelAwait") && !this.inModule))
     ) {
       this.raise(startPos, Errors.AwaitNotInAsyncContext);
       return this.parseAwait(startPos, startLoc);

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -537,13 +537,7 @@ export default class ExpressionParser extends LValParser {
     const startsExpr = this.hasPlugin("v8intrinsic")
       ? this.state.type.startsExpr
       : this.state.type.startsExpr && !this.match(tt.modulo);
-    if (
-      isAwait &&
-      startsExpr &&
-      !this.isAmbiguousAwait() &&
-      (this.scope.inFunction ||
-        (this.hasPlugin("topLevelAwait") && !this.inModule))
-    ) {
+    if (isAwait && startsExpr && !this.isAmbiguousAwait()) {
       this.raise(
         startPos,
         this.hasPlugin("topLevelAwait")

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -90,10 +90,8 @@ export default class UtilParser extends Tokenizer {
     );
   }
 
-  hasPrecedingLineBreak(): boolean {
-    return lineBreak.test(
-      this.input.slice(this.state.lastTokEnd, this.state.start),
-    );
+  hasPrecedingLineBreak(state: State = this.state): boolean {
+    return lineBreak.test(this.input.slice(state.lastTokEnd, state.start));
   }
 
   // TODO

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -90,8 +90,10 @@ export default class UtilParser extends Tokenizer {
     );
   }
 
-  hasPrecedingLineBreak(state: State = this.state): boolean {
-    return lineBreak.test(this.input.slice(state.lastTokEnd, state.start));
+  hasPrecedingLineBreak(): boolean {
+    return lineBreak.test(
+      this.input.slice(this.state.lastTokEnd, this.state.start),
+    );
   }
 
   // TODO

--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -154,6 +154,9 @@ export default class State {
   // Tokens length in token store
   tokensLength: number = 0;
 
+  // Positions of invalid await errors
+  invalidAwaitErrors: Set<number> = new Set();
+
   curPosition(): Position {
     return new Position(this.curLine, this.pos - this.lineStart);
   }

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/9/options.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/9/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token, expected \";\" (1:30)"
-}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/9/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/9/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":40,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":40}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (1:24)"
+    "SyntaxError: 'await' is only allowed within async functions (1:24)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/9/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/9/output.json
@@ -1,0 +1,54 @@
+{
+  "type": "File",
+  "start":0,"end":40,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":40}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (1:24)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":40,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":40}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start":0,"end":40,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":40}},
+        "id": {
+          "type": "Identifier",
+          "start":9,"end":12,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":12},"identifierName":"foo"},
+          "name": "foo"
+        },
+        "generator": false,
+        "async": false,
+        "params": [
+          {
+            "type": "Identifier",
+            "start":13,"end":20,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":20},"identifierName":"promise"},
+            "name": "promise"
+          }
+        ],
+        "body": {
+          "type": "BlockStatement",
+          "start":22,"end":40,"loc":{"start":{"line":1,"column":22},"end":{"line":1,"column":40}},
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start":24,"end":38,"loc":{"start":{"line":1,"column":24},"end":{"line":1,"column":38}},
+              "expression": {
+                "type": "AwaitExpression",
+                "start":24,"end":37,"loc":{"start":{"line":1,"column":24},"end":{"line":1,"column":37}},
+                "argument": {
+                  "type": "Identifier",
+                  "start":30,"end":37,"loc":{"start":{"line":1,"column":30},"end":{"line":1,"column":37},"identifierName":"promise"},
+                  "name": "promise"
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/allow-await-outside-function-throw/options.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/allow-await-outside-function-throw/options.json
@@ -1,4 +1,0 @@
-{
-  "allowAwaitOutsideFunction": true,
-  "throws": "Unexpected token, expected \";\" (2:15)"
-}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/allow-await-outside-function-throw/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/allow-await-outside-function-throw/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (2:9)"
+    "SyntaxError: 'await' is only allowed within async functions (2:9)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/allow-await-outside-function-throw/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/allow-await-outside-function-throw/output.json
@@ -1,0 +1,52 @@
+{
+  "type": "File",
+  "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (2:9)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":9,"end":10,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":10},"identifierName":"a"},
+          "name": "a"
+        },
+        "generator": false,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start":13,"end":33,"loc":{"start":{"line":1,"column":13},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ReturnStatement",
+              "start":17,"end":31,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":16}},
+              "argument": {
+                "type": "AwaitExpression",
+                "start":24,"end":31,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":16}},
+                "argument": {
+                  "type": "NumericLiteral",
+                  "start":30,"end":31,"loc":{"start":{"line":2,"column":15},"end":{"line":2,"column":16}},
+                  "extra": {
+                    "rawValue": 1,
+                    "raw": "1"
+                  },
+                  "value": 1
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-identifier-with-line-break-in-function/input.js
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-identifier-with-line-break-in-function/input.js
@@ -1,0 +1,4 @@
+function foo() {
+  await
+  foo;
+}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-identifier-with-line-break-in-function/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-identifier-with-line-break-in-function/output.json
@@ -1,0 +1,50 @@
+{
+  "type": "File",
+  "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":9,"end":12,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":12},"identifierName":"foo"},
+          "name": "foo"
+        },
+        "generator": false,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start":15,"end":33,"loc":{"start":{"line":1,"column":15},"end":{"line":4,"column":1}},
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start":19,"end":24,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":7}},
+              "expression": {
+                "type": "Identifier",
+                "start":19,"end":24,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":7},"identifierName":"await"},
+                "name": "await"
+              }
+            },
+            {
+              "type": "ExpressionStatement",
+              "start":27,"end":31,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":6}},
+              "expression": {
+                "type": "Identifier",
+                "start":27,"end":30,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":5},"identifierName":"foo"},
+                "name": "foo"
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-arrow-expression-disallowed/options.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-arrow-expression-disallowed/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token, expected \";\" (1:14)"
-}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-arrow-expression-disallowed/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-arrow-expression-disallowed/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":17,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":17}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (1:8)"
+    "SyntaxError: 'await' is only allowed within async functions (1:8)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-arrow-expression-disallowed/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-arrow-expression-disallowed/output.json
@@ -1,0 +1,48 @@
+{
+  "type": "File",
+  "start":0,"end":17,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":17}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (1:8)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":17,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":17}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":17,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":17}},
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start":0,"end":17,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":17}},
+          "id": null,
+          "generator": false,
+          "async": false,
+          "params": [],
+          "body": {
+            "type": "BlockStatement",
+            "start":6,"end":17,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":17}},
+            "body": [
+              {
+                "type": "ExpressionStatement",
+                "start":8,"end":15,"loc":{"start":{"line":1,"column":8},"end":{"line":1,"column":15}},
+                "expression": {
+                  "type": "AwaitExpression",
+                  "start":8,"end":15,"loc":{"start":{"line":1,"column":8},"end":{"line":1,"column":15}},
+                  "argument": {
+                    "type": "Identifier",
+                    "start":14,"end":15,"loc":{"start":{"line":1,"column":14},"end":{"line":1,"column":15},"identifierName":"x"},
+                    "name": "x"
+                  }
+                }
+              }
+            ],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-async-arrow-function/options.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-async-arrow-function/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token, expected \",\" (1:17)"
-}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-async-arrow-function/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-async-arrow-function/output.json
@@ -1,0 +1,58 @@
+{
+  "type": "File",
+  "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":26}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions (1:11)",
+    "SyntaxError: await is not allowed in async function parameters (1:11)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":26}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":26}},
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start":0,"end":25,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":25}},
+          "id": null,
+          "generator": false,
+          "async": true,
+          "params": [
+            {
+              "type": "AssignmentPattern",
+              "start":7,"end":18,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":18}},
+              "left": {
+                "type": "Identifier",
+                "start":7,"end":8,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":8},"identifierName":"x"},
+                "name": "x"
+              },
+              "right": {
+                "type": "AwaitExpression",
+                "start":11,"end":18,"loc":{"start":{"line":1,"column":11},"end":{"line":1,"column":18}},
+                "argument": {
+                  "type": "NumericLiteral",
+                  "start":17,"end":18,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":18}},
+                  "extra": {
+                    "rawValue": 2,
+                    "raw": "2"
+                  },
+                  "value": 2
+                }
+              }
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "start":23,"end":25,"loc":{"start":{"line":1,"column":23},"end":{"line":1,"column":25}},
+            "body": [],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-nested-function/options.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-nested-function/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token, expected \",\" (2:25)"
-}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-nested-function/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-nested-function/output.json
@@ -1,0 +1,77 @@
+{
+  "type": "File",
+  "start":0,"end":55,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (2:19)",
+    "SyntaxError: await is not allowed in async function parameters (2:19)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":55,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start":0,"end":55,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":15,"end":18,"loc":{"start":{"line":1,"column":15},"end":{"line":1,"column":18},"identifierName":"foo"},
+          "name": "foo"
+        },
+        "generator": false,
+        "async": true,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start":21,"end":55,"loc":{"start":{"line":1,"column":21},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "FunctionDeclaration",
+              "start":25,"end":53,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":30}},
+              "id": {
+                "type": "Identifier",
+                "start":34,"end":37,"loc":{"start":{"line":2,"column":11},"end":{"line":2,"column":14},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "generator": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "AssignmentPattern",
+                  "start":38,"end":49,"loc":{"start":{"line":2,"column":15},"end":{"line":2,"column":26}},
+                  "left": {
+                    "type": "Identifier",
+                    "start":38,"end":39,"loc":{"start":{"line":2,"column":15},"end":{"line":2,"column":16},"identifierName":"x"},
+                    "name": "x"
+                  },
+                  "right": {
+                    "type": "AwaitExpression",
+                    "start":42,"end":49,"loc":{"start":{"line":2,"column":19},"end":{"line":2,"column":26}},
+                    "argument": {
+                      "type": "NumericLiteral",
+                      "start":48,"end":49,"loc":{"start":{"line":2,"column":25},"end":{"line":2,"column":26}},
+                      "extra": {
+                        "rawValue": 2,
+                        "raw": "2"
+                      },
+                      "value": 2
+                    }
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start":51,"end":53,"loc":{"start":{"line":2,"column":28},"end":{"line":2,"column":30}},
+                "body": [],
+                "directives": []
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-nested-function/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-nested-function/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":55,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (2:19)",
+    "SyntaxError: 'await' is only allowed within async functions (2:19)",
     "SyntaxError: await is not allowed in async function parameters (2:19)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-await-with-object-exp-in-function/input.js
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-await-with-object-exp-in-function/input.js
@@ -1,0 +1,3 @@
+function foo() {
+  await { foo };
+}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-await-with-object-exp-in-function/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-await-with-object-exp-in-function/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (2:2)"
+    "SyntaxError: 'await' is only allowed within async functions (2:2)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-await-with-object-exp-in-function/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-await-with-object-exp-in-function/output.json
@@ -1,0 +1,69 @@
+{
+  "type": "File",
+  "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (2:2)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":9,"end":12,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":12},"identifierName":"foo"},
+          "name": "foo"
+        },
+        "generator": false,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start":15,"end":35,"loc":{"start":{"line":1,"column":15},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start":19,"end":33,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":16}},
+              "expression": {
+                "type": "AwaitExpression",
+                "start":19,"end":32,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":15}},
+                "argument": {
+                  "type": "ObjectExpression",
+                  "start":25,"end":32,"loc":{"start":{"line":2,"column":8},"end":{"line":2,"column":15}},
+                  "properties": [
+                    {
+                      "type": "ObjectProperty",
+                      "start":27,"end":30,"loc":{"start":{"line":2,"column":10},"end":{"line":2,"column":13}},
+                      "extra": {
+                        "shorthand": true
+                      },
+                      "method": false,
+                      "key": {
+                        "type": "Identifier",
+                        "start":27,"end":30,"loc":{"start":{"line":2,"column":10},"end":{"line":2,"column":13},"identifierName":"foo"},
+                        "name": "foo"
+                      },
+                      "computed": false,
+                      "shorthand": true,
+                      "value": {
+                        "type": "Identifier",
+                        "start":27,"end":30,"loc":{"start":{"line":2,"column":10},"end":{"line":2,"column":13},"identifierName":"foo"},
+                        "name": "foo"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-static-block/invalid-await/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-static-block/invalid-await/options.json
@@ -1,6 +1,3 @@
 {
-  "plugins": [
-    "classStaticBlock"
-  ],
-  "throws": "Unexpected token, expected \";\" (5:12)"
+  "plugins": ["classStaticBlock"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/class-static-block/invalid-await/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-static-block/invalid-await/output.json
@@ -1,0 +1,96 @@
+{
+  "type": "File",
+  "start":0,"end":95,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":1}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (5:6)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":95,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start":0,"end":95,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":15,"end":18,"loc":{"start":{"line":1,"column":15},"end":{"line":1,"column":18},"identifierName":"foo"},
+          "name": "foo"
+        },
+        "generator": false,
+        "async": true,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start":21,"end":95,"loc":{"start":{"line":1,"column":21},"end":{"line":8,"column":1}},
+          "body": [
+            {
+              "type": "ClassDeclaration",
+              "start":25,"end":93,"loc":{"start":{"line":2,"column":2},"end":{"line":7,"column":3}},
+              "id": {
+                "type": "Identifier",
+                "start":31,"end":32,"loc":{"start":{"line":2,"column":8},"end":{"line":2,"column":9},"identifierName":"C"},
+                "name": "C"
+              },
+              "superClass": null,
+              "body": {
+                "type": "ClassBody",
+                "start":33,"end":93,"loc":{"start":{"line":2,"column":10},"end":{"line":7,"column":3}},
+                "body": [
+                  {
+                    "type": "ClassMethod",
+                    "start":39,"end":54,"loc":{"start":{"line":3,"column":4},"end":{"line":3,"column":19}},
+                    "static": true,
+                    "key": {
+                      "type": "Identifier",
+                      "start":46,"end":49,"loc":{"start":{"line":3,"column":11},"end":{"line":3,"column":14},"identifierName":"foo"},
+                      "name": "foo"
+                    },
+                    "computed": false,
+                    "kind": "method",
+                    "id": null,
+                    "generator": false,
+                    "async": false,
+                    "params": [],
+                    "body": {
+                      "type": "BlockStatement",
+                      "start":52,"end":54,"loc":{"start":{"line":3,"column":17},"end":{"line":3,"column":19}},
+                      "body": [],
+                      "directives": []
+                    }
+                  },
+                  {
+                    "type": "StaticBlock",
+                    "start":59,"end":89,"loc":{"start":{"line":4,"column":4},"end":{"line":6,"column":5}},
+                    "body": [
+                      {
+                        "type": "ExpressionStatement",
+                        "start":74,"end":83,"loc":{"start":{"line":5,"column":6},"end":{"line":5,"column":15}},
+                        "expression": {
+                          "type": "AwaitExpression",
+                          "start":74,"end":82,"loc":{"start":{"line":5,"column":6},"end":{"line":5,"column":14}},
+                          "argument": {
+                            "type": "NumericLiteral",
+                            "start":80,"end":82,"loc":{"start":{"line":5,"column":12},"end":{"line":5,"column":14}},
+                            "extra": {
+                              "rawValue": 42,
+                              "raw": "42"
+                            },
+                            "value": 42
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-static-block/invalid-await/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-static-block/invalid-await/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":95,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":1}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (5:6)"
+    "SyntaxError: 'await' is only allowed within async functions (5:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-class-property/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-class-property/options.json
@@ -1,8 +1,4 @@
 {
-  "plugins": [
-    "topLevelAwait",
-    "classProperties"
-  ],
-  "sourceType": "module",
-  "throws": "Unexpected token, expected \";\" (2:12)"
+  "plugins": ["topLevelAwati", "classProperties"],
+  "sourceType": "module"
 }

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-class-property/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-class-property/output.json
@@ -1,0 +1,63 @@
+{
+  "type": "File",
+  "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions (2:6)",
+    "SyntaxError: 'await' is only allowed within async functions (2:6)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "specifiers": [],
+        "source": null,
+        "declaration": {
+          "type": "ClassDeclaration",
+          "start":7,"end":33,"loc":{"start":{"line":1,"column":7},"end":{"line":3,"column":1}},
+          "id": {
+            "type": "Identifier",
+            "start":13,"end":14,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":14},"identifierName":"C"},
+            "name": "C"
+          },
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "start":15,"end":33,"loc":{"start":{"line":1,"column":15},"end":{"line":3,"column":1}},
+            "body": [
+              {
+                "type": "ClassProperty",
+                "start":19,"end":31,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":14}},
+                "static": false,
+                "key": {
+                  "type": "Identifier",
+                  "start":19,"end":20,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":3},"identifierName":"p"},
+                  "name": "p"
+                },
+                "computed": false,
+                "value": {
+                  "type": "AwaitExpression",
+                  "start":23,"end":30,"loc":{"start":{"line":2,"column":6},"end":{"line":2,"column":13}},
+                  "argument": {
+                    "type": "NumericLiteral",
+                    "start":29,"end":30,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":13}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-class-property/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-class-property/output.json
@@ -2,7 +2,6 @@
   "type": "File",
   "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions (2:6)",
     "SyntaxError: 'await' is only allowed within async functions (2:6)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/top-level-script/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/top-level-script/options.json
@@ -1,5 +1,4 @@
 {
   "plugins": ["topLevelAwait"],
-  "sourceType": "script",
-  "throws": "Unexpected token, expected \";\" (1:6)"
+  "sourceType": "script"
 }

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/top-level-script/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/top-level-script/output.json
@@ -1,0 +1,33 @@
+{
+  "type": "File",
+  "start":0,"end":8,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":8}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (1:0)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":8,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":8}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":8,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":8}},
+        "expression": {
+          "type": "AwaitExpression",
+          "start":0,"end":7,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":7}},
+          "argument": {
+            "type": "NumericLiteral",
+            "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7}},
+            "extra": {
+              "rawValue": 0,
+              "raw": "0"
+            },
+            "value": 0
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/module-namespace/top-level-await/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/module-namespace/top-level-await/options.json
@@ -1,8 +1,4 @@
 {
   "sourceType": "module",
-  "plugins": [
-    "typescript",
-    "topLevelAwait"
-  ],
-  "throws": "Unexpected token, expected \";\" (2:20)"
+  "plugins": ["typescript", "topLevelAwait"]
 }

--- a/packages/babel-parser/test/fixtures/typescript/module-namespace/top-level-await/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/module-namespace/top-level-await/output.json
@@ -1,0 +1,60 @@
+{
+  "type": "File",
+  "start":0,"end":39,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (2:14)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":39,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSModuleDeclaration",
+        "start":0,"end":39,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":10,"end":11,"loc":{"start":{"line":1,"column":10},"end":{"line":1,"column":11},"identifierName":"N"},
+          "name": "N"
+        },
+        "body": {
+          "type": "TSModuleBlock",
+          "start":12,"end":39,"loc":{"start":{"line":1,"column":12},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "VariableDeclaration",
+              "start":18,"end":37,"loc":{"start":{"line":2,"column":4},"end":{"line":2,"column":23}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":24,"end":36,"loc":{"start":{"line":2,"column":10},"end":{"line":2,"column":22}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":24,"end":25,"loc":{"start":{"line":2,"column":10},"end":{"line":2,"column":11},"identifierName":"x"},
+                    "name": "x"
+                  },
+                  "init": {
+                    "type": "AwaitExpression",
+                    "start":28,"end":36,"loc":{"start":{"line":2,"column":14},"end":{"line":2,"column":22}},
+                    "argument": {
+                      "type": "NumericLiteral",
+                      "start":34,"end":36,"loc":{"start":{"line":2,"column":20},"end":{"line":2,"column":22}},
+                      "extra": {
+                        "rawValue": 42,
+                        "raw": "42"
+                      },
+                      "value": 42
+                    }
+                  }
+                }
+              ],
+              "kind": "const"
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12436, closes #11090
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR addresses only `await` problem, not `yield`.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12520"><img src="https://gitpod.io/api/apps/github/pbs/github.com/sosukesuzuki/babel.git/6d3b9c54291a098a4100c3247453eb2c094f27fe.svg" /></a>

