### PR TITLE
Implement `constantReexports` and `enumerableModuleMeta` assumptions

### DIFF
--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -334,6 +334,7 @@ export type NestingPath = RootPath | OverridesPath | EnvPath;
 export const assumptionsNames = new Set<string>([
   "arrayLikeIsIterable",
   "constantReexports",
+  "enumerableModuleMeta",
   "ignoreFunctionLength",
   "ignoreToPrimitiveHint",
   "iterableIsArray",

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -333,6 +333,7 @@ export type NestingPath = RootPath | OverridesPath | EnvPath;
 
 export const assumptionsNames = new Set<string>([
   "arrayLikeIsIterable",
+  "constantReexports",
   "ignoreFunctionLength",
   "ignoreToPrimitiveHint",
   "iterableIsArray",

--- a/packages/babel-helper-module-transforms/src/index.js
+++ b/packages/babel-helper-module-transforms/src/index.js
@@ -47,7 +47,7 @@ export function rewriteModuleStatementsAndPrepareHeader(
 
   const meta = normalizeAndLoadModuleMetadata(path, exportName, {
     noInterop,
-    loose,
+    initializeReexports: constantReexports,
     lazy,
     esNamespaceOnly,
   });

--- a/packages/babel-helper-module-transforms/src/index.js
+++ b/packages/babel-helper-module-transforms/src/index.js
@@ -27,14 +27,18 @@ export { hasExports, isSideEffectImport, isModule, rewriteThis };
 export function rewriteModuleStatementsAndPrepareHeader(
   path: NodePath,
   {
+    // TODO(Babel 8): Remove this
+    loose,
+
     exportName,
     strict,
     allowTopLevelThis,
     strictMode,
-    loose,
     noInterop,
     lazy,
     esNamespaceOnly,
+
+    constantReexports = loose,
   },
 ) {
   assert(isModule(path), "Cannot process module statements in a script");
@@ -78,7 +82,9 @@ export function rewriteModuleStatementsAndPrepareHeader(
   }
 
   // Create all of the statically known named exports.
-  headers.push(...buildExportInitializationStatements(path, meta, loose));
+  headers.push(
+    ...buildExportInitializationStatements(path, meta, constantReexports),
+  );
 
   return { meta, headers };
 }
@@ -128,7 +134,7 @@ export function wrapInterop(
 export function buildNamespaceInitStatements(
   metadata: ModuleMetadata,
   sourceMetadata: SourceModuleMetadata,
-  loose: boolean = false,
+  constantReexports: boolean = false,
 ) {
   const statements = [];
 
@@ -146,8 +152,8 @@ export function buildNamespaceInitStatements(
       }),
     );
   }
-  if (loose) {
-    statements.push(...buildReexportsFromMeta(metadata, sourceMetadata, loose));
+  if (constantReexports) {
+    statements.push(...buildReexportsFromMeta(metadata, sourceMetadata, true));
   }
   for (const exportName of sourceMetadata.reexportNamespace) {
     // Assign export to namespace object.
@@ -172,7 +178,7 @@ export function buildNamespaceInitStatements(
     const statement = buildNamespaceReexport(
       metadata,
       t.cloneNode(srcNamespace),
-      loose,
+      constantReexports,
     );
     statement.loc = sourceMetadata.reexportAll.loc;
 
@@ -183,8 +189,8 @@ export function buildNamespaceInitStatements(
 }
 
 const ReexportTemplate = {
-  loose: template.statement`EXPORTS.EXPORT_NAME = NAMESPACE_IMPORT;`,
-  looseComputed: template.statement`EXPORTS["EXPORT_NAME"] = NAMESPACE_IMPORT;`,
+  constant: template.statement`EXPORTS.EXPORT_NAME = NAMESPACE_IMPORT;`,
+  constantComputed: template.statement`EXPORTS["EXPORT_NAME"] = NAMESPACE_IMPORT;`,
   spec: template`
     Object.defineProperty(EXPORTS, "EXPORT_NAME", {
       enumerable: true,
@@ -198,7 +204,7 @@ const ReexportTemplate = {
 const buildReexportsFromMeta = (
   meta: ModuleMetadata,
   metadata: SourceModuleMetadata,
-  loose,
+  constantReexports: boolean,
 ) => {
   const namespace = metadata.lazy
     ? t.callExpression(t.identifier(metadata.name), [])
@@ -224,11 +230,11 @@ const buildReexportsFromMeta = (
       EXPORT_NAME: exportName,
       NAMESPACE_IMPORT,
     };
-    if (loose) {
+    if (constantReexports) {
       if (stringSpecifiers.has(exportName)) {
-        return ReexportTemplate.looseComputed(astNodes);
+        return ReexportTemplate.constantComputed(astNodes);
       } else {
-        return ReexportTemplate.loose(astNodes);
+        return ReexportTemplate.constant(astNodes);
       }
     } else {
       return ReexportTemplate.spec(astNodes);
@@ -257,8 +263,8 @@ function buildESModuleHeader(
 /**
  * Create a re-export initialization loop for a specific imported namespace.
  */
-function buildNamespaceReexport(metadata, namespace, loose) {
-  return (loose
+function buildNamespaceReexport(metadata, namespace, constantReexports) {
+  return (constantReexports
     ? template.statement`
         Object.keys(NAMESPACE).forEach(function(key) {
           if (key === "default" || key === "__esModule") return;
@@ -347,7 +353,7 @@ function buildExportNameListDeclaration(
 function buildExportInitializationStatements(
   programPath: NodePath,
   metadata: ModuleMetadata,
-  loose: boolean = false,
+  constantReexports: boolean = false,
 ) {
   const initStatements = [];
 
@@ -365,8 +371,8 @@ function buildExportInitializationStatements(
   }
 
   for (const data of metadata.source.values()) {
-    if (!loose) {
-      initStatements.push(...buildReexportsFromMeta(metadata, data, loose));
+    if (!constantReexports) {
+      initStatements.push(...buildReexportsFromMeta(metadata, data, false));
     }
     for (const exportName of data.reexportNamespace) {
       exportNames.push(exportName);

--- a/packages/babel-helper-module-transforms/src/index.js
+++ b/packages/babel-helper-module-transforms/src/index.js
@@ -39,6 +39,7 @@ export function rewriteModuleStatementsAndPrepareHeader(
     esNamespaceOnly,
 
     constantReexports = loose,
+    enumerableModuleMeta = loose,
   },
 ) {
   assert(isModule(path), "Cannot process module statements in a script");
@@ -71,7 +72,7 @@ export function rewriteModuleStatementsAndPrepareHeader(
 
   const headers = [];
   if (hasExports(meta) && !strict) {
-    headers.push(buildESModuleHeader(meta, loose /* enumerable */));
+    headers.push(buildESModuleHeader(meta, enumerableModuleMeta));
   }
 
   const nameList = buildExportNameListDeclaration(path, meta);
@@ -247,9 +248,9 @@ const buildReexportsFromMeta = (
  */
 function buildESModuleHeader(
   metadata: ModuleMetadata,
-  enumerable: boolean = false,
+  enumerableModuleMeta: boolean = false,
 ) {
-  return (enumerable
+  return (enumerableModuleMeta
     ? template.statement`
         EXPORTS.__esModule = true;
       `

--- a/packages/babel-plugin-transform-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-modules-amd/src/index.js
@@ -42,6 +42,8 @@ export default declare((api, options) => {
 
   const constantReexports =
     api.assumption("constantReexports") ?? options.loose;
+  const enumerableModuleMeta =
+    api.assumption("enumerableModuleMeta") ?? options.loose;
 
   return {
     name: "transform-modules-amd",
@@ -108,6 +110,7 @@ export default declare((api, options) => {
             path,
             {
               loose,
+              enumerableModuleMeta,
               constantReexports,
               strict,
               strictMode,

--- a/packages/babel-plugin-transform-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-modules-amd/src/index.js
@@ -39,6 +39,10 @@ export default declare((api, options) => {
   api.assertVersion(7);
 
   const { loose, allowTopLevelThis, strict, strictMode, noInterop } = options;
+
+  const constantReexports =
+    api.assumption("constantReexports") ?? options.loose;
+
   return {
     name: "transform-modules-amd",
 
@@ -104,6 +108,7 @@ export default declare((api, options) => {
             path,
             {
               loose,
+              constantReexports,
               strict,
               strictMode,
               allowTopLevelThis,
@@ -141,7 +146,11 @@ export default declare((api, options) => {
             }
 
             headers.push(
-              ...buildNamespaceInitStatements(meta, metadata, loose),
+              ...buildNamespaceInitStatements(
+                meta,
+                metadata,
+                constantReexports,
+              ),
             );
           }
 

--- a/packages/babel-plugin-transform-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-modules-amd/src/index.js
@@ -38,7 +38,7 @@ function injectWrapper(path, wrapper) {
 export default declare((api, options) => {
   api.assertVersion(7);
 
-  const { loose, allowTopLevelThis, strict, strictMode, noInterop } = options;
+  const { allowTopLevelThis, strict, strictMode, noInterop } = options;
 
   const constantReexports =
     api.assumption("constantReexports") ?? options.loose;
@@ -109,7 +109,6 @@ export default declare((api, options) => {
           const { meta, headers } = rewriteModuleStatementsAndPrepareHeader(
             path,
             {
-              loose,
               enumerableModuleMeta,
               constantReexports,
               strict,

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-2/input.mjs
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-2/input.mjs
@@ -1,0 +1,1 @@
+export {foo as default} from "foo";

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-2/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-2/output.js
@@ -1,0 +1,8 @@
+define(["exports", "foo"], function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.default = _foo.foo;
+});

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-2/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-2/output.js
@@ -4,5 +4,6 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.default = void 0;
   _exports.default = _foo.foo;
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-3/input.mjs
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-3/input.mjs
@@ -1,0 +1,1 @@
+export {foo as default, bar} from "foo";

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-3/output.js
@@ -1,0 +1,9 @@
+define(["exports", "foo"], function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.default = _foo.foo;
+  _exports.bar = _foo.bar;
+});

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-3/output.js
@@ -4,6 +4,7 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.bar = _exports.default = void 0;
   _exports.default = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-4/input.mjs
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-4/input.mjs
@@ -1,0 +1,1 @@
+export {foo as bar} from "foo";

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-4/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-4/output.js
@@ -1,0 +1,8 @@
+define(["exports", "foo"], function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.bar = _foo.foo;
+});

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-4/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-4/output.js
@@ -4,5 +4,6 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.bar = void 0;
   _exports.bar = _foo.foo;
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-5/input.mjs
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-5/input.mjs
@@ -1,0 +1,1 @@
+export {foo, bar} from "foo";

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-5/output.js
@@ -1,0 +1,9 @@
+define(["exports", "foo"], function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.foo = _foo.foo;
+  _exports.bar = _foo.bar;
+});

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-5/output.js
@@ -4,6 +4,7 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.bar = _exports.foo = void 0;
   _exports.foo = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-6/input.mjs
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-6/input.mjs
@@ -1,0 +1,1 @@
+export * from "foo";

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-6/output.js
@@ -1,0 +1,12 @@
+define(["exports", "foo"], function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  Object.keys(_foo).forEach(function (key) {
+    if (key === "default" || key === "__esModule") return;
+    if (key in _exports && _exports[key] === _foo[key]) return;
+    _exports[key] = _foo[key];
+  });
+});

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from/input.mjs
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from/input.mjs
@@ -1,0 +1,1 @@
+export {foo} from "foo";

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from/output.js
@@ -4,5 +4,6 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.foo = void 0;
   _exports.foo = _foo.foo;
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from/output.js
@@ -1,0 +1,8 @@
+define(["exports", "foo"], function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.foo = _foo.foo;
+});

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/import-export/input.mjs
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/import-export/input.mjs
@@ -1,0 +1,3 @@
+import { foo } from "./foo";
+
+export { foo };

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/import-export/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/import-export/output.js
@@ -1,0 +1,8 @@
+define(["exports", "./foo"], function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.foo = _foo.foo;
+});

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/options.json
@@ -1,0 +1,6 @@
+{
+  "assumptions": {
+    "constantReexports": true
+  },
+  "plugins": ["external-helpers", "transform-modules-amd"]
+}

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-enumerableModuleMeta/export/input.mjs
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-enumerableModuleMeta/export/input.mjs
@@ -1,0 +1,1 @@
+export var foo = 2;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-enumerableModuleMeta/export/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-enumerableModuleMeta/export/output.js
@@ -1,0 +1,8 @@
+define(["exports"], function (_exports) {
+  "use strict";
+
+  _exports.__esModule = true;
+  _exports.foo = void 0;
+  var foo = 2;
+  _exports.foo = foo;
+});

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-enumerableModuleMeta/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-enumerableModuleMeta/options.json
@@ -1,0 +1,6 @@
+{
+  "assumptions": {
+    "enumerableModuleMeta": true
+  },
+  "plugins": ["external-helpers", "transform-modules-amd"]
+}

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.js
@@ -39,6 +39,8 @@ export default declare((api, options) => {
 
   const constantReexports =
     api.assumption("constantReexports") ?? options.loose;
+  const enumerableModuleMeta =
+    api.assumption("enumerableModuleMeta") ?? options.loose;
 
   if (
     typeof lazy !== "boolean" &&
@@ -173,6 +175,7 @@ export default declare((api, options) => {
             {
               exportName: "exports",
               constantReexports,
+              enumerableModuleMeta,
               loose,
               strict,
               strictMode,

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.js
@@ -19,8 +19,6 @@ export default declare((api, options) => {
   const transformImportCall = createDynamicImportTransform(api);
 
   const {
-    loose,
-
     // 'true' for non-mjs files to strictly have .default, instead of having
     // destructuring-like behavior for their properties.
     strictNamespace = false,
@@ -176,7 +174,6 @@ export default declare((api, options) => {
               exportName: "exports",
               constantReexports,
               enumerableModuleMeta,
-              loose,
               strict,
               strictMode,
               allowTopLevelThis,

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.js
@@ -37,6 +37,9 @@ export default declare((api, options) => {
     allowCommonJSExports = true,
   } = options;
 
+  const constantReexports =
+    api.assumption("constantReexports") ?? options.loose;
+
   if (
     typeof lazy !== "boolean" &&
     typeof lazy !== "function" &&
@@ -169,6 +172,7 @@ export default declare((api, options) => {
             path,
             {
               exportName: "exports",
+              constantReexports,
               loose,
               strict,
               strictMode,
@@ -215,7 +219,11 @@ export default declare((api, options) => {
 
             headers.push(header);
             headers.push(
-              ...buildNamespaceInitStatements(meta, metadata, loose),
+              ...buildNamespaceInitStatements(
+                meta,
+                metadata,
+                constantReexports,
+              ),
             );
           }
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-2/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-2/input.mjs
@@ -1,0 +1,1 @@
+export {foo as default} from "foo";

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-2/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-2/output.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.default = void 0;
 
 var _foo = require("foo");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-2/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-2/output.js
@@ -1,0 +1,9 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _foo = require("foo");
+
+exports.default = _foo.foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-3/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-3/input.mjs
@@ -1,0 +1,1 @@
+export {foo as default, bar} from "foo";

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-3/output.js
@@ -1,0 +1,10 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _foo = require("foo");
+
+exports.default = _foo.foo;
+exports.bar = _foo.bar;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-3/output.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.bar = exports.default = void 0;
 
 var _foo = require("foo");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-4/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-4/input.mjs
@@ -1,0 +1,1 @@
+export {foo as bar} from "foo";

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-4/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-4/output.js
@@ -1,0 +1,9 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _foo = require("foo");
+
+exports.bar = _foo.foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-4/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-4/output.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.bar = void 0;
 
 var _foo = require("foo");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-5/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-5/input.mjs
@@ -1,0 +1,1 @@
+export {foo, bar} from "foo";

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-5/output.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.bar = exports.foo = void 0;
 
 var _foo = require("foo");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-5/output.js
@@ -1,0 +1,10 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _foo = require("foo");
+
+exports.foo = _foo.foo;
+exports.bar = _foo.bar;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-6/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-6/input.mjs
@@ -1,0 +1,1 @@
+export * from "foo";

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-6/output.js
@@ -1,0 +1,13 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _foo = require("foo");
+
+Object.keys(_foo).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === _foo[key]) return;
+  exports[key] = _foo[key];
+});

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from/input.mjs
@@ -1,0 +1,1 @@
+export {foo} from "foo";

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from/output.js
@@ -1,0 +1,9 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _foo = require("foo");
+
+exports.foo = _foo.foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from/output.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.foo = void 0;
 
 var _foo = require("foo");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/import-export/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/import-export/input.mjs
@@ -1,0 +1,3 @@
+import { foo } from "./foo";
+
+export { foo };

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/import-export/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/import-export/output.js
@@ -1,0 +1,9 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _foo = require("./foo");
+
+exports.foo = _foo.foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/options.json
@@ -1,0 +1,6 @@
+{
+  "assumptions": {
+    "constantReexports": true
+  },
+  "plugins": ["external-helpers", "transform-modules-commonjs"]
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-enumerableModuleMeta/export/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-enumerableModuleMeta/export/input.mjs
@@ -1,0 +1,1 @@
+export var foo = 2;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-enumerableModuleMeta/export/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-enumerableModuleMeta/export/output.js
@@ -1,0 +1,6 @@
+"use strict";
+
+exports.__esModule = true;
+exports.foo = void 0;
+var foo = 2;
+exports.foo = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-enumerableModuleMeta/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-enumerableModuleMeta/options.json
@@ -1,0 +1,6 @@
+{
+  "assumptions": {
+    "enumerableModuleMeta": true
+  },
+  "plugins": ["external-helpers", "transform-modules-commonjs"]
+}

--- a/packages/babel-plugin-transform-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-modules-umd/src/index.js
@@ -51,6 +51,9 @@ export default declare((api, options) => {
     noInterop,
   } = options;
 
+  const constantReexports =
+    api.assumption("constantReexports") ?? options.loose;
+
   /**
    * Build the assignment statements that initialize the UMD global.
    */
@@ -148,6 +151,7 @@ export default declare((api, options) => {
             path,
             {
               loose,
+              constantReexports,
               strict,
               strictMode,
               allowTopLevelThis,
@@ -201,7 +205,11 @@ export default declare((api, options) => {
             }
 
             headers.push(
-              ...buildNamespaceInitStatements(meta, metadata, loose),
+              ...buildNamespaceInitStatements(
+                meta,
+                metadata,
+                constantReexports,
+              ),
             );
           }
 

--- a/packages/babel-plugin-transform-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-modules-umd/src/index.js
@@ -44,7 +44,6 @@ export default declare((api, options) => {
   const {
     globals,
     exactGlobals,
-    loose,
     allowTopLevelThis,
     strict,
     strictMode,
@@ -152,7 +151,6 @@ export default declare((api, options) => {
           const { meta, headers } = rewriteModuleStatementsAndPrepareHeader(
             path,
             {
-              loose,
               constantReexports,
               enumerableModuleMeta,
               strict,

--- a/packages/babel-plugin-transform-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-modules-umd/src/index.js
@@ -53,6 +53,8 @@ export default declare((api, options) => {
 
   const constantReexports =
     api.assumption("constantReexports") ?? options.loose;
+  const enumerableModuleMeta =
+    api.assumption("enumerableModuleMeta") ?? options.loose;
 
   /**
    * Build the assignment statements that initialize the UMD global.
@@ -152,6 +154,7 @@ export default declare((api, options) => {
             {
               loose,
               constantReexports,
+              enumerableModuleMeta,
               strict,
               strictMode,
               allowTopLevelThis,

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-2/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-2/input.mjs
@@ -1,0 +1,1 @@
+export {foo as default} from "foo";

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-2/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-2/output.js
@@ -1,0 +1,20 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["exports", "foo"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports, require("foo"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports, global.foo);
+    global.input = mod.exports;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.default = _foo.foo;
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-2/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-2/output.js
@@ -16,5 +16,6 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.default = void 0;
   _exports.default = _foo.foo;
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-3/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-3/input.mjs
@@ -1,0 +1,1 @@
+export {foo as default, bar} from "foo";

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-3/output.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["exports", "foo"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports, require("foo"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports, global.foo);
+    global.input = mod.exports;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.default = _foo.foo;
+  _exports.bar = _foo.bar;
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-3/output.js
@@ -16,6 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.bar = _exports.default = void 0;
   _exports.default = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-4/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-4/input.mjs
@@ -1,0 +1,1 @@
+export {foo as bar} from "foo";

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-4/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-4/output.js
@@ -1,0 +1,20 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["exports", "foo"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports, require("foo"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports, global.foo);
+    global.input = mod.exports;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.bar = _foo.foo;
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-4/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-4/output.js
@@ -16,5 +16,6 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.bar = void 0;
   _exports.bar = _foo.foo;
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-5/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-5/input.mjs
@@ -1,0 +1,1 @@
+export {foo, bar} from "foo";

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-5/output.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["exports", "foo"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports, require("foo"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports, global.foo);
+    global.input = mod.exports;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.foo = _foo.foo;
+  _exports.bar = _foo.bar;
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-5/output.js
@@ -16,6 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.bar = _exports.foo = void 0;
   _exports.foo = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-6/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-6/input.mjs
@@ -1,0 +1,1 @@
+export * from "foo";

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-6/output.js
@@ -1,0 +1,24 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["exports", "foo"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports, require("foo"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports, global.foo);
+    global.input = mod.exports;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  Object.keys(_foo).forEach(function (key) {
+    if (key === "default" || key === "__esModule") return;
+    if (key in _exports && _exports[key] === _foo[key]) return;
+    _exports[key] = _foo[key];
+  });
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from/input.mjs
@@ -1,0 +1,1 @@
+export {foo} from "foo";

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from/output.js
@@ -16,5 +16,6 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.foo = void 0;
   _exports.foo = _foo.foo;
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from/output.js
@@ -1,0 +1,20 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["exports", "foo"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports, require("foo"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports, global.foo);
+    global.input = mod.exports;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.foo = _foo.foo;
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/import-export/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/import-export/input.mjs
@@ -1,0 +1,3 @@
+import { foo } from "./foo";
+
+export { foo };

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/import-export/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/import-export/output.js
@@ -1,0 +1,20 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["exports", "./foo"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports, require("./foo"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports, global.foo);
+    global.input = mod.exports;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.foo = _foo.foo;
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/options.json
@@ -1,0 +1,6 @@
+{
+  "assumptions": {
+    "constantReexports": true
+  },
+  "plugins": ["external-helpers", "transform-modules-umd"]
+}

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-enumerableModuleMeta/export/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-enumerableModuleMeta/export/input.mjs
@@ -1,0 +1,1 @@
+export var foo = 2;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-enumerableModuleMeta/export/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-enumerableModuleMeta/export/output.js
@@ -1,0 +1,20 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["exports"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports);
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports);
+    global.input = mod.exports;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
+  "use strict";
+
+  _exports.__esModule = true;
+  _exports.foo = void 0;
+  var foo = 2;
+  _exports.foo = foo;
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-enumerableModuleMeta/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-enumerableModuleMeta/options.json
@@ -1,0 +1,6 @@
+{
+  "assumptions": {
+    "enumerableModuleMeta": true
+  },
+  "plugins": ["external-helpers", "transform-modules-umd"]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Main PR: #12219
RFC: babel/rfcs#5

I'm open to rename the second assumption (https://github.com/babel/rfcs/pull/5/files#r555969950)


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12618"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/e521f6e277841583585508a3079c6e51e88b645f.svg" /></a>

