### PR TITLE
Make option getModuleId be used with relative imports

### DIFF
--- a/ARIJS-UMD-MIGRATION.md
+++ b/ARIJS-UMD-MIGRATION.md
@@ -1,0 +1,152 @@
+# @arijs UMD plugin — Babel 7 → 8 migration notes
+
+Working notes for porting the `@arijs/babel-plugin-transform-modules-umd` fork to
+Babel 8. Pick this up in WSL to finish building/testing/publishing.
+
+Branch: `modules-umd-imports-get-module-id` (this repo, `github.com:arijs/babel.git`).
+As of the last push it is rebased onto upstream **Babel 8 `main`** with one commit
+re-applying the custom feature.
+
+---
+
+## 1. Why this exists
+
+`front-end` (`d:/dev/github/front-end`) builds its UMD `lib/` with a custom Babel
+plugin published as two `@arijs` packages, forked from Babel **7.12.12**:
+
+- `@arijs/babel-plugin-transform-modules-umd` — the UMD plugin
+- `@arijs/babel-helper-module-transforms` — forked helper holding the custom
+  functions the plugin needs
+
+Both peer-depend on `@babel/core ^7`. front-end's `package.json` was bumped to
+Babel **8**, which broke the build (`ConfigError: Unknown option: .moduleIds`,
+and the `^7` peer of the @arijs packages). Goal: make the @arijs packages work on
+Babel 8 so front-end can build on Babel 8.
+
+## 2. The custom feature (what the fork adds over stock Babel)
+
+Original commit: `bc974c69f` "Make option getModuleId be used with relative imports".
+Rationale + maintainer discussion: https://github.com/babel/babel/pull/12582
+(opened against babel, never merged — JLHwung wanted a broader `getSource` design
+covering amd/cjs too). We keep it as a private fork.
+
+What it does: makes the `getModuleId()` Babel option apply to **relative imports**
+in UMD output, and adds an `importFileExt` option for the CommonJS `require()` paths.
+So an import like `./mylib/foo-bar` becomes a custom AMD module id
+(`custom-module-id/mylib/foo-bar`) and `require("./mylib/foo-bar.js")` instead of
+being left as the bare relative source.
+
+The shared logic lives in the **helper** package (not the plugin) on purpose, so
+the same functions could later be reused by the amd/cjs transformers — even though
+we only publish the umd plugin. This is why we keep `@arijs/babel-helper-module-transforms`
+as a real fork rather than inlining the functions into the plugin.
+
+Four functions added to the helper:
+- `withExtension(filename, ext)` — swap/add a file extension
+- `normalizePathSeparators(srcPath)` — `\` → `/` on Windows
+- `resolveRelativeImportPaths(importRelative, rootOpts)` — resolve a relative
+  import to `{ filename, filenameRelative }` against the importing file
+- `amdImportId(importRelative, rootOpts, pluginOpts)` — run `getModuleName`/
+  `getModuleId` on a relative import, falling back to `withExtension`
+
+front-end consumes it via `babel.config.mjs`:
+`{ globals: dfResult, exactGlobals: true, importFileExt: ".js" }` + top-level
+`moduleIds: true` / `getModuleId(name)`.
+
+## 3. Babel 7 → 8 API deltas that mattered
+
+Confirmed against upstream `main`:
+
+- Stock `@babel/helper-module-transforms@8` still exports everything the plugin
+  needs: `isModule`, `rewriteModuleStatementsAndPrepareHeader`, `hasExports`,
+  `isSideEffectImport`, `buildNamespaceInitStatements`, `ensureStatementsHoisted`,
+  `wrapInterop`, `getModuleName`.
+- Source files moved `.js` → `.ts`. Imports use explicit `.ts` extensions.
+- `loose` is gone → split into `constantReexports` / `enumerableModuleMeta`
+  (read via `api.assumption(...)`, with `options.loose` as deprecated fallback +
+  a `console.warn`).
+- `rewriteModuleStatementsAndPrepareHeader(path, opts)` now also takes
+  `importInterop` and `filename`.
+- `buildNamespaceInitStatements(meta, metadata, loose)` →
+  `(metadata, sourceMetadata, constantReexports?, wrapReference?)`.
+- `api.assertVersion(7)` → `api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"))`.
+- `getModuleName` is now a **re-export** in the helper index; to call it locally
+  inside `amdImportId` we changed it to a local `import` + added it to the
+  `export {}` list.
+- UMD plugin renamed `moduleName` literal handling to `moduleNameLiteral`.
+
+## 4. What was changed on this branch (commit `9d5b6b825d`)
+
+`packages/babel-helper-module-transforms/src/index.ts`
+- `import path from "node:path"`
+- `export { default as getModuleName } ...` → `import getModuleName ...` +
+  added `getModuleName` to the `export { hasExports, ... }` list (kept the
+  `export type { PluginOptions }`).
+- Appended the 4 functions (now TS-typed) after `buildNamespaceInitStatements`,
+  before `interface ReexportParts`.
+
+`packages/babel-plugin-transform-modules-umd/src/index.ts`
+- Started from Babel 8's current plugin (kept all v8 changes) and grafted the feature:
+  - import `withExtension`, `resolveRelativeImportPaths`, `amdImportId` from the helper
+  - added `importFileExt` to `Options` + destructure
+  - `buildBrowserInit`: exact-globals lookup `browserGlobals[filename] || browserGlobals[moduleNameOrBasename]`
+  - `buildBrowserArg`: extra `filename` param, lookup `(filename && browserGlobals[filename]) || browserGlobals[source]`
+  - loop over `meta.source`: `amdImportId(...)` for AMD args, `withExtension(source, importFileExt)` for the `require()`, pass resolved filename to `buildBrowserArg`
+  - module-name + `buildBrowserInit` use `fileOpts = this.file.opts`, with
+    `fileOpts.filenameRelative || fileOpts.filename || this.filename || "unknown"`
+
+`packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-get-module-id/`
+- `input.mjs`, `options.js`, `output.js` carried over from the 7.12 fork.
+- **`output.js` will probably need regenerating under Babel 8** (helper interop
+  output changed). Run the fixture with `OVERWRITE=true` and eyeball the diff —
+  the key assertions: custom AMD ids (`custom-module-id/...`), `.js` extension on
+  relative `require()`, exact globals resolved by filename.
+
+## 5. How the rebase was done (already done, FYI)
+
+```
+git remote add upstream https://github.com/babel/babel.git
+git fetch --no-tags upstream main
+git rebase upstream/main          # replays only bc974c69f
+# conflicts: helper index.js was modify/deleted (renamed to .ts); umd index.ts content conflict
+# resolved by taking Babel 8's .ts files and re-applying the feature by hand
+git push --force-with-lease origin modules-umd-imports-get-module-id
+```
+
+The branch history was rewritten (rebased onto a new base), hence the force-push.
+
+## 6. TODO in WSL
+
+1. **Bootstrap babel**: `yarn install` (yarn 4; needs `make` for the full
+   `make bootstrap`/`make build`, which is why we deferred this off Windows).
+2. **Run the umd plugin fixture test** (regenerates `output.js`):
+   - something like `yarn jest babel-plugin-transform-modules-umd` (babel-jest
+     transforms `src` on the fly, incl. the `REQUIRED_VERSION` macro).
+   - use `OVERWRITE=true yarn jest ...` to regenerate the fixture output, then review.
+3. **Typecheck (optional)**: `make tscheck` — the real type gate. The 4 helper
+   fns were typed loosely; tighten if tscheck complains. (Babel's JS build strips
+   types via Babel, so type errors don't block the build itself.)
+4. **Build + publish** the two `@arijs` packages (bump versions; they currently
+   sit at `0.1.3` peer `@babel/core ^7` — publish a new major that peers `^8`).
+5. **Wire front-end** (`d:/dev/github/front-end`):
+   - point `package.json` devDeps at the new @arijs versions (or `yarn link` /
+     `file:` for local testing before publishing).
+   - `npm run build` must regenerate `lib/` cleanly.
+   - `npm test` (mjs + cjs). Remember **cjs tests run off built `lib/`**, so
+     always `npm run build` before `npm test`.
+
+## 7. Gotchas
+
+- **`REQUIRED_VERSION` macro**: a Babel build-time replacement. Fine when built
+  via the monorepo; if the @arijs package is ever compiled standalone, replace it
+  with the literal `"^7.0.0-0 || ^8.0.0"` (the old 7.12 fork used the literal
+  `api.assertVersion(7)`).
+- **IDE type errors** (`node:path`, `console`): just this editor lacking Babel's
+  tsconfig/`@types/node`. Not real for Babel's build.
+- **front-end Babel 8 config**: the original build error `Unknown option:
+  .moduleIds` came from `babel.config.mjs` — verify `moduleIds`/`getModuleId`
+  top-level options still validate under Babel 8 once the plugin works; if Babel 8
+  rejects them at the top level, move that logic into the plugin options.
+- **Fallback** if Babel 8 proves too costly: front-end can stay on the latest
+  Babel **7.x** (it's still maintained/patched) and keep the existing @arijs
+  packages unchanged.

--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import path from "node:path";
 import { template, types as t } from "@babel/core";
 
 import { isModule } from "@babel/helper-module-imports";
@@ -21,10 +22,11 @@ import type { NodePath } from "@babel/core";
 
 export { buildDynamicImport } from "./dynamic-import.ts";
 
-export { default as getModuleName } from "./get-module-name.ts";
+import getModuleName from "./get-module-name.ts";
+import type { PluginOptions } from "./get-module-name.ts";
 export type { PluginOptions } from "./get-module-name.ts";
 
-export { hasExports, isSideEffectImport, isModule, rewriteThis };
+export { hasExports, isSideEffectImport, isModule, rewriteThis, getModuleName };
 
 export interface RewriteModuleStatementsAndPrepareHeaderOptions {
   exportName?: string;
@@ -247,6 +249,68 @@ export function buildNamespaceInitStatements(
     statements.push(statement);
   }
   return statements;
+}
+
+export function withExtension(filename: string, ext?: string | null): string {
+  return null == ext ? filename : filename.replace(/\.\w*$/, ext);
+}
+
+const reWinPathSep = /\\/g;
+
+export function normalizePathSeparators(srcPath: string): string {
+  return path.sep === "\\" ? srcPath.replace(reWinPathSep, "/") : srcPath;
+}
+
+const reRelativePath = /^\.*[\\/]/;
+
+interface ImportPaths {
+  filename: string | undefined;
+  filenameRelative: string | undefined;
+}
+
+export function resolveRelativeImportPaths(
+  importRelative: string,
+  rootOpts: { filename?: string; filenameRelative?: string },
+): ImportPaths {
+  if (!reRelativePath.test(importRelative)) {
+    return {
+      filename: importRelative,
+      filenameRelative: importRelative,
+    };
+  }
+  const rootAbsolute = rootOpts.filename;
+  const rootRelativeSource = rootOpts.filenameRelative;
+  const importAbsolute =
+    rootAbsolute &&
+    normalizePathSeparators(
+      path.join(path.dirname(rootAbsolute), importRelative),
+    );
+  const importRelativeSource =
+    rootRelativeSource &&
+    normalizePathSeparators(
+      path.join(path.dirname(rootRelativeSource), importRelative),
+    );
+  return {
+    filename: importAbsolute || undefined,
+    filenameRelative: importRelativeSource || undefined,
+  };
+}
+
+export function amdImportId(
+  importRelative: string,
+  rootOpts: { filename?: string; filenameRelative?: string },
+  pluginOpts: PluginOptions & { importFileExt?: string },
+): string {
+  if (!reRelativePath.test(importRelative)) return importRelative;
+  return (
+    getModuleName(
+      {
+        ...rootOpts,
+        ...resolveRelativeImportPaths(importRelative, rootOpts),
+      },
+      pluginOpts,
+    ) || withExtension(importRelative, pluginOpts.importFileExt)
+  );
 }
 
 interface ReexportParts {

--- a/packages/babel-plugin-transform-modules-umd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-umd/src/index.ts
@@ -10,6 +10,9 @@ import {
   ensureStatementsHoisted,
   wrapInterop,
   getModuleName,
+  withExtension,
+  resolveRelativeImportPaths,
+  amdImportId,
 } from "@babel/helper-module-transforms";
 import type { PluginOptions } from "@babel/helper-module-transforms";
 import { types as t, template, type NodePath } from "@babel/core";
@@ -45,6 +48,8 @@ export interface Options extends PluginOptions {
   exactGlobals?: boolean;
   globals?: Record<string, string>;
   importInterop?: RewriteModuleStatementsAndPrepareHeaderOptions["importInterop"];
+  /** Extension applied to relative CommonJS `require()` paths, e.g. ".js". */
+  importFileExt?: string;
   /** @deprecated Use the `constantReexports` and `enumerableModuleMeta` assumptions instead. */
   loose?: boolean;
   noInterop?: boolean;
@@ -70,6 +75,7 @@ export default declare((api, options: Options) => {
     strictMode,
     noInterop,
     importInterop,
+    importFileExt,
   } = options;
 
   const constantReexports =
@@ -96,7 +102,8 @@ export default declare((api, options: Options) => {
     let initAssignments = [];
 
     if (exactGlobals) {
-      const globalName = browserGlobals[moduleNameOrBasename];
+      const globalName =
+        browserGlobals[filename] || browserGlobals[moduleNameOrBasename];
 
       if (globalName) {
         initAssignments = [];
@@ -136,10 +143,12 @@ export default declare((api, options: Options) => {
     browserGlobals: Record<string, string>,
     exactGlobals: boolean | undefined,
     source: string,
+    filename: string | undefined,
   ) {
     let memberExpression: t.MemberExpression;
     if (exactGlobals) {
-      const globalRef = browserGlobals[source];
+      const globalRef =
+        (filename && browserGlobals[filename]) || browserGlobals[source];
       if (globalRef) {
         memberExpression = globalRef
           .split(".")
@@ -173,9 +182,10 @@ export default declare((api, options: Options) => {
         exit(path) {
           if (!isModule(path)) return;
 
+          const fileOpts = this.file.opts;
           const browserGlobals = globals || {};
 
-          const moduleName = getModuleName(this.file.opts, options);
+          const moduleName = getModuleName(fileOpts, options);
           let moduleNameLiteral: t.StringLiteral | undefined;
           if (moduleName) moduleNameLiteral = t.stringLiteral(moduleName);
 
@@ -208,14 +218,25 @@ export default declare((api, options: Options) => {
           }
 
           for (const [source, metadata] of meta.source) {
-            amdArgs.push(t.stringLiteral(source));
+            const {
+              filename: sourceFilename,
+              filenameRelative: sourceRelative,
+            } = resolveRelativeImportPaths(source, fileOpts);
+            amdArgs.push(
+              t.stringLiteral(amdImportId(source, fileOpts, options)),
+            );
             commonjsArgs.push(
               t.callExpression(t.identifier("require"), [
-                t.stringLiteral(source),
+                t.stringLiteral(withExtension(source, importFileExt)),
               ]),
             );
             browserArgs.push(
-              buildBrowserArg(browserGlobals, exactGlobals, source),
+              buildBrowserArg(
+                browserGlobals,
+                exactGlobals,
+                source,
+                sourceRelative || sourceFilename,
+              ),
             );
             importNames.push(t.identifier(metadata.name));
 
@@ -267,7 +288,10 @@ export default declare((api, options: Options) => {
               GLOBAL_TO_ASSIGN: buildBrowserInit(
                 browserGlobals,
                 exactGlobals,
-                this.filename || "unknown",
+                fileOpts.filenameRelative ||
+                  fileOpts.filename ||
+                  this.filename ||
+                  "unknown",
                 moduleNameLiteral,
               ),
             }) as t.Statement,

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-get-module-id/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-get-module-id/input.mjs
@@ -1,0 +1,4 @@
+import fooBar1 from "foo-bar";
+import fooBar2 from "./mylib/foo-bar";
+import fileExt from "./file.mjs";
+import fizzBuzz from "fizzbuzz";

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-get-module-id/options.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-get-module-id/options.js
@@ -1,0 +1,28 @@
+
+var reSourceRoot = /^umd\/imports-get-module-id\//;
+
+module.exports = {
+  "plugins": [
+    "external-helpers",
+    [
+      "transform-modules-umd",
+      {
+        "globals": {
+          "foo-bar": "fooBAR",
+          "fizzbuzz": "fizz.buzz",
+          "umd/imports-get-module-id/input.mjs": "customModuleId.input",
+          "umd/imports-get-module-id/mylib/foo-bar": "customModuleId.mylib.fooBar",
+          "umd/imports-get-module-id/file.mjs": "customModuleId.file",
+        },
+        "exactGlobals": true,
+        "importFileExt": ".js"
+      }
+    ]
+  ],
+  moduleIds: true,
+  getModuleId(name) {
+    if (reSourceRoot.test(name)) {
+      return 'custom-module-id/'+name.replace(reSourceRoot, '');
+    }
+  }
+};

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-get-module-id/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-get-module-id/output.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define("custom-module-id/input", ["foo-bar", "custom-module-id/mylib/foo-bar", "custom-module-id/file", "fizzbuzz"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("foo-bar"), require("./mylib/foo-bar"), require("./file.js"), require("fizzbuzz"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.fooBAR, global.customModuleId.mylib.fooBar, global.customModuleId.file, global.fizz.buzz);
+    global.customModuleId = global.customModuleId || {};
+    global.customModuleId.input = mod.exports;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_fooBar, _fooBar2, _file, _fizzbuzz) {
+  "use strict";
+
+  _fooBar = babelHelpers.interopRequireDefault(_fooBar);
+  _fooBar2 = babelHelpers.interopRequireDefault(_fooBar2);
+  _file = babelHelpers.interopRequireDefault(_file);
+  _fizzbuzz = babelHelpers.interopRequireDefault(_fizzbuzz);
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | None <!--`Fixes #1, Fixes #2` remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | 👍 (I think so, depends on interpretation)
| Major: Breaking Change?  | Maybe (not detected on tests)
| Minor: New Feature?      | Maybe
| Tests Added + Pass?      | Yes
| Documentation PR Link    | #TO-DO <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I want to make my UMD modules with AMD module IDs, but the `getModuleId()` option is not used on the imported module paths. Then a imported module gets a module ID when it is transformed, but the first module is not calling it by its new ID. I believe this to be a bug fix. I guess there are very few people using AMD modules and loaders anymore, but still.

There are some things in the code that are strange to me. For example, I'm assuming that import names that don't begin with "/", "./" or "../" should be left as they are. Maybe we could pass them to `getModuleId()` as well, but it looks that then I wouldn't be able to use `getModuleName()`, I'd have to call `getModuleId()` directly but I feel that adding another entry point might break something else.

Another thing that seems odd is that when using "globals" option, the entry module is searched by its `getModuleId()` value, but the imported module is called by its relative path despite also having a module Id. I don't like this asymmetry, shouldn't both names be get by the module Id or the relative path?

If someone else was using `getModuleId()` and relative imports, stuff might break for them. Maybe it would be necessary to add another option to the UMD plugin so users would opt-in into this feature.

I guess the AMD implementation is compatible only with require.js or other loaders that compute module IDs from file paths, but there are lighter AMD loaders that call modules only by the ID. If your code has two modules and you use `getModuleId()` on them, I think that they should each call the other by the module ID and not the relative path.

For now, I tried to do the simplest thing possible that solved my use case, but I feel that there are many details still that could be debated further. What do you guys think?

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12582"><img src="https://gitpod.io/api/apps/github/pbs/github.com/arijs/babel.git/bc974c69fdfc8baae3184fe324e66771473019a1.svg" /></a>

