### PR TITLE
improve types in  @babel/helper-function-name

### DIFF
--- a/packages/babel-helper-function-name/src/index.ts
+++ b/packages/babel-helper-function-name/src/index.ts
@@ -154,7 +154,7 @@ function visit(node, name, scope) {
  * @param {Boolean} localBinding whether a name could shadow a self-reference (e.g. converting arrow function)
  */
 export default function (
-  { node, parent, scope, id }: { node: any; parent: any; scope: any; id: any },
+  { node, parent, scope, id }: { node: any; parent?: any; scope: any; id: any },
   localBinding = false,
 ) {
   // has an `id` so we don't need to infer one

--- a/packages/babel-helper-function-name/src/index.ts
+++ b/packages/babel-helper-function-name/src/index.ts
@@ -154,7 +154,12 @@ function visit(node, name, scope) {
  * @param {Boolean} localBinding whether a name could shadow a self-reference (e.g. converting arrow function)
  */
 export default function (
-  { node, parent, scope, id }: { node: any; parent?: any; scope: any; id: any },
+  {
+    node,
+    parent,
+    scope,
+    id,
+  }: { node: any; parent?: any; scope: any; id?: any },
   localBinding = false,
 ) {
   // has an `id` so we don't need to infer one


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Make `parent` and `id` optional.

Followup for #12486, where `any` after was replaced with `{ node: any; parent: any; scope: any; id: any }`.

Found this when testing with other packages migrated to typescript(#11578).


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12550"><img src="https://gitpod.io/api/apps/github/pbs/github.com/zxbodya/babel.git/ca5583caa7a07334c1b3deb553a95fc956cccd95.svg" /></a>

