### PR TITLE
fix: allow to execute util scripts

### DIFF
--- a/packages/babel-preset-env/scripts/smoke-test.js
+++ b/packages/babel-preset-env/scripts/smoke-test.js
@@ -1,4 +1,4 @@
-const fs = require("fs-extra");
+const fs = require("fs");
 const execSync = require("child_process").execSync;
 const path = require("path");
 const pkg = require("../package.json");
@@ -14,7 +14,7 @@ try {
 
   console.log("Setting up smoke test dependencies");
 
-  fs.ensureDirSync(tempFolderPath);
+  fs.mkdirSync(tempFolderPath);
   process.chdir(tempFolderPath);
 
   const babelCliVersion = pkg.devDependencies["babel-cli"];


### PR DESCRIPTION
Currently both of those scripts can't be executed as this project removed fs-extra, from dependencies
Alternatively those scripts should be removed from source code

https://github.com/babel/babel/search?q=fs-extra

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | none
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | no
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | no
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12670"><img src="https://gitpod.io/api/apps/github/pbs/github.com/armano2/babel.git/49007a3ee101d21da04ad8dcab73c375bba5df20.svg" /></a>

