### PR TITLE
Add json schema of fixture runner options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,7 @@ packages/babel-standalone/babel.min.js
 /eslint/*/lib
 /eslint/*/LICENSE
 !/packages/babel-eslint-plugin/LICENSE
-/.vscode
+
 # local directory for VSCode Extension - https://marketplace.visualstudio.com/items?itemName=xyz.local-history
 /.history
 

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ packages/babel-standalone/babel.min.js
 /eslint/*/LICENSE
 !/packages/babel-eslint-plugin/LICENSE
 
+/.vscode
+!/.vscode/settings.example.json
 # local directory for VSCode Extension - https://marketplace.visualstudio.com/items?itemName=xyz.local-history
 /.history
 

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -1,5 +1,4 @@
 {
-  "editor.formatOnSave": true,
   "json.schemas": [
     {
       "fileMatch": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "editor.formatOnSave": true,
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "/**/fixtures/*/options.json",
+        "!/packages/babel-parser/test/fixtures/**/options.json"
+      ],
+      "url": "./packages/babel-helper-fixtures/data/schema.json"
+    },
+    {
+      "fileMatch": [
+        "/packages/babel-parser/test/fixtures/**/options.json"
+      ],
+      "url": "./packages/babel-parser/test/schema.json"
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,6 +334,14 @@ For both `@babel/plugin-x` and `@babel/parser`, you can easily generate an `outp
               - output.json (will be generated if not created)
 ```
 
+#### Editor setup
+
+We have JSON Schema definitions so that your editor can provide autocomplete for `options.json` files in fixtures:
+- `./packages/babel-helper-fixtures/data/schema.json` for plugins/presets tests
+- `./packages/babel-parser/test/schema.json` for parser tests
+
+If you use VS Code you can copy the contents of `.vscode/settings.example.json` into `.vscode/settings.json` to make it use the JSON Schema definitions. Other editors have different options to load JSON Schema files.
+
 ### Debugging code
 
 A common approach to debugging JavaScript code is to walk through the code using the [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/) debugger.

--- a/packages/babel-helper-fixtures/data/schema.json
+++ b/packages/babel-helper-fixtures/data/schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Options",
+  "description": "JSON schema for Babel Fixture Test Runner",
+  "allOf": [
+    { "$ref": "#/definitions/TaskOption" },
+    { "$ref": "https://json.schemastore.org/babelrc", "$comment": "Todo: switch to our inhouse schema" }
+  ],
+  "definitions": {
+    "OS": {
+      "type":"string",
+      "description": "The possible values of `process.platform`. See https://nodejs.org/api/process.html#process_process_platform",
+      "enum": ["aix", "darwin", "freebsd", "linux", "openbsd", "sunos", "win32"]
+    },
+    "TaskOption": {
+      "type": "object",
+      "properties": {
+        "BABEL_8_BREAKING": {
+          "description": "Whether this test should run when BABEL_8_BREAKING is enabled",
+          "type":"boolean"
+        },
+        "ignoreOutput": {
+          "description": "Whether the test should generate and compare with output.js",
+          "type": "boolean"
+        },
+        "minNodeVersion": {
+          "description": "The minimum Node.js version this test should run on",
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+){0,2}$"
+        },
+        "os": {
+          "description": "The OS this test should run on",
+          "anyOf": [
+            { "type": "array", "items": { "$ref": "#/definitions/OS" } },
+            {
+              "$ref": "#/definitions/OS"
+            }
+          ]
+        },
+        "throws": {
+          "description": "Expected thrown error message",
+          "type":"string",
+          "default": ""
+        },
+        "validateLogs": {
+          "description": "Whether this test should validate the stdout and stderr",
+          "type":"boolean",
+          "default": false
+        }
+      }
+    }
+  }
+}

