### PR TITLE
Publish to npm from GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,43 @@ on:
     tags: ["v*"]
 
 jobs:
-  github_release:
-    name: Trigger GitHub release
+  log-updates:
+    name: Log packages to publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the new tag
-        uses: actions/checkout@v1.0.0
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: This release will publish the following packages
+        run: git diff --name-only HEAD^..HEAD
+
+  npm-release:
+    name: Publish release on npm
+    runs-on: ubuntu-latest
+    needs: log-updates
+    environment: npm
+    steps:
+      - name: Checkout the new tag
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Build and Test
+        run: make prepublish
+      - name: Publish to npm
+        run: yarn release-tool publish --yes
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  github-release:
+    name: Trigger GitHub release
+    runs-on: ubuntu-latest
+    needs: npm-release
+    steps:
+      - name: Checkout the new tag
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Get tag info
         id: tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  pull_request:
 
 jobs:
   log-updates:
@@ -29,7 +30,18 @@ jobs:
       - name: Build and Test
         run: make prepublish
       - name: Publish to npm
-        run: yarn release-tool publish --yes
+        #run: yarn release-tool publish --yes
+        run: |
+          cd ..
+          mkdir test-package
+          cd test-package
+          node -p "JSON.stringify({ name: '@nicolo-ribaudo/babel-publish-test', version: '1.0.1', publishConfig: { access: 'public' } }, null, 2)" > package.json
+          echo 'It works!' > README.md
+          echo 'yarnPath: ../babel/.yarn/releases/yarn-2.4.0.cjs' > .yarnrc.yml
+          yarn
+          # Don't worry, GH hides this
+          echo $YARN_NPM_AUTH_TOKEN
+          yarn npm publish
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
 on:
   push:
     tags: ["v*"]
-  pull_request:
 
 jobs:
   log-updates:
@@ -30,18 +29,7 @@ jobs:
       - name: Build and Test
         run: make prepublish
       - name: Publish to npm
-        #run: yarn release-tool publish --yes
-        run: |
-          cd ..
-          mkdir test-package
-          cd test-package
-          node -p "JSON.stringify({ name: '@nicolo-ribaudo/babel-publish-test', version: '1.0.1', publishConfig: { access: 'public' } }, null, 2)" > package.json
-          echo 'It works!' > README.md
-          echo 'yarnPath: ../babel/.yarn/releases/yarn-2.4.0.cjs' > .yarnrc.yml
-          yarn
-          # Don't worry, GH hides this
-          echo $YARN_NPM_AUTH_TOKEN
-          yarn npm publish
+        run: yarn release-tool publish --yes
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/Makefile
+++ b/Makefile
@@ -225,17 +225,6 @@ ifneq ("$(shell grep 3155328e5 .yarn/releases/yarn-*.cjs -c)", "0")
 	@exit 1
 endif
 
-publish-ci: prepublish
-ifneq ("$(NPM_TOKEN)", "")
-	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-else
-	echo "Missing NPM_TOKEN env var"
-	exit 1
-endif
-	$(YARN) release-tool publish --yes
-	rm -f .npmrc
-	$(MAKE) clean
-
 publish-test:
 ifneq ("$(I_AM_USING_VERDACCIO)", "I_AM_SURE")
 	echo "You probably don't know what you are doing"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

Closes https://github.com/babel/babel/pull/10663

During GitHub Universe 2020, they presented [environments](https://docs.github.com/en/free-pro-team@latest/actions/reference/environments#referencing-an-environment) with manual approval for GitHub actions: regardless of who has write access to this repository, we can now granularly configure who has access to a given secret.

I gave access to @JLHwung, @existentialism, @hzoo and me.
Currently the stored `NPM_TOKEN` is mine, but it it works we should use @babel-bot's.

Now the publishing process is just this :tada:
```
# Create a new release commit
make new-version

# Push to GitHub
git push --follow-tags
``` 

I'm testing this action in the second commit (I'll revert it before merging), publishing an empty package.
This is what the UI looks like: https://drive.google.com/file/d/1q-kCP7rp-7UKZZfChrI3v-s2iVHi0KDE/view

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12526"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/a7bd3baae77fa66315a85925f8b9cd74ba6201c0.svg" /></a>

