### PR TITLE
Set the JSX runtime based on runtime-specific pragmas

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-use-classic-runtime-with-jsx-pragma/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-use-classic-runtime-with-jsx-pragma/input.js
@@ -1,1 +1,3 @@
+/** @jsx dom */
+
 var div = <div>test</div>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-use-classic-runtime-with-jsx-pragma/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-use-classic-runtime-with-jsx-pragma/output.mjs
@@ -1,0 +1,2 @@
+/** @jsx dom */
+var div = dom("div", null, "test");

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-use-automatic-runtime-with-import-source-pragma/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-use-automatic-runtime-with-import-source-pragma/input.js
@@ -1,4 +1,3 @@
-/** @jsxRuntime classic */
 /** @jsxImportSource foo */
 
 var div = <div>test</div>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-use-automatic-runtime-with-import-source-pragma/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-use-automatic-runtime-with-import-source-pragma/output.js
@@ -1,0 +1,6 @@
+var _fooJsxRuntime = require("foo/jsx-runtime");
+
+/** @jsxImportSource foo */
+var div = _fooJsxRuntime.jsx("div", {
+  children: "test"
+});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-warn-when-importSource-is-set/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-warn-when-importSource-is-set/options.json
@@ -3,7 +3,7 @@
     [
       "transform-react-jsx",
       {
-        "runtime": "automatic",
+        "runtime": "classic",
         "importSource": "foo"
       }
     ]

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-warn-when-importSource-pragma-is-set/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-warn-when-importSource-pragma-is-set/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "importSource cannot be set when runtime is classic."
-}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | fixes #12208
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | x
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

The goal of this PR is to allow for **local** configuration (in the form of pragmas) to override the ones in the config. This is IMHO especially important for tools that configure Babel configs on behalf of the users and don't allow customization in this area (CRA) or it's just not immediately obvious that they are doing it (Next.js).

In my original issue, I've been claiming that this matches what TS has implemented but it turns out not to be true - or at least not fully. It is true in TS that `@jsxImportSource` overrides the classic runtime from `tsconfig.json` but it's not true that `@jsx` overrides the automatic runtime from `tsconfig.json`. I thought the latter is true as well but it has turned out that I've not been checking the emitted code for this situation but the resolution of the types and while indeed the classic runtime types have been chosen in this situation it was a bug that I have later fixed so this has never been released in the stable versions of TS.

To sum up the TS situation - currently, the automatic runtime is **always** chosen if it's configured anywhere, locally, or in the config. What should we do about this situation? Changing TS to the proposed semantic from this PR would be breaking change for them. Would it be OK for such a change to be made in TS 4.2? cc @weswigham , any thoughts about this one?

cc @wooorm 