### PR TITLE
export types.BaseNode for generic utility use

### DIFF
--- a/packages/babel-types/scripts/generators/ast-types.js
+++ b/packages/babel-types/scripts/generators/ast-types.js
@@ -37,7 +37,7 @@ export interface SourceLocation {
   };
 }
 
-interface BaseNode {
+export interface BaseNode {
   leadingComments: ReadonlyArray<Comment> | null;
   innerComments: ReadonlyArray<Comment> | null;
   trailingComments: ReadonlyArray<Comment> | null;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | N/A
| Major: Breaking Change?  | N/A
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | N/A
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

I'm trying to write a utility that accepts a `NodePath` of any `BaseNode` type and does stuff with it (replaces etc.). So I need to type that utility with `BaseNode`, but that's not exported yet so this simply exports the `BaseNode`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12600"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/55e1a6b87b2202c458bbc76237deea1acb798e12.svg" /></a>

