### PR TITLE
fix: cloneNode(deep, withoutLoc) handles absent comments

### DIFF
--- a/packages/babel-types/src/clone/cloneNode.ts
+++ b/packages/babel-types/src/clone/cloneNode.ts
@@ -102,7 +102,9 @@ export default function cloneNode<T extends t.Node>(
   return newNode;
 }
 
-function cloneCommentsWithoutLoc<T extends t.Comment>(comments: T[]): T[] {
+function cloneCommentsWithoutLoc<T extends t.Comment>(
+  comments: ReadonlyArray<T>,
+): T[] {
   return comments.map(
     ({ type, value }) =>
       ({
@@ -113,6 +115,12 @@ function cloneCommentsWithoutLoc<T extends t.Comment>(comments: T[]): T[] {
   );
 }
 
-function maybeCloneComments(comments, deep, withoutLoc) {
-  return deep && withoutLoc ? cloneCommentsWithoutLoc(comments) : comments;
+function maybeCloneComments<T extends t.Comment>(
+  comments: ReadonlyArray<T> | null,
+  deep: boolean,
+  withoutLoc: boolean,
+): ReadonlyArray<T> | null {
+  return deep && withoutLoc && comments
+    ? cloneCommentsWithoutLoc(comments)
+    : comments;
 }

--- a/packages/babel-types/test/cloning.js
+++ b/packages/babel-types/test/cloning.js
@@ -42,6 +42,14 @@ describe("cloneNode", function () {
     expect(t.isNodesEquivalent(node, cloned)).toBe(true);
   });
 
+  it("should handle deep cloning without loc of fragments", function () {
+    const program = "foo();";
+    const node = parse(program);
+    const cloned = t.cloneNode(node, /* deep */ true, /* withoutLoc */ true);
+    expect(node).not.toBe(cloned);
+    expect(t.isNodesEquivalent(node, cloned)).toBe(true);
+  });
+
   it("should handle missing array element", function () {
     const node = parse("[,0]");
     const cloned = t.cloneNode(node);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | This one. :smile:
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | No
| Any Dependency Changes?  | No
| License                  | MIT

This fragment (maybe all fragments?) throw during `cloneNode()` with `deep` and `withoutLoc`.

```
foo();
```

`comments` is unset here. Handle it being unset, by passing through the `undefined`.



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12602"><img src="https://gitpod.io/api/apps/github/pbs/github.com/FauxFaux/babel.git/f21a48bc970821ec8c479021e1f66d0a2cb43f85.svg" /></a>

