### PR TITLE
Tweak helper compilation targets

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/options.json
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": ["transform-async-to-generator"],
-  "presets": ["env"]
+  "presets": [["env", { "targets": { "browsers": "ie 6" } }]]
 }

--- a/packages/babel-helper-compilation-targets/src/index.js
+++ b/packages/babel-helper-compilation-targets/src/index.js
@@ -26,21 +26,6 @@ export { unreleasedLabels } from "./targets";
 const v = new OptionValidator(packageName);
 const browserslistDefaults = browserslist.defaults;
 
-const validBrowserslistTargets = [
-  ...Object.keys(browserslist.data),
-  ...Object.keys(browserslist.aliases),
-];
-
-function objectToBrowserslist(object: Targets): Array<string> {
-  return Object.keys(object).reduce((list, targetName) => {
-    if (validBrowserslistTargets.indexOf(targetName) >= 0) {
-      const targetVersion = object[targetName];
-      return list.concat(`${targetName} ${targetVersion}`);
-    }
-    return list;
-  }, []);
-}
-
 function validateTargetNames(targets: Targets): TargetsTuple {
   const validTargets = Object.keys(TargetNames);
   for (const target of Object.keys(targets)) {
@@ -203,7 +188,7 @@ export default function getTargets(
     // of `defaults` in queries will be different since we don't want to break
     // the behavior of "no targets is the same as preset-latest".
     if (!hasTargets) {
-      browserslist.defaults = objectToBrowserslist(targets);
+      browserslist.defaults = [];
     }
 
     const browsers = browserslist(browsersquery, {

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/2694/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/2694/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": ["external-helpers"],
-  "presets": ["env"]
+  "presets": [["env", { "targets": { "browsers": "ie 6" } }]]
 }

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": ["external-helpers", "proposal-class-properties"],
-  "presets": ["env", "react"]
+  "presets": [["env", { "targets": { "browsers": "ie 6" } }], "react"]
 }

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/export-default-arrow-renaming-2/options.json
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/export-default-arrow-renaming-2/options.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["env"]
+  "presets": [["env", { "targets": { "browsers": "ie 6" } }]]
 }

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/export-default-arrow-renaming-3/options.json
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/export-default-arrow-renaming-3/options.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["env", "react"]
+  "presets": [["env", { "targets": { "browsers": "ie 6" } }], "react"]
 }

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/options.json
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/options.json
@@ -1,4 +1,4 @@
 {
-  "presets": ["env"],
+  "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": ["proposal-class-properties"]
 }

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/options.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["env"]
+  "presets": [["env", { "targets": { "browsers": "ie 6" } }]]
 }

--- a/packages/babel-preset-env/test/fixtures/corejs2/entry-shippedProposals/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs2/entry-shippedProposals/options.json
@@ -8,5 +8,6 @@
         "corejs": 2
       }
     ]
-  ]
+  ],
+  "plugins": [["external-helpers", { "helperVersion": "7.100.0" }]]
 }

--- a/packages/babel-preset-env/test/fixtures/corejs2/entry-shippedProposals/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs2/entry-shippedProposals/options.json
@@ -4,6 +4,7 @@
       "../../../../lib",
       {
         "shippedProposals": true,
+        "targets": { "browsers": "ie 6" },
         "useBuiltIns": "entry",
         "corejs": 2
       }

