### PR TITLE
chore: update typescript to 4.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "rollup-plugin-terser": "^7.0.0",
     "test262-stream": "^1.3.0",
     "through2": "^2.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.1.3"
   },
   "workspaces": [
     "codemods/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4863,7 +4863,7 @@ __metadata:
     rollup-plugin-terser: ^7.0.0
     test262-stream: ^1.3.0
     through2: ^2.0.0
-    typescript: ^4.0.5
+    typescript: ^4.1.3
   dependenciesMeta:
     core-js:
       built: false
@@ -12819,23 +12819,23 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-typescript@^4.0.5:
-  version: 4.0.5
-  resolution: "typescript@npm:4.0.5"
+typescript@^4.1.3:
+  version: 4.1.3
+  resolution: "typescript@npm:4.1.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ce94d4bbb914cc9d6fbd42e1476ab18c3292b262b8ba7ba76cd167a858545207a604e75bf1efbb75b8654c8f85deaa19795c3ef00098d7612855139b4ecc0240
+  checksum: 4f7ab1506ea22c7a1c313ec5b4285e93ce08d709ad6086d02d3096adb399ca339972ee56d1e578213c51dd0fb7b0fad50283c2d3c39642405644458ae29774f8
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.0.5#builtin<compat/typescript>":
-  version: 4.0.5
-  resolution: "typescript@patch:typescript@npm%3A4.0.5#builtin<compat/typescript>::version=4.0.5&hash=cc6730"
+"typescript@patch:typescript@^4.1.3#builtin<compat/typescript>":
+  version: 4.1.3
+  resolution: "typescript@patch:typescript@npm%3A4.1.3#builtin<compat/typescript>::version=4.1.3&hash=cc6730"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ada6fea7657a51d1b842682d31233e53a3cf509b0edbd6288fda3cfd01643d0190b7ea77837527c4d282c90e61690e19dbfd91be6913e7e7292aa0b588d3506c
+  checksum: 017af992148346e671d5b83b041773825888e9c94db8d2b9472cdbb6d6f0ee85927817473121524d319f8be6ffe5a6904d27ff6ef21356d2274fcadd52e17938
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Bumped `typescript` to `4.1.3`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`rollup-plugin-dts` requests a higher version of `typescript`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12652"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/1e4a21a674b25f93c2501197bc99a57eb6963297.svg" /></a>

