### PR TITLE
Fix disappearing polyfills when conflicting versions of preset are used

### DIFF
--- a/packages/babel-preset-env/src/polyfills/corejs3/entry-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs3/entry-plugin.js
@@ -56,7 +56,8 @@ export default function (
       modules.length === 1 &&
       polyfills.has(modules[0]) &&
       available.has(modules[0]) &&
-      getModulePath(modules[0]) === source
+      (getModulePath(modules[0]) === source ||
+        getModulePath(modules[0]) === `${source}.js`)
     ) {
       return false;
     }


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12545 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | No
| Any Dependency Changes?  | No
| License                  | MIT

If the preset-env is applied twice and
 - one version includes the extension change  from #10862
 - the other version does not include the change 
 
The core-js polyfills are removed from the bundle.
 
Example of breaking configuration can be found in the demo project: 
https://github.com/ertrzyiks/babel-loader-lost-polyfills-demo
 
The demo project uses preset-env and preset-react-app. The minimal configuration causing polyfills to disappear is the following:
```js
presets: [
  [
    // => Found "@babel/preset-env@7.12.11"
    require('@babel/preset-env').default,
    { corejs: 3, useBuiltIns: 'entry' }
  ],
  [
    //=> Found "babel-preset-react-app#@babel/preset-env@7.12.1"
    require('babel-preset-react-app/node_modules/@babel/preset-env').default, 
    { corejs: 3, useBuiltIns: 'entry' }
  ],
]
```



