### PR TITLE
feat(referencesImport): support named exports accessed via namespace imports

### DIFF
--- a/packages/babel-traverse/test/introspection.js
+++ b/packages/babel-traverse/test/introspection.js
@@ -100,4 +100,108 @@ describe("path/introspection", function () {
       });
     });
   });
+
+  describe("referencesImport", function () {
+    it("accepts a default import", function () {
+      const program = getPath(`import dep from "source"; dep;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "default")).toBe(true);
+    });
+    it("rejects a default import from the wrong module", function () {
+      const program = getPath(`import dep from "wrong-source"; dep;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "default")).toBe(false);
+    });
+    it("rejects a named instead of default import", function () {
+      const program = getPath(`import { dep } from "source"; dep;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "default")).toBe(false);
+    });
+
+    it("accepts a named import", function () {
+      const program = getPath(`import { dep } from "source"; dep;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "dep")).toBe(true);
+    });
+    it("accepts an aliased named import", function () {
+      const program = getPath(`import { dep as alias } from "source"; alias;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "dep")).toBe(true);
+    });
+    it("accepts a named import via a namespace import member expression", function () {
+      const program = getPath(`import * as ns from "source"; ns.dep;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "dep")).toBe(true);
+    });
+    it("accepts a named import via a namespace import optional member expression", function () {
+      const program = getPath(`import * as ns from "source"; ns?.dep;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "dep")).toBe(true);
+    });
+    it("accepts a named import via a namespace import computed member expression", function () {
+      const program = getPath(`import * as ns from "source"; ns["😅"];`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "😅")).toBe(true);
+    });
+    it("rejects a named import from the wrong module", function () {
+      const program = getPath(`import { dep } from "wrong-source"; dep;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "dep")).toBe(false);
+    });
+    it("rejects a default instead of named import", function () {
+      const program = getPath(`import dep from "source"; dep;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "dep")).toBe(false);
+    });
+    it('rejects the "export called *" trick', function () {
+      const program = getPath(`import * as ns from "source"; ns["*"].nested;`, {
+        sourceType: "module",
+        plugins: ["moduleStringNames"],
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "nested")).toBe(false);
+    });
+
+    it("accepts a namespace import", function () {
+      const program = getPath(`import * as dep from "source"; dep;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "*")).toBe(true);
+    });
+    it("rejects a namespace import from the wrong module", function () {
+      const program = getPath(`import * as dep from "wrong-source"; dep;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "*")).toBe(false);
+    });
+    it("rejects a default instead of a namespace import", () => {
+      const program = getPath(`import dep from "source"; dep;`, {
+        sourceType: "module",
+      });
+      const reference = program.get("body.1.expression");
+      expect(reference.referencesImport("source", "*")).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11455
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

See referenced issue (or tests) for explanation/example.
Not really a bug fix because it was unclear how smart `referencesImport` is - this makes it a bit less limited.
We could of course go even further, support some cases of computed properties, etc., but I'd argue this is a pretty good line to draw because `ns.dep` is by far the most common way to access a named import via a namespace import object.
Don't think I have permission to request reviews here so cc @nicolo-ribaudo 😅


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12603"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jeysal/babel.git/1b232a5d53fcc22c20b442b2ff694dfea1717650.svg" /></a>

