### PR TITLE
Add a utility action to update fixtures in PRs

### DIFF
--- a/.github/workflows/pr-bot-assistant.yml
+++ b/.github/workflows/pr-bot-assistant.yml
@@ -89,4 +89,4 @@ jobs:
           git config user.email "babel-bot@users.noreply.github.com"
           git add .
           git commit -m "Update fixtures (Windows)" --no-verify --quiet
-          git push "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ steps.pr-meta.outputs.repository }}.git" ${{ steps.pr-meta.outputs.branch }}
+          git push "https://babel-bot:${{ secrets.BOT_TOKEN }}@github.com/${{ steps.pr-meta.outputs.repository }}.git" ${{ steps.pr-meta.outputs.branch }}

--- a/.github/workflows/pr-bot-assistant.yml
+++ b/.github/workflows/pr-bot-assistant.yml
@@ -1,0 +1,92 @@
+name: Bot Assistant
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: Which task should @babel-bot run?
+        required: true
+        default: update-windows-fixtures
+      pull_request:
+        description: Pull Request number
+        required: true
+
+jobs:
+  validate-inputs:
+    name: "Validate inputs"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if it is a valid task
+        if: ${{ github.event.inputs.task != 'update-windows-fixtures' }}
+        run: |
+          echo "Invalid task: '${{ github.event.inputs.task }}'. The only supported tasks are:"
+          echo " - update-windows-fixtures"
+          exit 1
+      - uses: actions/checkout@v2
+      - name: Check if it is a valid PR
+        run: git ls-remote --exit-code origin refs/pull/${{ github.event.inputs.pull_request }}/head
+
+  update-windows-fixtures:
+    name: "Update Windows fixtures"
+    runs-on: windows-latest
+    needs: validate-inputs
+    if: ${{ github.event.inputs.task == 'update-windows-fixtures' }}
+    steps:
+      - name: Get Pull Request branch
+        uses: actions/github-script@v3
+        id: pr-meta
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pullRequest } = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ github.event.inputs.pull_request }},
+            });
+
+            const {
+              ref: branch,
+              repo: { full_name: repository }
+            } = pullRequest.head;
+
+            console.log(`::set-output name=branch::${branch}`);
+            console.log(`::set-output name=repository::${repository}`);
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ steps.pr-meta.outputs.repository }}
+          ref: ${{ steps.pr-meta.outputs.branch }}
+          fetch-depth: 0 # Otherwise we cannot push
+
+      - name: Use Node.js latest
+        uses: actions/setup-node@v2-beta
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-${{ hashFiles('yarn.lock') }}
+
+      - name: Install and build
+        run: make -j bootstrap
+
+      - name: Regenerate fixtures
+        # Hack: --color has supports-color@5 returned true for GitHub CI
+        # Remove once `chalk` is bumped to 4.0.
+        run: |
+          yarn jest -u --ci --color || true
+        env:
+          BABEL_ENV: test
+          OVERWRITE: true
+
+      - name: Commit updates
+        run: |
+          git config user.name "Babel Bot"
+          git config user.email "babel-bot@users.noreply.github.com"
+          git add .
+          git commit -m "Update fixtures (Windows)" --no-verify --quiet
+          git push "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ steps.pr-meta.outputs.repository }}.git" ${{ steps.pr-meta.outputs.branch }}

--- a/.github/workflows/pr-bot-assistant.yml
+++ b/.github/workflows/pr-bot-assistant.yml
@@ -58,6 +58,7 @@ jobs:
           repository: ${{ steps.pr-meta.outputs.repository }}
           ref: ${{ steps.pr-meta.outputs.branch }}
           fetch-depth: 0 # Otherwise we cannot push
+          persist-credentials: false # So that we can push with BOT_TOKEN, otherwise it doesn't trigger CI
 
       - name: Use Node.js latest
         uses: actions/setup-node@v2-beta

--- a/.github/workflows/pr-bot-assistant.yml
+++ b/.github/workflows/pr-bot-assistant.yml
@@ -72,7 +72,10 @@ jobs:
           key: yarn-${{ hashFiles('yarn.lock') }}
 
       - name: Install and build
-        run: make -j bootstrap
+        # make bootstrap modifies some files (babel-runtime-*/package.json), so we reset them
+        run: |
+          make -j bootstrap
+          git reset --hard HEAD
 
       - name: Regenerate fixtures
         # Hack: --color has supports-color@5 returned true for GitHub CI

--- a/.github/workflows/update-windows-fixtures.yml
+++ b/.github/workflows/update-windows-fixtures.yml
@@ -1,33 +1,14 @@
-name: Bot Assistant
+name: Update Windows Fixtures
 
 on:
   workflow_dispatch:
     inputs:
-      task:
-        description: Which task should @babel-bot run?
-        required: true
-        default: update-windows-fixtures
       pull_request:
         description: Pull Request number
         required: true
 
 jobs:
-  validate-inputs:
-    name: "Validate inputs"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if it is a valid task
-        if: ${{ github.event.inputs.task != 'update-windows-fixtures' }}
-        run: |
-          echo "Invalid task: '${{ github.event.inputs.task }}'. The only supported tasks are:"
-          echo " - update-windows-fixtures"
-          exit 1
-      - uses: actions/checkout@v2
-      - name: Check if it is a valid PR
-        run: git ls-remote --exit-code origin refs/pull/${{ github.event.inputs.pull_request }}/head
-
   update-windows-fixtures:
-    name: "Update Windows fixtures"
     runs-on: windows-latest
     needs: validate-inputs
     if: ${{ github.event.inputs.task == 'update-windows-fixtures' }}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We execute some test fixtures only on Windows, so it often happen that when someone who doesn't have Windows (= me) opens a PR targeting some specific packages (e.g. all the React plugins) it fails on CI and we have to manually update the fixtures by copying the expected outputs on CI.

This action, that needs to be manually triggered, automatically regenerates the fixtures: you can see it in action in https://github.com/babel/babel/pull/12546 ([`53e2752` (#12546)](https://github.com/babel/babel/pull/12546/commits/53e2752ce0ff4ea6c0dac2151715d3c0a65cc75d), https://github.com/nicolo-ribaudo/babel/actions/runs/438713324).

In the future we can setup an event listener so that @babel-bot can be pinged (something like "@babel-bot Update Windows fixtures"), but for now this is the UI:
![Schermata da 2020-12-22 19-00-26](https://user-images.githubusercontent.com/7000710/102921875-6aee1f00-448d-11eb-9ebc-8559c34d97c2.png)



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12547"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/b20b1dea117bb336ffbe15d8e69a69d599f874f2.svg" /></a>

