### PR TITLE
fix: babel-register transform internal dependencies

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -14,7 +14,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "main": "lib/index.js",
   "browser": {
-    "./lib/node.js": "./lib/browser.js"
+    "./lib/nodeWrapper.js": "./lib/browser.js"
   },
   "dependencies": {
     "find-cache-dir": "^2.0.0",

--- a/packages/babel-register/src/index.js
+++ b/packages/babel-register/src/index.js
@@ -9,7 +9,7 @@ exports = module.exports = function (...args) {
 };
 exports.__esModule = true;
 
-const node = require("./node");
+const node = require("./nodeWrapper");
 const register = node.default;
 
 Object.assign(exports, node);

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -7,6 +7,7 @@ import { OptionManager, DEFAULT_EXTENSIONS } from "@babel/core";
 import { addHook } from "pirates";
 import fs from "fs";
 import path from "path";
+import Module from "module";
 
 const maps = {};
 let transformOpts = {};
@@ -82,15 +83,19 @@ function compile(code, filename) {
 }
 
 let compiling = false;
+const internalModuleCache = Module._cache;
 
 function compileHook(code, filename) {
   if (compiling) return code;
 
+  const globalModuleCache = Module._cache;
   try {
     compiling = true;
+    Module._cache = internalModuleCache;
     return compile(code, filename);
   } finally {
     compiling = false;
+    Module._cache = globalModuleCache;
   }
 }
 

--- a/packages/babel-register/src/nodeWrapper.js
+++ b/packages/babel-register/src/nodeWrapper.js
@@ -1,0 +1,21 @@
+/**
+ * This file wraps the implementation of register so all modules `require()`-ed
+ * internally within register are stored in a separate module cache.
+ * This prevents un-transformed modules being stored in global module cache,
+ * and allows register to transform these modules if they are loaded externally.
+ */
+
+const Module = require("module");
+
+const globalModuleCache = Module._cache;
+const internalModuleCache = Object.create(null);
+
+Module._cache = internalModuleCache;
+const node = require("./node");
+Module._cache = globalModuleCache;
+
+// Add source-map-support to global cache as it's stateful
+const smsPath = require.resolve("source-map-support");
+globalModuleCache[smsPath] = internalModuleCache[smsPath];
+
+module.exports = node;

--- a/packages/babel-register/test/fixtures/internal-modules/index.js
+++ b/packages/babel-register/test/fixtures/internal-modules/index.js
@@ -1,0 +1,28 @@
+const register = require('../../..');
+
+// Plugin to add '/* transformed */' comment to start of function bodies
+const plugin = () => ( {
+  visitor: {
+    Function(path) {
+      const bodyNode = path.node.body;
+      (bodyNode.leadingComments || (bodyNode.leadingComments = [])).push( {
+        type: 'CommentBlock',
+        value: ' transformed '
+      } );
+    },
+  },
+} );
+
+register( {
+  ignore: [],
+  babelrc: false,
+  configFile: false,
+  plugins: [plugin]
+} );
+
+console.log(
+  JSON.stringify({
+    convertSourceMap: require('convert-source-map').fromObject.toString(),
+    isPlainObject: require('lodash/isPlainObject').toString()
+  })
+);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11964, Fixes #12662
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | n/a
| Any Dependency Changes?  | No
| License                  | MIT

As discussed in issues #11964 and #12662, babel-register fails to transform modules which Babel uses internally. In a few cases (e.g. `require('to-fast-properties')`), this can cause babel-register to throw an error.

These issues arise when babel-register is called with `ignore: []` option so it transforms the contents of `node_modules`.

There are two reasons why modules don't get transformed:

1. The modules are `require()`-ed within babel-register before the pirates hook is activated.
2. The modules are lazily-required during transform, and register [bails out of transforming them](https://github.com/babel/babel/blob/10978bb65a4b4e8874ca8dd3054b8c31b5838b7f/packages/babel-register/src/node.js#L87) to prevent an infinite loop.

This PR fixes both problems.

Prior to loading `lib/node.js`, it creates a mock module cache. All `require()` calls within babel register use this internal module cache, so untransformed modules are not populated in the global (normal) module cache. When these modules are loaded externally, they pass through register's transform.

Usually, messing around with Node's module cache would be considered pretty hacky, but in the context of babel-register, it seems more reasonable to me.

There is a special case for `source-map-support` package which is shared between both the global module cache and register's internal module cache. This is necessary as the module is stateful. It would be ideal to transform this module too, but the workaround necessary to do so is pretty tortuous, so I've omitted it from this PR.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12665"><img src="https://gitpod.io/api/apps/github/pbs/github.com/overlookmotel/babel.git/a438bf4bb88b8a15d82a4253c2e5f4c20fd06138.svg" /></a>

