### PR TITLE
Optimize jsx spreads of object expressions

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/duplicate-props/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/duplicate-props/input.js
@@ -1,0 +1,7 @@
+<p prop prop>text</p>;
+
+<p {...{prop, prop}}>text</p>;
+
+<p prop {...{prop}}>text</p>;
+
+<p {...{prop}} prop>text</p>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/duplicate-props/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/duplicate-props/output.mjs
@@ -1,0 +1,29 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+
+/*#__PURE__*/
+_jsx("p", {
+  prop: true,
+  prop: true,
+  children: "text"
+});
+
+/*#__PURE__*/
+_jsx("p", {
+  prop,
+  prop,
+  children: "text"
+});
+
+/*#__PURE__*/
+_jsx("p", {
+  prop: true,
+  prop,
+  children: "text"
+});
+
+/*#__PURE__*/
+_jsx("p", {
+  prop,
+  prop: true,
+  children: "text"
+});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/input.js
@@ -1,0 +1,7 @@
+<p {...props}>text</p>;
+
+<div {...props}>{contents}</div>;
+
+<img alt="" {...{src, title}} />;
+
+<blockquote {...{cite}}>{items}</blockquote>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/output.mjs
@@ -1,0 +1,24 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+
+/*#__PURE__*/
+_jsx("p", { ...props,
+  children: "text"
+});
+
+/*#__PURE__*/
+_jsx("div", { ...props,
+  children: contents
+});
+
+/*#__PURE__*/
+_jsx("img", {
+  alt: "",
+  src,
+  title
+});
+
+/*#__PURE__*/
+_jsx("blockquote", {
+  cite,
+  children: items
+});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/avoids-spread/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/avoids-spread/input.js
@@ -1,0 +1,11 @@
+<E {...props} last />;
+
+<E first {...props} />;
+
+<E {...pre} {...suf} />;
+
+<E first {...pre} mid {...suf} />;
+
+<E {...pre} mid {...suf} last />;
+
+<E {...pre} mid1 mid2 {...suf} />;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/avoids-spread/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/avoids-spread/output.js
@@ -1,0 +1,32 @@
+/*#__PURE__*/
+React.createElement(E, babelHelpers.extends({}, props, {
+  last: true
+}));
+
+/*#__PURE__*/
+React.createElement(E, babelHelpers.extends({
+  first: true
+}, props));
+
+/*#__PURE__*/
+React.createElement(E, babelHelpers.extends({}, pre, suf));
+
+/*#__PURE__*/
+React.createElement(E, babelHelpers.extends({
+  first: true
+}, pre, {
+  mid: true
+}, suf));
+
+/*#__PURE__*/
+React.createElement(E, babelHelpers.extends({}, pre, {
+  mid: true
+}, suf, {
+  last: true
+}));
+
+/*#__PURE__*/
+React.createElement(E, babelHelpers.extends({}, pre, {
+  mid1: true,
+  mid2: true
+}, suf));

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/duplicate-props/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/duplicate-props/input.js
@@ -1,0 +1,7 @@
+<p prop prop>text</p>;
+
+<p {...{prop, prop}}>text</p>;
+
+<p prop {...{prop}}>text</p>;
+
+<p {...{prop}} prop>text</p>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/duplicate-props/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/duplicate-props/output.js
@@ -1,0 +1,23 @@
+/*#__PURE__*/
+React.createElement("p", {
+  prop: true,
+  prop: true
+}, "text");
+
+/*#__PURE__*/
+React.createElement("p", {
+  prop,
+  prop
+}, "text");
+
+/*#__PURE__*/
+React.createElement("p", {
+  prop: true,
+  prop
+}, "text");
+
+/*#__PURE__*/
+React.createElement("p", {
+  prop,
+  prop: true
+}, "text");

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/input.js
@@ -1,0 +1,7 @@
+<p {...props}>text</p>;
+
+<div {...props}>{contents}</div>;
+
+<img alt="" {...{src, title}} />;
+
+<blockquote {...{cite}}>{items}</blockquote>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/output.js
@@ -1,0 +1,17 @@
+/*#__PURE__*/
+React.createElement("p", props, "text");
+
+/*#__PURE__*/
+React.createElement("div", props, contents);
+
+/*#__PURE__*/
+React.createElement("img", {
+  alt: "",
+  src,
+  title
+});
+
+/*#__PURE__*/
+React.createElement("blockquote", {
+  cite
+}, items);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | part of https://github.com/preactjs/preact/issues/2773
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Kinda?
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

The result of spreading an object expression is known at compile time enabling better code generation without a spread or extends helper.

Replace `convertAttribute` function with `accumulateAttribute` to allow multiple attributes to be created from one input.

Rework special case check for spreads when runtime is classic and `useSpread` is false to check the last added prop rather than the attribute before conversion.

There are edge cases where this will result in vastly smaller code as the helpers which would otherwise be inlined are no longer required. I believe the logic to be sound in all cases, happy to any additional tests that would be helpful.

Generated code differences:
```diff
  /*#__PURE__*/
- React.createElement("img", babelHelpers.extends({
-   alt: ""
- }, {
+ React.createElement("img", {
+   alt: "", 
    src,
    title
- }));
+ }); 
```
```diff
  /*#__PURE__*/
  _jsx("img", {
    alt: "", 
-   ...{
-     src,
-     title
-   }   
+   src,
+   title
  }); 
  
  /*#__PURE__*/
- _jsx("blockquote", { ...{
-     cite
-   },  
+ _jsx("blockquote", {
+   cite,
    children: items
  }); 
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12557"><img src="https://gitpod.io/api/apps/github/pbs/github.com/bz2/babel.git/d8afcecbc508518d12161ef3ff3b956342e5ad4a.svg" /></a>

