### PR TITLE
fix(parser): throw error with wrong typescript 'export declare'

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2281,6 +2281,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       // "export declare" is equivalent to just "export".
       const isDeclare = this.eatContextual("declare");
 
+      if (
+        this.isContextual("declare") ||
+        !this.shouldParseExportDeclaration()
+      ) {
+        super.unexpected(this.state.start, this.state.value);
+      }
+
       let declaration: ?N.Declaration;
 
       if (this.match(tt.name)) {

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2284,8 +2284,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const isDeclare = this.eatContextual("declare");
 
       if (
-        this.isContextual("declare") ||
-        !this.shouldParseExportDeclaration()
+        isDeclare &&
+        (this.isContextual("declare") || !this.shouldParseExportDeclaration())
       ) {
         throw this.raise(
           this.state.start,

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -74,6 +74,8 @@ const TSErrors = Object.freeze({
   EmptyHeritageClauseType: "'%0' list cannot be empty.",
   EmptyTypeArguments: "Type argument list cannot be empty.",
   EmptyTypeParameters: "Type parameter list cannot be empty.",
+  ExpectedAmbientAfterExportDeclare:
+    "'export declare' must be followed by an ambient declaration.",
   IndexSignatureHasAbstract:
     "Index signatures cannot have the 'abstract' modifier",
   IndexSignatureHasAccessibility:
@@ -2285,7 +2287,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         this.isContextual("declare") ||
         !this.shouldParseExportDeclaration()
       ) {
-        super.unexpected(this.state.start, this.state.value);
+        throw this.raise(
+          this.state.start,
+          TSErrors.ExpectedAmbientAfterExportDeclare,
+        );
       }
 
       let declaration: ?N.Declaration;

--- a/packages/babel-parser/test/fixtures/typescript/export/declare-invalid/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/export/declare-invalid/input.ts
@@ -1,0 +1,1 @@
+export declare foo;

--- a/packages/babel-parser/test/fixtures/typescript/export/declare-invalid/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/export/declare-invalid/options.json
@@ -1,0 +1,7 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "typescript"
+  ],
+  "throws": "foo (1:15)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/export/declare-invalid/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/export/declare-invalid/options.json
@@ -3,5 +3,5 @@
   "plugins": [
     "typescript"
   ],
-  "throws": "foo (1:15)"
+  "throws": "'export declare' must be followed by an ambient declaration. (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/typescript/export/declare/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/export/declare/input.ts
@@ -6,3 +6,5 @@ export declare type T = number;
 export declare module M {}
 export declare namespace N {}
 export declare enum foo {}
+export declare var bar: string;
+export declare var _bar;

--- a/packages/babel-parser/test/fixtures/typescript/export/declare/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/export/declare/output.json
@@ -1,9 +1,9 @@
 {
   "type": "File",
-  "start":0,"end":238,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":26}},
+  "start":0,"end":295,"loc":{"start":{"line":1,"column":0},"end":{"line":10,"column":24}},
   "program": {
     "type": "Program",
-    "start":0,"end":238,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":26}},
+    "start":0,"end":295,"loc":{"start":{"line":1,"column":0},"end":{"line":10,"column":24}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
@@ -193,6 +193,64 @@
             "name": "foo"
           },
           "members": [],
+          "declare": true
+        }
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start":239,"end":270,"loc":{"start":{"line":9,"column":0},"end":{"line":9,"column":31}},
+        "exportKind": "type",
+        "specifiers": [],
+        "source": null,
+        "declaration": {
+          "type": "VariableDeclaration",
+          "start":246,"end":270,"loc":{"start":{"line":9,"column":7},"end":{"line":9,"column":31}},
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "start":258,"end":269,"loc":{"start":{"line":9,"column":19},"end":{"line":9,"column":30}},
+              "id": {
+                "type": "Identifier",
+                "start":258,"end":269,"loc":{"start":{"line":9,"column":19},"end":{"line":9,"column":30},"identifierName":"bar"},
+                "name": "bar",
+                "typeAnnotation": {
+                  "type": "TSTypeAnnotation",
+                  "start":261,"end":269,"loc":{"start":{"line":9,"column":22},"end":{"line":9,"column":30}},
+                  "typeAnnotation": {
+                    "type": "TSStringKeyword",
+                    "start":263,"end":269,"loc":{"start":{"line":9,"column":24},"end":{"line":9,"column":30}}
+                  }
+                }
+              },
+              "init": null
+            }
+          ],
+          "kind": "var",
+          "declare": true
+        }
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start":271,"end":295,"loc":{"start":{"line":10,"column":0},"end":{"line":10,"column":24}},
+        "exportKind": "type",
+        "specifiers": [],
+        "source": null,
+        "declaration": {
+          "type": "VariableDeclaration",
+          "start":278,"end":295,"loc":{"start":{"line":10,"column":7},"end":{"line":10,"column":24}},
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "start":290,"end":294,"loc":{"start":{"line":10,"column":19},"end":{"line":10,"column":23}},
+              "id": {
+                "type": "Identifier",
+                "start":290,"end":294,"loc":{"start":{"line":10,"column":19},"end":{"line":10,"column":23},"identifierName":"_bar"},
+                "name": "_bar"
+              },
+              "init": null
+            }
+          ],
+          "kind": "var",
           "declare": true
         }
       }

--- a/packages/babel-parser/test/fixtures/typescript/export/double-declare/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/export/double-declare/input.ts
@@ -1,0 +1,1 @@
+export declare declare var name;

--- a/packages/babel-parser/test/fixtures/typescript/export/double-declare/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/export/double-declare/options.json
@@ -3,5 +3,5 @@
   "plugins": [
     "typescript"
   ],
-  "throws": "declare (1:15)"
+  "throws": "'export declare' must be followed by an ambient declaration. (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/typescript/export/double-declare/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/export/double-declare/options.json
@@ -1,0 +1,7 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "typescript"
+  ],
+  "throws": "declare (1:15)"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12658  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
We check if after the first `declare` there is an exportable value.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12684"><img src="https://gitpod.io/api/apps/github/pbs/github.com/fedeci/babel.git/1cb13af452ad63307e2747037f8c7b36df8b02ae.svg" /></a>

