### PR TITLE
Declare template objects inline

### DIFF
--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
@@ -4,14 +4,6 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 
 var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral"));
 
-function _templateObject() {
-  const data = (0, _taggedTemplateLiteral2.default)(["foo"]);
+var _templateObject;
 
-  _templateObject = function () {
-    return data;
-  };
-
-  return data;
-}
-
-tag(_templateObject());
+tag(_templateObject || (_templateObject = (0, _taggedTemplateLiteral2.default)(["foo"])));

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
@@ -4,14 +4,6 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 
 var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral"));
 
-function _templateObject() {
-  const data = (0, _taggedTemplateLiteral2.default)(["foo"]);
+var _templateObject;
 
-  _templateObject = function () {
-    return data;
-  };
-
-  return data;
-}
-
-tag(_templateObject());
+tag(_templateObject || (_templateObject = (0, _taggedTemplateLiteral2.default)(["foo"])));

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/cache-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/cache-revision/output.js
@@ -1,33 +1,15 @@
-function _templateObject2() {
-  const data = _taggedTemplateLiteral(["some template"]);
-
-  _templateObject2 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject() {
-  const data = _taggedTemplateLiteral(["some template"]);
-
-  _templateObject = function () {
-    return data;
-  };
-
-  return data;
-}
+var _templateObject, _templateObject2;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
 var tag = v => v;
 
 function foo() {
-  return tag(_templateObject());
+  return tag(_templateObject || (_templateObject = _taggedTemplateLiteral(["some template"])));
 }
 
 function bar() {
-  return tag(_templateObject2());
+  return tag(_templateObject2 || (_templateObject2 = _taggedTemplateLiteral(["some template"])));
 }
 
 expect(foo()).toBe(foo());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
@@ -1,24 +1,6 @@
-function _templateObject2() {
-  const data = _taggedTemplateLiteral(["first", "second"]);
-
-  _templateObject2 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject() {
-  const data = _taggedTemplateLiteral(["wow"]);
-
-  _templateObject = function () {
-    return data;
-  };
-
-  return data;
-}
+var _templateObject, _templateObject2;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-var foo = tag(_templateObject());
-var bar = tag(_templateObject2(), 1);
+var foo = tag(_templateObject || (_templateObject = _taggedTemplateLiteral(["wow"])));
+var bar = tag(_templateObject2 || (_templateObject2 = _taggedTemplateLiteral(["first", "second"])), 1);

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag-with-unicode-escapes/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag-with-unicode-escapes/output.js
@@ -1,13 +1,5 @@
-function _templateObject() {
-  const data = _taggedTemplateLiteral(["aa\uD835\uDC9C\uD835\uDC9C"], ["\\u0061\\u{0061}\\ud835\\udc9c\\u{1d49c}"]);
-
-  _templateObject = function () {
-    return data;
-  };
-
-  return data;
-}
+var _templateObject;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-var foo = bar(_templateObject());
+var foo = bar(_templateObject || (_templateObject = _taggedTemplateLiteral(["aa\uD835\uDC9C\uD835\uDC9C"], ["\\u0061\\u{0061}\\ud835\\udc9c\\u{1d49c}"])));

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
@@ -1,35 +1,7 @@
-function _templateObject3() {
-  const data = _taggedTemplateLiteral(["wow\naB", " ", ""], ["wow\\naB", " ", ""]);
-
-  _templateObject3 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject2() {
-  const data = _taggedTemplateLiteral(["wow\nab", " ", ""], ["wow\\nab", " ", ""]);
-
-  _templateObject2 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject() {
-  const data = _taggedTemplateLiteral(["wow\na", "b ", ""], ["wow\\na", "b ", ""]);
-
-  _templateObject = function () {
-    return data;
-  };
-
-  return data;
-}
+var _templateObject, _templateObject2, _templateObject3;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-var foo = bar(_templateObject(), 42, _.foobar());
-var bar = bar(_templateObject2(), 42, _.foobar());
-var bar = bar(_templateObject3(), 42, _.baz());
+var foo = bar(_templateObject || (_templateObject = _taggedTemplateLiteral(["wow\na", "b ", ""], ["wow\\na", "b ", ""])), 42, _.foobar());
+var bar = bar(_templateObject2 || (_templateObject2 = _taggedTemplateLiteral(["wow\nab", " ", ""], ["wow\\nab", " ", ""])), 42, _.foobar());
+var bar = bar(_templateObject3 || (_templateObject3 = _taggedTemplateLiteral(["wow\naB", " ", ""], ["wow\\naB", " ", ""])), 42, _.baz());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
@@ -1,94 +1,16 @@
-function _templateObject8() {
-  const data = _taggedTemplateLiteral([void 0], ["\\01"]);
-
-  _templateObject8 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject7() {
-  const data = _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u{-0}", "right"]);
-
-  _templateObject7 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject6() {
-  const data = _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u000g", "right"]);
-
-  _templateObject6 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject5() {
-  const data = _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\xg", "right"]);
-
-  _templateObject5 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject4() {
-  const data = _taggedTemplateLiteral(["left", void 0], ["left", "\\xg"]);
-
-  _templateObject4 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject3() {
-  const data = _taggedTemplateLiteral([void 0, "right"], ["\\xg", "right"]);
-
-  _templateObject3 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject2() {
-  const data = _taggedTemplateLiteral([void 0], ["\\01"]);
-
-  _templateObject2 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject() {
-  const data = _taggedTemplateLiteral([void 0], ["\\unicode and \\u{55}"]);
-
-  _templateObject = function () {
-    return data;
-  };
-
-  return data;
-}
+var _templateObject, _templateObject2, _templateObject3, _templateObject4, _templateObject5, _templateObject6, _templateObject7, _templateObject8;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-tag(_templateObject());
-tag(_templateObject2());
-tag(_templateObject3(), 0);
-tag(_templateObject4(), 0);
-tag(_templateObject5(), 0, 1);
-tag(_templateObject6(), 0, 1);
-tag(_templateObject7(), 0, 1);
+tag(_templateObject || (_templateObject = _taggedTemplateLiteral([void 0], ["\\unicode and \\u{55}"])));
+tag(_templateObject2 || (_templateObject2 = _taggedTemplateLiteral([void 0], ["\\01"])));
+tag(_templateObject3 || (_templateObject3 = _taggedTemplateLiteral([void 0, "right"], ["\\xg", "right"])), 0);
+tag(_templateObject4 || (_templateObject4 = _taggedTemplateLiteral(["left", void 0], ["left", "\\xg"])), 0);
+tag(_templateObject5 || (_templateObject5 = _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\xg", "right"])), 0, 1);
+tag(_templateObject6 || (_templateObject6 = _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u000g", "right"])), 0, 1);
+tag(_templateObject7 || (_templateObject7 = _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u{-0}", "right"])), 0, 1);
 
 function a() {
   var undefined = 4;
-  tag(_templateObject8());
+  tag(_templateObject8 || (_templateObject8 = _taggedTemplateLiteral([void 0], ["\\01"])));
 }

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
@@ -1,35 +1,7 @@
-function _templateObject3() {
-  const data = _taggedTemplateLiteralLoose(["wow\naB", " ", ""], ["wow\\naB", " ", ""]);
-
-  _templateObject3 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject2() {
-  const data = _taggedTemplateLiteralLoose(["wow\nab", " ", ""], ["wow\\nab", " ", ""]);
-
-  _templateObject2 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject() {
-  const data = _taggedTemplateLiteralLoose(["wow\na", "b ", ""], ["wow\\na", "b ", ""]);
-
-  _templateObject = function () {
-    return data;
-  };
-
-  return data;
-}
+var _templateObject, _templateObject2, _templateObject3;
 
 function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
-var foo = bar(_templateObject(), 42, _.foobar());
-var bar = bar(_templateObject2(), 42, _.foobar());
-var bar = bar(_templateObject3(), 42, _.baz());
+var foo = bar(_templateObject || (_templateObject = _taggedTemplateLiteralLoose(["wow\na", "b ", ""], ["wow\\na", "b ", ""])), 42, _.foobar());
+var bar = bar(_templateObject2 || (_templateObject2 = _taggedTemplateLiteralLoose(["wow\nab", " ", ""], ["wow\\nab", " ", ""])), 42, _.foobar());
+var bar = bar(_templateObject3 || (_templateObject3 = _taggedTemplateLiteralLoose(["wow\naB", " ", ""], ["wow\\naB", " ", ""])), 42, _.baz());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
@@ -1,94 +1,16 @@
-function _templateObject8() {
-  const data = _taggedTemplateLiteralLoose([void 0], ["\\01"]);
-
-  _templateObject8 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject7() {
-  const data = _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u{-0}", "right"]);
-
-  _templateObject7 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject6() {
-  const data = _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u000g", "right"]);
-
-  _templateObject6 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject5() {
-  const data = _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\xg", "right"]);
-
-  _templateObject5 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject4() {
-  const data = _taggedTemplateLiteralLoose(["left", void 0], ["left", "\\xg"]);
-
-  _templateObject4 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject3() {
-  const data = _taggedTemplateLiteralLoose([void 0, "right"], ["\\xg", "right"]);
-
-  _templateObject3 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject2() {
-  const data = _taggedTemplateLiteralLoose([void 0], ["\\01"]);
-
-  _templateObject2 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject() {
-  const data = _taggedTemplateLiteralLoose([void 0], ["\\unicode and \\u{55}"]);
-
-  _templateObject = function () {
-    return data;
-  };
-
-  return data;
-}
+var _templateObject, _templateObject2, _templateObject3, _templateObject4, _templateObject5, _templateObject6, _templateObject7, _templateObject8;
 
 function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
-tag(_templateObject());
-tag(_templateObject2());
-tag(_templateObject3(), 0);
-tag(_templateObject4(), 0);
-tag(_templateObject5(), 0, 1);
-tag(_templateObject6(), 0, 1);
-tag(_templateObject7(), 0, 1);
+tag(_templateObject || (_templateObject = _taggedTemplateLiteralLoose([void 0], ["\\unicode and \\u{55}"])));
+tag(_templateObject2 || (_templateObject2 = _taggedTemplateLiteralLoose([void 0], ["\\01"])));
+tag(_templateObject3 || (_templateObject3 = _taggedTemplateLiteralLoose([void 0, "right"], ["\\xg", "right"])), 0);
+tag(_templateObject4 || (_templateObject4 = _taggedTemplateLiteralLoose(["left", void 0], ["left", "\\xg"])), 0);
+tag(_templateObject5 || (_templateObject5 = _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\xg", "right"])), 0, 1);
+tag(_templateObject6 || (_templateObject6 = _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u000g", "right"])), 0, 1);
+tag(_templateObject7 || (_templateObject7 = _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u{-0}", "right"])), 0, 1);
 
 function a() {
   var undefined = 4;
-  tag(_templateObject8());
+  tag(_templateObject8 || (_templateObject8 = _taggedTemplateLiteralLoose([void 0], ["\\01"])));
 }

--- a/packages/babel-plugin-transform-unicode-escapes/test/fixtures/unicode-escapes/tagged-template-transformed/output.js
+++ b/packages/babel-plugin-transform-unicode-escapes/test/fixtures/unicode-escapes/tagged-template-transformed/output.js
@@ -1,57 +1,9 @@
-function _templateObject5() {
-  const data = _taggedTemplateLiteral(["\\\\u{1d49c}"], ["\\\\\\\\u{1d49c}"]);
-
-  _templateObject5 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject4() {
-  const data = _taggedTemplateLiteral(["\\\uD835\uDC9C"], ["\\\\\\u{1d49c}"]);
-
-  _templateObject4 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject3() {
-  const data = _taggedTemplateLiteral(["\\u{1d49c}"], ["\\\\u{1d49c}"]);
-
-  _templateObject3 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject2() {
-  const data = _taggedTemplateLiteral(["\uD835\uDC9C"], ["\\u{1d49c}"]);
-
-  _templateObject2 = function () {
-    return data;
-  };
-
-  return data;
-}
-
-function _templateObject() {
-  const data = _taggedTemplateLiteral(["\uD835\uDC9C\uD835\uDC9C\uD835\uDC9C"], ["\uD835\uDC9C\\ud835\\udc9c\\u{1d49c}"]);
-
-  _templateObject = function () {
-    return data;
-  };
-
-  return data;
-}
+var _templateObject, _templateObject2, _templateObject3, _templateObject4, _templateObject5;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-test(_templateObject());
-test(_templateObject2());
-test(_templateObject3());
-test(_templateObject4());
-test(_templateObject5());
+test(_templateObject || (_templateObject = _taggedTemplateLiteral(["\uD835\uDC9C\uD835\uDC9C\uD835\uDC9C"], ["\uD835\uDC9C\\ud835\\udc9c\\u{1d49c}"])));
+test(_templateObject2 || (_templateObject2 = _taggedTemplateLiteral(["\uD835\uDC9C"], ["\\u{1d49c}"])));
+test(_templateObject3 || (_templateObject3 = _taggedTemplateLiteral(["\\u{1d49c}"], ["\\\\u{1d49c}"])));
+test(_templateObject4 || (_templateObject4 = _taggedTemplateLiteral(["\\\uD835\uDC9C"], ["\\\\\\u{1d49c}"])));
+test(_templateObject5 || (_templateObject5 = _taggedTemplateLiteral(["\\\\u{1d49c}"], ["\\\\\\\\u{1d49c}"])));

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-tagged-template-literals/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-tagged-template-literals/output.js
@@ -1,13 +1,5 @@
-function _templateObject() {
-  var data = _taggedTemplateLiteral(["Safari 12 borked"]);
-
-  _templateObject = function _templateObject() {
-    return data;
-  };
-
-  return data;
-}
+var _templateObject;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-tag(_templateObject());
+tag(_templateObject || (_templateObject = _taggedTemplateLiteral(["Safari 12 borked"])));


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Template literal objects are cached globally per source location, so they cannot be evaluated twice.
We were solving this by using a singleton function defined in the top-level scope, but we can remove the functions and use `cachedObject || (cachedObject = ...)` inline, where `cachedObject` is a variable in the top-level scope.

This PR makes the output smaller when using terser, since the `function` and `return` keyword cannot be minified away with function declarations.

---

Input code:
```js
foo`ab`;
foo`a${x}b`;
```

<details>
<summary>Output code (`main`):</summary>

```js
function _templateObject2() {
  var data = babelHelpers.taggedTemplateLiteral(["a", "b"]);

  _templateObject2 = function _templateObject2() {
    return data;
  };

  return data;
}

function _templateObject() {
  var data = babelHelpers.taggedTemplateLiteral(["ab"]);

  _templateObject = function _templateObject() {
    return data;
  };

  return data;
}

function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }

foo(_templateObject());
foo(_templateObject2(), x);
```

</details>


<details>
<summary>Output code (this PR):</summary>

```js
var _templateObject, _templateObject2;

foo(_templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral(["ab"])));
foo(_templateObject2 || (_templateObject2 = babelHelpers.taggedTemplateLiteral(["a", "b"])), x);
```

</details>

<details>
<summary>Output code (`main` + terser): 211 bytes</summary>

```js
function e(){var r=babelHelpers.taggedTemplateLiteral(["a","b"]);return e=function(){return r},r}function r(){var e=babelHelpers.taggedTemplateLiteral(["ab"]);return r=function(){return e},e}foo(r()),foo(e(),x);
```

</details>


<details>
<summary>Output code (this PR + terser): 123 bytes</summary>

```js
var e,a;foo(e||(e=babelHelpers.taggedTemplateLiteral(["ab"]))),foo(a||(a=babelHelpers.taggedTemplateLiteral(["a","b"])),x);
```

</details>

---

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12588"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/0cad61b8152b76aa32c48bcbe14555e3001a2f4d.svg" /></a>

