### PR TITLE
fix: print warning messages to stderr

### DIFF
--- a/packages/babel-helper-compilation-targets/src/index.js
+++ b/packages/babel-helper-compilation-targets/src/index.js
@@ -118,17 +118,14 @@ function outputDecimalWarning(
     return;
   }
 
-  console.log("Warning, the following targets are using a decimal version:");
-  console.log("");
+  console.warn("Warning, the following targets are using a decimal version:\n");
   decimalTargets.forEach(({ target, value }) =>
-    console.log(`  ${target}: ${value}`),
+    console.warn(`  ${target}: ${value}`),
   );
-  console.log("");
-  console.log(
-    "We recommend using a string for minor/patch versions to avoid numbers like 6.10",
-  );
-  console.log("getting parsed as 6.1, which can lead to unexpected behavior.");
-  console.log("");
+  console.warn(`
+We recommend using a string for minor/patch versions to avoid numbers like 6.10
+getting parsed as 6.1, which can lead to unexpected behavior.
+`);
 }
 
 function semverifyTarget(target, value) {

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -251,23 +251,18 @@ export default declare((api, opts) => {
       hasUglifyTarget = true;
       delete optionsTargets.uglify;
 
-      console.log("");
-      console.log("The uglify target has been deprecated. Set the top level");
-      console.log("option `forceAllTransforms: true` instead.");
-      console.log("");
+      console.warn(`
+The uglify target has been deprecated. Set the top level
+option \`forceAllTransforms: true\` instead.
+`);
     }
   }
 
   if (optionsTargets?.esmodules && optionsTargets.browsers) {
-    console.log("");
-    console.log(
-      "@babel/preset-env: esmodules and browsers targets have been specified together.",
-    );
-    console.log(
-      // $FlowIgnore
-      `\`browsers\` target, \`${optionsTargets.browsers}\` will be ignored.`,
-    );
-    console.log("");
+    console.warn(`
+@babel/preset-env: esmodules and browsers targets have been specified together.
+\`browsers\` target, \`${optionsTargets.browsers.toString()}\` will be ignored.
+`);
   }
 
   const targets = getTargets(

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -184,7 +184,7 @@ export function normalizeCoreJSOption(
   const version = rawVersion ? coerce(String(rawVersion)) : false;
 
   if (!useBuiltIns && version) {
-    console.log(
+    console.warn(
       "\nWARNING (@babel/preset-env): The `corejs` option only has an effect when the `useBuiltIns` option is not `false`\n",
     );
   }

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stderr.txt
@@ -1,0 +1,1 @@
+WARNING (@babel/preset-env): The `corejs` option only has an effect when the `useBuiltIns` option is not `false`

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
@@ -1,5 +1,3 @@
-WARNING (@babel/preset-env): The `corejs` option only has an effect when the `useBuiltIns` option is not `false`
-
 @babel/preset-env: `DEBUG` option
 
 Using targets:

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stderr.txt
@@ -1,0 +1,6 @@
+Warning, the following targets are using a decimal version:
+
+  electron: 0.36
+
+We recommend using a string for minor/patch versions to avoid numbers like 6.10
+getting parsed as 6.1, which can lead to unexpected behavior.

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -1,10 +1,3 @@
-Warning, the following targets are using a decimal version:
-
-  electron: 0.36
-
-We recommend using a string for minor/patch versions to avoid numbers like 6.10
-getting parsed as 6.1, which can lead to unexpected behavior.
-
 @babel/preset-env: `DEBUG` option
 
 Using targets:

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stderr.txt
@@ -1,0 +1,7 @@
+Warning, the following targets are using a decimal version:
+
+  electron: 0.36
+  node: 6.1
+
+We recommend using a string for minor/patch versions to avoid numbers like 6.10
+getting parsed as 6.1, which can lead to unexpected behavior.

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -1,11 +1,3 @@
-Warning, the following targets are using a decimal version:
-
-  electron: 0.36
-  node: 6.1
-
-We recommend using a string for minor/patch versions to avoid numbers like 6.10
-getting parsed as 6.1, which can lead to unexpected behavior.
-
 @babel/preset-env: `DEBUG` option
 
 Using targets:

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stderr.txt
@@ -1,0 +1,6 @@
+Warning, the following targets are using a decimal version:
+
+  electron: 0.36
+
+We recommend using a string for minor/patch versions to avoid numbers like 6.10
+getting parsed as 6.1, which can lead to unexpected behavior.

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -1,10 +1,3 @@
-Warning, the following targets are using a decimal version:
-
-  electron: 0.36
-
-We recommend using a string for minor/patch versions to avoid numbers like 6.10
-getting parsed as 6.1, which can lead to unexpected behavior.
-
 @babel/preset-env: `DEBUG` option
 
 Using targets:

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stderr.txt
@@ -1,0 +1,7 @@
+Warning, the following targets are using a decimal version:
+
+  electron: 0.36
+  node: 6.1
+
+We recommend using a string for minor/patch versions to avoid numbers like 6.10
+getting parsed as 6.1, which can lead to unexpected behavior.

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -1,11 +1,3 @@
-Warning, the following targets are using a decimal version:
-
-  electron: 0.36
-  node: 6.1
-
-We recommend using a string for minor/patch versions to avoid numbers like 6.10
-getting parsed as 6.1, which can lead to unexpected behavior.
-
 @babel/preset-env: `DEBUG` option
 
 Using targets:

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stderr.txt
@@ -7,3 +7,6 @@ You should also be sure that the version you pass to the `corejs` option matches
 
 More info about useBuiltIns: https://babeljs.io/docs/en/babel-preset-env#usebuiltins
 More info about core-js: https://babeljs.io/docs/en/babel-preset-env#corejs
+
+The uglify target has been deprecated. Set the top level
+option `forceAllTransforms: true` instead.

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
@@ -1,6 +1,3 @@
-The uglify target has been deprecated. Set the top level
-option `forceAllTransforms: true` instead.
-
 @babel/preset-env: `DEBUG` option
 
 Using targets:

--- a/packages/babel-preset-env/test/fixtures/debug/plugins-only/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/plugins-only/stderr.txt
@@ -1,0 +1,6 @@
+Warning, the following targets are using a decimal version:
+
+  node: 7.4
+
+We recommend using a string for minor/patch versions to avoid numbers like 6.10
+getting parsed as 6.1, which can lead to unexpected behavior.

--- a/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
@@ -1,10 +1,3 @@
-Warning, the following targets are using a decimal version:
-
-  node: 7.4
-
-We recommend using a string for minor/patch versions to avoid numbers like 6.10
-getting parsed as 6.1, which can lead to unexpected behavior.
-
 @babel/preset-env: `DEBUG` option
 
 Using targets:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12625 
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

This PR outputs a warning message to stderr instead of stdout. Note that we have already handled such warning messages through `console.warn`:

https://github.com/babel/babel/blob/bd4590e546faab5238b95a41ffc8bef995e16352/packages/babel-preset-env/src/normalize-options.js#L162


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12626"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/7ac2a629472235b990e3d580ac716bf5079fc7b8.svg" /></a>