--- a/packages/babel-parser/data/schema.json
+++ b/packages/babel-parser/data/schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "DecoratorsPluginOptions": {
+      "properties": {
+        "decoratorsBeforeExport": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "FlowPluginOptions": {
+      "properties": {
+        "all": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "PipelineOperatorPluginOptions": {
+      "properties": {
+        "proposal": {
+          "enum": ["fsharp", "minimal", "smart"],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "RecordAndTuplePluginOptions": {
+      "properties": {
+        "syntaxType": {
+          "enum": ["bar", "hash"],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+    "allowAwaitOutsideFunction": {
+      "description": "By default, await use is not allowed outside of an async function.\nSet this to true to accept such code.",
+      "type": "boolean"
+    },
+    "allowImportExportEverywhere": {
+      "description": "By default, import and export declarations can only appear at a program's top level.\nSetting this option to true allows them anywhere where a statement is allowed.",
+      "type": "boolean"
+    },
+    "allowReturnOutsideFunction": {
+      "description": "By default, a return statement at the top level raises an error.\nSet this to true to accept such code.",
+      "type": "boolean"
+    },
+    "allowSuperOutsideMethod": {
+      "type": "boolean"
+    },
+    "allowUndeclaredExports": {
+      "description": "By default, exported identifiers must refer to a declared variable.\nSet this to true to allow export statements to reference undeclared variables.",
+      "type": "boolean"
+    },
+    "createParenthesizedExpressions": {
+      "description": "By default, the parser adds information about parentheses by setting\n`extra.parenthesized` to `true` as needed.\nWhen this option is `true` the parser creates `ParenthesizedExpression`\nAST nodes instead of using the `extra` property.",
+      "type": "boolean"
+    },
+    "errorRecovery": {
+      "description": "By default, Babel always throws an error when it finds some invalid code.\nWhen this option is set to true, it will store the parsing error and\ntry to continue parsing the invalid input file.",
+      "type": "boolean"
+    },
+    "plugins": {
+      "description": "Array containing the plugins that you want to enable.",
+      "items": {
+        "anyOf": [
+          {
+            "items": [
+              {
+                "enum": ["decorators"],
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/DecoratorsPluginOptions"
+              }
+            ],
+            "additionalItems": false,
+            "type": "array"
+          },
+          {
+            "items": [
+              {
+                "enum": ["pipelineOperator"],
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/PipelineOperatorPluginOptions"
+              }
+            ],
+            "additionalItems": false,
+            "type": "array"
+          },
+          {
+            "items": [
+              {
+                "enum": ["recordAndTuple"],
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/RecordAndTuplePluginOptions"
+              }
+            ],
+            "additionalItems": false,
+            "type": "array"
+          },
+          {
+            "items": [
+              {
+                "enum": ["flow"],
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/FlowPluginOptions"
+              }
+            ],
+            "additionalItems": false,
+            "type": "array"
+          },
+          {
+            "enum": [
+              "asyncGenerators",
+              "bigInt",
+              "classPrivateMethods",
+              "classPrivateProperties",
+              "classProperties",
+              "classStaticBlock",
+              "decimal",
+              "decorators",
+              "decorators-legacy",
+              "doExpressions",
+              "dynamicImport",
+              "estree",
+              "exportDefaultFrom",
+              "exportNamespaceFrom",
+              "flow",
+              "flowComments",
+              "functionBind",
+              "functionSent",
+              "importAssertions",
+              "importMeta",
+              "jsx",
+              "logicalAssignment",
+              "moduleStringNames",
+              "nullishCoalescingOperator",
+              "numericSeparator",
+              "objectRestSpread",
+              "optionalCatchBinding",
+              "optionalChaining",
+              "partialApplication",
+              "pipelineOperator",
+              "placeholders",
+              "privateIn",
+              "throwExpressions",
+              "topLevelAwait",
+              "typescript",
+              "v8intrinsic"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "ranges": {
+      "description": "Adds a ranges property to each node: [node.start, node.end]",
+      "type": "boolean"
+    },
+    "sourceFilename": {
+      "description": "Correlate output AST nodes with their source filename.\nUseful when generating code and source maps from the ASTs of multiple input files.",
+      "type": "string"
+    },
+    "sourceType": {
+      "description": "Indicate the mode the code should be parsed in.\nCan be one of \"script\", \"module\", or \"unambiguous\". Defaults to \"script\".\n\"unambiguous\" will make @babel/parser attempt to guess, based on the presence\nof ES6 import or export statements.\nFiles with ES6 imports and exports are considered \"module\" and are otherwise \"script\".",
+      "enum": ["module", "script", "unambiguous"],
+      "type": "string"
+    },
+    "startLine": {
+      "description": "By default, the first line of code parsed is treated as line 1.\nYou can provide a line number to alternatively start with.\nUseful for integration with other source tools.",
+      "type": "number"
+    },
+    "strictMode": {
+      "description": "Should the parser work in strict mode.\nDefaults to true if sourceType === 'module'. Otherwise, false.",
+      "type": "boolean"
+    },
+    "tokens": {
+      "description": "Adds all parsed tokens to a tokens property on the File node.",
+      "type": "boolean"
+    }
+  },
+  "type": "object"
+}

--- a/packages/babel-parser/test/schema.json
+++ b/packages/babel-parser/test/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Options",
+  "description": "JSON schema for Babel Parser Fixture Test Runner",
+  "allOf": [
+    { "$ref": "#/definitions/TaskOption" },
+    { "$ref": "../data/schema.json" }
+  ],
+  "definitions": {
+    "TaskOption": {
+      "type": "object",
+      "properties": {
+        "throws": {
+          "description": "Expected thrown error message",
+          "type":"string",
+          "default": ""
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Add basic JSON schema of Babel fixture runners. Configure `json.schemas` so that it works on VSCode.

![image](https://user-images.githubusercontent.com/3607926/104374509-f9cfe380-54ef-11eb-9c53-da9f3f98b19b.png)

![image](https://user-images.githubusercontent.com/3607926/104374634-21bf4700-54f0-11eb-94ae-330f312b4a53.png)

Note that currently `/data/schema.json` will be published to npm. I am either good with publishing or not.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12619"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/e254a382e326699af798716c388c7b6065caeaa9.svg" /></a>



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12619"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

