### PR TITLE
Avoid hitting __proto__ in _inheritsLoose

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -474,10 +474,12 @@ helpers.inherits = helper("7.0.0-beta.0")`
 `;
 
 helpers.inheritsLoose = helper("7.0.0-beta.0")`
+  import setPrototypeOf from "setPrototypeOf";
+
   export default function _inheritsLoose(subClass, superClass) {
     subClass.prototype = Object.create(superClass.prototype);
     subClass.prototype.constructor = subClass;
-    subClass.__proto__ = superClass;
+    setPrototypeOf(subClass, superClass);
   }
 `;
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
@@ -1,4 +1,4 @@
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
 
 function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-data-defined-on-parent/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let Base = /*#__PURE__*/function () {
   function Base() {}

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-getter-defined-on-parent/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let Base = function Base() {};
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-data-defined-on-parent/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let Base = function Base() {};
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-getter-defined-on-parent/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-not-defined-on-parent/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let Base = function Base() {};
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-setter-defined-on-parent/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-assign/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-assign/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let Base = function Base() {};
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-update/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-update/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let Base = function Base() {};
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-data-defined-on-parent/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let Base = function Base() {};
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-getter-defined-on-parent/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-data-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-data-on-obj/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let Base = function Base() {};
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-getter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-getter-on-obj/output.js
@@ -4,7 +4,9 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let Base = function Base() {};
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-not-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-not-on-obj/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let Base = function Base() {};
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-setter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-setter-on-obj/output.js
@@ -4,7 +4,9 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let Base = function Base() {};
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-setter-defined-on-parent/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-superClass/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-superClass/output.js
@@ -1,6 +1,8 @@
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 let B = function B() {
   "use strict";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Not filed, see description below.
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes (updated existing tests)
| Documentation PR Link    | None
| Any Dependency Changes?  | None
| License                  | MIT

This avoids hitting `__proto__` for hardened environments where `__proto__` is disabled.

See discussion in https://github.com/nodejs/node/issues/31951 and these changes: https://github.com/nodejs/node/pull/32279, https://github.com/denoland/deno/pull/4341.

Note that per spec, `__proto__` is defined in [section B.2.2](https://262.ecma-international.org/11.0/#sec-additional-properties-of-the-object.prototype-object) (Additional ECMAScript Features for Web Browsers → B.2.2 Additional Properties of the Object.prototype Object), which is [optional for non-browsers](https://262.ecma-international.org/11.0/#sec-additional-ecmascript-features-for-web-browsers):
> The ECMAScript language syntax and semantics defined in this annex are required when the ECMAScript host is a web browser. The content of this annex is normative but optional if the ECMAScript host is not a web browser.

Class transforms should not rely on `__proto__` to be present, as classes are defined in [section 14.6](https://262.ecma-international.org/11.0/#sec-class-definitions).


To check that this works, run with: `NODE_OPTIONS=--disable-proto=throw` before and after this change (or any generated `output.js` files in loose mode):
```console
[chalker@workstation babel]$ git checkout main  
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
[chalker@workstation babel]$ NODE_OPTIONS=--disable-proto=throw node ./packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
/home/chalker/repo/babel/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js:1
function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
                                                                                                                                                                        ^

Error: Accessing Object.prototype.__proto__ has been disallowed with --disable-proto=throw
    at _inheritsLoose (/home/chalker/repo/babel/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js:1:169)
    at /home/chalker/repo/babel/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js:18:3
    at Object.<anonymous> (/home/chalker/repo/babel/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js:25:2)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
    at Module.load (internal/modules/cjs/loader.js:985:32)
    at Function.Module._load (internal/modules/cjs/loader.js:878:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'ERR_PROTO_ACCESS'
}
```
```console
[chalker@workstation babel]$ git checkout chalker/set-proto
Switched to branch 'chalker/set-proto'
Your branch is up to date with 'chalker/chalker/set-proto'.
[chalker@workstation babel]$ NODE_OPTIONS=--disable-proto=throw node ./packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
[chalker@workstation babel]$
```

I believe this could be a semver-patch or a semver-minor for v7.

Note: before v7, this was not the only place which hit `__proto__`, but https://github.com/babel/babel/pull/7675 resolved the other one in v7.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12693"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ChALkeR/babel.git/f7924494a13de0dcd1cecbd059f72f72c48db73d.svg" /></a>