--- a/packages/babel-preset-env/test/fixtures/corejs2/entry-shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/corejs2/entry-shippedProposals/output.js
@@ -296,32 +296,6 @@ require("core-js/modules/web.dom.iterable.js");
 
 require("regenerator-runtime/runtime.js");
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
-function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
-
-function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
-
-function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
-
-function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
-
-function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; var wrappedAwait = value instanceof _AwaitValue; Promise.resolve(wrappedAwait ? value.wrapped : value).then(function (arg) { if (wrappedAwait) { resume(key === "return" ? "return" : "next", arg); return; } settle(result.done ? "return" : "normal", arg); }, function (err) { resume("throw", err); }); } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen["return"] !== "function") { this["return"] = undefined; } }
-
-if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
-
-_AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
-
-_AsyncGenerator.prototype["throw"] = function (arg) { return this._invoke("throw", arg); };
-
-_AsyncGenerator.prototype["return"] = function (arg) { return this._invoke("return", arg); };
-
-function _AwaitValue(value) { this.wrapped = value; }
-
 var _x$y$a$b = {
   x: 1,
   y: 2,
@@ -330,9 +304,8 @@ var _x$y$a$b = {
 },
     x = _x$y$a$b.x,
     y = _x$y$a$b.y,
-    z = _objectWithoutProperties(_x$y$a$b, ["x", "y"]);
-
-var n = _objectSpread({
+    z = babelHelpers.objectWithoutProperties(_x$y$a$b, ["x", "y"]);
+var n = babelHelpers.objectSpread2({
   x: x,
   y: y
 }, z);
@@ -342,13 +315,13 @@ function agf() {
 }
 
 function _agf() {
-  _agf = _wrapAsyncGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
+  _agf = babelHelpers.wrapAsyncGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
     return regeneratorRuntime.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
             _context.next = 2;
-            return _awaitAsyncGenerator(1);
+            return babelHelpers.awaitAsyncGenerator(1);
 
           case 2:
             _context.next = 4;

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-evaluated-instance-methods/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-evaluated-instance-methods/options.json
@@ -4,6 +4,7 @@
       "../../../../lib",
       {
         "useBuiltIns": "usage",
+        "targets": { "browsers": "ie 6" },
         "corejs": 2,
         "modules": false
       }

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-evaluated-not-confident/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-evaluated-not-confident/options.json
@@ -4,6 +4,7 @@
       "../../../../lib",
       {
         "useBuiltIns": "usage",
+        "targets": { "browsers": "ie 6" },
         "corejs": 2,
         "modules": false
       }

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-instance-methods/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-instance-methods/options.json
@@ -4,6 +4,7 @@
       "../../../../lib",
       {
         "useBuiltIns": "usage",
+        "targets": { "browsers": "ie 6" },
         "corejs": 2,
         "modules": false
       }

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-shippedProposals/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-shippedProposals/options.json
@@ -5,6 +5,7 @@
       "../../../../lib",
       {
         "shippedProposals": true,
+        "targets": { "browsers": "ie 6" },
         "useBuiltIns": "usage",
         "corejs": 2
       }

--- a/packages/babel-preset-env/test/fixtures/corejs3/entry-ie-11/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/entry-ie-11/options.json
@@ -6,7 +6,6 @@
         "targets": {
           "ie": 11
         },
-        "modules": false,
         "useBuiltIns": "entry",
         "corejs": 3,
         "modules": false

--- a/packages/babel-preset-env/test/fixtures/corejs3/entry-ie-9/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/entry-ie-9/options.json
@@ -6,7 +6,6 @@
         "targets": {
           "ie": 9
         },
-        "modules": false,
         "useBuiltIns": "entry",
         "corejs": 3,
         "modules": false

--- a/packages/babel-preset-env/test/fixtures/corejs3/exclude-regenerator/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/exclude-regenerator/options.json
@@ -5,6 +5,7 @@
       {
         "modules": false,
         "useBuiltIns": "entry",
+        "targets": { "browsers": "ie 6" },
         "corejs": 3,
         "exclude": ["transform-regenerator"]
       }

--- a/packages/babel-preset-env/test/fixtures/corejs3/exclude-regenerator/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs3/exclude-regenerator/output.mjs
@@ -33,7 +33,6 @@ import "core-js/modules/es.array.map.js";
 import "core-js/modules/es.array.of.js";
 import "core-js/modules/es.array.reduce.js";
 import "core-js/modules/es.array.reduce-right.js";
-import "core-js/modules/es.array.reverse.js";
 import "core-js/modules/es.array.slice.js";
 import "core-js/modules/es.array.some.js";
 import "core-js/modules/es.array.sort.js";

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-determanated-instance-methods/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-determanated-instance-methods/options.json
@@ -4,6 +4,7 @@
       "../../../../lib",
       {
         "useBuiltIns": "usage",
+        "targets": { "browsers": "ie 6" },
         "corejs": 3,
         "modules": false
       }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-instance-methods/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-instance-methods/options.json
@@ -4,6 +4,7 @@
       "../../../../lib",
       {
         "useBuiltIns": "usage",
+        "targets": { "browsers": "ie 6" },
         "corejs": 3,
         "modules": false
       }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-object-destructuring/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-object-destructuring/options.json
@@ -5,6 +5,7 @@
       {
         "useBuiltIns": "usage",
         "corejs": 3,
+        "targets": { "browsers": "ie 6" },
         "modules": false,
         "exclude": ["transform-destructuring"]
       }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-static-methods/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-static-methods/options.json
@@ -5,6 +5,7 @@
       {
         "useBuiltIns": "usage",
         "corejs": 3,
+        "targets": { "browsers": "ie 6" },
         "modules": false,
         "exclude": ["transform-destructuring"]
       }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-timers/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-timers/options.json
@@ -4,6 +4,7 @@
       "../../../../lib",
       {
         "useBuiltIns": "usage",
+        "targets": { "browsers": "ie 6" },
         "corejs": 3,
         "modules": false
       }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-typed-array-static/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-typed-array-static/options.json
@@ -4,6 +4,7 @@
       "../../../../lib",
       {
         "useBuiltIns": "usage",
+        "targets": { "browsers": "ie 6" },
         "corejs": 3,
         "modules": false
       }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-typed-array/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-typed-array/options.json
@@ -4,6 +4,7 @@
       "../../../../lib",
       {
         "useBuiltIns": "usage",
+        "targets": { "browsers": "ie 6" },
         "corejs": 3,
         "modules": false
       }

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/options.json
@@ -6,6 +6,7 @@
       "env",
       {
         "debug": true,
+        "targets": { "browsers": "ie 6" },
         "corejs": 3
       }
     ]

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
@@ -3,50 +3,52 @@ WARNING (@babel/preset-env): The `corejs` option only has an effect when the `us
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/options.json
@@ -7,6 +7,7 @@
       {
         "debug": true,
         "useBuiltIns": "entry",
+        "targets": { "browsers": "ie 6" },
         "corejs": { "version": 2, "proposals": true }
       }
     ]

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
@@ -1,200 +1,202 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/input.mjs] Replaced @babel/polyfill entries with the following polyfills:
-  es6.array.copy-within {}
-  es6.array.every {}
-  es6.array.fill {}
-  es6.array.filter {}
-  es6.array.find {}
-  es6.array.find-index {}
-  es7.array.flat-map {}
-  es6.array.for-each {}
-  es6.array.from {}
-  es7.array.includes {}
-  es6.array.index-of {}
-  es6.array.is-array {}
-  es6.array.iterator {}
-  es6.array.last-index-of {}
-  es6.array.map {}
-  es6.array.of {}
-  es6.array.reduce {}
-  es6.array.reduce-right {}
-  es6.array.some {}
-  es6.array.sort {}
-  es6.array.species {}
-  es6.date.now {}
-  es6.date.to-iso-string {}
-  es6.date.to-json {}
-  es6.date.to-primitive {}
-  es6.date.to-string {}
-  es6.function.bind {}
-  es6.function.has-instance {}
-  es6.function.name {}
-  es6.map {}
-  es6.math.acosh {}
-  es6.math.asinh {}
-  es6.math.atanh {}
-  es6.math.cbrt {}
-  es6.math.clz32 {}
-  es6.math.cosh {}
-  es6.math.expm1 {}
-  es6.math.fround {}
-  es6.math.hypot {}
-  es6.math.imul {}
-  es6.math.log1p {}
-  es6.math.log10 {}
-  es6.math.log2 {}
-  es6.math.sign {}
-  es6.math.sinh {}
-  es6.math.tanh {}
-  es6.math.trunc {}
-  es6.number.constructor {}
-  es6.number.epsilon {}
-  es6.number.is-finite {}
-  es6.number.is-integer {}
-  es6.number.is-nan {}
-  es6.number.is-safe-integer {}
-  es6.number.max-safe-integer {}
-  es6.number.min-safe-integer {}
-  es6.number.parse-float {}
-  es6.number.parse-int {}
-  es6.object.assign {}
-  es6.object.create {}
-  es7.object.define-getter {}
-  es7.object.define-setter {}
-  es6.object.define-property {}
-  es6.object.define-properties {}
-  es7.object.entries {}
-  es6.object.freeze {}
-  es6.object.get-own-property-descriptor {}
-  es7.object.get-own-property-descriptors {}
-  es6.object.get-own-property-names {}
-  es6.object.get-prototype-of {}
-  es7.object.lookup-getter {}
-  es7.object.lookup-setter {}
-  es6.object.prevent-extensions {}
-  es6.object.to-string {}
-  es6.object.is {}
-  es6.object.is-frozen {}
-  es6.object.is-sealed {}
-  es6.object.is-extensible {}
-  es6.object.keys {}
-  es6.object.seal {}
-  es6.object.set-prototype-of {}
-  es7.object.values {}
-  es6.promise {}
-  es7.promise.finally {}
-  es6.reflect.apply {}
-  es6.reflect.construct {}
-  es6.reflect.define-property {}
-  es6.reflect.delete-property {}
-  es6.reflect.get {}
-  es6.reflect.get-own-property-descriptor {}
-  es6.reflect.get-prototype-of {}
-  es6.reflect.has {}
-  es6.reflect.is-extensible {}
-  es6.reflect.own-keys {}
-  es6.reflect.prevent-extensions {}
-  es6.reflect.set {}
-  es6.reflect.set-prototype-of {}
-  es6.regexp.constructor {}
-  es6.regexp.flags {}
-  es6.regexp.match {}
-  es6.regexp.replace {}
-  es6.regexp.split {}
-  es6.regexp.search {}
-  es6.regexp.to-string {}
-  es6.set {}
-  es6.symbol {}
-  es7.symbol.async-iterator {}
-  es6.string.anchor {}
-  es6.string.big {}
-  es6.string.blink {}
-  es6.string.bold {}
-  es6.string.code-point-at {}
-  es6.string.ends-with {}
-  es6.string.fixed {}
-  es6.string.fontcolor {}
-  es6.string.fontsize {}
-  es6.string.from-code-point {}
-  es6.string.includes {}
-  es6.string.italics {}
-  es6.string.iterator {}
-  es6.string.link {}
-  es7.string.pad-start {}
-  es7.string.pad-end {}
-  es6.string.raw {}
-  es6.string.repeat {}
-  es6.string.small {}
-  es6.string.starts-with {}
-  es6.string.strike {}
-  es6.string.sub {}
-  es6.string.sup {}
-  es6.string.trim {}
-  es7.string.trim-left {}
-  es7.string.trim-right {}
-  es6.typed.array-buffer {}
-  es6.typed.data-view {}
-  es6.typed.int8-array {}
-  es6.typed.uint8-array {}
-  es6.typed.uint8-clamped-array {}
-  es6.typed.int16-array {}
-  es6.typed.uint16-array {}
-  es6.typed.int32-array {}
-  es6.typed.uint32-array {}
-  es6.typed.float32-array {}
-  es6.typed.float64-array {}
-  es6.weak-map {}
-  es6.weak-set {}
-  web.timers {}
-  web.immediate {}
-  web.dom.iterable {}
+  es6.array.copy-within { "ie":"6" }
+  es6.array.every { "ie":"6" }
+  es6.array.fill { "ie":"6" }
+  es6.array.filter { "ie":"6" }
+  es6.array.find { "ie":"6" }
+  es6.array.find-index { "ie":"6" }
+  es7.array.flat-map { "ie":"6" }
+  es6.array.for-each { "ie":"6" }
+  es6.array.from { "ie":"6" }
+  es7.array.includes { "ie":"6" }
+  es6.array.index-of { "ie":"6" }
+  es6.array.is-array { "ie":"6" }
+  es6.array.iterator { "ie":"6" }
+  es6.array.last-index-of { "ie":"6" }
+  es6.array.map { "ie":"6" }
+  es6.array.of { "ie":"6" }
+  es6.array.reduce { "ie":"6" }
+  es6.array.reduce-right { "ie":"6" }
+  es6.array.some { "ie":"6" }
+  es6.array.sort { "ie":"6" }
+  es6.array.species { "ie":"6" }
+  es6.date.now { "ie":"6" }
+  es6.date.to-iso-string { "ie":"6" }
+  es6.date.to-json { "ie":"6" }
+  es6.date.to-primitive { "ie":"6" }
+  es6.date.to-string { "ie":"6" }
+  es6.function.bind { "ie":"6" }
+  es6.function.has-instance { "ie":"6" }
+  es6.function.name { "ie":"6" }
+  es6.map { "ie":"6" }
+  es6.math.acosh { "ie":"6" }
+  es6.math.asinh { "ie":"6" }
+  es6.math.atanh { "ie":"6" }
+  es6.math.cbrt { "ie":"6" }
+  es6.math.clz32 { "ie":"6" }
+  es6.math.cosh { "ie":"6" }
+  es6.math.expm1 { "ie":"6" }
+  es6.math.fround { "ie":"6" }
+  es6.math.hypot { "ie":"6" }
+  es6.math.imul { "ie":"6" }
+  es6.math.log1p { "ie":"6" }
+  es6.math.log10 { "ie":"6" }
+  es6.math.log2 { "ie":"6" }
+  es6.math.sign { "ie":"6" }
+  es6.math.sinh { "ie":"6" }
+  es6.math.tanh { "ie":"6" }
+  es6.math.trunc { "ie":"6" }
+  es6.number.constructor { "ie":"6" }
+  es6.number.epsilon { "ie":"6" }
+  es6.number.is-finite { "ie":"6" }
+  es6.number.is-integer { "ie":"6" }
+  es6.number.is-nan { "ie":"6" }
+  es6.number.is-safe-integer { "ie":"6" }
+  es6.number.max-safe-integer { "ie":"6" }
+  es6.number.min-safe-integer { "ie":"6" }
+  es6.number.parse-float { "ie":"6" }
+  es6.number.parse-int { "ie":"6" }
+  es6.object.assign { "ie":"6" }
+  es6.object.create { "ie":"6" }
+  es7.object.define-getter { "ie":"6" }
+  es7.object.define-setter { "ie":"6" }
+  es6.object.define-property { "ie":"6" }
+  es6.object.define-properties { "ie":"6" }
+  es7.object.entries { "ie":"6" }
+  es6.object.freeze { "ie":"6" }
+  es6.object.get-own-property-descriptor { "ie":"6" }
+  es7.object.get-own-property-descriptors { "ie":"6" }
+  es6.object.get-own-property-names { "ie":"6" }
+  es6.object.get-prototype-of { "ie":"6" }
+  es7.object.lookup-getter { "ie":"6" }
+  es7.object.lookup-setter { "ie":"6" }
+  es6.object.prevent-extensions { "ie":"6" }
+  es6.object.to-string { "ie":"6" }
+  es6.object.is { "ie":"6" }
+  es6.object.is-frozen { "ie":"6" }
+  es6.object.is-sealed { "ie":"6" }
+  es6.object.is-extensible { "ie":"6" }
+  es6.object.keys { "ie":"6" }
+  es6.object.seal { "ie":"6" }
+  es6.object.set-prototype-of { "ie":"6" }
+  es7.object.values { "ie":"6" }
+  es6.promise { "ie":"6" }
+  es7.promise.finally { "ie":"6" }
+  es6.reflect.apply { "ie":"6" }
+  es6.reflect.construct { "ie":"6" }
+  es6.reflect.define-property { "ie":"6" }
+  es6.reflect.delete-property { "ie":"6" }
+  es6.reflect.get { "ie":"6" }
+  es6.reflect.get-own-property-descriptor { "ie":"6" }
+  es6.reflect.get-prototype-of { "ie":"6" }
+  es6.reflect.has { "ie":"6" }
+  es6.reflect.is-extensible { "ie":"6" }
+  es6.reflect.own-keys { "ie":"6" }
+  es6.reflect.prevent-extensions { "ie":"6" }
+  es6.reflect.set { "ie":"6" }
+  es6.reflect.set-prototype-of { "ie":"6" }
+  es6.regexp.constructor { "ie":"6" }
+  es6.regexp.flags { "ie":"6" }
+  es6.regexp.match { "ie":"6" }
+  es6.regexp.replace { "ie":"6" }
+  es6.regexp.split { "ie":"6" }
+  es6.regexp.search { "ie":"6" }
+  es6.regexp.to-string { "ie":"6" }
+  es6.set { "ie":"6" }
+  es6.symbol { "ie":"6" }
+  es7.symbol.async-iterator { "ie":"6" }
+  es6.string.anchor { "ie":"6" }
+  es6.string.big { "ie":"6" }
+  es6.string.blink { "ie":"6" }
+  es6.string.bold { "ie":"6" }
+  es6.string.code-point-at { "ie":"6" }
+  es6.string.ends-with { "ie":"6" }
+  es6.string.fixed { "ie":"6" }
+  es6.string.fontcolor { "ie":"6" }
+  es6.string.fontsize { "ie":"6" }
+  es6.string.from-code-point { "ie":"6" }
+  es6.string.includes { "ie":"6" }
+  es6.string.italics { "ie":"6" }
+  es6.string.iterator { "ie":"6" }
+  es6.string.link { "ie":"6" }
+  es7.string.pad-start { "ie":"6" }
+  es7.string.pad-end { "ie":"6" }
+  es6.string.raw { "ie":"6" }
+  es6.string.repeat { "ie":"6" }
+  es6.string.small { "ie":"6" }
+  es6.string.starts-with { "ie":"6" }
+  es6.string.strike { "ie":"6" }
+  es6.string.sub { "ie":"6" }
+  es6.string.sup { "ie":"6" }
+  es6.string.trim { "ie":"6" }
+  es7.string.trim-left { "ie":"6" }
+  es7.string.trim-right { "ie":"6" }
+  es6.typed.array-buffer { "ie":"6" }
+  es6.typed.data-view { "ie":"6" }
+  es6.typed.int8-array { "ie":"6" }
+  es6.typed.uint8-array { "ie":"6" }
+  es6.typed.uint8-clamped-array { "ie":"6" }
+  es6.typed.int16-array { "ie":"6" }
+  es6.typed.uint16-array { "ie":"6" }
+  es6.typed.int32-array { "ie":"6" }
+  es6.typed.uint32-array { "ie":"6" }
+  es6.typed.float32-array { "ie":"6" }
+  es6.typed.float64-array { "ie":"6" }
+  es6.weak-map { "ie":"6" }
+  es6.weak-set { "ie":"6" }
+  web.timers { "ie":"6" }
+  web.immediate { "ie":"6" }
+  web.dom.iterable { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/options.json
@@ -6,6 +6,7 @@
       "env",
       {
         "debug": true,
+        "targets": { "browsers": "ie 6" },
         "shippedProposals": true,
         "useBuiltIns": "entry",
         "corejs": 2

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
@@ -1,202 +1,204 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties {}
-  proposal-private-methods {}
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-class-properties { "ie":"6" }
+  proposal-private-methods { "ie":"6" }
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/input.mjs] Replaced @babel/polyfill entries with the following polyfills:
-  es6.array.copy-within {}
-  es6.array.every {}
-  es6.array.fill {}
-  es6.array.filter {}
-  es6.array.find {}
-  es6.array.find-index {}
-  es7.array.flat-map {}
-  es6.array.for-each {}
-  es6.array.from {}
-  es7.array.includes {}
-  es6.array.index-of {}
-  es6.array.is-array {}
-  es6.array.iterator {}
-  es6.array.last-index-of {}
-  es6.array.map {}
-  es6.array.of {}
-  es6.array.reduce {}
-  es6.array.reduce-right {}
-  es6.array.some {}
-  es6.array.sort {}
-  es6.array.species {}
-  es6.date.now {}
-  es6.date.to-iso-string {}
-  es6.date.to-json {}
-  es6.date.to-primitive {}
-  es6.date.to-string {}
-  es6.function.bind {}
-  es6.function.has-instance {}
-  es6.function.name {}
-  es6.map {}
-  es6.math.acosh {}
-  es6.math.asinh {}
-  es6.math.atanh {}
-  es6.math.cbrt {}
-  es6.math.clz32 {}
-  es6.math.cosh {}
-  es6.math.expm1 {}
-  es6.math.fround {}
-  es6.math.hypot {}
-  es6.math.imul {}
-  es6.math.log1p {}
-  es6.math.log10 {}
-  es6.math.log2 {}
-  es6.math.sign {}
-  es6.math.sinh {}
-  es6.math.tanh {}
-  es6.math.trunc {}
-  es6.number.constructor {}
-  es6.number.epsilon {}
-  es6.number.is-finite {}
-  es6.number.is-integer {}
-  es6.number.is-nan {}
-  es6.number.is-safe-integer {}
-  es6.number.max-safe-integer {}
-  es6.number.min-safe-integer {}
-  es6.number.parse-float {}
-  es6.number.parse-int {}
-  es6.object.assign {}
-  es6.object.create {}
-  es7.object.define-getter {}
-  es7.object.define-setter {}
-  es6.object.define-property {}
-  es6.object.define-properties {}
-  es7.object.entries {}
-  es6.object.freeze {}
-  es6.object.get-own-property-descriptor {}
-  es7.object.get-own-property-descriptors {}
-  es6.object.get-own-property-names {}
-  es6.object.get-prototype-of {}
-  es7.object.lookup-getter {}
-  es7.object.lookup-setter {}
-  es6.object.prevent-extensions {}
-  es6.object.to-string {}
-  es6.object.is {}
-  es6.object.is-frozen {}
-  es6.object.is-sealed {}
-  es6.object.is-extensible {}
-  es6.object.keys {}
-  es6.object.seal {}
-  es6.object.set-prototype-of {}
-  es7.object.values {}
-  es6.promise {}
-  es7.promise.finally {}
-  es6.reflect.apply {}
-  es6.reflect.construct {}
-  es6.reflect.define-property {}
-  es6.reflect.delete-property {}
-  es6.reflect.get {}
-  es6.reflect.get-own-property-descriptor {}
-  es6.reflect.get-prototype-of {}
-  es6.reflect.has {}
-  es6.reflect.is-extensible {}
-  es6.reflect.own-keys {}
-  es6.reflect.prevent-extensions {}
-  es6.reflect.set {}
-  es6.reflect.set-prototype-of {}
-  es6.regexp.constructor {}
-  es6.regexp.flags {}
-  es6.regexp.match {}
-  es6.regexp.replace {}
-  es6.regexp.split {}
-  es6.regexp.search {}
-  es6.regexp.to-string {}
-  es6.set {}
-  es6.symbol {}
-  es7.symbol.async-iterator {}
-  es6.string.anchor {}
-  es6.string.big {}
-  es6.string.blink {}
-  es6.string.bold {}
-  es6.string.code-point-at {}
-  es6.string.ends-with {}
-  es6.string.fixed {}
-  es6.string.fontcolor {}
-  es6.string.fontsize {}
-  es6.string.from-code-point {}
-  es6.string.includes {}
-  es6.string.italics {}
-  es6.string.iterator {}
-  es6.string.link {}
-  es7.string.pad-start {}
-  es7.string.pad-end {}
-  es6.string.raw {}
-  es6.string.repeat {}
-  es6.string.small {}
-  es6.string.starts-with {}
-  es6.string.strike {}
-  es6.string.sub {}
-  es6.string.sup {}
-  es6.string.trim {}
-  es7.string.trim-left {}
-  es7.string.trim-right {}
-  es6.typed.array-buffer {}
-  es6.typed.data-view {}
-  es6.typed.int8-array {}
-  es6.typed.uint8-array {}
-  es6.typed.uint8-clamped-array {}
-  es6.typed.int16-array {}
-  es6.typed.uint16-array {}
-  es6.typed.int32-array {}
-  es6.typed.uint32-array {}
-  es6.typed.float32-array {}
-  es6.typed.float64-array {}
-  es6.weak-map {}
-  es6.weak-set {}
-  web.timers {}
-  web.immediate {}
-  web.dom.iterable {}
+  es6.array.copy-within { "ie":"6" }
+  es6.array.every { "ie":"6" }
+  es6.array.fill { "ie":"6" }
+  es6.array.filter { "ie":"6" }
+  es6.array.find { "ie":"6" }
+  es6.array.find-index { "ie":"6" }
+  es7.array.flat-map { "ie":"6" }
+  es6.array.for-each { "ie":"6" }
+  es6.array.from { "ie":"6" }
+  es7.array.includes { "ie":"6" }
+  es6.array.index-of { "ie":"6" }
+  es6.array.is-array { "ie":"6" }
+  es6.array.iterator { "ie":"6" }
+  es6.array.last-index-of { "ie":"6" }
+  es6.array.map { "ie":"6" }
+  es6.array.of { "ie":"6" }
+  es6.array.reduce { "ie":"6" }
+  es6.array.reduce-right { "ie":"6" }
+  es6.array.some { "ie":"6" }
+  es6.array.sort { "ie":"6" }
+  es6.array.species { "ie":"6" }
+  es6.date.now { "ie":"6" }
+  es6.date.to-iso-string { "ie":"6" }
+  es6.date.to-json { "ie":"6" }
+  es6.date.to-primitive { "ie":"6" }
+  es6.date.to-string { "ie":"6" }
+  es6.function.bind { "ie":"6" }
+  es6.function.has-instance { "ie":"6" }
+  es6.function.name { "ie":"6" }
+  es6.map { "ie":"6" }
+  es6.math.acosh { "ie":"6" }
+  es6.math.asinh { "ie":"6" }
+  es6.math.atanh { "ie":"6" }
+  es6.math.cbrt { "ie":"6" }
+  es6.math.clz32 { "ie":"6" }
+  es6.math.cosh { "ie":"6" }
+  es6.math.expm1 { "ie":"6" }
+  es6.math.fround { "ie":"6" }
+  es6.math.hypot { "ie":"6" }
+  es6.math.imul { "ie":"6" }
+  es6.math.log1p { "ie":"6" }
+  es6.math.log10 { "ie":"6" }
+  es6.math.log2 { "ie":"6" }
+  es6.math.sign { "ie":"6" }
+  es6.math.sinh { "ie":"6" }
+  es6.math.tanh { "ie":"6" }
+  es6.math.trunc { "ie":"6" }
+  es6.number.constructor { "ie":"6" }
+  es6.number.epsilon { "ie":"6" }
+  es6.number.is-finite { "ie":"6" }
+  es6.number.is-integer { "ie":"6" }
+  es6.number.is-nan { "ie":"6" }
+  es6.number.is-safe-integer { "ie":"6" }
+  es6.number.max-safe-integer { "ie":"6" }
+  es6.number.min-safe-integer { "ie":"6" }
+  es6.number.parse-float { "ie":"6" }
+  es6.number.parse-int { "ie":"6" }
+  es6.object.assign { "ie":"6" }
+  es6.object.create { "ie":"6" }
+  es7.object.define-getter { "ie":"6" }
+  es7.object.define-setter { "ie":"6" }
+  es6.object.define-property { "ie":"6" }
+  es6.object.define-properties { "ie":"6" }
+  es7.object.entries { "ie":"6" }
+  es6.object.freeze { "ie":"6" }
+  es6.object.get-own-property-descriptor { "ie":"6" }
+  es7.object.get-own-property-descriptors { "ie":"6" }
+  es6.object.get-own-property-names { "ie":"6" }
+  es6.object.get-prototype-of { "ie":"6" }
+  es7.object.lookup-getter { "ie":"6" }
+  es7.object.lookup-setter { "ie":"6" }
+  es6.object.prevent-extensions { "ie":"6" }
+  es6.object.to-string { "ie":"6" }
+  es6.object.is { "ie":"6" }
+  es6.object.is-frozen { "ie":"6" }
+  es6.object.is-sealed { "ie":"6" }
+  es6.object.is-extensible { "ie":"6" }
+  es6.object.keys { "ie":"6" }
+  es6.object.seal { "ie":"6" }
+  es6.object.set-prototype-of { "ie":"6" }
+  es7.object.values { "ie":"6" }
+  es6.promise { "ie":"6" }
+  es7.promise.finally { "ie":"6" }
+  es6.reflect.apply { "ie":"6" }
+  es6.reflect.construct { "ie":"6" }
+  es6.reflect.define-property { "ie":"6" }
+  es6.reflect.delete-property { "ie":"6" }
+  es6.reflect.get { "ie":"6" }
+  es6.reflect.get-own-property-descriptor { "ie":"6" }
+  es6.reflect.get-prototype-of { "ie":"6" }
+  es6.reflect.has { "ie":"6" }
+  es6.reflect.is-extensible { "ie":"6" }
+  es6.reflect.own-keys { "ie":"6" }
+  es6.reflect.prevent-extensions { "ie":"6" }
+  es6.reflect.set { "ie":"6" }
+  es6.reflect.set-prototype-of { "ie":"6" }
+  es6.regexp.constructor { "ie":"6" }
+  es6.regexp.flags { "ie":"6" }
+  es6.regexp.match { "ie":"6" }
+  es6.regexp.replace { "ie":"6" }
+  es6.regexp.split { "ie":"6" }
+  es6.regexp.search { "ie":"6" }
+  es6.regexp.to-string { "ie":"6" }
+  es6.set { "ie":"6" }
+  es6.symbol { "ie":"6" }
+  es7.symbol.async-iterator { "ie":"6" }
+  es6.string.anchor { "ie":"6" }
+  es6.string.big { "ie":"6" }
+  es6.string.blink { "ie":"6" }
+  es6.string.bold { "ie":"6" }
+  es6.string.code-point-at { "ie":"6" }
+  es6.string.ends-with { "ie":"6" }
+  es6.string.fixed { "ie":"6" }
+  es6.string.fontcolor { "ie":"6" }
+  es6.string.fontsize { "ie":"6" }
+  es6.string.from-code-point { "ie":"6" }
+  es6.string.includes { "ie":"6" }
+  es6.string.italics { "ie":"6" }
+  es6.string.iterator { "ie":"6" }
+  es6.string.link { "ie":"6" }
+  es7.string.pad-start { "ie":"6" }
+  es7.string.pad-end { "ie":"6" }
+  es6.string.raw { "ie":"6" }
+  es6.string.repeat { "ie":"6" }
+  es6.string.small { "ie":"6" }
+  es6.string.starts-with { "ie":"6" }
+  es6.string.strike { "ie":"6" }
+  es6.string.sub { "ie":"6" }
+  es6.string.sup { "ie":"6" }
+  es6.string.trim { "ie":"6" }
+  es7.string.trim-left { "ie":"6" }
+  es7.string.trim-right { "ie":"6" }
+  es6.typed.array-buffer { "ie":"6" }
+  es6.typed.data-view { "ie":"6" }
+  es6.typed.int8-array { "ie":"6" }
+  es6.typed.uint8-array { "ie":"6" }
+  es6.typed.uint8-clamped-array { "ie":"6" }
+  es6.typed.int16-array { "ie":"6" }
+  es6.typed.uint16-array { "ie":"6" }
+  es6.typed.int32-array { "ie":"6" }
+  es6.typed.uint32-array { "ie":"6" }
+  es6.typed.float32-array { "ie":"6" }
+  es6.typed.float64-array { "ie":"6" }
+  es6.weak-map { "ie":"6" }
+  es6.weak-set { "ie":"6" }
+  web.timers { "ie":"6" }
+  web.immediate { "ie":"6" }
+  web.dom.iterable { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/options.json
@@ -6,6 +6,7 @@
       "env",
       {
         "debug": true,
+        "targets": { "browsers": "ie 6" },
         "shippedProposals": true,
         "useBuiltIns": "entry",
         "corejs": 3

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
@@ -1,344 +1,345 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties {}
-  proposal-private-methods {}
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-class-properties { "ie":"6" }
+  proposal-private-methods { "ie":"6" }
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/input.mjs] Replaced core-js entries with the following polyfills:
-  es.symbol {}
-  es.symbol.description {}
-  es.symbol.async-iterator {}
-  es.symbol.has-instance {}
-  es.symbol.is-concat-spreadable {}
-  es.symbol.iterator {}
-  es.symbol.match {}
-  es.symbol.replace {}
-  es.symbol.search {}
-  es.symbol.species {}
-  es.symbol.split {}
-  es.symbol.to-primitive {}
-  es.symbol.to-string-tag {}
-  es.symbol.unscopables {}
-  es.array.concat {}
-  es.array.copy-within {}
-  es.array.every {}
-  es.array.fill {}
-  es.array.filter {}
-  es.array.find {}
-  es.array.find-index {}
-  es.array.flat {}
-  es.array.flat-map {}
-  es.array.for-each {}
-  es.array.from {}
-  es.array.includes {}
-  es.array.index-of {}
-  es.array.is-array {}
-  es.array.iterator {}
-  es.array.join {}
-  es.array.last-index-of {}
-  es.array.map {}
-  es.array.of {}
-  es.array.reduce {}
-  es.array.reduce-right {}
-  es.array.reverse {}
-  es.array.slice {}
-  es.array.some {}
-  es.array.sort {}
-  es.array.species {}
-  es.array.splice {}
-  es.array.unscopables.flat {}
-  es.array.unscopables.flat-map {}
-  es.array-buffer.constructor {}
-  es.array-buffer.is-view {}
-  es.array-buffer.slice {}
-  es.data-view {}
-  es.date.now {}
-  es.date.to-iso-string {}
-  es.date.to-json {}
-  es.date.to-primitive {}
-  es.date.to-string {}
-  es.function.bind {}
-  es.function.has-instance {}
-  es.function.name {}
-  es.json.to-string-tag {}
-  es.map {}
-  es.math.acosh {}
-  es.math.asinh {}
-  es.math.atanh {}
-  es.math.cbrt {}
-  es.math.clz32 {}
-  es.math.cosh {}
-  es.math.expm1 {}
-  es.math.fround {}
-  es.math.hypot {}
-  es.math.imul {}
-  es.math.log10 {}
-  es.math.log1p {}
-  es.math.log2 {}
-  es.math.sign {}
-  es.math.sinh {}
-  es.math.tanh {}
-  es.math.to-string-tag {}
-  es.math.trunc {}
-  es.number.constructor {}
-  es.number.epsilon {}
-  es.number.is-finite {}
-  es.number.is-integer {}
-  es.number.is-nan {}
-  es.number.is-safe-integer {}
-  es.number.max-safe-integer {}
-  es.number.min-safe-integer {}
-  es.number.parse-float {}
-  es.number.parse-int {}
-  es.number.to-fixed {}
-  es.number.to-precision {}
-  es.object.assign {}
-  es.object.create {}
-  es.object.define-getter {}
-  es.object.define-properties {}
-  es.object.define-property {}
-  es.object.define-setter {}
-  es.object.entries {}
-  es.object.freeze {}
-  es.object.from-entries {}
-  es.object.get-own-property-descriptor {}
-  es.object.get-own-property-descriptors {}
-  es.object.get-own-property-names {}
-  es.object.get-prototype-of {}
-  es.object.is {}
-  es.object.is-extensible {}
-  es.object.is-frozen {}
-  es.object.is-sealed {}
-  es.object.keys {}
-  es.object.lookup-getter {}
-  es.object.lookup-setter {}
-  es.object.prevent-extensions {}
-  es.object.seal {}
-  es.object.set-prototype-of {}
-  es.object.to-string {}
-  es.object.values {}
-  es.parse-float {}
-  es.parse-int {}
-  es.promise {}
-  es.promise.finally {}
-  es.reflect.apply {}
-  es.reflect.construct {}
-  es.reflect.define-property {}
-  es.reflect.delete-property {}
-  es.reflect.get {}
-  es.reflect.get-own-property-descriptor {}
-  es.reflect.get-prototype-of {}
-  es.reflect.has {}
-  es.reflect.is-extensible {}
-  es.reflect.own-keys {}
-  es.reflect.prevent-extensions {}
-  es.reflect.set {}
-  es.reflect.set-prototype-of {}
-  es.regexp.constructor {}
-  es.regexp.exec {}
-  es.regexp.flags {}
-  es.regexp.to-string {}
-  es.set {}
-  es.string.code-point-at {}
-  es.string.ends-with {}
-  es.string.from-code-point {}
-  es.string.includes {}
-  es.string.iterator {}
-  es.string.match {}
-  es.string.pad-end {}
-  es.string.pad-start {}
-  es.string.raw {}
-  es.string.repeat {}
-  es.string.replace {}
-  es.string.search {}
-  es.string.split {}
-  es.string.starts-with {}
-  es.string.trim {}
-  es.string.trim-end {}
-  es.string.trim-start {}
-  es.string.anchor {}
-  es.string.big {}
-  es.string.blink {}
-  es.string.bold {}
-  es.string.fixed {}
-  es.string.fontcolor {}
-  es.string.fontsize {}
-  es.string.italics {}
-  es.string.link {}
-  es.string.small {}
-  es.string.strike {}
-  es.string.sub {}
-  es.string.sup {}
-  es.typed-array.float32-array {}
-  es.typed-array.float64-array {}
-  es.typed-array.int8-array {}
-  es.typed-array.int16-array {}
-  es.typed-array.int32-array {}
-  es.typed-array.uint8-array {}
-  es.typed-array.uint8-clamped-array {}
-  es.typed-array.uint16-array {}
-  es.typed-array.uint32-array {}
-  es.typed-array.copy-within {}
-  es.typed-array.every {}
-  es.typed-array.fill {}
-  es.typed-array.filter {}
-  es.typed-array.find {}
-  es.typed-array.find-index {}
-  es.typed-array.for-each {}
-  es.typed-array.from {}
-  es.typed-array.includes {}
-  es.typed-array.index-of {}
-  es.typed-array.iterator {}
-  es.typed-array.join {}
-  es.typed-array.last-index-of {}
-  es.typed-array.map {}
-  es.typed-array.of {}
-  es.typed-array.reduce {}
-  es.typed-array.reduce-right {}
-  es.typed-array.reverse {}
-  es.typed-array.set {}
-  es.typed-array.slice {}
-  es.typed-array.some {}
-  es.typed-array.sort {}
-  es.typed-array.subarray {}
-  es.typed-array.to-locale-string {}
-  es.typed-array.to-string {}
-  es.weak-map {}
-  es.weak-set {}
-  esnext.aggregate-error {}
-  esnext.array.last-index {}
-  esnext.array.last-item {}
-  esnext.composite-key {}
-  esnext.composite-symbol {}
-  esnext.global-this {}
-  esnext.map.delete-all {}
-  esnext.map.every {}
-  esnext.map.filter {}
-  esnext.map.find {}
-  esnext.map.find-key {}
-  esnext.map.from {}
-  esnext.map.group-by {}
-  esnext.map.includes {}
-  esnext.map.key-by {}
-  esnext.map.key-of {}
-  esnext.map.map-keys {}
-  esnext.map.map-values {}
-  esnext.map.merge {}
-  esnext.map.of {}
-  esnext.map.reduce {}
-  esnext.map.some {}
-  esnext.map.update {}
-  esnext.math.clamp {}
-  esnext.math.deg-per-rad {}
-  esnext.math.degrees {}
-  esnext.math.fscale {}
-  esnext.math.iaddh {}
-  esnext.math.imulh {}
-  esnext.math.isubh {}
-  esnext.math.rad-per-deg {}
-  esnext.math.radians {}
-  esnext.math.scale {}
-  esnext.math.seeded-prng {}
-  esnext.math.signbit {}
-  esnext.math.umulh {}
-  esnext.number.from-string {}
-  esnext.observable {}
-  esnext.promise.all-settled {}
-  esnext.promise.any {}
-  esnext.promise.try {}
-  esnext.reflect.define-metadata {}
-  esnext.reflect.delete-metadata {}
-  esnext.reflect.get-metadata {}
-  esnext.reflect.get-metadata-keys {}
-  esnext.reflect.get-own-metadata {}
-  esnext.reflect.get-own-metadata-keys {}
-  esnext.reflect.has-metadata {}
-  esnext.reflect.has-own-metadata {}
-  esnext.reflect.metadata {}
-  esnext.set.add-all {}
-  esnext.set.delete-all {}
-  esnext.set.difference {}
-  esnext.set.every {}
-  esnext.set.filter {}
-  esnext.set.find {}
-  esnext.set.from {}
-  esnext.set.intersection {}
-  esnext.set.is-disjoint-from {}
-  esnext.set.is-subset-of {}
-  esnext.set.is-superset-of {}
-  esnext.set.join {}
-  esnext.set.map {}
-  esnext.set.of {}
-  esnext.set.reduce {}
-  esnext.set.some {}
-  esnext.set.symmetric-difference {}
-  esnext.set.union {}
-  esnext.string.at {}
-  esnext.string.code-points {}
-  esnext.string.match-all {}
-  esnext.string.replace-all {}
-  esnext.symbol.dispose {}
-  esnext.symbol.observable {}
-  esnext.symbol.pattern-match {}
-  esnext.weak-map.delete-all {}
-  esnext.weak-map.from {}
-  esnext.weak-map.of {}
-  esnext.weak-set.add-all {}
-  esnext.weak-set.delete-all {}
-  esnext.weak-set.from {}
-  esnext.weak-set.of {}
-  web.dom-collections.for-each {}
-  web.dom-collections.iterator {}
-  web.immediate {}
-  web.queue-microtask {}
-  web.timers {}
-  web.url {}
-  web.url.to-json {}
-  web.url-search-params {}
+  es.symbol { "ie":"6" }
+  es.symbol.description { "ie":"6" }
+  es.symbol.async-iterator { "ie":"6" }
+  es.symbol.has-instance { "ie":"6" }
+  es.symbol.is-concat-spreadable { "ie":"6" }
+  es.symbol.iterator { "ie":"6" }
+  es.symbol.match { "ie":"6" }
+  es.symbol.replace { "ie":"6" }
+  es.symbol.search { "ie":"6" }
+  es.symbol.species { "ie":"6" }
+  es.symbol.split { "ie":"6" }
+  es.symbol.to-primitive { "ie":"6" }
+  es.symbol.to-string-tag { "ie":"6" }
+  es.symbol.unscopables { "ie":"6" }
+  es.array.concat { "ie":"6" }
+  es.array.copy-within { "ie":"6" }
+  es.array.every { "ie":"6" }
+  es.array.fill { "ie":"6" }
+  es.array.filter { "ie":"6" }
+  es.array.find { "ie":"6" }
+  es.array.find-index { "ie":"6" }
+  es.array.flat { "ie":"6" }
+  es.array.flat-map { "ie":"6" }
+  es.array.for-each { "ie":"6" }
+  es.array.from { "ie":"6" }
+  es.array.includes { "ie":"6" }
+  es.array.index-of { "ie":"6" }
+  es.array.is-array { "ie":"6" }
+  es.array.iterator { "ie":"6" }
+  es.array.join { "ie":"6" }
+  es.array.last-index-of { "ie":"6" }
+  es.array.map { "ie":"6" }
+  es.array.of { "ie":"6" }
+  es.array.reduce { "ie":"6" }
+  es.array.reduce-right { "ie":"6" }
+  es.array.slice { "ie":"6" }
+  es.array.some { "ie":"6" }
+  es.array.sort { "ie":"6" }
+  es.array.species { "ie":"6" }
+  es.array.splice { "ie":"6" }
+  es.array.unscopables.flat { "ie":"6" }
+  es.array.unscopables.flat-map { "ie":"6" }
+  es.array-buffer.constructor { "ie":"6" }
+  es.array-buffer.is-view { "ie":"6" }
+  es.array-buffer.slice { "ie":"6" }
+  es.data-view { "ie":"6" }
+  es.date.now { "ie":"6" }
+  es.date.to-iso-string { "ie":"6" }
+  es.date.to-json { "ie":"6" }
+  es.date.to-primitive { "ie":"6" }
+  es.date.to-string { "ie":"6" }
+  es.function.bind { "ie":"6" }
+  es.function.has-instance { "ie":"6" }
+  es.function.name { "ie":"6" }
+  es.json.to-string-tag { "ie":"6" }
+  es.map { "ie":"6" }
+  es.math.acosh { "ie":"6" }
+  es.math.asinh { "ie":"6" }
+  es.math.atanh { "ie":"6" }
+  es.math.cbrt { "ie":"6" }
+  es.math.clz32 { "ie":"6" }
+  es.math.cosh { "ie":"6" }
+  es.math.expm1 { "ie":"6" }
+  es.math.fround { "ie":"6" }
+  es.math.hypot { "ie":"6" }
+  es.math.imul { "ie":"6" }
+  es.math.log10 { "ie":"6" }
+  es.math.log1p { "ie":"6" }
+  es.math.log2 { "ie":"6" }
+  es.math.sign { "ie":"6" }
+  es.math.sinh { "ie":"6" }
+  es.math.tanh { "ie":"6" }
+  es.math.to-string-tag { "ie":"6" }
+  es.math.trunc { "ie":"6" }
+  es.number.constructor { "ie":"6" }
+  es.number.epsilon { "ie":"6" }
+  es.number.is-finite { "ie":"6" }
+  es.number.is-integer { "ie":"6" }
+  es.number.is-nan { "ie":"6" }
+  es.number.is-safe-integer { "ie":"6" }
+  es.number.max-safe-integer { "ie":"6" }
+  es.number.min-safe-integer { "ie":"6" }
+  es.number.parse-float { "ie":"6" }
+  es.number.parse-int { "ie":"6" }
+  es.number.to-fixed { "ie":"6" }
+  es.number.to-precision { "ie":"6" }
+  es.object.assign { "ie":"6" }
+  es.object.create { "ie":"6" }
+  es.object.define-getter { "ie":"6" }
+  es.object.define-properties { "ie":"6" }
+  es.object.define-property { "ie":"6" }
+  es.object.define-setter { "ie":"6" }
+  es.object.entries { "ie":"6" }
+  es.object.freeze { "ie":"6" }
+  es.object.from-entries { "ie":"6" }
+  es.object.get-own-property-descriptor { "ie":"6" }
+  es.object.get-own-property-descriptors { "ie":"6" }
+  es.object.get-own-property-names { "ie":"6" }
+  es.object.get-prototype-of { "ie":"6" }
+  es.object.is { "ie":"6" }
+  es.object.is-extensible { "ie":"6" }
+  es.object.is-frozen { "ie":"6" }
+  es.object.is-sealed { "ie":"6" }
+  es.object.keys { "ie":"6" }
+  es.object.lookup-getter { "ie":"6" }
+  es.object.lookup-setter { "ie":"6" }
+  es.object.prevent-extensions { "ie":"6" }
+  es.object.seal { "ie":"6" }
+  es.object.set-prototype-of { "ie":"6" }
+  es.object.to-string { "ie":"6" }
+  es.object.values { "ie":"6" }
+  es.parse-float { "ie":"6" }
+  es.parse-int { "ie":"6" }
+  es.promise { "ie":"6" }
+  es.promise.finally { "ie":"6" }
+  es.reflect.apply { "ie":"6" }
+  es.reflect.construct { "ie":"6" }
+  es.reflect.define-property { "ie":"6" }
+  es.reflect.delete-property { "ie":"6" }
+  es.reflect.get { "ie":"6" }
+  es.reflect.get-own-property-descriptor { "ie":"6" }
+  es.reflect.get-prototype-of { "ie":"6" }
+  es.reflect.has { "ie":"6" }
+  es.reflect.is-extensible { "ie":"6" }
+  es.reflect.own-keys { "ie":"6" }
+  es.reflect.prevent-extensions { "ie":"6" }
+  es.reflect.set { "ie":"6" }
+  es.reflect.set-prototype-of { "ie":"6" }
+  es.regexp.constructor { "ie":"6" }
+  es.regexp.exec { "ie":"6" }
+  es.regexp.flags { "ie":"6" }
+  es.regexp.to-string { "ie":"6" }
+  es.set { "ie":"6" }
+  es.string.code-point-at { "ie":"6" }
+  es.string.ends-with { "ie":"6" }
+  es.string.from-code-point { "ie":"6" }
+  es.string.includes { "ie":"6" }
+  es.string.iterator { "ie":"6" }
+  es.string.match { "ie":"6" }
+  es.string.pad-end { "ie":"6" }
+  es.string.pad-start { "ie":"6" }
+  es.string.raw { "ie":"6" }
+  es.string.repeat { "ie":"6" }
+  es.string.replace { "ie":"6" }
+  es.string.search { "ie":"6" }
+  es.string.split { "ie":"6" }
+  es.string.starts-with { "ie":"6" }
+  es.string.trim { "ie":"6" }
+  es.string.trim-end { "ie":"6" }
+  es.string.trim-start { "ie":"6" }
+  es.string.anchor { "ie":"6" }
+  es.string.big { "ie":"6" }
+  es.string.blink { "ie":"6" }
+  es.string.bold { "ie":"6" }
+  es.string.fixed { "ie":"6" }
+  es.string.fontcolor { "ie":"6" }
+  es.string.fontsize { "ie":"6" }
+  es.string.italics { "ie":"6" }
+  es.string.link { "ie":"6" }
+  es.string.small { "ie":"6" }
+  es.string.strike { "ie":"6" }
+  es.string.sub { "ie":"6" }
+  es.string.sup { "ie":"6" }
+  es.typed-array.float32-array { "ie":"6" }
+  es.typed-array.float64-array { "ie":"6" }
+  es.typed-array.int8-array { "ie":"6" }
+  es.typed-array.int16-array { "ie":"6" }
+  es.typed-array.int32-array { "ie":"6" }
+  es.typed-array.uint8-array { "ie":"6" }
+  es.typed-array.uint8-clamped-array { "ie":"6" }
+  es.typed-array.uint16-array { "ie":"6" }
+  es.typed-array.uint32-array { "ie":"6" }
+  es.typed-array.copy-within { "ie":"6" }
+  es.typed-array.every { "ie":"6" }
+  es.typed-array.fill { "ie":"6" }
+  es.typed-array.filter { "ie":"6" }
+  es.typed-array.find { "ie":"6" }
+  es.typed-array.find-index { "ie":"6" }
+  es.typed-array.for-each { "ie":"6" }
+  es.typed-array.from { "ie":"6" }
+  es.typed-array.includes { "ie":"6" }
+  es.typed-array.index-of { "ie":"6" }
+  es.typed-array.iterator { "ie":"6" }
+  es.typed-array.join { "ie":"6" }
+  es.typed-array.last-index-of { "ie":"6" }
+  es.typed-array.map { "ie":"6" }
+  es.typed-array.of { "ie":"6" }
+  es.typed-array.reduce { "ie":"6" }
+  es.typed-array.reduce-right { "ie":"6" }
+  es.typed-array.reverse { "ie":"6" }
+  es.typed-array.set { "ie":"6" }
+  es.typed-array.slice { "ie":"6" }
+  es.typed-array.some { "ie":"6" }
+  es.typed-array.sort { "ie":"6" }
+  es.typed-array.subarray { "ie":"6" }
+  es.typed-array.to-locale-string { "ie":"6" }
+  es.typed-array.to-string { "ie":"6" }
+  es.weak-map { "ie":"6" }
+  es.weak-set { "ie":"6" }
+  esnext.aggregate-error { "ie":"6" }
+  esnext.array.last-index { "ie":"6" }
+  esnext.array.last-item { "ie":"6" }
+  esnext.composite-key { "ie":"6" }
+  esnext.composite-symbol { "ie":"6" }
+  esnext.global-this { "ie":"6" }
+  esnext.map.delete-all { "ie":"6" }
+  esnext.map.every { "ie":"6" }
+  esnext.map.filter { "ie":"6" }
+  esnext.map.find { "ie":"6" }
+  esnext.map.find-key { "ie":"6" }
+  esnext.map.from { "ie":"6" }
+  esnext.map.group-by { "ie":"6" }
+  esnext.map.includes { "ie":"6" }
+  esnext.map.key-by { "ie":"6" }
+  esnext.map.key-of { "ie":"6" }
+  esnext.map.map-keys { "ie":"6" }
+  esnext.map.map-values { "ie":"6" }
+  esnext.map.merge { "ie":"6" }
+  esnext.map.of { "ie":"6" }
+  esnext.map.reduce { "ie":"6" }
+  esnext.map.some { "ie":"6" }
+  esnext.map.update { "ie":"6" }
+  esnext.math.clamp { "ie":"6" }
+  esnext.math.deg-per-rad { "ie":"6" }
+  esnext.math.degrees { "ie":"6" }
+  esnext.math.fscale { "ie":"6" }
+  esnext.math.iaddh { "ie":"6" }
+  esnext.math.imulh { "ie":"6" }
+  esnext.math.isubh { "ie":"6" }
+  esnext.math.rad-per-deg { "ie":"6" }
+  esnext.math.radians { "ie":"6" }
+  esnext.math.scale { "ie":"6" }
+  esnext.math.seeded-prng { "ie":"6" }
+  esnext.math.signbit { "ie":"6" }
+  esnext.math.umulh { "ie":"6" }
+  esnext.number.from-string { "ie":"6" }
+  esnext.observable { "ie":"6" }
+  esnext.promise.all-settled { "ie":"6" }
+  esnext.promise.any { "ie":"6" }
+  esnext.promise.try { "ie":"6" }
+  esnext.reflect.define-metadata { "ie":"6" }
+  esnext.reflect.delete-metadata { "ie":"6" }
+  esnext.reflect.get-metadata { "ie":"6" }
+  esnext.reflect.get-metadata-keys { "ie":"6" }
+  esnext.reflect.get-own-metadata { "ie":"6" }
+  esnext.reflect.get-own-metadata-keys { "ie":"6" }
+  esnext.reflect.has-metadata { "ie":"6" }
+  esnext.reflect.has-own-metadata { "ie":"6" }
+  esnext.reflect.metadata { "ie":"6" }
+  esnext.set.add-all { "ie":"6" }
+  esnext.set.delete-all { "ie":"6" }
+  esnext.set.difference { "ie":"6" }
+  esnext.set.every { "ie":"6" }
+  esnext.set.filter { "ie":"6" }
+  esnext.set.find { "ie":"6" }
+  esnext.set.from { "ie":"6" }
+  esnext.set.intersection { "ie":"6" }
+  esnext.set.is-disjoint-from { "ie":"6" }
+  esnext.set.is-subset-of { "ie":"6" }
+  esnext.set.is-superset-of { "ie":"6" }
+  esnext.set.join { "ie":"6" }
+  esnext.set.map { "ie":"6" }
+  esnext.set.of { "ie":"6" }
+  esnext.set.reduce { "ie":"6" }
+  esnext.set.some { "ie":"6" }
+  esnext.set.symmetric-difference { "ie":"6" }
+  esnext.set.union { "ie":"6" }
+  esnext.string.at { "ie":"6" }
+  esnext.string.code-points { "ie":"6" }
+  esnext.string.match-all { "ie":"6" }
+  esnext.string.replace-all { "ie":"6" }
+  esnext.symbol.dispose { "ie":"6" }
+  esnext.symbol.observable { "ie":"6" }
+  esnext.symbol.pattern-match { "ie":"6" }
+  esnext.weak-map.delete-all { "ie":"6" }
+  esnext.weak-map.from { "ie":"6" }
+  esnext.weak-map.of { "ie":"6" }
+  esnext.weak-set.add-all { "ie":"6" }
+  esnext.weak-set.delete-all { "ie":"6" }
+  esnext.weak-set.from { "ie":"6" }
+  esnext.weak-set.of { "ie":"6" }
+  web.dom-collections.for-each { "ie":"6" }
+  web.dom-collections.iterator { "ie":"6" }
+  web.immediate { "ie":"6" }
+  web.queue-microtask { "ie":"6" }
+  web.timers { "ie":"6" }
+  web.url { "ie":"6" }
+  web.url.to-json { "ie":"6" }
+  web.url-search-params { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/options.json
@@ -6,6 +6,7 @@
       "env",
       {
         "debug": true,
+        "targets": { "browsers": "ie 6" },
         "shippedProposals": true,
         "useBuiltIns": "entry",
         "corejs": 3

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
@@ -1,53 +1,55 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties {}
-  proposal-private-methods {}
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-class-properties { "ie":"6" }
+  proposal-private-methods { "ie":"6" }
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/options.json
@@ -6,6 +6,7 @@
       "env",
       {
         "debug": true,
+        "targets": { "browsers": "ie 6" },
         "shippedProposals": true,
         "useBuiltIns": "entry",
         "corejs": 3

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
@@ -1,339 +1,340 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties {}
-  proposal-private-methods {}
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-class-properties { "ie":"6" }
+  proposal-private-methods { "ie":"6" }
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/input.mjs] Replaced core-js entries with the following polyfills:
-  es.symbol {}
-  es.symbol.description {}
-  es.symbol.async-iterator {}
-  es.symbol.has-instance {}
-  es.symbol.is-concat-spreadable {}
-  es.symbol.iterator {}
-  es.symbol.match {}
-  es.symbol.replace {}
-  es.symbol.search {}
-  es.symbol.species {}
-  es.symbol.split {}
-  es.symbol.to-primitive {}
-  es.symbol.to-string-tag {}
-  es.symbol.unscopables {}
-  es.array.concat {}
-  es.array.copy-within {}
-  es.array.every {}
-  es.array.fill {}
-  es.array.filter {}
-  es.array.find {}
-  es.array.find-index {}
-  es.array.flat {}
-  es.array.flat-map {}
-  es.array.for-each {}
-  es.array.from {}
-  es.array.includes {}
-  es.array.index-of {}
-  es.array.is-array {}
-  es.array.iterator {}
-  es.array.join {}
-  es.array.last-index-of {}
-  es.array.map {}
-  es.array.of {}
-  es.array.reduce {}
-  es.array.reduce-right {}
-  es.array.reverse {}
-  es.array.slice {}
-  es.array.some {}
-  es.array.sort {}
-  es.array.species {}
-  es.array.splice {}
-  es.array.unscopables.flat {}
-  es.array.unscopables.flat-map {}
-  es.array-buffer.constructor {}
-  es.array-buffer.is-view {}
-  es.array-buffer.slice {}
-  es.data-view {}
-  es.date.now {}
-  es.date.to-iso-string {}
-  es.date.to-json {}
-  es.date.to-primitive {}
-  es.date.to-string {}
-  es.function.bind {}
-  es.function.has-instance {}
-  es.function.name {}
-  es.json.to-string-tag {}
-  es.map {}
-  es.math.acosh {}
-  es.math.asinh {}
-  es.math.atanh {}
-  es.math.cbrt {}
-  es.math.clz32 {}
-  es.math.cosh {}
-  es.math.expm1 {}
-  es.math.fround {}
-  es.math.hypot {}
-  es.math.imul {}
-  es.math.log10 {}
-  es.math.log1p {}
-  es.math.log2 {}
-  es.math.sign {}
-  es.math.sinh {}
-  es.math.tanh {}
-  es.math.to-string-tag {}
-  es.math.trunc {}
-  es.number.constructor {}
-  es.number.epsilon {}
-  es.number.is-finite {}
-  es.number.is-integer {}
-  es.number.is-nan {}
-  es.number.is-safe-integer {}
-  es.number.max-safe-integer {}
-  es.number.min-safe-integer {}
-  es.number.parse-float {}
-  es.number.parse-int {}
-  es.number.to-fixed {}
-  es.number.to-precision {}
-  es.object.assign {}
-  es.object.create {}
-  es.object.define-getter {}
-  es.object.define-properties {}
-  es.object.define-property {}
-  es.object.define-setter {}
-  es.object.entries {}
-  es.object.freeze {}
-  es.object.from-entries {}
-  es.object.get-own-property-descriptor {}
-  es.object.get-own-property-descriptors {}
-  es.object.get-own-property-names {}
-  es.object.get-prototype-of {}
-  es.object.is {}
-  es.object.is-extensible {}
-  es.object.is-frozen {}
-  es.object.is-sealed {}
-  es.object.keys {}
-  es.object.lookup-getter {}
-  es.object.lookup-setter {}
-  es.object.prevent-extensions {}
-  es.object.seal {}
-  es.object.set-prototype-of {}
-  es.object.to-string {}
-  es.object.values {}
-  es.parse-float {}
-  es.parse-int {}
-  es.promise {}
-  es.promise.finally {}
-  es.reflect.apply {}
-  es.reflect.construct {}
-  es.reflect.define-property {}
-  es.reflect.delete-property {}
-  es.reflect.get {}
-  es.reflect.get-own-property-descriptor {}
-  es.reflect.get-prototype-of {}
-  es.reflect.has {}
-  es.reflect.is-extensible {}
-  es.reflect.own-keys {}
-  es.reflect.prevent-extensions {}
-  es.reflect.set {}
-  es.reflect.set-prototype-of {}
-  es.regexp.constructor {}
-  es.regexp.exec {}
-  es.regexp.flags {}
-  es.regexp.to-string {}
-  es.set {}
-  es.string.code-point-at {}
-  es.string.ends-with {}
-  es.string.from-code-point {}
-  es.string.includes {}
-  es.string.iterator {}
-  es.string.match {}
-  es.string.pad-end {}
-  es.string.pad-start {}
-  es.string.raw {}
-  es.string.repeat {}
-  es.string.replace {}
-  es.string.search {}
-  es.string.split {}
-  es.string.starts-with {}
-  es.string.trim {}
-  es.string.trim-end {}
-  es.string.trim-start {}
-  es.string.anchor {}
-  es.string.big {}
-  es.string.blink {}
-  es.string.bold {}
-  es.string.fixed {}
-  es.string.fontcolor {}
-  es.string.fontsize {}
-  es.string.italics {}
-  es.string.link {}
-  es.string.small {}
-  es.string.strike {}
-  es.string.sub {}
-  es.string.sup {}
-  es.typed-array.float32-array {}
-  es.typed-array.float64-array {}
-  es.typed-array.int8-array {}
-  es.typed-array.int16-array {}
-  es.typed-array.int32-array {}
-  es.typed-array.uint8-array {}
-  es.typed-array.uint8-clamped-array {}
-  es.typed-array.uint16-array {}
-  es.typed-array.uint32-array {}
-  es.typed-array.copy-within {}
-  es.typed-array.every {}
-  es.typed-array.fill {}
-  es.typed-array.filter {}
-  es.typed-array.find {}
-  es.typed-array.find-index {}
-  es.typed-array.for-each {}
-  es.typed-array.from {}
-  es.typed-array.includes {}
-  es.typed-array.index-of {}
-  es.typed-array.iterator {}
-  es.typed-array.join {}
-  es.typed-array.last-index-of {}
-  es.typed-array.map {}
-  es.typed-array.of {}
-  es.typed-array.reduce {}
-  es.typed-array.reduce-right {}
-  es.typed-array.reverse {}
-  es.typed-array.set {}
-  es.typed-array.slice {}
-  es.typed-array.some {}
-  es.typed-array.sort {}
-  es.typed-array.subarray {}
-  es.typed-array.to-locale-string {}
-  es.typed-array.to-string {}
-  es.weak-map {}
-  es.weak-set {}
-  esnext.aggregate-error {}
-  esnext.array.last-index {}
-  esnext.array.last-item {}
-  esnext.composite-key {}
-  esnext.composite-symbol {}
-  esnext.global-this {}
-  esnext.map.delete-all {}
-  esnext.map.every {}
-  esnext.map.filter {}
-  esnext.map.find {}
-  esnext.map.find-key {}
-  esnext.map.from {}
-  esnext.map.group-by {}
-  esnext.map.includes {}
-  esnext.map.key-by {}
-  esnext.map.key-of {}
-  esnext.map.map-keys {}
-  esnext.map.map-values {}
-  esnext.map.merge {}
-  esnext.map.of {}
-  esnext.map.reduce {}
-  esnext.map.some {}
-  esnext.map.update {}
-  esnext.math.clamp {}
-  esnext.math.deg-per-rad {}
-  esnext.math.degrees {}
-  esnext.math.fscale {}
-  esnext.math.iaddh {}
-  esnext.math.imulh {}
-  esnext.math.isubh {}
-  esnext.math.rad-per-deg {}
-  esnext.math.radians {}
-  esnext.math.scale {}
-  esnext.math.seeded-prng {}
-  esnext.math.signbit {}
-  esnext.math.umulh {}
-  esnext.number.from-string {}
-  esnext.observable {}
-  esnext.promise.all-settled {}
-  esnext.promise.any {}
-  esnext.promise.try {}
-  esnext.reflect.define-metadata {}
-  esnext.reflect.delete-metadata {}
-  esnext.reflect.get-metadata {}
-  esnext.reflect.get-metadata-keys {}
-  esnext.reflect.get-own-metadata {}
-  esnext.reflect.get-own-metadata-keys {}
-  esnext.reflect.has-metadata {}
-  esnext.reflect.has-own-metadata {}
-  esnext.reflect.metadata {}
-  esnext.set.add-all {}
-  esnext.set.delete-all {}
-  esnext.set.difference {}
-  esnext.set.every {}
-  esnext.set.filter {}
-  esnext.set.find {}
-  esnext.set.from {}
-  esnext.set.intersection {}
-  esnext.set.is-disjoint-from {}
-  esnext.set.is-subset-of {}
-  esnext.set.is-superset-of {}
-  esnext.set.join {}
-  esnext.set.map {}
-  esnext.set.of {}
-  esnext.set.reduce {}
-  esnext.set.some {}
-  esnext.set.symmetric-difference {}
-  esnext.set.union {}
-  esnext.string.at {}
-  esnext.string.code-points {}
-  esnext.string.match-all {}
-  esnext.string.replace-all {}
-  esnext.symbol.dispose {}
-  esnext.symbol.observable {}
-  esnext.symbol.pattern-match {}
-  esnext.weak-map.delete-all {}
-  esnext.weak-map.from {}
-  esnext.weak-map.of {}
-  esnext.weak-set.add-all {}
-  esnext.weak-set.delete-all {}
-  esnext.weak-set.from {}
-  esnext.weak-set.of {}
-  web.url {}
-  web.url.to-json {}
-  web.url-search-params {}
+  es.symbol { "ie":"6" }
+  es.symbol.description { "ie":"6" }
+  es.symbol.async-iterator { "ie":"6" }
+  es.symbol.has-instance { "ie":"6" }
+  es.symbol.is-concat-spreadable { "ie":"6" }
+  es.symbol.iterator { "ie":"6" }
+  es.symbol.match { "ie":"6" }
+  es.symbol.replace { "ie":"6" }
+  es.symbol.search { "ie":"6" }
+  es.symbol.species { "ie":"6" }
+  es.symbol.split { "ie":"6" }
+  es.symbol.to-primitive { "ie":"6" }
+  es.symbol.to-string-tag { "ie":"6" }
+  es.symbol.unscopables { "ie":"6" }
+  es.array.concat { "ie":"6" }
+  es.array.copy-within { "ie":"6" }
+  es.array.every { "ie":"6" }
+  es.array.fill { "ie":"6" }
+  es.array.filter { "ie":"6" }
+  es.array.find { "ie":"6" }
+  es.array.find-index { "ie":"6" }
+  es.array.flat { "ie":"6" }
+  es.array.flat-map { "ie":"6" }
+  es.array.for-each { "ie":"6" }
+  es.array.from { "ie":"6" }
+  es.array.includes { "ie":"6" }
+  es.array.index-of { "ie":"6" }
+  es.array.is-array { "ie":"6" }
+  es.array.iterator { "ie":"6" }
+  es.array.join { "ie":"6" }
+  es.array.last-index-of { "ie":"6" }
+  es.array.map { "ie":"6" }
+  es.array.of { "ie":"6" }
+  es.array.reduce { "ie":"6" }
+  es.array.reduce-right { "ie":"6" }
+  es.array.slice { "ie":"6" }
+  es.array.some { "ie":"6" }
+  es.array.sort { "ie":"6" }
+  es.array.species { "ie":"6" }
+  es.array.splice { "ie":"6" }
+  es.array.unscopables.flat { "ie":"6" }
+  es.array.unscopables.flat-map { "ie":"6" }
+  es.array-buffer.constructor { "ie":"6" }
+  es.array-buffer.is-view { "ie":"6" }
+  es.array-buffer.slice { "ie":"6" }
+  es.data-view { "ie":"6" }
+  es.date.now { "ie":"6" }
+  es.date.to-iso-string { "ie":"6" }
+  es.date.to-json { "ie":"6" }
+  es.date.to-primitive { "ie":"6" }
+  es.date.to-string { "ie":"6" }
+  es.function.bind { "ie":"6" }
+  es.function.has-instance { "ie":"6" }
+  es.function.name { "ie":"6" }
+  es.json.to-string-tag { "ie":"6" }
+  es.map { "ie":"6" }
+  es.math.acosh { "ie":"6" }
+  es.math.asinh { "ie":"6" }
+  es.math.atanh { "ie":"6" }
+  es.math.cbrt { "ie":"6" }
+  es.math.clz32 { "ie":"6" }
+  es.math.cosh { "ie":"6" }
+  es.math.expm1 { "ie":"6" }
+  es.math.fround { "ie":"6" }
+  es.math.hypot { "ie":"6" }
+  es.math.imul { "ie":"6" }
+  es.math.log10 { "ie":"6" }
+  es.math.log1p { "ie":"6" }
+  es.math.log2 { "ie":"6" }
+  es.math.sign { "ie":"6" }
+  es.math.sinh { "ie":"6" }
+  es.math.tanh { "ie":"6" }
+  es.math.to-string-tag { "ie":"6" }
+  es.math.trunc { "ie":"6" }
+  es.number.constructor { "ie":"6" }
+  es.number.epsilon { "ie":"6" }
+  es.number.is-finite { "ie":"6" }
+  es.number.is-integer { "ie":"6" }
+  es.number.is-nan { "ie":"6" }
+  es.number.is-safe-integer { "ie":"6" }
+  es.number.max-safe-integer { "ie":"6" }
+  es.number.min-safe-integer { "ie":"6" }
+  es.number.parse-float { "ie":"6" }
+  es.number.parse-int { "ie":"6" }
+  es.number.to-fixed { "ie":"6" }
+  es.number.to-precision { "ie":"6" }
+  es.object.assign { "ie":"6" }
+  es.object.create { "ie":"6" }
+  es.object.define-getter { "ie":"6" }
+  es.object.define-properties { "ie":"6" }
+  es.object.define-property { "ie":"6" }
+  es.object.define-setter { "ie":"6" }
+  es.object.entries { "ie":"6" }
+  es.object.freeze { "ie":"6" }
+  es.object.from-entries { "ie":"6" }
+  es.object.get-own-property-descriptor { "ie":"6" }
+  es.object.get-own-property-descriptors { "ie":"6" }
+  es.object.get-own-property-names { "ie":"6" }
+  es.object.get-prototype-of { "ie":"6" }
+  es.object.is { "ie":"6" }
+  es.object.is-extensible { "ie":"6" }
+  es.object.is-frozen { "ie":"6" }
+  es.object.is-sealed { "ie":"6" }
+  es.object.keys { "ie":"6" }
+  es.object.lookup-getter { "ie":"6" }
+  es.object.lookup-setter { "ie":"6" }
+  es.object.prevent-extensions { "ie":"6" }
+  es.object.seal { "ie":"6" }
+  es.object.set-prototype-of { "ie":"6" }
+  es.object.to-string { "ie":"6" }
+  es.object.values { "ie":"6" }
+  es.parse-float { "ie":"6" }
+  es.parse-int { "ie":"6" }
+  es.promise { "ie":"6" }
+  es.promise.finally { "ie":"6" }
+  es.reflect.apply { "ie":"6" }
+  es.reflect.construct { "ie":"6" }
+  es.reflect.define-property { "ie":"6" }
+  es.reflect.delete-property { "ie":"6" }
+  es.reflect.get { "ie":"6" }
+  es.reflect.get-own-property-descriptor { "ie":"6" }
+  es.reflect.get-prototype-of { "ie":"6" }
+  es.reflect.has { "ie":"6" }
+  es.reflect.is-extensible { "ie":"6" }
+  es.reflect.own-keys { "ie":"6" }
+  es.reflect.prevent-extensions { "ie":"6" }
+  es.reflect.set { "ie":"6" }
+  es.reflect.set-prototype-of { "ie":"6" }
+  es.regexp.constructor { "ie":"6" }
+  es.regexp.exec { "ie":"6" }
+  es.regexp.flags { "ie":"6" }
+  es.regexp.to-string { "ie":"6" }
+  es.set { "ie":"6" }
+  es.string.code-point-at { "ie":"6" }
+  es.string.ends-with { "ie":"6" }
+  es.string.from-code-point { "ie":"6" }
+  es.string.includes { "ie":"6" }
+  es.string.iterator { "ie":"6" }
+  es.string.match { "ie":"6" }
+  es.string.pad-end { "ie":"6" }
+  es.string.pad-start { "ie":"6" }
+  es.string.raw { "ie":"6" }
+  es.string.repeat { "ie":"6" }
+  es.string.replace { "ie":"6" }
+  es.string.search { "ie":"6" }
+  es.string.split { "ie":"6" }
+  es.string.starts-with { "ie":"6" }
+  es.string.trim { "ie":"6" }
+  es.string.trim-end { "ie":"6" }
+  es.string.trim-start { "ie":"6" }
+  es.string.anchor { "ie":"6" }
+  es.string.big { "ie":"6" }
+  es.string.blink { "ie":"6" }
+  es.string.bold { "ie":"6" }
+  es.string.fixed { "ie":"6" }
+  es.string.fontcolor { "ie":"6" }
+  es.string.fontsize { "ie":"6" }
+  es.string.italics { "ie":"6" }
+  es.string.link { "ie":"6" }
+  es.string.small { "ie":"6" }
+  es.string.strike { "ie":"6" }
+  es.string.sub { "ie":"6" }
+  es.string.sup { "ie":"6" }
+  es.typed-array.float32-array { "ie":"6" }
+  es.typed-array.float64-array { "ie":"6" }
+  es.typed-array.int8-array { "ie":"6" }
+  es.typed-array.int16-array { "ie":"6" }
+  es.typed-array.int32-array { "ie":"6" }
+  es.typed-array.uint8-array { "ie":"6" }
+  es.typed-array.uint8-clamped-array { "ie":"6" }
+  es.typed-array.uint16-array { "ie":"6" }
+  es.typed-array.uint32-array { "ie":"6" }
+  es.typed-array.copy-within { "ie":"6" }
+  es.typed-array.every { "ie":"6" }
+  es.typed-array.fill { "ie":"6" }
+  es.typed-array.filter { "ie":"6" }
+  es.typed-array.find { "ie":"6" }
+  es.typed-array.find-index { "ie":"6" }
+  es.typed-array.for-each { "ie":"6" }
+  es.typed-array.from { "ie":"6" }
+  es.typed-array.includes { "ie":"6" }
+  es.typed-array.index-of { "ie":"6" }
+  es.typed-array.iterator { "ie":"6" }
+  es.typed-array.join { "ie":"6" }
+  es.typed-array.last-index-of { "ie":"6" }
+  es.typed-array.map { "ie":"6" }
+  es.typed-array.of { "ie":"6" }
+  es.typed-array.reduce { "ie":"6" }
+  es.typed-array.reduce-right { "ie":"6" }
+  es.typed-array.reverse { "ie":"6" }
+  es.typed-array.set { "ie":"6" }
+  es.typed-array.slice { "ie":"6" }
+  es.typed-array.some { "ie":"6" }
+  es.typed-array.sort { "ie":"6" }
+  es.typed-array.subarray { "ie":"6" }
+  es.typed-array.to-locale-string { "ie":"6" }
+  es.typed-array.to-string { "ie":"6" }
+  es.weak-map { "ie":"6" }
+  es.weak-set { "ie":"6" }
+  esnext.aggregate-error { "ie":"6" }
+  esnext.array.last-index { "ie":"6" }
+  esnext.array.last-item { "ie":"6" }
+  esnext.composite-key { "ie":"6" }
+  esnext.composite-symbol { "ie":"6" }
+  esnext.global-this { "ie":"6" }
+  esnext.map.delete-all { "ie":"6" }
+  esnext.map.every { "ie":"6" }
+  esnext.map.filter { "ie":"6" }
+  esnext.map.find { "ie":"6" }
+  esnext.map.find-key { "ie":"6" }
+  esnext.map.from { "ie":"6" }
+  esnext.map.group-by { "ie":"6" }
+  esnext.map.includes { "ie":"6" }
+  esnext.map.key-by { "ie":"6" }
+  esnext.map.key-of { "ie":"6" }
+  esnext.map.map-keys { "ie":"6" }
+  esnext.map.map-values { "ie":"6" }
+  esnext.map.merge { "ie":"6" }
+  esnext.map.of { "ie":"6" }
+  esnext.map.reduce { "ie":"6" }
+  esnext.map.some { "ie":"6" }
+  esnext.map.update { "ie":"6" }
+  esnext.math.clamp { "ie":"6" }
+  esnext.math.deg-per-rad { "ie":"6" }
+  esnext.math.degrees { "ie":"6" }
+  esnext.math.fscale { "ie":"6" }
+  esnext.math.iaddh { "ie":"6" }
+  esnext.math.imulh { "ie":"6" }
+  esnext.math.isubh { "ie":"6" }
+  esnext.math.rad-per-deg { "ie":"6" }
+  esnext.math.radians { "ie":"6" }
+  esnext.math.scale { "ie":"6" }
+  esnext.math.seeded-prng { "ie":"6" }
+  esnext.math.signbit { "ie":"6" }
+  esnext.math.umulh { "ie":"6" }
+  esnext.number.from-string { "ie":"6" }
+  esnext.observable { "ie":"6" }
+  esnext.promise.all-settled { "ie":"6" }
+  esnext.promise.any { "ie":"6" }
+  esnext.promise.try { "ie":"6" }
+  esnext.reflect.define-metadata { "ie":"6" }
+  esnext.reflect.delete-metadata { "ie":"6" }
+  esnext.reflect.get-metadata { "ie":"6" }
+  esnext.reflect.get-metadata-keys { "ie":"6" }
+  esnext.reflect.get-own-metadata { "ie":"6" }
+  esnext.reflect.get-own-metadata-keys { "ie":"6" }
+  esnext.reflect.has-metadata { "ie":"6" }
+  esnext.reflect.has-own-metadata { "ie":"6" }
+  esnext.reflect.metadata { "ie":"6" }
+  esnext.set.add-all { "ie":"6" }
+  esnext.set.delete-all { "ie":"6" }
+  esnext.set.difference { "ie":"6" }
+  esnext.set.every { "ie":"6" }
+  esnext.set.filter { "ie":"6" }
+  esnext.set.find { "ie":"6" }
+  esnext.set.from { "ie":"6" }
+  esnext.set.intersection { "ie":"6" }
+  esnext.set.is-disjoint-from { "ie":"6" }
+  esnext.set.is-subset-of { "ie":"6" }
+  esnext.set.is-superset-of { "ie":"6" }
+  esnext.set.join { "ie":"6" }
+  esnext.set.map { "ie":"6" }
+  esnext.set.of { "ie":"6" }
+  esnext.set.reduce { "ie":"6" }
+  esnext.set.some { "ie":"6" }
+  esnext.set.symmetric-difference { "ie":"6" }
+  esnext.set.union { "ie":"6" }
+  esnext.string.at { "ie":"6" }
+  esnext.string.code-points { "ie":"6" }
+  esnext.string.match-all { "ie":"6" }
+  esnext.string.replace-all { "ie":"6" }
+  esnext.symbol.dispose { "ie":"6" }
+  esnext.symbol.observable { "ie":"6" }
+  esnext.symbol.pattern-match { "ie":"6" }
+  esnext.weak-map.delete-all { "ie":"6" }
+  esnext.weak-map.from { "ie":"6" }
+  esnext.weak-map.of { "ie":"6" }
+  esnext.weak-set.add-all { "ie":"6" }
+  esnext.weak-set.delete-all { "ie":"6" }
+  esnext.weak-set.from { "ie":"6" }
+  esnext.weak-set.of { "ie":"6" }
+  web.url { "ie":"6" }
+  web.url.to-json { "ie":"6" }
+  web.url-search-params { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/options.json
@@ -7,6 +7,7 @@
       {
         "debug": true,
         "shippedProposals": true,
+        "targets": { "browsers": "ie 6" },
         "useBuiltIns": "entry",
         "corejs": 3
       }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
@@ -1,254 +1,255 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties {}
-  proposal-private-methods {}
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-class-properties { "ie":"6" }
+  proposal-private-methods { "ie":"6" }
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/input.mjs] Replaced core-js entries with the following polyfills:
-  es.symbol {}
-  es.symbol.description {}
-  es.symbol.async-iterator {}
-  es.symbol.has-instance {}
-  es.symbol.is-concat-spreadable {}
-  es.symbol.iterator {}
-  es.symbol.match {}
-  es.symbol.replace {}
-  es.symbol.search {}
-  es.symbol.species {}
-  es.symbol.split {}
-  es.symbol.to-primitive {}
-  es.symbol.to-string-tag {}
-  es.symbol.unscopables {}
-  es.array.concat {}
-  es.array.copy-within {}
-  es.array.every {}
-  es.array.fill {}
-  es.array.filter {}
-  es.array.find {}
-  es.array.find-index {}
-  es.array.flat {}
-  es.array.flat-map {}
-  es.array.for-each {}
-  es.array.from {}
-  es.array.includes {}
-  es.array.index-of {}
-  es.array.is-array {}
-  es.array.iterator {}
-  es.array.join {}
-  es.array.last-index-of {}
-  es.array.map {}
-  es.array.of {}
-  es.array.reduce {}
-  es.array.reduce-right {}
-  es.array.reverse {}
-  es.array.slice {}
-  es.array.some {}
-  es.array.sort {}
-  es.array.species {}
-  es.array.splice {}
-  es.array.unscopables.flat {}
-  es.array.unscopables.flat-map {}
-  es.array-buffer.constructor {}
-  es.array-buffer.is-view {}
-  es.array-buffer.slice {}
-  es.data-view {}
-  es.date.now {}
-  es.date.to-iso-string {}
-  es.date.to-json {}
-  es.date.to-primitive {}
-  es.date.to-string {}
-  es.function.bind {}
-  es.function.has-instance {}
-  es.function.name {}
-  es.json.to-string-tag {}
-  es.map {}
-  es.math.acosh {}
-  es.math.asinh {}
-  es.math.atanh {}
-  es.math.cbrt {}
-  es.math.clz32 {}
-  es.math.cosh {}
-  es.math.expm1 {}
-  es.math.fround {}
-  es.math.hypot {}
-  es.math.imul {}
-  es.math.log10 {}
-  es.math.log1p {}
-  es.math.log2 {}
-  es.math.sign {}
-  es.math.sinh {}
-  es.math.tanh {}
-  es.math.to-string-tag {}
-  es.math.trunc {}
-  es.number.constructor {}
-  es.number.epsilon {}
-  es.number.is-finite {}
-  es.number.is-integer {}
-  es.number.is-nan {}
-  es.number.is-safe-integer {}
-  es.number.max-safe-integer {}
-  es.number.min-safe-integer {}
-  es.number.parse-float {}
-  es.number.parse-int {}
-  es.number.to-fixed {}
-  es.number.to-precision {}
-  es.object.assign {}
-  es.object.create {}
-  es.object.define-getter {}
-  es.object.define-properties {}
-  es.object.define-property {}
-  es.object.define-setter {}
-  es.object.entries {}
-  es.object.freeze {}
-  es.object.from-entries {}
-  es.object.get-own-property-descriptor {}
-  es.object.get-own-property-descriptors {}
-  es.object.get-own-property-names {}
-  es.object.get-prototype-of {}
-  es.object.is {}
-  es.object.is-extensible {}
-  es.object.is-frozen {}
-  es.object.is-sealed {}
-  es.object.keys {}
-  es.object.lookup-getter {}
-  es.object.lookup-setter {}
-  es.object.prevent-extensions {}
-  es.object.seal {}
-  es.object.set-prototype-of {}
-  es.object.to-string {}
-  es.object.values {}
-  es.parse-float {}
-  es.parse-int {}
-  es.promise {}
-  es.promise.finally {}
-  es.reflect.apply {}
-  es.reflect.construct {}
-  es.reflect.define-property {}
-  es.reflect.delete-property {}
-  es.reflect.get {}
-  es.reflect.get-own-property-descriptor {}
-  es.reflect.get-prototype-of {}
-  es.reflect.has {}
-  es.reflect.is-extensible {}
-  es.reflect.own-keys {}
-  es.reflect.prevent-extensions {}
-  es.reflect.set {}
-  es.reflect.set-prototype-of {}
-  es.regexp.constructor {}
-  es.regexp.exec {}
-  es.regexp.flags {}
-  es.regexp.to-string {}
-  es.set {}
-  es.string.code-point-at {}
-  es.string.ends-with {}
-  es.string.from-code-point {}
-  es.string.includes {}
-  es.string.iterator {}
-  es.string.match {}
-  es.string.pad-end {}
-  es.string.pad-start {}
-  es.string.raw {}
-  es.string.repeat {}
-  es.string.replace {}
-  es.string.search {}
-  es.string.split {}
-  es.string.starts-with {}
-  es.string.trim {}
-  es.string.trim-end {}
-  es.string.trim-start {}
-  es.string.anchor {}
-  es.string.big {}
-  es.string.blink {}
-  es.string.bold {}
-  es.string.fixed {}
-  es.string.fontcolor {}
-  es.string.fontsize {}
-  es.string.italics {}
-  es.string.link {}
-  es.string.small {}
-  es.string.strike {}
-  es.string.sub {}
-  es.string.sup {}
-  es.typed-array.float32-array {}
-  es.typed-array.float64-array {}
-  es.typed-array.int8-array {}
-  es.typed-array.int16-array {}
-  es.typed-array.int32-array {}
-  es.typed-array.uint8-array {}
-  es.typed-array.uint8-clamped-array {}
-  es.typed-array.uint16-array {}
-  es.typed-array.uint32-array {}
-  es.typed-array.copy-within {}
-  es.typed-array.every {}
-  es.typed-array.fill {}
-  es.typed-array.filter {}
-  es.typed-array.find {}
-  es.typed-array.find-index {}
-  es.typed-array.for-each {}
-  es.typed-array.from {}
-  es.typed-array.includes {}
-  es.typed-array.index-of {}
-  es.typed-array.iterator {}
-  es.typed-array.join {}
-  es.typed-array.last-index-of {}
-  es.typed-array.map {}
-  es.typed-array.of {}
-  es.typed-array.reduce {}
-  es.typed-array.reduce-right {}
-  es.typed-array.reverse {}
-  es.typed-array.set {}
-  es.typed-array.slice {}
-  es.typed-array.some {}
-  es.typed-array.sort {}
-  es.typed-array.subarray {}
-  es.typed-array.to-locale-string {}
-  es.typed-array.to-string {}
-  es.weak-map {}
-  es.weak-set {}
+  es.symbol { "ie":"6" }
+  es.symbol.description { "ie":"6" }
+  es.symbol.async-iterator { "ie":"6" }
+  es.symbol.has-instance { "ie":"6" }
+  es.symbol.is-concat-spreadable { "ie":"6" }
+  es.symbol.iterator { "ie":"6" }
+  es.symbol.match { "ie":"6" }
+  es.symbol.replace { "ie":"6" }
+  es.symbol.search { "ie":"6" }
+  es.symbol.species { "ie":"6" }
+  es.symbol.split { "ie":"6" }
+  es.symbol.to-primitive { "ie":"6" }
+  es.symbol.to-string-tag { "ie":"6" }
+  es.symbol.unscopables { "ie":"6" }
+  es.array.concat { "ie":"6" }
+  es.array.copy-within { "ie":"6" }
+  es.array.every { "ie":"6" }
+  es.array.fill { "ie":"6" }
+  es.array.filter { "ie":"6" }
+  es.array.find { "ie":"6" }
+  es.array.find-index { "ie":"6" }
+  es.array.flat { "ie":"6" }
+  es.array.flat-map { "ie":"6" }
+  es.array.for-each { "ie":"6" }
+  es.array.from { "ie":"6" }
+  es.array.includes { "ie":"6" }
+  es.array.index-of { "ie":"6" }
+  es.array.is-array { "ie":"6" }
+  es.array.iterator { "ie":"6" }
+  es.array.join { "ie":"6" }
+  es.array.last-index-of { "ie":"6" }
+  es.array.map { "ie":"6" }
+  es.array.of { "ie":"6" }
+  es.array.reduce { "ie":"6" }
+  es.array.reduce-right { "ie":"6" }
+  es.array.slice { "ie":"6" }
+  es.array.some { "ie":"6" }
+  es.array.sort { "ie":"6" }
+  es.array.species { "ie":"6" }
+  es.array.splice { "ie":"6" }
+  es.array.unscopables.flat { "ie":"6" }
+  es.array.unscopables.flat-map { "ie":"6" }
+  es.array-buffer.constructor { "ie":"6" }
+  es.array-buffer.is-view { "ie":"6" }
+  es.array-buffer.slice { "ie":"6" }
+  es.data-view { "ie":"6" }
+  es.date.now { "ie":"6" }
+  es.date.to-iso-string { "ie":"6" }
+  es.date.to-json { "ie":"6" }
+  es.date.to-primitive { "ie":"6" }
+  es.date.to-string { "ie":"6" }
+  es.function.bind { "ie":"6" }
+  es.function.has-instance { "ie":"6" }
+  es.function.name { "ie":"6" }
+  es.json.to-string-tag { "ie":"6" }
+  es.map { "ie":"6" }
+  es.math.acosh { "ie":"6" }
+  es.math.asinh { "ie":"6" }
+  es.math.atanh { "ie":"6" }
+  es.math.cbrt { "ie":"6" }
+  es.math.clz32 { "ie":"6" }
+  es.math.cosh { "ie":"6" }
+  es.math.expm1 { "ie":"6" }
+  es.math.fround { "ie":"6" }
+  es.math.hypot { "ie":"6" }
+  es.math.imul { "ie":"6" }
+  es.math.log10 { "ie":"6" }
+  es.math.log1p { "ie":"6" }
+  es.math.log2 { "ie":"6" }
+  es.math.sign { "ie":"6" }
+  es.math.sinh { "ie":"6" }
+  es.math.tanh { "ie":"6" }
+  es.math.to-string-tag { "ie":"6" }
+  es.math.trunc { "ie":"6" }
+  es.number.constructor { "ie":"6" }
+  es.number.epsilon { "ie":"6" }
+  es.number.is-finite { "ie":"6" }
+  es.number.is-integer { "ie":"6" }
+  es.number.is-nan { "ie":"6" }
+  es.number.is-safe-integer { "ie":"6" }
+  es.number.max-safe-integer { "ie":"6" }
+  es.number.min-safe-integer { "ie":"6" }
+  es.number.parse-float { "ie":"6" }
+  es.number.parse-int { "ie":"6" }
+  es.number.to-fixed { "ie":"6" }
+  es.number.to-precision { "ie":"6" }
+  es.object.assign { "ie":"6" }
+  es.object.create { "ie":"6" }
+  es.object.define-getter { "ie":"6" }
+  es.object.define-properties { "ie":"6" }
+  es.object.define-property { "ie":"6" }
+  es.object.define-setter { "ie":"6" }
+  es.object.entries { "ie":"6" }
+  es.object.freeze { "ie":"6" }
+  es.object.from-entries { "ie":"6" }
+  es.object.get-own-property-descriptor { "ie":"6" }
+  es.object.get-own-property-descriptors { "ie":"6" }
+  es.object.get-own-property-names { "ie":"6" }
+  es.object.get-prototype-of { "ie":"6" }
+  es.object.is { "ie":"6" }
+  es.object.is-extensible { "ie":"6" }
+  es.object.is-frozen { "ie":"6" }
+  es.object.is-sealed { "ie":"6" }
+  es.object.keys { "ie":"6" }
+  es.object.lookup-getter { "ie":"6" }
+  es.object.lookup-setter { "ie":"6" }
+  es.object.prevent-extensions { "ie":"6" }
+  es.object.seal { "ie":"6" }
+  es.object.set-prototype-of { "ie":"6" }
+  es.object.to-string { "ie":"6" }
+  es.object.values { "ie":"6" }
+  es.parse-float { "ie":"6" }
+  es.parse-int { "ie":"6" }
+  es.promise { "ie":"6" }
+  es.promise.finally { "ie":"6" }
+  es.reflect.apply { "ie":"6" }
+  es.reflect.construct { "ie":"6" }
+  es.reflect.define-property { "ie":"6" }
+  es.reflect.delete-property { "ie":"6" }
+  es.reflect.get { "ie":"6" }
+  es.reflect.get-own-property-descriptor { "ie":"6" }
+  es.reflect.get-prototype-of { "ie":"6" }
+  es.reflect.has { "ie":"6" }
+  es.reflect.is-extensible { "ie":"6" }
+  es.reflect.own-keys { "ie":"6" }
+  es.reflect.prevent-extensions { "ie":"6" }
+  es.reflect.set { "ie":"6" }
+  es.reflect.set-prototype-of { "ie":"6" }
+  es.regexp.constructor { "ie":"6" }
+  es.regexp.exec { "ie":"6" }
+  es.regexp.flags { "ie":"6" }
+  es.regexp.to-string { "ie":"6" }
+  es.set { "ie":"6" }
+  es.string.code-point-at { "ie":"6" }
+  es.string.ends-with { "ie":"6" }
+  es.string.from-code-point { "ie":"6" }
+  es.string.includes { "ie":"6" }
+  es.string.iterator { "ie":"6" }
+  es.string.match { "ie":"6" }
+  es.string.pad-end { "ie":"6" }
+  es.string.pad-start { "ie":"6" }
+  es.string.raw { "ie":"6" }
+  es.string.repeat { "ie":"6" }
+  es.string.replace { "ie":"6" }
+  es.string.search { "ie":"6" }
+  es.string.split { "ie":"6" }
+  es.string.starts-with { "ie":"6" }
+  es.string.trim { "ie":"6" }
+  es.string.trim-end { "ie":"6" }
+  es.string.trim-start { "ie":"6" }
+  es.string.anchor { "ie":"6" }
+  es.string.big { "ie":"6" }
+  es.string.blink { "ie":"6" }
+  es.string.bold { "ie":"6" }
+  es.string.fixed { "ie":"6" }
+  es.string.fontcolor { "ie":"6" }
+  es.string.fontsize { "ie":"6" }
+  es.string.italics { "ie":"6" }
+  es.string.link { "ie":"6" }
+  es.string.small { "ie":"6" }
+  es.string.strike { "ie":"6" }
+  es.string.sub { "ie":"6" }
+  es.string.sup { "ie":"6" }
+  es.typed-array.float32-array { "ie":"6" }
+  es.typed-array.float64-array { "ie":"6" }
+  es.typed-array.int8-array { "ie":"6" }
+  es.typed-array.int16-array { "ie":"6" }
+  es.typed-array.int32-array { "ie":"6" }
+  es.typed-array.uint8-array { "ie":"6" }
+  es.typed-array.uint8-clamped-array { "ie":"6" }
+  es.typed-array.uint16-array { "ie":"6" }
+  es.typed-array.uint32-array { "ie":"6" }
+  es.typed-array.copy-within { "ie":"6" }
+  es.typed-array.every { "ie":"6" }
+  es.typed-array.fill { "ie":"6" }
+  es.typed-array.filter { "ie":"6" }
+  es.typed-array.find { "ie":"6" }
+  es.typed-array.find-index { "ie":"6" }
+  es.typed-array.for-each { "ie":"6" }
+  es.typed-array.from { "ie":"6" }
+  es.typed-array.includes { "ie":"6" }
+  es.typed-array.index-of { "ie":"6" }
+  es.typed-array.iterator { "ie":"6" }
+  es.typed-array.join { "ie":"6" }
+  es.typed-array.last-index-of { "ie":"6" }
+  es.typed-array.map { "ie":"6" }
+  es.typed-array.of { "ie":"6" }
+  es.typed-array.reduce { "ie":"6" }
+  es.typed-array.reduce-right { "ie":"6" }
+  es.typed-array.reverse { "ie":"6" }
+  es.typed-array.set { "ie":"6" }
+  es.typed-array.slice { "ie":"6" }
+  es.typed-array.some { "ie":"6" }
+  es.typed-array.sort { "ie":"6" }
+  es.typed-array.subarray { "ie":"6" }
+  es.typed-array.to-locale-string { "ie":"6" }
+  es.typed-array.to-string { "ie":"6" }
+  es.weak-map { "ie":"6" }
+  es.weak-set { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/options.json
@@ -7,6 +7,7 @@
       {
         "debug": true,
         "useBuiltIns": "entry",
+        "targets": { "browsers": "ie 6" },
         "corejs": { "version": 3, "proposals": true }
       }
     ]

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
@@ -1,138 +1,140 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/input.mjs] Replaced core-js entries with the following polyfills:
-  es.map {}
-  esnext.aggregate-error {}
-  esnext.array.last-index {}
-  esnext.array.last-item {}
-  esnext.composite-key {}
-  esnext.composite-symbol {}
-  esnext.global-this {}
-  esnext.map.delete-all {}
-  esnext.map.every {}
-  esnext.map.filter {}
-  esnext.map.find {}
-  esnext.map.find-key {}
-  esnext.map.from {}
-  esnext.map.group-by {}
-  esnext.map.includes {}
-  esnext.map.key-by {}
-  esnext.map.key-of {}
-  esnext.map.map-keys {}
-  esnext.map.map-values {}
-  esnext.map.merge {}
-  esnext.map.of {}
-  esnext.map.reduce {}
-  esnext.map.some {}
-  esnext.map.update {}
-  esnext.math.clamp {}
-  esnext.math.deg-per-rad {}
-  esnext.math.degrees {}
-  esnext.math.fscale {}
-  esnext.math.iaddh {}
-  esnext.math.imulh {}
-  esnext.math.isubh {}
-  esnext.math.rad-per-deg {}
-  esnext.math.radians {}
-  esnext.math.scale {}
-  esnext.math.seeded-prng {}
-  esnext.math.signbit {}
-  esnext.math.umulh {}
-  esnext.number.from-string {}
-  esnext.observable {}
-  esnext.promise.all-settled {}
-  esnext.promise.any {}
-  esnext.promise.try {}
-  esnext.reflect.define-metadata {}
-  esnext.reflect.delete-metadata {}
-  esnext.reflect.get-metadata {}
-  esnext.reflect.get-metadata-keys {}
-  esnext.reflect.get-own-metadata {}
-  esnext.reflect.get-own-metadata-keys {}
-  esnext.reflect.has-metadata {}
-  esnext.reflect.has-own-metadata {}
-  esnext.reflect.metadata {}
-  esnext.set.add-all {}
-  esnext.set.delete-all {}
-  esnext.set.difference {}
-  esnext.set.every {}
-  esnext.set.filter {}
-  esnext.set.find {}
-  esnext.set.from {}
-  esnext.set.intersection {}
-  esnext.set.is-disjoint-from {}
-  esnext.set.is-subset-of {}
-  esnext.set.is-superset-of {}
-  esnext.set.join {}
-  esnext.set.map {}
-  esnext.set.of {}
-  esnext.set.reduce {}
-  esnext.set.some {}
-  esnext.set.symmetric-difference {}
-  esnext.set.union {}
-  esnext.string.at {}
-  esnext.string.code-points {}
-  esnext.string.match-all {}
-  esnext.string.replace-all {}
-  esnext.symbol.dispose {}
-  esnext.symbol.observable {}
-  esnext.symbol.pattern-match {}
-  esnext.weak-map.delete-all {}
-  esnext.weak-map.from {}
-  esnext.weak-map.of {}
-  esnext.weak-set.add-all {}
-  esnext.weak-set.delete-all {}
-  esnext.weak-set.from {}
-  esnext.weak-set.of {}
-  web.url {}
-  web.url.to-json {}
-  web.url-search-params {}
+  es.map { "ie":"6" }
+  esnext.aggregate-error { "ie":"6" }
+  esnext.array.last-index { "ie":"6" }
+  esnext.array.last-item { "ie":"6" }
+  esnext.composite-key { "ie":"6" }
+  esnext.composite-symbol { "ie":"6" }
+  esnext.global-this { "ie":"6" }
+  esnext.map.delete-all { "ie":"6" }
+  esnext.map.every { "ie":"6" }
+  esnext.map.filter { "ie":"6" }
+  esnext.map.find { "ie":"6" }
+  esnext.map.find-key { "ie":"6" }
+  esnext.map.from { "ie":"6" }
+  esnext.map.group-by { "ie":"6" }
+  esnext.map.includes { "ie":"6" }
+  esnext.map.key-by { "ie":"6" }
+  esnext.map.key-of { "ie":"6" }
+  esnext.map.map-keys { "ie":"6" }
+  esnext.map.map-values { "ie":"6" }
+  esnext.map.merge { "ie":"6" }
+  esnext.map.of { "ie":"6" }
+  esnext.map.reduce { "ie":"6" }
+  esnext.map.some { "ie":"6" }
+  esnext.map.update { "ie":"6" }
+  esnext.math.clamp { "ie":"6" }
+  esnext.math.deg-per-rad { "ie":"6" }
+  esnext.math.degrees { "ie":"6" }
+  esnext.math.fscale { "ie":"6" }
+  esnext.math.iaddh { "ie":"6" }
+  esnext.math.imulh { "ie":"6" }
+  esnext.math.isubh { "ie":"6" }
+  esnext.math.rad-per-deg { "ie":"6" }
+  esnext.math.radians { "ie":"6" }
+  esnext.math.scale { "ie":"6" }
+  esnext.math.seeded-prng { "ie":"6" }
+  esnext.math.signbit { "ie":"6" }
+  esnext.math.umulh { "ie":"6" }
+  esnext.number.from-string { "ie":"6" }
+  esnext.observable { "ie":"6" }
+  esnext.promise.all-settled { "ie":"6" }
+  esnext.promise.any { "ie":"6" }
+  esnext.promise.try { "ie":"6" }
+  esnext.reflect.define-metadata { "ie":"6" }
+  esnext.reflect.delete-metadata { "ie":"6" }
+  esnext.reflect.get-metadata { "ie":"6" }
+  esnext.reflect.get-metadata-keys { "ie":"6" }
+  esnext.reflect.get-own-metadata { "ie":"6" }
+  esnext.reflect.get-own-metadata-keys { "ie":"6" }
+  esnext.reflect.has-metadata { "ie":"6" }
+  esnext.reflect.has-own-metadata { "ie":"6" }
+  esnext.reflect.metadata { "ie":"6" }
+  esnext.set.add-all { "ie":"6" }
+  esnext.set.delete-all { "ie":"6" }
+  esnext.set.difference { "ie":"6" }
+  esnext.set.every { "ie":"6" }
+  esnext.set.filter { "ie":"6" }
+  esnext.set.find { "ie":"6" }
+  esnext.set.from { "ie":"6" }
+  esnext.set.intersection { "ie":"6" }
+  esnext.set.is-disjoint-from { "ie":"6" }
+  esnext.set.is-subset-of { "ie":"6" }
+  esnext.set.is-superset-of { "ie":"6" }
+  esnext.set.join { "ie":"6" }
+  esnext.set.map { "ie":"6" }
+  esnext.set.of { "ie":"6" }
+  esnext.set.reduce { "ie":"6" }
+  esnext.set.some { "ie":"6" }
+  esnext.set.symmetric-difference { "ie":"6" }
+  esnext.set.union { "ie":"6" }
+  esnext.string.at { "ie":"6" }
+  esnext.string.code-points { "ie":"6" }
+  esnext.string.match-all { "ie":"6" }
+  esnext.string.replace-all { "ie":"6" }
+  esnext.symbol.dispose { "ie":"6" }
+  esnext.symbol.observable { "ie":"6" }
+  esnext.symbol.pattern-match { "ie":"6" }
+  esnext.weak-map.delete-all { "ie":"6" }
+  esnext.weak-map.from { "ie":"6" }
+  esnext.weak-map.of { "ie":"6" }
+  esnext.weak-set.add-all { "ie":"6" }
+  esnext.weak-set.delete-all { "ie":"6" }
+  esnext.weak-set.from { "ie":"6" }
+  esnext.weak-set.of { "ie":"6" }
+  web.url { "ie":"6" }
+  web.url.to-json { "ie":"6" }
+  web.url-search-params { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/options.json
@@ -6,6 +6,7 @@
       "env",
       {
         "debug": true,
+        "targets": { "browsers": "ie 6" },
         "shippedProposals": true,
         "useBuiltIns": "entry",
         "corejs": 3

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
@@ -1,104 +1,106 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties {}
-  proposal-private-methods {}
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-class-properties { "ie":"6" }
+  proposal-private-methods { "ie":"6" }
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/input.mjs] Replaced core-js entries with the following polyfills:
-  es.symbol {}
-  es.json.to-string-tag {}
-  es.math.to-string-tag {}
-  es.object.assign {}
-  es.object.create {}
-  es.object.define-getter {}
-  es.object.define-properties {}
-  es.object.define-property {}
-  es.object.define-setter {}
-  es.object.entries {}
-  es.object.freeze {}
-  es.object.from-entries {}
-  es.object.get-own-property-descriptor {}
-  es.object.get-own-property-descriptors {}
-  es.object.get-own-property-names {}
-  es.object.get-prototype-of {}
-  es.object.is {}
-  es.object.is-extensible {}
-  es.object.is-frozen {}
-  es.object.is-sealed {}
-  es.object.keys {}
-  es.object.lookup-getter {}
-  es.object.lookup-setter {}
-  es.object.prevent-extensions {}
-  es.object.seal {}
-  es.object.set-prototype-of {}
-  es.object.to-string {}
-  es.object.values {}
-  es.reflect.apply {}
-  es.reflect.construct {}
-  es.reflect.define-property {}
-  es.reflect.delete-property {}
-  es.reflect.get {}
-  es.reflect.get-own-property-descriptor {}
-  es.reflect.get-prototype-of {}
-  es.reflect.has {}
-  es.reflect.is-extensible {}
-  es.reflect.own-keys {}
-  es.reflect.prevent-extensions {}
-  es.reflect.set {}
-  es.reflect.set-prototype-of {}
-  esnext.reflect.define-metadata {}
-  esnext.reflect.delete-metadata {}
-  esnext.reflect.get-metadata {}
-  esnext.reflect.get-metadata-keys {}
-  esnext.reflect.get-own-metadata {}
-  esnext.reflect.get-own-metadata-keys {}
-  esnext.reflect.has-metadata {}
-  esnext.reflect.has-own-metadata {}
-  esnext.reflect.metadata {}
+  es.symbol { "ie":"6" }
+  es.json.to-string-tag { "ie":"6" }
+  es.math.to-string-tag { "ie":"6" }
+  es.object.assign { "ie":"6" }
+  es.object.create { "ie":"6" }
+  es.object.define-getter { "ie":"6" }
+  es.object.define-properties { "ie":"6" }
+  es.object.define-property { "ie":"6" }
+  es.object.define-setter { "ie":"6" }
+  es.object.entries { "ie":"6" }
+  es.object.freeze { "ie":"6" }
+  es.object.from-entries { "ie":"6" }
+  es.object.get-own-property-descriptor { "ie":"6" }
+  es.object.get-own-property-descriptors { "ie":"6" }
+  es.object.get-own-property-names { "ie":"6" }
+  es.object.get-prototype-of { "ie":"6" }
+  es.object.is { "ie":"6" }
+  es.object.is-extensible { "ie":"6" }
+  es.object.is-frozen { "ie":"6" }
+  es.object.is-sealed { "ie":"6" }
+  es.object.keys { "ie":"6" }
+  es.object.lookup-getter { "ie":"6" }
+  es.object.lookup-setter { "ie":"6" }
+  es.object.prevent-extensions { "ie":"6" }
+  es.object.seal { "ie":"6" }
+  es.object.set-prototype-of { "ie":"6" }
+  es.object.to-string { "ie":"6" }
+  es.object.values { "ie":"6" }
+  es.reflect.apply { "ie":"6" }
+  es.reflect.construct { "ie":"6" }
+  es.reflect.define-property { "ie":"6" }
+  es.reflect.delete-property { "ie":"6" }
+  es.reflect.get { "ie":"6" }
+  es.reflect.get-own-property-descriptor { "ie":"6" }
+  es.reflect.get-prototype-of { "ie":"6" }
+  es.reflect.has { "ie":"6" }
+  es.reflect.is-extensible { "ie":"6" }
+  es.reflect.own-keys { "ie":"6" }
+  es.reflect.prevent-extensions { "ie":"6" }
+  es.reflect.set { "ie":"6" }
+  es.reflect.set-prototype-of { "ie":"6" }
+  esnext.reflect.define-metadata { "ie":"6" }
+  esnext.reflect.delete-metadata { "ie":"6" }
+  esnext.reflect.get-metadata { "ie":"6" }
+  esnext.reflect.get-metadata-keys { "ie":"6" }
+  esnext.reflect.get-own-metadata { "ie":"6" }
+  esnext.reflect.get-own-metadata-keys { "ie":"6" }
+  esnext.reflect.has-metadata { "ie":"6" }
+  esnext.reflect.has-own-metadata { "ie":"6" }
+  esnext.reflect.metadata { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/options.json
@@ -6,6 +6,7 @@
       "env",
       {
         "debug": true,
+        "targets": { "browsers": "ie 6" },
         "shippedProposals": true,
         "useBuiltIns": "entry",
         "corejs": 3

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
@@ -1,262 +1,263 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties {}
-  proposal-private-methods {}
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-class-properties { "ie":"6" }
+  proposal-private-methods { "ie":"6" }
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/input.mjs] Replaced core-js entries with the following polyfills:
-  es.symbol {}
-  es.symbol.description {}
-  es.symbol.async-iterator {}
-  es.symbol.has-instance {}
-  es.symbol.is-concat-spreadable {}
-  es.symbol.iterator {}
-  es.symbol.match {}
-  es.symbol.replace {}
-  es.symbol.search {}
-  es.symbol.species {}
-  es.symbol.split {}
-  es.symbol.to-primitive {}
-  es.symbol.to-string-tag {}
-  es.symbol.unscopables {}
-  es.array.concat {}
-  es.array.copy-within {}
-  es.array.every {}
-  es.array.fill {}
-  es.array.filter {}
-  es.array.find {}
-  es.array.find-index {}
-  es.array.flat {}
-  es.array.flat-map {}
-  es.array.for-each {}
-  es.array.from {}
-  es.array.includes {}
-  es.array.index-of {}
-  es.array.is-array {}
-  es.array.iterator {}
-  es.array.join {}
-  es.array.last-index-of {}
-  es.array.map {}
-  es.array.of {}
-  es.array.reduce {}
-  es.array.reduce-right {}
-  es.array.reverse {}
-  es.array.slice {}
-  es.array.some {}
-  es.array.sort {}
-  es.array.species {}
-  es.array.splice {}
-  es.array.unscopables.flat {}
-  es.array.unscopables.flat-map {}
-  es.array-buffer.constructor {}
-  es.array-buffer.is-view {}
-  es.array-buffer.slice {}
-  es.data-view {}
-  es.date.now {}
-  es.date.to-iso-string {}
-  es.date.to-json {}
-  es.date.to-primitive {}
-  es.date.to-string {}
-  es.function.bind {}
-  es.function.has-instance {}
-  es.function.name {}
-  es.json.to-string-tag {}
-  es.map {}
-  es.math.acosh {}
-  es.math.asinh {}
-  es.math.atanh {}
-  es.math.cbrt {}
-  es.math.clz32 {}
-  es.math.cosh {}
-  es.math.expm1 {}
-  es.math.fround {}
-  es.math.hypot {}
-  es.math.imul {}
-  es.math.log10 {}
-  es.math.log1p {}
-  es.math.log2 {}
-  es.math.sign {}
-  es.math.sinh {}
-  es.math.tanh {}
-  es.math.to-string-tag {}
-  es.math.trunc {}
-  es.number.constructor {}
-  es.number.epsilon {}
-  es.number.is-finite {}
-  es.number.is-integer {}
-  es.number.is-nan {}
-  es.number.is-safe-integer {}
-  es.number.max-safe-integer {}
-  es.number.min-safe-integer {}
-  es.number.parse-float {}
-  es.number.parse-int {}
-  es.number.to-fixed {}
-  es.number.to-precision {}
-  es.object.assign {}
-  es.object.create {}
-  es.object.define-getter {}
-  es.object.define-properties {}
-  es.object.define-property {}
-  es.object.define-setter {}
-  es.object.entries {}
-  es.object.freeze {}
-  es.object.from-entries {}
-  es.object.get-own-property-descriptor {}
-  es.object.get-own-property-descriptors {}
-  es.object.get-own-property-names {}
-  es.object.get-prototype-of {}
-  es.object.is {}
-  es.object.is-extensible {}
-  es.object.is-frozen {}
-  es.object.is-sealed {}
-  es.object.keys {}
-  es.object.lookup-getter {}
-  es.object.lookup-setter {}
-  es.object.prevent-extensions {}
-  es.object.seal {}
-  es.object.set-prototype-of {}
-  es.object.to-string {}
-  es.object.values {}
-  es.parse-float {}
-  es.parse-int {}
-  es.promise {}
-  es.promise.finally {}
-  es.reflect.apply {}
-  es.reflect.construct {}
-  es.reflect.define-property {}
-  es.reflect.delete-property {}
-  es.reflect.get {}
-  es.reflect.get-own-property-descriptor {}
-  es.reflect.get-prototype-of {}
-  es.reflect.has {}
-  es.reflect.is-extensible {}
-  es.reflect.own-keys {}
-  es.reflect.prevent-extensions {}
-  es.reflect.set {}
-  es.reflect.set-prototype-of {}
-  es.regexp.constructor {}
-  es.regexp.exec {}
-  es.regexp.flags {}
-  es.regexp.to-string {}
-  es.set {}
-  es.string.code-point-at {}
-  es.string.ends-with {}
-  es.string.from-code-point {}
-  es.string.includes {}
-  es.string.iterator {}
-  es.string.match {}
-  es.string.pad-end {}
-  es.string.pad-start {}
-  es.string.raw {}
-  es.string.repeat {}
-  es.string.replace {}
-  es.string.search {}
-  es.string.split {}
-  es.string.starts-with {}
-  es.string.trim {}
-  es.string.trim-end {}
-  es.string.trim-start {}
-  es.string.anchor {}
-  es.string.big {}
-  es.string.blink {}
-  es.string.bold {}
-  es.string.fixed {}
-  es.string.fontcolor {}
-  es.string.fontsize {}
-  es.string.italics {}
-  es.string.link {}
-  es.string.small {}
-  es.string.strike {}
-  es.string.sub {}
-  es.string.sup {}
-  es.typed-array.float32-array {}
-  es.typed-array.float64-array {}
-  es.typed-array.int8-array {}
-  es.typed-array.int16-array {}
-  es.typed-array.int32-array {}
-  es.typed-array.uint8-array {}
-  es.typed-array.uint8-clamped-array {}
-  es.typed-array.uint16-array {}
-  es.typed-array.uint32-array {}
-  es.typed-array.copy-within {}
-  es.typed-array.every {}
-  es.typed-array.fill {}
-  es.typed-array.filter {}
-  es.typed-array.find {}
-  es.typed-array.find-index {}
-  es.typed-array.for-each {}
-  es.typed-array.from {}
-  es.typed-array.includes {}
-  es.typed-array.index-of {}
-  es.typed-array.iterator {}
-  es.typed-array.join {}
-  es.typed-array.last-index-of {}
-  es.typed-array.map {}
-  es.typed-array.of {}
-  es.typed-array.reduce {}
-  es.typed-array.reduce-right {}
-  es.typed-array.reverse {}
-  es.typed-array.set {}
-  es.typed-array.slice {}
-  es.typed-array.some {}
-  es.typed-array.sort {}
-  es.typed-array.subarray {}
-  es.typed-array.to-locale-string {}
-  es.typed-array.to-string {}
-  es.weak-map {}
-  es.weak-set {}
-  web.dom-collections.for-each {}
-  web.dom-collections.iterator {}
-  web.immediate {}
-  web.queue-microtask {}
-  web.timers {}
-  web.url {}
-  web.url.to-json {}
-  web.url-search-params {}
+  es.symbol { "ie":"6" }
+  es.symbol.description { "ie":"6" }
+  es.symbol.async-iterator { "ie":"6" }
+  es.symbol.has-instance { "ie":"6" }
+  es.symbol.is-concat-spreadable { "ie":"6" }
+  es.symbol.iterator { "ie":"6" }
+  es.symbol.match { "ie":"6" }
+  es.symbol.replace { "ie":"6" }
+  es.symbol.search { "ie":"6" }
+  es.symbol.species { "ie":"6" }
+  es.symbol.split { "ie":"6" }
+  es.symbol.to-primitive { "ie":"6" }
+  es.symbol.to-string-tag { "ie":"6" }
+  es.symbol.unscopables { "ie":"6" }
+  es.array.concat { "ie":"6" }
+  es.array.copy-within { "ie":"6" }
+  es.array.every { "ie":"6" }
+  es.array.fill { "ie":"6" }
+  es.array.filter { "ie":"6" }
+  es.array.find { "ie":"6" }
+  es.array.find-index { "ie":"6" }
+  es.array.flat { "ie":"6" }
+  es.array.flat-map { "ie":"6" }
+  es.array.for-each { "ie":"6" }
+  es.array.from { "ie":"6" }
+  es.array.includes { "ie":"6" }
+  es.array.index-of { "ie":"6" }
+  es.array.is-array { "ie":"6" }
+  es.array.iterator { "ie":"6" }
+  es.array.join { "ie":"6" }
+  es.array.last-index-of { "ie":"6" }
+  es.array.map { "ie":"6" }
+  es.array.of { "ie":"6" }
+  es.array.reduce { "ie":"6" }
+  es.array.reduce-right { "ie":"6" }
+  es.array.slice { "ie":"6" }
+  es.array.some { "ie":"6" }
+  es.array.sort { "ie":"6" }
+  es.array.species { "ie":"6" }
+  es.array.splice { "ie":"6" }
+  es.array.unscopables.flat { "ie":"6" }
+  es.array.unscopables.flat-map { "ie":"6" }
+  es.array-buffer.constructor { "ie":"6" }
+  es.array-buffer.is-view { "ie":"6" }
+  es.array-buffer.slice { "ie":"6" }
+  es.data-view { "ie":"6" }
+  es.date.now { "ie":"6" }
+  es.date.to-iso-string { "ie":"6" }
+  es.date.to-json { "ie":"6" }
+  es.date.to-primitive { "ie":"6" }
+  es.date.to-string { "ie":"6" }
+  es.function.bind { "ie":"6" }
+  es.function.has-instance { "ie":"6" }
+  es.function.name { "ie":"6" }
+  es.json.to-string-tag { "ie":"6" }
+  es.map { "ie":"6" }
+  es.math.acosh { "ie":"6" }
+  es.math.asinh { "ie":"6" }
+  es.math.atanh { "ie":"6" }
+  es.math.cbrt { "ie":"6" }
+  es.math.clz32 { "ie":"6" }
+  es.math.cosh { "ie":"6" }
+  es.math.expm1 { "ie":"6" }
+  es.math.fround { "ie":"6" }
+  es.math.hypot { "ie":"6" }
+  es.math.imul { "ie":"6" }
+  es.math.log10 { "ie":"6" }
+  es.math.log1p { "ie":"6" }
+  es.math.log2 { "ie":"6" }
+  es.math.sign { "ie":"6" }
+  es.math.sinh { "ie":"6" }
+  es.math.tanh { "ie":"6" }
+  es.math.to-string-tag { "ie":"6" }
+  es.math.trunc { "ie":"6" }
+  es.number.constructor { "ie":"6" }
+  es.number.epsilon { "ie":"6" }
+  es.number.is-finite { "ie":"6" }
+  es.number.is-integer { "ie":"6" }
+  es.number.is-nan { "ie":"6" }
+  es.number.is-safe-integer { "ie":"6" }
+  es.number.max-safe-integer { "ie":"6" }
+  es.number.min-safe-integer { "ie":"6" }
+  es.number.parse-float { "ie":"6" }
+  es.number.parse-int { "ie":"6" }
+  es.number.to-fixed { "ie":"6" }
+  es.number.to-precision { "ie":"6" }
+  es.object.assign { "ie":"6" }
+  es.object.create { "ie":"6" }
+  es.object.define-getter { "ie":"6" }
+  es.object.define-properties { "ie":"6" }
+  es.object.define-property { "ie":"6" }
+  es.object.define-setter { "ie":"6" }
+  es.object.entries { "ie":"6" }
+  es.object.freeze { "ie":"6" }
+  es.object.from-entries { "ie":"6" }
+  es.object.get-own-property-descriptor { "ie":"6" }
+  es.object.get-own-property-descriptors { "ie":"6" }
+  es.object.get-own-property-names { "ie":"6" }
+  es.object.get-prototype-of { "ie":"6" }
+  es.object.is { "ie":"6" }
+  es.object.is-extensible { "ie":"6" }
+  es.object.is-frozen { "ie":"6" }
+  es.object.is-sealed { "ie":"6" }
+  es.object.keys { "ie":"6" }
+  es.object.lookup-getter { "ie":"6" }
+  es.object.lookup-setter { "ie":"6" }
+  es.object.prevent-extensions { "ie":"6" }
+  es.object.seal { "ie":"6" }
+  es.object.set-prototype-of { "ie":"6" }
+  es.object.to-string { "ie":"6" }
+  es.object.values { "ie":"6" }
+  es.parse-float { "ie":"6" }
+  es.parse-int { "ie":"6" }
+  es.promise { "ie":"6" }
+  es.promise.finally { "ie":"6" }
+  es.reflect.apply { "ie":"6" }
+  es.reflect.construct { "ie":"6" }
+  es.reflect.define-property { "ie":"6" }
+  es.reflect.delete-property { "ie":"6" }
+  es.reflect.get { "ie":"6" }
+  es.reflect.get-own-property-descriptor { "ie":"6" }
+  es.reflect.get-prototype-of { "ie":"6" }
+  es.reflect.has { "ie":"6" }
+  es.reflect.is-extensible { "ie":"6" }
+  es.reflect.own-keys { "ie":"6" }
+  es.reflect.prevent-extensions { "ie":"6" }
+  es.reflect.set { "ie":"6" }
+  es.reflect.set-prototype-of { "ie":"6" }
+  es.regexp.constructor { "ie":"6" }
+  es.regexp.exec { "ie":"6" }
+  es.regexp.flags { "ie":"6" }
+  es.regexp.to-string { "ie":"6" }
+  es.set { "ie":"6" }
+  es.string.code-point-at { "ie":"6" }
+  es.string.ends-with { "ie":"6" }
+  es.string.from-code-point { "ie":"6" }
+  es.string.includes { "ie":"6" }
+  es.string.iterator { "ie":"6" }
+  es.string.match { "ie":"6" }
+  es.string.pad-end { "ie":"6" }
+  es.string.pad-start { "ie":"6" }
+  es.string.raw { "ie":"6" }
+  es.string.repeat { "ie":"6" }
+  es.string.replace { "ie":"6" }
+  es.string.search { "ie":"6" }
+  es.string.split { "ie":"6" }
+  es.string.starts-with { "ie":"6" }
+  es.string.trim { "ie":"6" }
+  es.string.trim-end { "ie":"6" }
+  es.string.trim-start { "ie":"6" }
+  es.string.anchor { "ie":"6" }
+  es.string.big { "ie":"6" }
+  es.string.blink { "ie":"6" }
+  es.string.bold { "ie":"6" }
+  es.string.fixed { "ie":"6" }
+  es.string.fontcolor { "ie":"6" }
+  es.string.fontsize { "ie":"6" }
+  es.string.italics { "ie":"6" }
+  es.string.link { "ie":"6" }
+  es.string.small { "ie":"6" }
+  es.string.strike { "ie":"6" }
+  es.string.sub { "ie":"6" }
+  es.string.sup { "ie":"6" }
+  es.typed-array.float32-array { "ie":"6" }
+  es.typed-array.float64-array { "ie":"6" }
+  es.typed-array.int8-array { "ie":"6" }
+  es.typed-array.int16-array { "ie":"6" }
+  es.typed-array.int32-array { "ie":"6" }
+  es.typed-array.uint8-array { "ie":"6" }
+  es.typed-array.uint8-clamped-array { "ie":"6" }
+  es.typed-array.uint16-array { "ie":"6" }
+  es.typed-array.uint32-array { "ie":"6" }
+  es.typed-array.copy-within { "ie":"6" }
+  es.typed-array.every { "ie":"6" }
+  es.typed-array.fill { "ie":"6" }
+  es.typed-array.filter { "ie":"6" }
+  es.typed-array.find { "ie":"6" }
+  es.typed-array.find-index { "ie":"6" }
+  es.typed-array.for-each { "ie":"6" }
+  es.typed-array.from { "ie":"6" }
+  es.typed-array.includes { "ie":"6" }
+  es.typed-array.index-of { "ie":"6" }
+  es.typed-array.iterator { "ie":"6" }
+  es.typed-array.join { "ie":"6" }
+  es.typed-array.last-index-of { "ie":"6" }
+  es.typed-array.map { "ie":"6" }
+  es.typed-array.of { "ie":"6" }
+  es.typed-array.reduce { "ie":"6" }
+  es.typed-array.reduce-right { "ie":"6" }
+  es.typed-array.reverse { "ie":"6" }
+  es.typed-array.set { "ie":"6" }
+  es.typed-array.slice { "ie":"6" }
+  es.typed-array.some { "ie":"6" }
+  es.typed-array.sort { "ie":"6" }
+  es.typed-array.subarray { "ie":"6" }
+  es.typed-array.to-locale-string { "ie":"6" }
+  es.typed-array.to-string { "ie":"6" }
+  es.weak-map { "ie":"6" }
+  es.weak-set { "ie":"6" }
+  web.dom-collections.for-each { "ie":"6" }
+  web.dom-collections.iterator { "ie":"6" }
+  web.immediate { "ie":"6" }
+  web.queue-microtask { "ie":"6" }
+  web.timers { "ie":"6" }
+  web.url { "ie":"6" }
+  web.url.to-json { "ie":"6" }
+  web.url-search-params { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/options.json
@@ -5,6 +5,9 @@
     [
       "env",
       {
+        "targets": {
+          "browsers": "ie 6"
+        },
         "debug": true,
         "shippedProposals": true,
         "useBuiltIns": "entry",

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
@@ -1,140 +1,142 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties {}
-  proposal-private-methods {}
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-class-properties { "ie":"6" }
+  proposal-private-methods { "ie":"6" }
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/input.mjs] Replaced core-js entries with the following polyfills:
-  es.map {}
-  esnext.aggregate-error {}
-  esnext.array.last-index {}
-  esnext.array.last-item {}
-  esnext.composite-key {}
-  esnext.composite-symbol {}
-  esnext.global-this {}
-  esnext.map.delete-all {}
-  esnext.map.every {}
-  esnext.map.filter {}
-  esnext.map.find {}
-  esnext.map.find-key {}
-  esnext.map.from {}
-  esnext.map.group-by {}
-  esnext.map.includes {}
-  esnext.map.key-by {}
-  esnext.map.key-of {}
-  esnext.map.map-keys {}
-  esnext.map.map-values {}
-  esnext.map.merge {}
-  esnext.map.of {}
-  esnext.map.reduce {}
-  esnext.map.some {}
-  esnext.map.update {}
-  esnext.math.clamp {}
-  esnext.math.deg-per-rad {}
-  esnext.math.degrees {}
-  esnext.math.fscale {}
-  esnext.math.iaddh {}
-  esnext.math.imulh {}
-  esnext.math.isubh {}
-  esnext.math.rad-per-deg {}
-  esnext.math.radians {}
-  esnext.math.scale {}
-  esnext.math.seeded-prng {}
-  esnext.math.signbit {}
-  esnext.math.umulh {}
-  esnext.number.from-string {}
-  esnext.observable {}
-  esnext.promise.all-settled {}
-  esnext.promise.any {}
-  esnext.promise.try {}
-  esnext.reflect.define-metadata {}
-  esnext.reflect.delete-metadata {}
-  esnext.reflect.get-metadata {}
-  esnext.reflect.get-metadata-keys {}
-  esnext.reflect.get-own-metadata {}
-  esnext.reflect.get-own-metadata-keys {}
-  esnext.reflect.has-metadata {}
-  esnext.reflect.has-own-metadata {}
-  esnext.reflect.metadata {}
-  esnext.set.add-all {}
-  esnext.set.delete-all {}
-  esnext.set.difference {}
-  esnext.set.every {}
-  esnext.set.filter {}
-  esnext.set.find {}
-  esnext.set.from {}
-  esnext.set.intersection {}
-  esnext.set.is-disjoint-from {}
-  esnext.set.is-subset-of {}
-  esnext.set.is-superset-of {}
-  esnext.set.join {}
-  esnext.set.map {}
-  esnext.set.of {}
-  esnext.set.reduce {}
-  esnext.set.some {}
-  esnext.set.symmetric-difference {}
-  esnext.set.union {}
-  esnext.string.at {}
-  esnext.string.code-points {}
-  esnext.string.match-all {}
-  esnext.string.replace-all {}
-  esnext.symbol.dispose {}
-  esnext.symbol.observable {}
-  esnext.symbol.pattern-match {}
-  esnext.weak-map.delete-all {}
-  esnext.weak-map.from {}
-  esnext.weak-map.of {}
-  esnext.weak-set.add-all {}
-  esnext.weak-set.delete-all {}
-  esnext.weak-set.from {}
-  esnext.weak-set.of {}
-  web.url {}
-  web.url.to-json {}
-  web.url-search-params {}
+  es.map { "ie":"6" }
+  esnext.aggregate-error { "ie":"6" }
+  esnext.array.last-index { "ie":"6" }
+  esnext.array.last-item { "ie":"6" }
+  esnext.composite-key { "ie":"6" }
+  esnext.composite-symbol { "ie":"6" }
+  esnext.global-this { "ie":"6" }
+  esnext.map.delete-all { "ie":"6" }
+  esnext.map.every { "ie":"6" }
+  esnext.map.filter { "ie":"6" }
+  esnext.map.find { "ie":"6" }
+  esnext.map.find-key { "ie":"6" }
+  esnext.map.from { "ie":"6" }
+  esnext.map.group-by { "ie":"6" }
+  esnext.map.includes { "ie":"6" }
+  esnext.map.key-by { "ie":"6" }
+  esnext.map.key-of { "ie":"6" }
+  esnext.map.map-keys { "ie":"6" }
+  esnext.map.map-values { "ie":"6" }
+  esnext.map.merge { "ie":"6" }
+  esnext.map.of { "ie":"6" }
+  esnext.map.reduce { "ie":"6" }
+  esnext.map.some { "ie":"6" }
+  esnext.map.update { "ie":"6" }
+  esnext.math.clamp { "ie":"6" }
+  esnext.math.deg-per-rad { "ie":"6" }
+  esnext.math.degrees { "ie":"6" }
+  esnext.math.fscale { "ie":"6" }
+  esnext.math.iaddh { "ie":"6" }
+  esnext.math.imulh { "ie":"6" }
+  esnext.math.isubh { "ie":"6" }
+  esnext.math.rad-per-deg { "ie":"6" }
+  esnext.math.radians { "ie":"6" }
+  esnext.math.scale { "ie":"6" }
+  esnext.math.seeded-prng { "ie":"6" }
+  esnext.math.signbit { "ie":"6" }
+  esnext.math.umulh { "ie":"6" }
+  esnext.number.from-string { "ie":"6" }
+  esnext.observable { "ie":"6" }
+  esnext.promise.all-settled { "ie":"6" }
+  esnext.promise.any { "ie":"6" }
+  esnext.promise.try { "ie":"6" }
+  esnext.reflect.define-metadata { "ie":"6" }
+  esnext.reflect.delete-metadata { "ie":"6" }
+  esnext.reflect.get-metadata { "ie":"6" }
+  esnext.reflect.get-metadata-keys { "ie":"6" }
+  esnext.reflect.get-own-metadata { "ie":"6" }
+  esnext.reflect.get-own-metadata-keys { "ie":"6" }
+  esnext.reflect.has-metadata { "ie":"6" }
+  esnext.reflect.has-own-metadata { "ie":"6" }
+  esnext.reflect.metadata { "ie":"6" }
+  esnext.set.add-all { "ie":"6" }
+  esnext.set.delete-all { "ie":"6" }
+  esnext.set.difference { "ie":"6" }
+  esnext.set.every { "ie":"6" }
+  esnext.set.filter { "ie":"6" }
+  esnext.set.find { "ie":"6" }
+  esnext.set.from { "ie":"6" }
+  esnext.set.intersection { "ie":"6" }
+  esnext.set.is-disjoint-from { "ie":"6" }
+  esnext.set.is-subset-of { "ie":"6" }
+  esnext.set.is-superset-of { "ie":"6" }
+  esnext.set.join { "ie":"6" }
+  esnext.set.map { "ie":"6" }
+  esnext.set.of { "ie":"6" }
+  esnext.set.reduce { "ie":"6" }
+  esnext.set.some { "ie":"6" }
+  esnext.set.symmetric-difference { "ie":"6" }
+  esnext.set.union { "ie":"6" }
+  esnext.string.at { "ie":"6" }
+  esnext.string.code-points { "ie":"6" }
+  esnext.string.match-all { "ie":"6" }
+  esnext.string.replace-all { "ie":"6" }
+  esnext.symbol.dispose { "ie":"6" }
+  esnext.symbol.observable { "ie":"6" }
+  esnext.symbol.pattern-match { "ie":"6" }
+  esnext.weak-map.delete-all { "ie":"6" }
+  esnext.weak-map.from { "ie":"6" }
+  esnext.weak-map.of { "ie":"6" }
+  esnext.weak-set.add-all { "ie":"6" }
+  esnext.weak-set.delete-all { "ie":"6" }
+  esnext.weak-set.from { "ie":"6" }
+  esnext.weak-set.of { "ie":"6" }
+  web.url { "ie":"6" }
+  web.url.to-json { "ie":"6" }
+  web.url-search-params { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/options.json
@@ -6,6 +6,9 @@
       "env",
       {
         "debug": true,
+        "targets": {
+          "browsers": "ie 6"
+        },
         "shippedProposals": true,
         "useBuiltIns": "entry",
         "corejs": 3

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
@@ -1,62 +1,64 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties {}
-  proposal-private-methods {}
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-class-properties { "ie":"6" }
+  proposal-private-methods { "ie":"6" }
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/input.mjs] Replaced core-js entries with the following polyfills:
-  web.dom-collections.for-each {}
-  web.dom-collections.iterator {}
-  web.immediate {}
-  web.queue-microtask {}
-  web.timers {}
-  web.url {}
-  web.url.to-json {}
-  web.url-search-params {}
+  web.dom-collections.for-each { "ie":"6" }
+  web.dom-collections.iterator { "ie":"6" }
+  web.immediate { "ie":"6" }
+  web.queue-microtask { "ie":"6" }
+  web.timers { "ie":"6" }
+  web.url { "ie":"6" }
+  web.url.to-json { "ie":"6" }
+  web.url-search-params { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/options.json
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/options.json
@@ -6,6 +6,9 @@
       "env",
       {
         "debug": true,
+        "targets": {
+          "browsers": "ie 6"
+        },
         "shippedProposals": true,
         "useBuiltIns": "entry"
       }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
@@ -1,202 +1,204 @@
 @babel/preset-env: `DEBUG` option
 
 Using targets:
-{}
+{
+  "ie": "6"
+}
 
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties {}
-  proposal-private-methods {}
-  proposal-numeric-separator {}
-  proposal-logical-assignment-operators {}
-  proposal-nullish-coalescing-operator {}
-  proposal-optional-chaining {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  transform-parameters {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  transform-dotall-regex {}
-  proposal-unicode-property-regex {}
-  transform-named-capturing-groups-regex {}
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  proposal-class-properties { "ie":"6" }
+  proposal-private-methods { "ie":"6" }
+  proposal-numeric-separator { "ie":"6" }
+  proposal-logical-assignment-operators { "ie":"6" }
+  proposal-nullish-coalescing-operator { "ie":"6" }
+  proposal-optional-chaining { "ie":"6" }
+  proposal-json-strings { "ie":"6" }
+  proposal-optional-catch-binding { "ie":"6" }
+  transform-parameters { "ie":"6" }
+  proposal-async-generator-functions { "ie":"6" }
+  proposal-object-rest-spread { "ie":"6" }
+  transform-dotall-regex { "ie":"6" }
+  proposal-unicode-property-regex { "ie":"6" }
+  transform-named-capturing-groups-regex { "ie":"6" }
+  transform-async-to-generator { "ie":"6" }
+  transform-exponentiation-operator { "ie":"6" }
+  transform-template-literals { "ie":"6" }
+  transform-literals { "ie":"6" }
+  transform-function-name { "ie":"6" }
+  transform-arrow-functions { "ie":"6" }
+  transform-block-scoped-functions { "ie":"6" }
+  transform-classes { "ie":"6" }
+  transform-object-super { "ie":"6" }
+  transform-shorthand-properties { "ie":"6" }
+  transform-duplicate-keys { "ie":"6" }
+  transform-computed-properties { "ie":"6" }
+  transform-for-of { "ie":"6" }
+  transform-sticky-regex { "ie":"6" }
+  transform-unicode-escapes { "ie":"6" }
+  transform-unicode-regex { "ie":"6" }
+  transform-spread { "ie":"6" }
+  transform-destructuring { "ie":"6" }
+  transform-block-scoping { "ie":"6" }
+  transform-typeof-symbol { "ie":"6" }
+  transform-new-target { "ie":"6" }
+  transform-regenerator { "ie":"6" }
+  transform-member-expression-literals { "ie":"6" }
+  transform-property-literals { "ie":"6" }
+  transform-reserved-words { "ie":"6" }
+  proposal-export-namespace-from { "ie":"6" }
+  transform-modules-commonjs { "ie":"6" }
+  proposal-dynamic-import { "ie":"6" }
 
 Using polyfills with `entry` option:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/input.mjs] Replaced @babel/polyfill entries with the following polyfills:
-  es6.array.copy-within {}
-  es6.array.every {}
-  es6.array.fill {}
-  es6.array.filter {}
-  es6.array.find {}
-  es6.array.find-index {}
-  es7.array.flat-map {}
-  es6.array.for-each {}
-  es6.array.from {}
-  es7.array.includes {}
-  es6.array.index-of {}
-  es6.array.is-array {}
-  es6.array.iterator {}
-  es6.array.last-index-of {}
-  es6.array.map {}
-  es6.array.of {}
-  es6.array.reduce {}
-  es6.array.reduce-right {}
-  es6.array.some {}
-  es6.array.sort {}
-  es6.array.species {}
-  es6.date.now {}
-  es6.date.to-iso-string {}
-  es6.date.to-json {}
-  es6.date.to-primitive {}
-  es6.date.to-string {}
-  es6.function.bind {}
-  es6.function.has-instance {}
-  es6.function.name {}
-  es6.map {}
-  es6.math.acosh {}
-  es6.math.asinh {}
-  es6.math.atanh {}
-  es6.math.cbrt {}
-  es6.math.clz32 {}
-  es6.math.cosh {}
-  es6.math.expm1 {}
-  es6.math.fround {}
-  es6.math.hypot {}
-  es6.math.imul {}
-  es6.math.log1p {}
-  es6.math.log10 {}
-  es6.math.log2 {}
-  es6.math.sign {}
-  es6.math.sinh {}
-  es6.math.tanh {}
-  es6.math.trunc {}
-  es6.number.constructor {}
-  es6.number.epsilon {}
-  es6.number.is-finite {}
-  es6.number.is-integer {}
-  es6.number.is-nan {}
-  es6.number.is-safe-integer {}
-  es6.number.max-safe-integer {}
-  es6.number.min-safe-integer {}
-  es6.number.parse-float {}
-  es6.number.parse-int {}
-  es6.object.assign {}
-  es6.object.create {}
-  es7.object.define-getter {}
-  es7.object.define-setter {}
-  es6.object.define-property {}
-  es6.object.define-properties {}
-  es7.object.entries {}
-  es6.object.freeze {}
-  es6.object.get-own-property-descriptor {}
-  es7.object.get-own-property-descriptors {}
-  es6.object.get-own-property-names {}
-  es6.object.get-prototype-of {}
-  es7.object.lookup-getter {}
-  es7.object.lookup-setter {}
-  es6.object.prevent-extensions {}
-  es6.object.to-string {}
-  es6.object.is {}
-  es6.object.is-frozen {}
-  es6.object.is-sealed {}
-  es6.object.is-extensible {}
-  es6.object.keys {}
-  es6.object.seal {}
-  es6.object.set-prototype-of {}
-  es7.object.values {}
-  es6.promise {}
-  es7.promise.finally {}
-  es6.reflect.apply {}
-  es6.reflect.construct {}
-  es6.reflect.define-property {}
-  es6.reflect.delete-property {}
-  es6.reflect.get {}
-  es6.reflect.get-own-property-descriptor {}
-  es6.reflect.get-prototype-of {}
-  es6.reflect.has {}
-  es6.reflect.is-extensible {}
-  es6.reflect.own-keys {}
-  es6.reflect.prevent-extensions {}
-  es6.reflect.set {}
-  es6.reflect.set-prototype-of {}
-  es6.regexp.constructor {}
-  es6.regexp.flags {}
-  es6.regexp.match {}
-  es6.regexp.replace {}
-  es6.regexp.split {}
-  es6.regexp.search {}
-  es6.regexp.to-string {}
-  es6.set {}
-  es6.symbol {}
-  es7.symbol.async-iterator {}
-  es6.string.anchor {}
-  es6.string.big {}
-  es6.string.blink {}
-  es6.string.bold {}
-  es6.string.code-point-at {}
-  es6.string.ends-with {}
-  es6.string.fixed {}
-  es6.string.fontcolor {}
-  es6.string.fontsize {}
-  es6.string.from-code-point {}
-  es6.string.includes {}
-  es6.string.italics {}
-  es6.string.iterator {}
-  es6.string.link {}
-  es7.string.pad-start {}
-  es7.string.pad-end {}
-  es6.string.raw {}
-  es6.string.repeat {}
-  es6.string.small {}
-  es6.string.starts-with {}
-  es6.string.strike {}
-  es6.string.sub {}
-  es6.string.sup {}
-  es6.string.trim {}
-  es7.string.trim-left {}
-  es7.string.trim-right {}
-  es6.typed.array-buffer {}
-  es6.typed.data-view {}
-  es6.typed.int8-array {}
-  es6.typed.uint8-array {}
-  es6.typed.uint8-clamped-array {}
-  es6.typed.int16-array {}
-  es6.typed.uint16-array {}
-  es6.typed.int32-array {}
-  es6.typed.uint32-array {}
-  es6.typed.float32-array {}
-  es6.typed.float64-array {}
-  es6.weak-map {}
-  es6.weak-set {}
-  web.timers {}
-  web.immediate {}
-  web.dom.iterable {}
+  es6.array.copy-within { "ie":"6" }
+  es6.array.every { "ie":"6" }
+  es6.array.fill { "ie":"6" }
+  es6.array.filter { "ie":"6" }
+  es6.array.find { "ie":"6" }
+  es6.array.find-index { "ie":"6" }
+  es7.array.flat-map { "ie":"6" }
+  es6.array.for-each { "ie":"6" }
+  es6.array.from { "ie":"6" }
+  es7.array.includes { "ie":"6" }
+  es6.array.index-of { "ie":"6" }
+  es6.array.is-array { "ie":"6" }
+  es6.array.iterator { "ie":"6" }
+  es6.array.last-index-of { "ie":"6" }
+  es6.array.map { "ie":"6" }
+  es6.array.of { "ie":"6" }
+  es6.array.reduce { "ie":"6" }
+  es6.array.reduce-right { "ie":"6" }
+  es6.array.some { "ie":"6" }
+  es6.array.sort { "ie":"6" }
+  es6.array.species { "ie":"6" }
+  es6.date.now { "ie":"6" }
+  es6.date.to-iso-string { "ie":"6" }
+  es6.date.to-json { "ie":"6" }
+  es6.date.to-primitive { "ie":"6" }
+  es6.date.to-string { "ie":"6" }
+  es6.function.bind { "ie":"6" }
+  es6.function.has-instance { "ie":"6" }
+  es6.function.name { "ie":"6" }
+  es6.map { "ie":"6" }
+  es6.math.acosh { "ie":"6" }
+  es6.math.asinh { "ie":"6" }
+  es6.math.atanh { "ie":"6" }
+  es6.math.cbrt { "ie":"6" }
+  es6.math.clz32 { "ie":"6" }
+  es6.math.cosh { "ie":"6" }
+  es6.math.expm1 { "ie":"6" }
+  es6.math.fround { "ie":"6" }
+  es6.math.hypot { "ie":"6" }
+  es6.math.imul { "ie":"6" }
+  es6.math.log1p { "ie":"6" }
+  es6.math.log10 { "ie":"6" }
+  es6.math.log2 { "ie":"6" }
+  es6.math.sign { "ie":"6" }
+  es6.math.sinh { "ie":"6" }
+  es6.math.tanh { "ie":"6" }
+  es6.math.trunc { "ie":"6" }
+  es6.number.constructor { "ie":"6" }
+  es6.number.epsilon { "ie":"6" }
+  es6.number.is-finite { "ie":"6" }
+  es6.number.is-integer { "ie":"6" }
+  es6.number.is-nan { "ie":"6" }
+  es6.number.is-safe-integer { "ie":"6" }
+  es6.number.max-safe-integer { "ie":"6" }
+  es6.number.min-safe-integer { "ie":"6" }
+  es6.number.parse-float { "ie":"6" }
+  es6.number.parse-int { "ie":"6" }
+  es6.object.assign { "ie":"6" }
+  es6.object.create { "ie":"6" }
+  es7.object.define-getter { "ie":"6" }
+  es7.object.define-setter { "ie":"6" }
+  es6.object.define-property { "ie":"6" }
+  es6.object.define-properties { "ie":"6" }
+  es7.object.entries { "ie":"6" }
+  es6.object.freeze { "ie":"6" }
+  es6.object.get-own-property-descriptor { "ie":"6" }
+  es7.object.get-own-property-descriptors { "ie":"6" }
+  es6.object.get-own-property-names { "ie":"6" }
+  es6.object.get-prototype-of { "ie":"6" }
+  es7.object.lookup-getter { "ie":"6" }
+  es7.object.lookup-setter { "ie":"6" }
+  es6.object.prevent-extensions { "ie":"6" }
+  es6.object.to-string { "ie":"6" }
+  es6.object.is { "ie":"6" }
+  es6.object.is-frozen { "ie":"6" }
+  es6.object.is-sealed { "ie":"6" }
+  es6.object.is-extensible { "ie":"6" }
+  es6.object.keys { "ie":"6" }
+  es6.object.seal { "ie":"6" }
+  es6.object.set-prototype-of { "ie":"6" }
+  es7.object.values { "ie":"6" }
+  es6.promise { "ie":"6" }
+  es7.promise.finally { "ie":"6" }
+  es6.reflect.apply { "ie":"6" }
+  es6.reflect.construct { "ie":"6" }
+  es6.reflect.define-property { "ie":"6" }
+  es6.reflect.delete-property { "ie":"6" }
+  es6.reflect.get { "ie":"6" }
+  es6.reflect.get-own-property-descriptor { "ie":"6" }
+  es6.reflect.get-prototype-of { "ie":"6" }
+  es6.reflect.has { "ie":"6" }
+  es6.reflect.is-extensible { "ie":"6" }
+  es6.reflect.own-keys { "ie":"6" }
+  es6.reflect.prevent-extensions { "ie":"6" }
+  es6.reflect.set { "ie":"6" }
+  es6.reflect.set-prototype-of { "ie":"6" }
+  es6.regexp.constructor { "ie":"6" }
+  es6.regexp.flags { "ie":"6" }
+  es6.regexp.match { "ie":"6" }
+  es6.regexp.replace { "ie":"6" }
+  es6.regexp.split { "ie":"6" }
+  es6.regexp.search { "ie":"6" }
+  es6.regexp.to-string { "ie":"6" }
+  es6.set { "ie":"6" }
+  es6.symbol { "ie":"6" }
+  es7.symbol.async-iterator { "ie":"6" }
+  es6.string.anchor { "ie":"6" }
+  es6.string.big { "ie":"6" }
+  es6.string.blink { "ie":"6" }
+  es6.string.bold { "ie":"6" }
+  es6.string.code-point-at { "ie":"6" }
+  es6.string.ends-with { "ie":"6" }
+  es6.string.fixed { "ie":"6" }
+  es6.string.fontcolor { "ie":"6" }
+  es6.string.fontsize { "ie":"6" }
+  es6.string.from-code-point { "ie":"6" }
+  es6.string.includes { "ie":"6" }
+  es6.string.italics { "ie":"6" }
+  es6.string.iterator { "ie":"6" }
+  es6.string.link { "ie":"6" }
+  es7.string.pad-start { "ie":"6" }
+  es7.string.pad-end { "ie":"6" }
+  es6.string.raw { "ie":"6" }
+  es6.string.repeat { "ie":"6" }
+  es6.string.small { "ie":"6" }
+  es6.string.starts-with { "ie":"6" }
+  es6.string.strike { "ie":"6" }
+  es6.string.sub { "ie":"6" }
+  es6.string.sup { "ie":"6" }
+  es6.string.trim { "ie":"6" }
+  es7.string.trim-left { "ie":"6" }
+  es7.string.trim-right { "ie":"6" }
+  es6.typed.array-buffer { "ie":"6" }
+  es6.typed.data-view { "ie":"6" }
+  es6.typed.int8-array { "ie":"6" }
+  es6.typed.uint8-array { "ie":"6" }
+  es6.typed.uint8-clamped-array { "ie":"6" }
+  es6.typed.int16-array { "ie":"6" }
+  es6.typed.uint16-array { "ie":"6" }
+  es6.typed.int32-array { "ie":"6" }
+  es6.typed.uint32-array { "ie":"6" }
+  es6.typed.float32-array { "ie":"6" }
+  es6.typed.float64-array { "ie":"6" }
+  es6.weak-map { "ie":"6" }
+  es6.weak-set { "ie":"6" }
+  web.timers { "ie":"6" }
+  web.immediate { "ie":"6" }
+  web.dom.iterable { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/auto-esm-unsupported-import-unsupported/output.js
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/auto-esm-unsupported-import-unsupported/output.js
@@ -1,11 +1,5 @@
 "use strict";
 
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-
 Promise.resolve().then(function () {
-  return _interopRequireWildcard(require("foo"));
+  return babelHelpers.interopRequireWildcard(require("foo"));
 });

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/modules-amd/output.js
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/modules-amd/output.js
@@ -1,13 +1,7 @@
 define(["require"], function (_require) {
-  function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-  function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
-
-  function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-
   new Promise(function (_resolve, _reject) {
     return _require(["foo"], function (imported) {
-      return _resolve(_interopRequireWildcard(imported));
+      return _resolve(babelHelpers.interopRequireWildcard(imported));
     }, _reject);
   });
 });

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/modules-cjs/output.js
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/modules-cjs/output.js
@@ -1,11 +1,5 @@
 "use strict";
 
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-
 Promise.resolve().then(function () {
-  return _interopRequireWildcard(require("foo"));
+  return babelHelpers.interopRequireWildcard(require("foo"));
 });

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/modules-systemjs/options.json
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/modules-systemjs/options.json
@@ -1,4 +1,4 @@
 {
   "validateLogs": true,
-  "presets": [["env", { "modules": "systemjs" }]]
+  "presets": [["env", { "modules": "systemjs", "targets": { "browsers": "ie 6" } }]]
 }

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/options.json
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["external-helpers", { "helperVersion": "7.100" }]]
+}

--- a/packages/babel-preset-env/test/fixtures/export-namespace-from/auto-esm-not-supported/output.js
+++ b/packages/babel-preset-env/test/fixtures/export-namespace-from/auto-esm-not-supported/output.js
@@ -5,8 +5,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.foo = void 0;
 
-var _foo = _interopRequireDefault(require("./foo.mjs"));
+var _foo = babelHelpers.interopRequireDefault(require("./foo.mjs"));
 
 exports.foo = _foo;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }

--- a/packages/babel-preset-env/test/fixtures/export-namespace-from/options.json
+++ b/packages/babel-preset-env/test/fixtures/export-namespace-from/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["external-helpers", { "helperVersion": "7.100" }]]
+}

--- a/packages/babel-preset-env/test/fixtures/modules/auto-cjs/options.json
+++ b/packages/babel-preset-env/test/fixtures/modules/auto-cjs/options.json
@@ -3,5 +3,5 @@
     "name": "test-fixture",
     "supportsStaticESM": false
   },
-  "presets": ["env"]
+  "presets": [["env", { "targets": { "browsers": "ie 6" } }]]
 }

--- a/packages/babel-preset-env/test/fixtures/modules/auto-cjs/output.js
+++ b/packages/babel-preset-env/test/fixtures/modules/auto-cjs/output.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var _mod = _interopRequireDefault(require("mod"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+var _mod = babelHelpers.interopRequireDefault(require("mod"));
 
 console.log(_mod["default"]);

--- a/packages/babel-preset-env/test/fixtures/modules/auto-unknown/options.json
+++ b/packages/babel-preset-env/test/fixtures/modules/auto-unknown/options.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["env"]
+  "presets": [["env", { "targets": { "browsers": "ie 6" } }]]
 }

--- a/packages/babel-preset-env/test/fixtures/modules/auto-unknown/output.js
+++ b/packages/babel-preset-env/test/fixtures/modules/auto-unknown/output.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var _mod = _interopRequireDefault(require("mod"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+var _mod = babelHelpers.interopRequireDefault(require("mod"));
 
 console.log(_mod["default"]);

--- a/packages/babel-preset-env/test/fixtures/modules/modules-cjs/output.js
+++ b/packages/babel-preset-env/test/fixtures/modules/modules-cjs/output.js
@@ -1,5 +1,3 @@
 "use strict";
 
-var _a = _interopRequireDefault(require("a"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+var _a = babelHelpers.interopRequireDefault(require("a"));

--- a/packages/babel-preset-env/test/fixtures/modules/modules-commonjs/output.js
+++ b/packages/babel-preset-env/test/fixtures/modules/modules-commonjs/output.js
@@ -1,5 +1,3 @@
 "use strict";
 
-var _a = _interopRequireDefault(require("a"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+var _a = babelHelpers.interopRequireDefault(require("a"));

--- a/packages/babel-preset-env/test/fixtures/modules/modules-systemjs/options.json
+++ b/packages/babel-preset-env/test/fixtures/modules/modules-systemjs/options.json
@@ -3,7 +3,8 @@
     [
       "../../../../lib",
       {
-        "modules": "systemjs"
+        "modules": "systemjs",
+        "targets": { "browsers": "ie 6" }
       }
     ]
   ]

--- a/packages/babel-preset-env/test/fixtures/modules/modules-umd/output.js
+++ b/packages/babel-preset-env/test/fixtures/modules/modules-umd/output.js
@@ -13,7 +13,5 @@
 })(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_a) {
   "use strict";
 
-  _a = _interopRequireDefault(_a);
-
-  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+  _a = babelHelpers.interopRequireDefault(_a);
 });

--- a/packages/babel-preset-env/test/fixtures/modules/options.json
+++ b/packages/babel-preset-env/test/fixtures/modules/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["external-helpers", { "helperVersion": "7.100" }]]
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/browserslist-defaults-not-ie/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/browserslist-defaults-not-ie/output.js
@@ -1,19 +1,7 @@
 "use strict";
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
 var test = function test(a, _ref, c) {
-  var _ref2 = _slicedToArray(_ref, 1),
+  var _ref2 = babelHelpers.slicedToArray(_ref, 1),
       b = _ref2[0];
 
   return "";

--- a/packages/babel-preset-env/test/fixtures/preset-options/esmodules-async-functions/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options/esmodules-async-functions/output.mjs
@@ -1,12 +1,8 @@
-function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
-
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
-
 function f() {
   return _f.apply(this, arguments);
 }
 
 function _f() {
-  _f = _asyncToGenerator(function* () {});
+  _f = babelHelpers.asyncToGenerator(function* () {});
   return _f.apply(this, arguments);
 }

--- a/packages/babel-preset-env/test/fixtures/preset-options/include-scoped/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options/include-scoped/output.mjs
@@ -1,5 +1,3 @@
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
 let Foo = function Foo() {
-  _classCallCheck(this, Foo);
+  babelHelpers.classCallCheck(this, Foo);
 };

--- a/packages/babel-preset-env/test/fixtures/preset-options/include/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options/include/output.mjs
@@ -1,5 +1,3 @@
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
 let Foo = function Foo() {
-  _classCallCheck(this, Foo);
+  babelHelpers.classCallCheck(this, Foo);
 };

--- a/packages/babel-preset-env/test/fixtures/preset-options/loose-with-typeof-symbol-includes/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options/loose-with-typeof-symbol-includes/options.json
@@ -4,6 +4,7 @@
       "../../../../lib",
       {
         "loose": true,
+        "targets": { "browsers": "ie 6" },
         "include": ["transform-typeof-symbol"]
       }
     ]

--- a/packages/babel-preset-env/test/fixtures/preset-options/loose-with-typeof-symbol-includes/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/loose-with-typeof-symbol-includes/output.js
@@ -1,5 +1,3 @@
 "use strict";
 
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-_typeof(Symbol());
+babelHelpers["typeof"](Symbol());

--- a/packages/babel-preset-env/test/fixtures/preset-options/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["external-helpers", { "helperVersion": "7.100" }]]
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-tagged-template-literals/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-tagged-template-literals/output.js
@@ -1,5 +1,3 @@
 var _templateObject;
 
-function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
-
-tag(_templateObject || (_templateObject = _taggedTemplateLiteral(["Safari 12 borked"])));
+tag(_templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral(["Safari 12 borked"])));

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
@@ -1,29 +1,3 @@
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
-function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
-
-function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
-
-function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
-
-function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
-
-function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; var wrappedAwait = value instanceof _AwaitValue; Promise.resolve(wrappedAwait ? value.wrapped : value).then(function (arg) { if (wrappedAwait) { resume(key === "return" ? "return" : "next", arg); return; } settle(result.done ? "return" : "normal", arg); }, function (err) { resume("throw", err); }); } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen["return"] !== "function") { this["return"] = undefined; } }
-
-if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
-
-_AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
-
-_AsyncGenerator.prototype["throw"] = function (arg) { return this._invoke("throw", arg); };
-
-_AsyncGenerator.prototype["return"] = function (arg) { return this._invoke("return", arg); };
-
-function _AwaitValue(value) { this.wrapped = value; }
-
 var _x$y$a$b = {
   x: 1,
   y: 2,
@@ -32,9 +6,8 @@ var _x$y$a$b = {
 },
     x = _x$y$a$b.x,
     y = _x$y$a$b.y,
-    z = _objectWithoutProperties(_x$y$a$b, ["x", "y"]);
-
-var n = _objectSpread({
+    z = babelHelpers.objectWithoutProperties(_x$y$a$b, ["x", "y"]);
+var n = babelHelpers.objectSpread2({
   x: x,
   y: y
 }, z);
@@ -44,13 +17,13 @@ function agf() {
 }
 
 function _agf() {
-  _agf = _wrapAsyncGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
+  _agf = babelHelpers.wrapAsyncGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
     return regeneratorRuntime.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
             _context.next = 2;
-            return _awaitAsyncGenerator(1);
+            return babelHelpers.awaitAsyncGenerator(1);
 
           case 2:
             _context.next = 4;

--- a/packages/babel-preset-env/test/fixtures/preset-options/spec/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/spec/output.js
@@ -1,11 +1,8 @@
 var _this = this;
 
-function _newArrowCheck(innerThis, boundThis) { if (innerThis !== boundThis) { throw new TypeError("Cannot instantiate an arrow function"); } }
-
 var bar = "bar";
 
 var x = function x() {
-  _newArrowCheck(this, _this);
-
+  babelHelpers.newArrowCheck(this, _this);
   return "foo".concat(bar);
 }.bind(this);

--- a/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/options.json
+++ b/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/options.json
@@ -6,5 +6,6 @@
         "modules": false
       }
     ]
-  ]
+  ],
+  "plugins": [["external-helpers", { "helperVersion": "7.100" }]]
 }

--- a/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/output.js
+++ b/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/output.js
@@ -1,24 +1,10 @@
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
-function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e2) { throw _e2; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e3) { didErr = true; err = _e3; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
 // https://github.com/babel/babel/issues/7557
-var _iterator = _createForOfIteratorHelper(c),
+var _iterator = babelHelpers.createForOfIteratorHelper(c),
     _step;
 
 try {
   var _loop = function _loop() {
-    var _step$value = _slicedToArray(_step.value, 1),
+    var _step$value = babelHelpers.slicedToArray(_step.value, 1),
         a = _step$value[0];
 
     a = 1;

--- a/packages/babel-preset-env/test/fixtures/shipped-proposals/node-12/options.json
+++ b/packages/babel-preset-env/test/fixtures/shipped-proposals/node-12/options.json
@@ -4,5 +4,6 @@
       "targets": { "node": 12 },
       "shippedProposals": true
     }]
-  ]
+  ],
+  "plugins": [["external-helpers", { "helperVersion": "7.100" }]]
 }

--- a/packages/babel-preset-env/test/fixtures/shipped-proposals/node-12/output.js
+++ b/packages/babel-preset-env/test/fixtures/shipped-proposals/node-12/output.js
@@ -1,8 +1,6 @@
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 class A {
   constructor() {
-    _defineProperty(this, "x", void 0);
+    babelHelpers.defineProperty(this, "x", void 0);
   }
 
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is extracted from #10897 but only includes small clean-up of `@babel/helper-compilation-targets`. It also adds `browsers: "ie 6"` to those test fixtures which does not specify a valid target, so the tests can be more focused and will not be impacted when we later align the preset-env defaults to browserlists defaults.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12615"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/7f8994f824e71fbdfd76ac90077149a687ad0c1e.svg" /></a>

