### PR TITLE
The first-line comment is removed unexpectedly

### DIFF
--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/declared-types/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/declared-types/output.mjs
@@ -1,4 +1,5 @@
 export class C2 {}
+// Not-even E
 // everything removed
 export { C2 as C3 }; // only C2->C3
 

--- a/packages/babel-traverse/src/path/comments.js
+++ b/packages/babel-traverse/src/path/comments.js
@@ -22,7 +22,7 @@ export function shareCommentsWithSiblings() {
   const hasNext = Boolean(next.node);
   if (hasPrev && !hasNext) {
     prev.addComments("trailing", trailing);
-  } else if (hasNext && !hasPrev) {
+  } else if (hasNext) {
     next.addComments("leading", leading);
   }
 }

--- a/packages/babel-traverse/test/fixtures/regression/first-line-comment-removed-unexpectedly/input.mjs
+++ b/packages/babel-traverse/test/fixtures/regression/first-line-comment-removed-unexpectedly/input.mjs
@@ -1,0 +1,4 @@
+// test
+import React from 'react';
+
+export default class A extends B {}

--- a/packages/babel-traverse/test/fixtures/regression/first-line-comment-removed-unexpectedly/options.json
+++ b/packages/babel-traverse/test/fixtures/regression/first-line-comment-removed-unexpectedly/options.json
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "targets": ["defaults"]
+      }
+    ]
+  ]
+}

--- a/packages/babel-traverse/test/fixtures/regression/first-line-comment-removed-unexpectedly/output.js
+++ b/packages/babel-traverse/test/fixtures/regression/first-line-comment-removed-unexpectedly/output.js
@@ -1,0 +1,45 @@
+"use strict";
+
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+// test
+var A = /*#__PURE__*/function (_B) {
+  _inherits(A, _B);
+
+  var _super = _createSuper(A);
+
+  function A() {
+    _classCallCheck(this, A);
+
+    return _super.apply(this, arguments);
+  }
+
+  return A;
+}(B);
+
+exports.default = A;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11971 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

As explained in #11971, the first comment is sometimes removed while it shouldn't. Consider the following snippet from the issue:
```javascript
// test
import React from 'react';

export default class A extends B {}```

The bug occurs during the transformation of the AST. When the `ImportDeclaration` node is removed, its leading comment should be transfered to one of its sibling node. And it pretty much does unless you want to compile for IE 11 or lower which causes some extra JavaScript code to be generated in the top of the file.

This results in a failure in two if statements. The comment will be added to the previous node if the removed node doesn't have a next node or to the next node if it doesn't have a previous node. If it has both a previous and a next node, then the comment is simply discarded.
