### PR TITLE
fix: start TypePredicate node after returnToken

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1050,6 +1050,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         const t: N.TsTypeAnnotation = this.startNode();
         this.expect(returnToken);
 
+        const node = this.startNode<N.TsTypePredicate>();
+
         const asserts = !!this.tsTryParse(
           this.tsParseTypePredicateAsserts.bind(this),
         );
@@ -1061,7 +1063,6 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           // if it turns out to be a `TSThisType`, wrap it with `TSTypePredicate`
           // : asserts this
           if (thisTypePredicate.type === "TSThisType") {
-            const node: N.TsTypePredicate = this.startNodeAtNode(t);
             node.parameterName = (thisTypePredicate: N.TsThisType);
             node.asserts = true;
             thisTypePredicate = this.finishNode(node, "TSTypePredicate");
@@ -1082,7 +1083,6 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             return this.tsParseTypeAnnotation(/* eatColon */ false, t);
           }
 
-          const node: N.TsTypePredicate = this.startNodeAtNode(t);
           // : asserts foo
           node.parameterName = this.parseIdentifier();
           node.asserts = asserts;
@@ -1092,7 +1092,6 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
         // : asserts foo is type
         const type = this.tsParseTypeAnnotation(/* eatColon */ false);
-        const node = this.startNodeAtNode(t);
         node.parameterName = typePredicateVariable;
         node.typeAnnotation = type;
         node.asserts = asserts;

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/predicate-types/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/predicate-types/output.json
@@ -18,7 +18,7 @@
             "start":8,"end":21,"loc":{"start":{"line":1,"column":8},"end":{"line":1,"column":21}},
             "typeAnnotation": {
               "type": "TSTypePredicate",
-              "start":8,"end":21,"loc":{"start":{"line":1,"column":8},"end":{"line":1,"column":21}},
+              "start":10,"end":21,"loc":{"start":{"line":1,"column":10},"end":{"line":1,"column":21}},
               "parameterName": {
                 "type": "Identifier",
                 "start":10,"end":11,"loc":{"start":{"line":1,"column":10},"end":{"line":1,"column":11},"identifierName":"x"},

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/arrow-function/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/arrow-function/output.json
@@ -27,7 +27,7 @@
                 "start":32,"end":57,"loc":{"start":{"line":1,"column":32},"end":{"line":1,"column":57}},
                 "typeAnnotation": {
                   "type": "TSTypePredicate",
-                  "start":32,"end":57,"loc":{"start":{"line":1,"column":32},"end":{"line":1,"column":57}},
+                  "start":34,"end":57,"loc":{"start":{"line":1,"column":34},"end":{"line":1,"column":57}},
                   "parameterName": {
                     "type": "Identifier",
                     "start":42,"end":47,"loc":{"start":{"line":1,"column":42},"end":{"line":1,"column":47},"identifierName":"value"},
@@ -93,7 +93,7 @@
                 "start":96,"end":111,"loc":{"start":{"line":2,"column":32},"end":{"line":2,"column":47}},
                 "typeAnnotation": {
                   "type": "TSTypePredicate",
-                  "start":96,"end":111,"loc":{"start":{"line":2,"column":32},"end":{"line":2,"column":47}},
+                  "start":98,"end":111,"loc":{"start":{"line":2,"column":34},"end":{"line":2,"column":47}},
                   "parameterName": {
                     "type": "Identifier",
                     "start":106,"end":111,"loc":{"start":{"line":2,"column":42},"end":{"line":2,"column":47},"identifierName":"value"},

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-this/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-this/output.json
@@ -40,7 +40,7 @@
                 "start":15,"end":29,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":19}},
                 "typeAnnotation": {
                   "type": "TSTypePredicate",
-                  "start":15,"end":29,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":19}},
+                  "start":17,"end":29,"loc":{"start":{"line":2,"column":7},"end":{"line":2,"column":19}},
                   "parameterName": {
                     "type": "TSThisType",
                     "start":25,"end":29,"loc":{"start":{"line":2,"column":15},"end":{"line":2,"column":19}}

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var-with-predicate/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var-with-predicate/output.json
@@ -54,7 +54,7 @@
                 "start":42,"end":67,"loc":{"start":{"line":2,"column":32},"end":{"line":2,"column":57}},
                 "typeAnnotation": {
                   "type": "TSTypePredicate",
-                  "start":42,"end":67,"loc":{"start":{"line":2,"column":32},"end":{"line":2,"column":57}},
+                  "start":44,"end":67,"loc":{"start":{"line":2,"column":34},"end":{"line":2,"column":57}},
                   "parameterName": {
                     "type": "Identifier",
                     "start":52,"end":57,"loc":{"start":{"line":2,"column":42},"end":{"line":2,"column":47},"identifierName":"value"},

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var/output.json
@@ -10,6 +10,7 @@
       {
         "type": "TSDeclareFunction",
         "start":0,"end":63,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":63}},
+        "declare": true,
         "id": {
           "type": "Identifier",
           "start":17,"end":31,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":31},"identifierName":"assertIsString"},
@@ -37,7 +38,7 @@
           "start":47,"end":62,"loc":{"start":{"line":1,"column":47},"end":{"line":1,"column":62}},
           "typeAnnotation": {
             "type": "TSTypePredicate",
-            "start":47,"end":62,"loc":{"start":{"line":1,"column":47},"end":{"line":1,"column":62}},
+            "start":49,"end":62,"loc":{"start":{"line":1,"column":49},"end":{"line":1,"column":62}},
             "parameterName": {
               "type": "Identifier",
               "start":57,"end":62,"loc":{"start":{"line":1,"column":57},"end":{"line":1,"column":62},"identifierName":"value"},
@@ -45,8 +46,7 @@
             },
             "asserts": true
           }
-        },
-        "declare": true
+        }
       }
     ],
     "directives": []

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/declare-asserts-var-with-predicate/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/declare-asserts-var-with-predicate/output.json
@@ -10,6 +10,7 @@
       {
         "type": "TSDeclareFunction",
         "start":0,"end":73,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":73}},
+        "declare": true,
         "id": {
           "type": "Identifier",
           "start":17,"end":31,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":31},"identifierName":"assertIsString"},
@@ -37,7 +38,7 @@
           "start":47,"end":72,"loc":{"start":{"line":1,"column":47},"end":{"line":1,"column":72}},
           "typeAnnotation": {
             "type": "TSTypePredicate",
-            "start":47,"end":72,"loc":{"start":{"line":1,"column":47},"end":{"line":1,"column":72}},
+            "start":49,"end":72,"loc":{"start":{"line":1,"column":49},"end":{"line":1,"column":72}},
             "parameterName": {
               "type": "Identifier",
               "start":57,"end":62,"loc":{"start":{"line":1,"column":57},"end":{"line":1,"column":62},"identifierName":"value"},
@@ -53,8 +54,7 @@
             },
             "asserts": true
           }
-        },
-        "declare": true
+        }
       }
     ],
     "directives": []

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration/output.json
@@ -37,7 +37,7 @@
           "start":34,"end":59,"loc":{"start":{"line":1,"column":34},"end":{"line":1,"column":59}},
           "typeAnnotation": {
             "type": "TSTypePredicate",
-            "start":34,"end":59,"loc":{"start":{"line":1,"column":34},"end":{"line":1,"column":59}},
+            "start":36,"end":59,"loc":{"start":{"line":1,"column":36},"end":{"line":1,"column":59}},
             "parameterName": {
               "type": "Identifier",
               "start":44,"end":49,"loc":{"start":{"line":1,"column":44},"end":{"line":1,"column":49},"identifierName":"value"},
@@ -91,7 +91,7 @@
           "start":98,"end":113,"loc":{"start":{"line":2,"column":34},"end":{"line":2,"column":49}},
           "typeAnnotation": {
             "type": "TSTypePredicate",
-            "start":98,"end":113,"loc":{"start":{"line":2,"column":34},"end":{"line":2,"column":49}},
+            "start":100,"end":113,"loc":{"start":{"line":2,"column":36},"end":{"line":2,"column":49}},
             "parameterName": {
               "type": "Identifier",
               "start":108,"end":113,"loc":{"start":{"line":2,"column":44},"end":{"line":2,"column":49},"identifierName":"value"},

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/invalid-escaped-asserts-keyword/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/invalid-escaped-asserts-keyword/output.json
@@ -13,6 +13,7 @@
       {
         "type": "TSDeclareFunction",
         "start":0,"end":68,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":68}},
+        "declare": true,
         "id": {
           "type": "Identifier",
           "start":17,"end":31,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":31},"identifierName":"assertIsString"},
@@ -40,7 +41,7 @@
           "start":47,"end":67,"loc":{"start":{"line":1,"column":47},"end":{"line":1,"column":67}},
           "typeAnnotation": {
             "type": "TSTypePredicate",
-            "start":47,"end":67,"loc":{"start":{"line":1,"column":47},"end":{"line":1,"column":67}},
+            "start":49,"end":67,"loc":{"start":{"line":1,"column":49},"end":{"line":1,"column":67}},
             "parameterName": {
               "type": "Identifier",
               "start":62,"end":67,"loc":{"start":{"line":1,"column":62},"end":{"line":1,"column":67},"identifierName":"value"},
@@ -48,8 +49,7 @@
             },
             "asserts": true
           }
-        },
-        "declare": true
+        }
       }
     ],
     "directives": []

--- a/packages/babel-parser/test/fixtures/typescript/function/predicate-types/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/function/predicate-types/output.json
@@ -37,7 +37,7 @@
           "start":18,"end":32,"loc":{"start":{"line":1,"column":18},"end":{"line":1,"column":32}},
           "typeAnnotation": {
             "type": "TSTypePredicate",
-            "start":18,"end":32,"loc":{"start":{"line":1,"column":18},"end":{"line":1,"column":32}},
+            "start":20,"end":32,"loc":{"start":{"line":1,"column":20},"end":{"line":1,"column":32}},
             "parameterName": {
               "type": "Identifier",
               "start":20,"end":21,"loc":{"start":{"line":1,"column":20},"end":{"line":1,"column":21},"identifierName":"x"},
@@ -94,7 +94,7 @@
             "start":53,"end":67,"loc":{"start":{"line":2,"column":17},"end":{"line":2,"column":31}},
             "typeAnnotation": {
               "type": "TSTypePredicate",
-              "start":53,"end":67,"loc":{"start":{"line":2,"column":17},"end":{"line":2,"column":31}},
+              "start":55,"end":67,"loc":{"start":{"line":2,"column":19},"end":{"line":2,"column":31}},
               "parameterName": {
                 "type": "Identifier",
                 "start":55,"end":56,"loc":{"start":{"line":2,"column":19},"end":{"line":2,"column":20},"identifierName":"x"},


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12676 
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12678"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/adc7beec3b8ee4cc4c4e8d09b8bbc380f90b05cf.svg" /></a>

