### PR TITLE
chore: update rollup to 2.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "lodash": "^4.17.20",
     "mergeiterator": "^1.2.5",
     "prettier": "^2.2.1",
-    "rollup": "^2.26.5",
+    "rollup": "^2.36.2",
     "rollup-plugin-dts": "^2.0.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-terser": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4857,7 +4857,7 @@ __metadata:
     lodash: ^4.17.20
     mergeiterator: ^1.2.5
     prettier: ^2.2.1
-    rollup: ^2.26.5
+    rollup: ^2.36.2
     rollup-plugin-dts: ^2.0.0
     rollup-plugin-node-polyfills: ^0.2.1
     rollup-plugin-terser: ^7.0.0
@@ -11610,9 +11610,9 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.26.5":
-  version: 2.26.5
-  resolution: "rollup@npm:2.26.5"
+"rollup@npm:^2.36.2":
+  version: 2.36.2
+  resolution: "rollup@npm:2.36.2"
   dependencies:
     fsevents: ~2.1.2
   dependenciesMeta:
@@ -11620,7 +11620,7 @@ fsevents@^1.2.7:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 92b0e96cc32af0dc18f42c12aed671085b1ba684d4b3211ac019912c7947830f624c2f1913108975630f8712667f0b9fa2999895f86a68ac4ddffbc2c88ea208
+  checksum: 65a892680d0da59b77a8174d90ff203bd8f4a34a5ec9d230d9bbf735ecad700426f1e079ed1953cd24bc9c0fcf77aed7219da77db11347222814e8d9364c60cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Bumped rollup to 2.36
| License                  | MIT

<!-- Describe your changes below in as much detail as possible --> 
`rollup-plugin-dts` requests a higher version of `rollup`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12651"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/3efb29fa90012232130f24a11c86925663ffb4f4.svg" /></a>

