### PR TITLE
Support TypeScript 4.2 abstract constructor signatures

### DIFF
--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -194,6 +194,10 @@ export function TSFunctionType(this: Printer, node: t.TSFunctionType) {
 }
 
 export function TSConstructorType(this: Printer, node: t.TSConstructorType) {
+  if (node.abstract) {
+    this.word("abstract");
+    this.space();
+  }
   this.word("new");
   this.space();
   this.tsPrintFunctionOrConstructorType(node);

--- a/packages/babel-generator/test/fixtures/typescript/abstract-constructor-signature-types/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/abstract-constructor-signature-types/input.js
@@ -1,0 +1,1 @@
+const x: abstract new () => void;

--- a/packages/babel-generator/test/fixtures/typescript/abstract-constructor-signature-types/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/abstract-constructor-signature-types/output.js
@@ -1,0 +1,1 @@
+const x: abstract new () => void;

--- a/packages/babel-generator/test/fixtures/typescript/constructor-signature-types/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/constructor-signature-types/input.js
@@ -1,0 +1,1 @@
+const x: new () => void;

--- a/packages/babel-generator/test/fixtures/typescript/constructor-signature-types/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/constructor-signature-types/output.js
@@ -1,0 +1,1 @@
+const x: new () => void;

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -794,15 +794,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     ): N.TsFunctionOrConstructorType {
       const node: N.TsFunctionOrConstructorType = this.startNode();
       if (type === "TSConstructorType") {
+        // $FlowIgnore
+        node.abstract = !!abstract;
         if (abstract) {
-          // $FlowIgnore
-          node.abstract = true;
           // eat "abstract"
           this.expectContextual("abstract");
           this.expect(tt._new);
         } else {
-          // $FlowIgnore
-          node.abstract = false;
           this.expect(tt._new);
         }
       }

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -796,13 +796,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (type === "TSConstructorType") {
         // $FlowIgnore
         node.abstract = !!abstract;
-        if (abstract) {
-          // eat "abstract"
-          this.expectContextual("abstract");
-          this.expect(tt._new);
-        } else {
-          this.expect(tt._new);
-        }
+        if (abstract) this.next();
+        this.expect(tt._new);
       }
       this.tsFillSignature(tt.arrow, node);
       return this.finishNode(node, type);

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -797,7 +797,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         // $FlowIgnore
         node.abstract = !!abstract;
         if (abstract) this.next();
-        this.expect(tt._new);
+        this.next(); // eat `new`
       }
       this.tsFillSignature(tt.arrow, node);
       return this.finishNode(node, type);

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1250,6 +1250,7 @@ export type TsConstructorType = TsTypeBase &
   TsSignatureDeclarationBase & {
     type: "TSConstructorType",
     typeAnnotation: TsTypeAnnotation,
+    abstract: boolean,
   };
 
 export type TsTypeReference = TsTypeBase & {

--- a/packages/babel-parser/test/fixtures/typescript/types/abstract-constructor-signatures/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/abstract-constructor-signatures/input.ts
@@ -1,0 +1,1 @@
+let x: abstract new () => void = X;

--- a/packages/babel-parser/test/fixtures/typescript/types/abstract-constructor-signatures/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/abstract-constructor-signatures/output.json
@@ -1,0 +1,52 @@
+{
+  "type": "File",
+  "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":35}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":35}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":35}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":4,"end":34,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":34}},
+            "id": {
+              "type": "Identifier",
+              "start":4,"end":30,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":30},"identifierName":"x"},
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":5,"end":30,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":30}},
+                "typeAnnotation": {
+                  "type": "TSConstructorType",
+                  "start":7,"end":30,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":30}},
+                  "abstract": true,
+                  "parameters": [],
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "start":23,"end":30,"loc":{"start":{"line":1,"column":23},"end":{"line":1,"column":30}},
+                    "typeAnnotation": {
+                      "type": "TSVoidKeyword",
+                      "start":26,"end":30,"loc":{"start":{"line":1,"column":26},"end":{"line":1,"column":30}}
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "Identifier",
+              "start":33,"end":34,"loc":{"start":{"line":1,"column":33},"end":{"line":1,"column":34},"identifierName":"X"},
+              "name": "X"
+            }
+          }
+        ],
+        "kind": "let"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/types/constructor-signatures/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/constructor-signatures/input.ts
@@ -1,0 +1,1 @@
+let x: new () => void = X;

