### PR TITLE
Add errorRecovery option to type definitions in babel-parser

### DIFF
--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -47,6 +47,13 @@ export interface ParserOptions {
    * Set this to true to allow export statements to reference undeclared variables.
    */
   allowUndeclaredExports?: boolean;
+  
+  /**
+   * By default, Babel always throws an error when it finds some invalid code.
+   * When this option is set to true, it will store the parsing error and
+   * try to continue parsing the invalid input file.
+   */
+  errorRecovery?: boolean;
 
   /**
    * Indicate the mode the code should be parsed in.

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -47,7 +47,7 @@ export interface ParserOptions {
    * Set this to true to allow export statements to reference undeclared variables.
    */
   allowUndeclaredExports?: boolean;
-  
+
   /**
    * By default, Babel always throws an error when it finds some invalid code.
    * When this option is set to true, it will store the parsing error and


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

As specified in https://babeljs.io/docs/en/babel-parser/, there is a working option that can be passed to `babel-parser` named `errorRecovery`. This was recently added in `v7.7.0`. However, the type definition for this option was never properly added - this PR fixes that.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12564"><img src="https://gitpod.io/api/apps/github/pbs/github.com/panzarino/babel.git/b9b18d5e7237f594a531dc43bde1824655dcadb6.svg" /></a>

