### PR TITLE
[babel 8] Replace lodash/escapeRegExp with escape-string-regexp

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -54,7 +54,7 @@
     "@babel/types": "workspace:^7.12.10",
     "convert-source-map": "^1.7.0",
     "debug": "^4.1.0",
-    "escape-string-regexp": "condition:BABEL_8_BREAKING ? ^4.0.0",
+    "escape-string-regexp": "condition:BABEL_8_BREAKING ? ^4.0.0 : ",
     "gensync": "^1.0.0-beta.1",
     "json5": "^2.1.2",
     "lodash": "^4.17.19",

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -54,6 +54,7 @@
     "@babel/types": "workspace:^7.12.10",
     "convert-source-map": "^1.7.0",
     "debug": "^4.1.0",
+    "escape-string-regexp": "condition:BABEL_8_BREAKING ? ^4.0.0",
     "gensync": "^1.0.0-beta.1",
     "json5": "^2.1.2",
     "lodash": "^4.17.19",

--- a/packages/babel-core/src/config/pattern-to-regex.js
+++ b/packages/babel-core/src/config/pattern-to-regex.js
@@ -1,7 +1,6 @@
 // @flow
 import path from "path";
 
-// $FlowIgnore
 const escapeRegExp = process.env.BABEL_8_BREAKING
   ? require("escape-string-regexp")
   : require("lodash/escapeRegExp");
@@ -43,11 +42,13 @@ export default function pathToPattern(
         // *.ext matches a wildcard with an extension.
         if (part.indexOf("*.") === 0) {
           return (
+            // $FlowIgnore
             substitution + escapeRegExp(part.slice(1)) + (last ? endSep : sep)
           );
         }
 
         // Otherwise match the pattern text.
+        // $FlowIgnore
         return escapeRegExp(part) + (last ? endSep : sep);
       }),
     ].join(""),

--- a/packages/babel-core/src/config/pattern-to-regex.js
+++ b/packages/babel-core/src/config/pattern-to-regex.js
@@ -1,6 +1,7 @@
 // @flow
 import path from "path";
 
+// $FlowIgnore
 const escapeRegExp = process.env.BABEL_8_BREAKING
   ? require("escape-string-regexp")
   : require("lodash/escapeRegExp");

--- a/packages/babel-core/src/config/pattern-to-regex.js
+++ b/packages/babel-core/src/config/pattern-to-regex.js
@@ -1,6 +1,9 @@
 // @flow
 import path from "path";
-import escapeRegExp from "lodash/escapeRegExp";
+
+const escapeRegExp = process.env.BABEL_8_BREAKING
+  ? require("escape-string-regexp")
+  : require("lodash/escapeRegExp");
 
 const sep = `\\${path.sep}`;
 const endSep = `(?:${sep}|$)`;

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -19,6 +19,7 @@
     "@babel/core": "workspace:^7.12.10",
     "@babel/helper-fixtures": "workspace:^7.12.12",
     "babel-check-duplicated-nodes": "^1.0.0",
+    "escape-string-regexp": "condition:BABEL_8_BREAKING ? ^4.0.0",
     "jest-diff": "^24.8.0",
     "lodash": "^4.17.19",
     "quick-lru": "5.1.0",

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -19,7 +19,7 @@
     "@babel/core": "workspace:^7.12.10",
     "@babel/helper-fixtures": "workspace:^7.12.12",
     "babel-check-duplicated-nodes": "^1.0.0",
-    "escape-string-regexp": "condition:BABEL_8_BREAKING ? ^4.0.0",
+    "escape-string-regexp": "condition:BABEL_8_BREAKING ? ^4.0.0 : ",
     "jest-diff": "^24.8.0",
     "lodash": "^4.17.19",
     "quick-lru": "5.1.0",

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -7,7 +7,6 @@ import {
 } from "@babel/helper-fixtures";
 import sourceMap from "source-map";
 import { codeFrameColumns } from "@babel/code-frame";
-import escapeRegExp from "lodash/escapeRegExp";
 import * as helpers from "./helpers";
 import merge from "lodash/merge";
 import assert from "assert";
@@ -16,8 +15,11 @@ import path from "path";
 import vm from "vm";
 import checkDuplicatedNodes from "babel-check-duplicated-nodes";
 import QuickLRU from "quick-lru";
-
 import diff from "jest-diff";
+
+const escapeRegExp = process.env.BABEL_8_BREAKING
+  ? require("escape-string-regexp")
+  : require("lodash/escapeRegExp");
 
 const cachedScripts = new QuickLRU({ maxSize: 10 });
 const contextModuleCache = new WeakMap();

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -17,6 +17,7 @@ import checkDuplicatedNodes from "babel-check-duplicated-nodes";
 import QuickLRU from "quick-lru";
 import diff from "jest-diff";
 