--- a/packages/babel-parser/test/fixtures/typescript/types/constructor-signatures/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/constructor-signatures/output.json
@@ -1,0 +1,52 @@
+{
+  "type": "File",
+  "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":26}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":26}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":26}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":4,"end":25,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":25}},
+            "id": {
+              "type": "Identifier",
+              "start":4,"end":21,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":21},"identifierName":"x"},
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":5,"end":21,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":21}},
+                "typeAnnotation": {
+                  "type": "TSConstructorType",
+                  "start":7,"end":21,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":21}},
+                  "abstract": false,
+                  "parameters": [],
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "start":14,"end":21,"loc":{"start":{"line":1,"column":14},"end":{"line":1,"column":21}},
+                    "typeAnnotation": {
+                      "type": "TSVoidKeyword",
+                      "start":17,"end":21,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":21}}
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "Identifier",
+              "start":24,"end":25,"loc":{"start":{"line":1,"column":24},"end":{"line":1,"column":25},"identifierName":"X"},
+              "name": "X"
+            }
+          }
+        ],
+        "kind": "let"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/types/types-named-abstract/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/types-named-abstract/input.ts
@@ -1,0 +1,2 @@
+type abstract = "abstract";
+let x: abstract;

--- a/packages/babel-parser/test/fixtures/typescript/types/types-named-abstract/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/types-named-abstract/output.json
@@ -1,0 +1,65 @@
+{
+  "type": "File",
+  "start":0,"end":44,"loc":{"start":{"line":1,"column":0},"end":{"line":2,"column":16}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":44,"loc":{"start":{"line":1,"column":0},"end":{"line":2,"column":16}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start":0,"end":27,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":27}},
+        "id": {
+          "type": "Identifier",
+          "start":5,"end":13,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":13},"identifierName":"abstract"},
+          "name": "abstract"
+        },
+        "typeAnnotation": {
+          "type": "TSLiteralType",
+          "start":16,"end":26,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":26}},
+          "literal": {
+            "type": "StringLiteral",
+            "start":16,"end":26,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":26}},
+            "extra": {
+              "rawValue": "abstract",
+              "raw": "\"abstract\""
+            },
+            "value": "abstract"
+          }
+        }
+      },
+      {
+        "type": "VariableDeclaration",
+        "start":28,"end":44,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":16}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":32,"end":43,"loc":{"start":{"line":2,"column":4},"end":{"line":2,"column":15}},
+            "id": {
+              "type": "Identifier",
+              "start":32,"end":43,"loc":{"start":{"line":2,"column":4},"end":{"line":2,"column":15},"identifierName":"x"},
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":33,"end":43,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":15}},
+                "typeAnnotation": {
+                  "type": "TSTypeReference",
+                  "start":35,"end":43,"loc":{"start":{"line":2,"column":7},"end":{"line":2,"column":15}},
+                  "typeName": {
+                    "type": "Identifier",
+                    "start":35,"end":43,"loc":{"start":{"line":2,"column":7},"end":{"line":2,"column":15},"identifierName":"abstract"},
+                    "name": "abstract"
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -1767,6 +1767,7 @@ export interface TSConstructorType extends BaseNode {
   typeParameters?: TSTypeParameterDeclaration | null;
   parameters: Array<Identifier | RestElement>;
   typeAnnotation?: TSTypeAnnotation | null;
+  abstract?: boolean | null;
 }
 
 export interface TSTypeReference extends BaseNode {

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -157,14 +157,22 @@ defineType("TSThisType", {
   fields: {},
 });
 
-const fnOrCtr = {
+const fnOrCtrBase = {
   aliases: ["TSType"],
   visitor: ["typeParameters", "parameters", "typeAnnotation"],
-  fields: signatureDeclarationCommon,
 };
 
-defineType("TSFunctionType", fnOrCtr);
-defineType("TSConstructorType", fnOrCtr);
+defineType("TSFunctionType", {
+  ...fnOrCtrBase,
+  fields: signatureDeclarationCommon,
+});
+defineType("TSConstructorType", {
+  ...fnOrCtrBase,
+  fields: {
+    ...signatureDeclarationCommon,
+    abstract: validateOptional(bool),
+  },
+});
 
 defineType("TSTypeReference", {
   aliases: ["TSType"],


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  N/A
| Minor: New Feature?      | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
https://devblogs.microsoft.com/typescript/announcing-typescript-4-2-beta/#abstract-construct-signatures
```ts
let Ctor: abstract new () => HasArea = Shape;
```
Extends `TSConstructorType` to add an `abstract` property


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12628"><img src="https://gitpod.io/api/apps/github/pbs/github.com/sosukesuzuki/babel.git/321d707f587ba34cb3d529e68ddb88788cccb79a.svg" /></a>

