### PR TITLE
babel-register run default register with global module cache

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -108,8 +108,6 @@ export function revert() {
   if (piratesRevert) piratesRevert();
 }
 
-register();
-
 export default function register(opts?: Object = {}) {
   // Clone to avoid mutating the arguments object with the 'delete's below.
   opts = {

--- a/packages/babel-register/src/nodeWrapper.js
+++ b/packages/babel-register/src/nodeWrapper.js
@@ -18,4 +18,7 @@ Module._cache = globalModuleCache;
 const smsPath = require.resolve("source-map-support");
 globalModuleCache[smsPath] = internalModuleCache[smsPath];
 
+const register = node.default;
+register();
+
 module.exports = node;


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | n/a
| Any Dependency Changes?  | No
| License                  | MIT

Small follow-up to PR #12665.

This moves the default call to `register()` from `node.js` into `nodeWrapper.js`, so `register()` executes with global module cache.

In my original implementation, the default call to `register()` executes with internal module cache, whereas the user calling `register( /* options */ )` executes with global module cache.

Right now, it makes no difference either way, as `register` function contains no code which could call `require()`. But if this changed in future, this amendment would ensure behaviour is consistent. 

Sorry, I should have included this in the previous PR.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12674"><img src="https://gitpod.io/api/apps/github/pbs/github.com/overlookmotel/babel.git/8674e1d171458f8288049457c6b89efbaddf56f1.svg" /></a>

