### PR TITLE
chore: do not push objectRestSpread parser option in Babel 8

### DIFF
--- a/packages/babel-plugin-syntax-typescript/src/index.js
+++ b/packages/babel-plugin-syntax-typescript/src/index.js
@@ -34,7 +34,7 @@ export default declare((api, { isTSX }) => {
       parserOpts.plugins.push("typescript", "classProperties");
 
       if (!process.env.BABEL_8_BREAKING) {
-        // This is enabled by default since @babel/parser 8
+        // This is enabled by default since @babel/parser 7.1.5
         parserOpts.plugins.push("objectRestSpread");
       }
 

--- a/packages/babel-plugin-syntax-typescript/src/index.js
+++ b/packages/babel-plugin-syntax-typescript/src/index.js
@@ -31,12 +31,12 @@ export default declare((api, { isTSX }) => {
       // in TS depends on the extensions, and is purely dependent on 'isTSX'.
       removePlugin(plugins, "jsx");
 
-      parserOpts.plugins.push(
-        "typescript",
-        "classProperties",
-        // TODO: This is enabled by default now, remove in Babel 8
-        "objectRestSpread",
-      );
+      parserOpts.plugins.push("typescript", "classProperties");
+
+      if (!process.env.BABEL_8_BREAKING) {
+        // This is enabled by default since @babel/parser 8
+        parserOpts.plugins.push("objectRestSpread");
+      }
 
       if (isTSX) {
         parserOpts.plugins.push("jsx");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR backports #10915 so we can merge to `main`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12607"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/eeaaa1f18ae67e3996d43fd1151db10abe2229f5.svg" /></a>