+// $FlowIgnore
 const escapeRegExp = process.env.BABEL_8_BREAKING
   ? require("escape-string-regexp")
   : require("lodash/escapeRegExp");

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -17,6 +17,7 @@
     "./lib/nodeWrapper.js": "./lib/browser.js"
   },
   "dependencies": {
+    "escape-string-regexp": "condition:BABEL_8_BREAKING ? ^4.0.0",
     "find-cache-dir": "condition:BABEL_8_BREAKING ? ^3.3.1 : ^2.0.0",
     "lodash": "^4.17.19",
     "make-dir": "^2.1.0",

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -17,7 +17,7 @@
     "./lib/nodeWrapper.js": "./lib/browser.js"
   },
   "dependencies": {
-    "escape-string-regexp": "condition:BABEL_8_BREAKING ? ^4.0.0",
+    "escape-string-regexp": "condition:BABEL_8_BREAKING ? ^4.0.0 : ",
     "find-cache-dir": "condition:BABEL_8_BREAKING ? ^3.3.1 : ^2.0.0",
     "lodash": "^4.17.19",
     "make-dir": "^2.1.0",

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -1,13 +1,16 @@
 import deepClone from "lodash/cloneDeep";
 import sourceMapSupport from "source-map-support";
 import * as registerCache from "./cache";
-import escapeRegExp from "lodash/escapeRegExp";
 import * as babel from "@babel/core";
 import { OptionManager, DEFAULT_EXTENSIONS } from "@babel/core";
 import { addHook } from "pirates";
 import fs from "fs";
 import path from "path";
 import Module from "module";
+
+const escapeRegExp = process.env.BABEL_8_BREAKING
+  ? require("escape-string-regexp")
+  : require("lodash/escapeRegExp");
 
 const maps = {};
 let transformOpts = {};

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -8,6 +8,7 @@ import fs from "fs";
 import path from "path";
 import Module from "module";
 
+// $FlowIgnore
 const escapeRegExp = process.env.BABEL_8_BREAKING
   ? require("escape-string-regexp")
   : require("lodash/escapeRegExp");

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -149,16 +149,19 @@ export default function register(opts?: Object = {}) {
   if (transformOpts.ignore === undefined && transformOpts.only === undefined) {
     transformOpts.only = [
       // Only compile things inside the current working directory.
+      // $FlowIgnore
       new RegExp("^" + escapeRegExp(cwd), "i"),
     ];
     transformOpts.ignore = [
       // Ignore any node_modules inside the current working directory.
       new RegExp(
         "^" +
+          // $FlowIgnore
           escapeRegExp(cwd) +
           "(?:" +
           path.sep +
           ".*)?" +
+          // $FlowIgnore
           escapeRegExp(path.sep + "node_modules" + path.sep),
         "i",
       ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,6 +139,7 @@ __metadata:
     "@babel/types": "workspace:^7.12.10"
     convert-source-map: ^1.7.0
     debug: ^4.1.0
+    escape-string-regexp: "condition:BABEL_8_BREAKING ? ^4.0.0 : "
     gensync: ^1.0.0-beta.1
     json5: ^2.1.2
     lodash: ^4.17.19
@@ -759,6 +760,7 @@ __metadata:
     "@babel/core": "workspace:^7.12.10"
     "@babel/helper-fixtures": "workspace:^7.12.12"
     babel-check-duplicated-nodes: ^1.0.0
+    escape-string-regexp: "condition:BABEL_8_BREAKING ? ^4.0.0 : "
     jest-diff: ^24.8.0
     lodash: ^4.17.19
     quick-lru: 5.1.0
@@ -3146,6 +3148,7 @@ __metadata:
     "@babel/core": "workspace:*"
     "@babel/plugin-transform-modules-commonjs": "workspace:*"
     browserify: ^16.5.2
+    escape-string-regexp: "condition:BABEL_8_BREAKING ? ^4.0.0 : "
     find-cache-dir: "condition:BABEL_8_BREAKING ? ^3.3.1 : ^2.0.0"
     lodash: ^4.17.19
     make-dir: ^2.1.0
@@ -6464,6 +6467,22 @@ __metadata:
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
   checksum: 1e31ff50d66f47cd0dfffa702061127116ccf9886d1f54a802a7b3bc95b94cab0cbf5b145cc5ac199036df6fd9d1bb24af1fa1bfed87c94879e950fbee5f86d1
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp-BABEL_8_BREAKING-true@npm:escape-string-regexp@^4.0.0":
+  version: 4.0.0
+  resolution: "escape-string-regexp@npm:4.0.0"
+  checksum: c747be8d5ff7873127e3e0cffe7d2206a37208077fa9c30a3c1bb4f26bebd081c8c24d5fba7a99449f9d20670bea3dc5e1b6098b0f074b099bd38766271a272f
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp@condition:BABEL_8_BREAKING ? ^4.0.0 : ":
+  version: 0.0.0-condition-76f759
+  resolution: "escape-string-regexp@condition:BABEL_8_BREAKING?^4.0.0:#76f759"
+  dependencies:
+    escape-string-regexp-BABEL_8_BREAKING-true: "npm:escape-string-regexp@^4.0.0"
+  checksum: 1c6b06b9d1094aa0c4bcb60d0d8d82237c35a11132cddf9ecf3fe52a356ae1cf5a65a7d2cfc19cfdb7397474dbbfeafeab74944a5f5e35a6e615db7019209a7d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Major: Breaking Change?  | Yes but behind `BABEL_8_BREAKING`
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | `lodash.escapeRegExp` to `escape-string-regexp`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Backport of https://github.com/babel/babel/pull/11842, modified to use the whole conditional dep thing + similar approach in source with chokidar. (I'd also recommend for these utils maybe we could just inline tho)


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12677"><img src="https://gitpod.io/api/apps/github/pbs/github.com/hzoo/babel.git/eb11de58b8048b4644ca61436986beaf2e81e4db.svg" /></a>

