### PR TITLE
[babel 8] Disallow synchronous usage of `babel.*` callback methods

### DIFF
--- a/packages/babel-core/src/config/full.ts
+++ b/packages/babel-core/src/config/full.ts
@@ -430,7 +430,7 @@ const validateIfOptionNeedsFilename = (
       [
         `Preset ${formattedPresetName} requires a filename to be set when babel is called directly,`,
         `\`\`\``,
-        `babel.transform(code, { filename: 'file.ts', presets: [${formattedPresetName}] });`,
+        `babel.transformSync(code, { filename: 'file.ts', presets: [${formattedPresetName}] });`,
         `\`\`\``,
         `See https://babeljs.io/docs/en/options#filename for more information.`,
       ].join("\n"),

--- a/packages/babel-core/src/index.ts
+++ b/packages/babel-core/src/index.ts
@@ -63,10 +63,10 @@ export const DEFAULT_EXTENSIONS = Object.freeze([
 ] as const);
 
 // For easier backward-compatibility, provide an API like the one we exposed in Babel 6.
-import { loadOptions } from "./config";
+import { loadOptionsSync } from "./config";
 export class OptionManager {
   init(opts: {}) {
-    return loadOptions(opts);
+    return loadOptionsSync(opts);
   }
 }
 

--- a/packages/babel-core/src/parse.ts
+++ b/packages/babel-core/src/parse.ts
@@ -39,9 +39,18 @@ export const parse: Parse = function parse(code, opts?, callback?) {
     opts = undefined;
   }
 
-  // For backward-compat with Babel 7's early betas, we allow sync parsing when
-  // no callback is given. Will be dropped in some future Babel major version.
-  if (callback === undefined) return parseRunner.sync(code, opts);
+  if (callback === undefined) {
+    if (process.env.BABEL_8_BREAKING) {
+      throw new Error(
+        "Starting from Babel 8.0.0, the 'parse' function expects a callback. If you need to call it synchronously, please use 'parseSync'.",
+      );
+    } else {
+      console.warn(
+        "Starting from Babel 8.0.0, the 'parse' function will expect a callback. If you need to call it synchronously, please use 'parseSync'.",
+      );
+      return parseRunner.sync(code, opts);
+    }
+  }
 
   parseRunner.errback(code, opts, callback);
 };

--- a/packages/babel-core/src/parse.ts
+++ b/packages/babel-core/src/parse.ts
@@ -45,9 +45,9 @@ export const parse: Parse = function parse(code, opts?, callback?) {
         "Starting from Babel 8.0.0, the 'parse' function expects a callback. If you need to call it synchronously, please use 'parseSync'.",
       );
     } else {
-      console.warn(
-        "Starting from Babel 8.0.0, the 'parse' function will expect a callback. If you need to call it synchronously, please use 'parseSync'.",
-      );
+      // console.warn(
+      //   "Starting from Babel 8.0.0, the 'parse' function will expect a callback. If you need to call it synchronously, please use 'parseSync'.",
+      // );
       return parseRunner.sync(code, opts);
     }
   }

--- a/packages/babel-core/src/transform-ast.ts
+++ b/packages/babel-core/src/transform-ast.ts
@@ -45,10 +45,17 @@ export const transformFromAst: TransformFromAst = function transformFromAst(
     opts = undefined;
   }
 
-  // For backward-compat with Babel 6, we allow sync transformation when
-  // no callback is given. Will be dropped in some future Babel major version.
   if (callback === undefined) {
-    return transformFromAstRunner.sync(ast, code, opts);
+    if (process.env.BABEL_8_BREAKING) {
+      throw new Error(
+        "Starting from Babel 8.0.0, the 'transformFromAst' function expects a callback. If you need to call it synchronously, please use 'transformFromAstSync'.",
+      );
+    } else {
+      console.warn(
+        "Starting from Babel 8.0.0, the 'transformFromAst' function will expect a callback. If you need to call it synchronously, please use 'transformFromAstSync'.",
+      );
+      return transformFromAstRunner.sync(ast, code, opts);
+    }
   }
 
   transformFromAstRunner.errback(ast, code, opts, callback);

--- a/packages/babel-core/src/transform-ast.ts
+++ b/packages/babel-core/src/transform-ast.ts
@@ -51,9 +51,9 @@ export const transformFromAst: TransformFromAst = function transformFromAst(
         "Starting from Babel 8.0.0, the 'transformFromAst' function expects a callback. If you need to call it synchronously, please use 'transformFromAstSync'.",
       );
     } else {
-      console.warn(
-        "Starting from Babel 8.0.0, the 'transformFromAst' function will expect a callback. If you need to call it synchronously, please use 'transformFromAstSync'.",
-      );
+      // console.warn(
+      //   "Starting from Babel 8.0.0, the 'transformFromAst' function will expect a callback. If you need to call it synchronously, please use 'transformFromAstSync'.",
+      // );
       return transformFromAstRunner.sync(ast, code, opts);
     }
   }

--- a/packages/babel-core/src/transform.ts
+++ b/packages/babel-core/src/transform.ts
@@ -37,9 +37,9 @@ export const transform: Transform = function transform(code, opts?, callback?) {
         "Starting from Babel 8.0.0, the 'transform' function expects a callback. If you need to call it synchronously, please use 'transformSync'.",
       );
     } else {
-      console.warn(
-        "Starting from Babel 8.0.0, the 'transform' function will expect a callback. If you need to call it synchronously, please use 'transformSync'.",
-      );
+      // console.warn(
+      //   "Starting from Babel 8.0.0, the 'transform' function will expect a callback. If you need to call it synchronously, please use 'transformSync'.",
+      // );
       return transformRunner.sync(code, opts);
     }
   }

--- a/packages/babel-core/src/transform.ts
+++ b/packages/babel-core/src/transform.ts
@@ -31,9 +31,18 @@ export const transform: Transform = function transform(code, opts?, callback?) {
     opts = undefined;
   }
 
-  // For backward-compat with Babel 6, we allow sync transformation when
-  // no callback is given. Will be dropped in some future Babel major version.
-  if (callback === undefined) return transformRunner.sync(code, opts);
+  if (callback === undefined) {
+    if (process.env.BABEL_8_BREAKING) {
+      throw new Error(
+        "Starting from Babel 8.0.0, the 'transform' function expects a callback. If you need to call it synchronously, please use 'transformSync'.",
+      );
+    } else {
+      console.warn(
+        "Starting from Babel 8.0.0, the 'transform' function will expect a callback. If you need to call it synchronously, please use 'transformSync'.",
+      );
+      return transformRunner.sync(code, opts);
+    }
+  }
 
   transformRunner.errback(code, opts, callback);
 };

--- a/packages/babel-core/test/parse.js
+++ b/packages/babel-core/test/parse.js
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { parse } from "../lib/index.js";
+import { parseSync } from "../lib/index.js";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
 
@@ -15,12 +15,12 @@ function fixture(...args) {
   );
 }
 
-describe("parse", function () {
+describe("parseSync", function () {
   it("should parse using configuration from .babelrc when a filename is provided", function () {
     const input = fs.readFileSync(fixture("input.js"), "utf8");
     const output = require(fixture("output"));
 
-    const result = parse(input, {
+    const result = parseSync(input, {
       filename: fixture("input.js"),
       cwd: fixture(),
     });
@@ -31,7 +31,7 @@ describe("parse", function () {
     const input = fs.readFileSync(fixture("input.js"), "utf8");
     const output = require(fixture("output.json"));
 
-    const result = parse(input, {
+    const result = parseSync(input, {
       parserOpts: {
         plugins: [["decorators", { decoratorsBeforeExport: false }]],
       },

--- a/packages/babel-core/test/path.js
+++ b/packages/babel-core/test/path.js
@@ -1,4 +1,4 @@
-import { transform } from "../lib/index.js";
+import { transformSync } from "../lib/index.js";
 import { fileURLToPath } from "url";
 import path from "path";
 
@@ -11,7 +11,7 @@ describe("traversal path", function () {
   it("replaceWithSourceString", function () {
     const expectCode = "function foo() {}";
 
-    const actualCode = transform(expectCode, {
+    const actualCode = transformSync(expectCode, {
       cwd,
       plugins: [
         new Plugin({
@@ -30,7 +30,7 @@ describe("traversal path", function () {
   it("replaceWith (arrow expression body to block statement body)", function () {
     const expectCode = "var fn = () => true;";
 
-    const actualCode = transform(expectCode, {
+    const actualCode = transformSync(expectCode, {
       cwd,
       plugins: [
         new Plugin({
@@ -60,7 +60,7 @@ describe("traversal path", function () {
   it("replaceWith (arrow block statement body to expression body)", function () {
     const expectCode = "var fn = () => { return true; }";
 
-    const actualCode = transform(expectCode, {
+    const actualCode = transformSync(expectCode, {
       cwd,
       plugins: [
         new Plugin({
@@ -82,7 +82,7 @@ describe("traversal path", function () {
   it("replaceWith (for-in left expression to variable declaration)", function () {
     const expectCode = "for (KEY in right);";
 
-    const actualCode = transform(expectCode, {
+    const actualCode = transformSync(expectCode, {
       cwd,
       plugins: [
         new Plugin({
@@ -113,7 +113,7 @@ describe("traversal path", function () {
   it("replaceWith (for-in left variable declaration to expression)", function () {
     const expectCode = "for (var KEY in right);";
 
-    const actualCode = transform(expectCode, {
+    const actualCode = transformSync(expectCode, {
       cwd,
       plugins: [
         new Plugin({
@@ -135,7 +135,7 @@ describe("traversal path", function () {
   it("replaceWith (for-loop left expression to variable declaration)", function () {
     const expectCode = "for (KEY;;);";
 
-    const actualCode = transform(expectCode, {
+    const actualCode = transformSync(expectCode, {
       cwd,
       plugins: [
         new Plugin({
@@ -166,7 +166,7 @@ describe("traversal path", function () {
   it("replaceWith (for-loop left variable declaration to expression)", function () {
     const expectCode = "for (var KEY;;);";
 
-    const actualCode = transform(expectCode, {
+    const actualCode = transformSync(expectCode, {
       cwd,
       plugins: [
         new Plugin({

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -22,7 +22,7 @@ describe("addon resolution", function () {
   it("should find module: presets", function () {
     process.chdir("module-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["module:preset"],
@@ -32,7 +32,7 @@ describe("addon resolution", function () {
   it("should find module: plugins", function () {
     process.chdir("module-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["module:plugin"],
@@ -42,7 +42,7 @@ describe("addon resolution", function () {
   it("should find standard presets", function () {
     process.chdir("standard-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["mod"],
@@ -52,7 +52,7 @@ describe("addon resolution", function () {
   it("should find standard plugins", function () {
     process.chdir("standard-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["mod"],
@@ -62,7 +62,7 @@ describe("addon resolution", function () {
   it("should find standard presets with an existing prefix", function () {
     process.chdir("standard-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["babel-preset-mod"],
@@ -72,7 +72,7 @@ describe("addon resolution", function () {
   it("should find standard plugins with an existing prefix", function () {
     process.chdir("standard-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["babel-plugin-mod"],
@@ -82,7 +82,7 @@ describe("addon resolution", function () {
   it("should find @babel scoped presets", function () {
     process.chdir("babel-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["@babel/foo"],
@@ -92,7 +92,7 @@ describe("addon resolution", function () {
   it("should find @babel scoped plugins", function () {
     process.chdir("babel-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["@babel/foo"],
@@ -102,7 +102,7 @@ describe("addon resolution", function () {
   it("should find @babel scoped presets with an existing prefix", function () {
     process.chdir("babel-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["@babel/preset-foo"],
@@ -112,7 +112,7 @@ describe("addon resolution", function () {
   it("should find @babel scoped plugins", function () {
     process.chdir("babel-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["@babel/plugin-foo"],
@@ -122,7 +122,7 @@ describe("addon resolution", function () {
   it("should find @foo scoped presets", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["@foo/mod"],
@@ -132,7 +132,7 @@ describe("addon resolution", function () {
   it("should find @foo scoped plugins", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["@foo/mod"],
@@ -142,7 +142,7 @@ describe("addon resolution", function () {
   it("should find @foo scoped presets with an inner babel-preset", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["@foo/thing.babel-preset-convert"],
@@ -152,7 +152,7 @@ describe("addon resolution", function () {
   it("should find @foo scoped plugins with an inner babel-plugin", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["@foo/thing.babel-plugin-convert"],
@@ -162,7 +162,7 @@ describe("addon resolution", function () {
   it("should find @foo scoped presets with an babel-preset suffix", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["@foo/thing-babel-preset"],
@@ -172,7 +172,7 @@ describe("addon resolution", function () {
   it("should find @foo scoped plugins with an babel-plugin suffix", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["@foo/thing-babel-plugin"],
@@ -182,7 +182,7 @@ describe("addon resolution", function () {
   it("should find @foo scoped presets with an existing prefix", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["@foo/babel-preset-mod"],
@@ -192,7 +192,7 @@ describe("addon resolution", function () {
   it("should find @foo scoped plugins with an existing prefix", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["@foo/babel-plugin-mod"],
@@ -202,7 +202,7 @@ describe("addon resolution", function () {
   it("should find @foo/babel-plugin when specified", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["@foo/babel-plugin"],
@@ -212,7 +212,7 @@ describe("addon resolution", function () {
   it("should find @foo/babel-preset when specified", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["@foo/babel-preset"],
@@ -222,7 +222,7 @@ describe("addon resolution", function () {
   it("should find @foo/babel-plugin/index when specified", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["@foo/babel-plugin/index"],
@@ -232,7 +232,7 @@ describe("addon resolution", function () {
   it("should find @foo/babel-preset/index when specified", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["@foo/babel-preset/index"],
@@ -242,7 +242,7 @@ describe("addon resolution", function () {
   it("should find @foo/babel-plugin when just scope given", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["@foo"],
@@ -252,7 +252,7 @@ describe("addon resolution", function () {
   it("should find @foo/babel-preset when just scope given", function () {
     process.chdir("foo-org-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["@foo"],
@@ -262,7 +262,7 @@ describe("addon resolution", function () {
   it("should find relative path presets", function () {
     process.chdir("relative-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["./dir/preset.js"],
@@ -272,7 +272,7 @@ describe("addon resolution", function () {
   it("should find relative path plugins", function () {
     process.chdir("relative-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["./dir/plugin.js"],
@@ -282,7 +282,7 @@ describe("addon resolution", function () {
   it("should find module file presets", function () {
     process.chdir("nested-module-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["mod/preset"],
@@ -292,7 +292,7 @@ describe("addon resolution", function () {
   it("should find module file plugins", function () {
     process.chdir("nested-module-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["mod/plugin"],
@@ -302,7 +302,7 @@ describe("addon resolution", function () {
   it("should find @foo scoped module file presets", function () {
     process.chdir("scoped-nested-module-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["@foo/mod/preset"],
@@ -312,7 +312,7 @@ describe("addon resolution", function () {
   it("should find @foo scoped module file plugins", function () {
     process.chdir("scoped-nested-module-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["@foo/mod/plugin"],
@@ -322,7 +322,7 @@ describe("addon resolution", function () {
   it("should find @babel scoped module file presets", function () {
     process.chdir("babel-scoped-nested-module-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       presets: ["@babel/mod/preset"],
@@ -332,7 +332,7 @@ describe("addon resolution", function () {
   it("should find @babel scoped module file plugins", function () {
     process.chdir("babel-scoped-nested-module-paths");
 
-    babel.transform("", {
+    babel.transformSync("", {
       filename: "filename.js",
       babelrc: false,
       plugins: ["@babel/mod/plugin"],
@@ -344,7 +344,7 @@ describe("addon resolution", function () {
     process.chdir("throw-module-paths");
 
     expect(() => {
-      babel.transform("", {
+      babel.transformSync("", {
         filename: "filename.js",
         babelrc: false,
         presets: ["foo"],
@@ -364,7 +364,7 @@ describe("addon resolution", function () {
     process.chdir("throw-module-paths");
 
     expect(() => {
-      babel.transform("", {
+      babel.transformSync("", {
         filename: "filename.js",
         babelrc: false,
         plugins: ["foo"],
@@ -380,7 +380,7 @@ describe("addon resolution", function () {
     process.chdir("throw-babel-paths");
 
     expect(() => {
-      babel.transform("", {
+      babel.transformSync("", {
         filename: "filename.js",
         babelrc: false,
         presets: ["foo"],
@@ -396,7 +396,7 @@ describe("addon resolution", function () {
     process.chdir("throw-babel-paths");
 
     expect(() => {
-      babel.transform("", {
+      babel.transformSync("", {
         filename: "filename.js",
         babelrc: false,
         plugins: ["foo"],
@@ -412,7 +412,7 @@ describe("addon resolution", function () {
     process.chdir("throw-opposite-paths");
 
     expect(() => {
-      babel.transform("", {
+      babel.transformSync("", {
         filename: "filename.js",
         babelrc: false,
         presets: ["testplugin"],
@@ -428,7 +428,7 @@ describe("addon resolution", function () {
     process.chdir("throw-opposite-paths");
 
     expect(() => {
-      babel.transform("", {
+      babel.transformSync("", {
         filename: "filename.js",
         babelrc: false,
         plugins: ["testpreset"],
@@ -444,7 +444,7 @@ describe("addon resolution", function () {
     process.chdir("throw-missing-paths");
 
     expect(() => {
-      babel.transform("", {
+      babel.transformSync("", {
         filename: "filename.js",
         babelrc: false,
         presets: ["foo"],
@@ -456,7 +456,7 @@ describe("addon resolution", function () {
     process.chdir("throw-missing-paths");
 
     expect(() => {
-      babel.transform("", {
+      babel.transformSync("", {
         filename: "filename.js",
         babelrc: false,
         plugins: ["foo"],

--- a/packages/babel-helper-module-imports/test/index.js
+++ b/packages/babel-helper-module-imports/test/index.js
@@ -18,7 +18,7 @@ function test(sourceType, opts, initializer, inputCode, expectedCode) {
     inputCode = "";
   }
 
-  const result = babel.transform(inputCode, {
+  const result = babel.transformSync(inputCode, {
     cwd,
     sourceType,
     filename: "example" + (sourceType === "module" ? ".mjs" : ".js"),

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -34,7 +34,7 @@ const sharedTestContext = createContext();
 // default. Tests can still set `configFile: true | string`
 // to re-enable config loading.
 function transformWithoutConfigFile(code, opts) {
-  return babel.transform(code, {
+  return babel.transformSync(code, {
     configFile: false,
     babelrc: false,
     ...opts,
@@ -257,7 +257,7 @@ function run(task) {
     // Ignore Babel logs of exec.js files.
     // They will be validated in input/output files.
     ({ result } = maybeMockConsole(validateLogs, () =>
-      babel.transform(execCode, execOpts),
+      babel.transformSync(execCode, execOpts),
     ));
 
     checkDuplicateNodes(result.ast);
@@ -279,7 +279,7 @@ function run(task) {
     let actualLogs;
 
     ({ result, actualLogs } = maybeMockConsole(validateLogs, () =>
-      babel.transform(inputCode, getOpts(actual)),
+      babel.transformSync(inputCode, getOpts(actual)),
     ));
 
     const outputCode = normalizeOutput(result.code);

--- a/packages/babel-node/src/_babel-node.ts
+++ b/packages/babel-node/src/_babel-node.ts
@@ -130,7 +130,7 @@ const _eval = function (code, filename) {
   code = code.trim();
   if (!code) return undefined;
 
-  code = babel.transform(code, {
+  code = babel.transformSync(code, {
     filename: filename,
     presets: program.presets,
     plugins: (program.plugins || []).concat([replPlugin]),

--- a/packages/babel-plugin-proposal-class-static-block/test/plugin-ordering.test.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/plugin-ordering.test.js
@@ -11,7 +11,7 @@ describe("plugin ordering", () => {
     }
     `;
     expect(
-      babel.transform(source, {
+      babel.transformSync(source, {
         filename: "example.js",
         highlightCode: false,
         configFile: false,

--- a/packages/babel-plugin-syntax-decorators/test/index.js
+++ b/packages/babel-plugin-syntax-decorators/test/index.js
@@ -1,9 +1,9 @@
-import { parse } from "@babel/core";
+import { parseSync } from "@babel/core";
 import syntaxDecorators from "../lib/index.js";
 
 function makeParser(code, options) {
   return () =>
-    parse(code, {
+    parseSync(code, {
       babelrc: false,
       configFile: false,
       plugins: [[syntaxDecorators, options]],

--- a/packages/babel-plugin-transform-modules-commonjs/test/copied-nodes.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/copied-nodes.js
@@ -7,7 +7,7 @@ import transformCommonJS from "../lib/index.js";
 test("Doesn't use the same object for two different nodes in the AST", function () {
   const code = 'import Foo from "bar"; Foo; Foo;';
 
-  const ast = babel.transform(code, {
+  const ast = babel.transformSync(code, {
     cwd: path.dirname(fileURLToPath(import.meta.url)),
     ast: true,
     plugins: [[transformCommonJS, { loose: true }]],

--- a/packages/babel-plugin-transform-modules-commonjs/test/esmodule-flag.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/esmodule-flag.js
@@ -22,7 +22,7 @@ test("Re-export doesn't overwrite __esModule flag", function () {
   };
   context.exports = context.module.exports;
 
-  code = babel.transform(code, {
+  code = babel.transformSync(code, {
     cwd: path.dirname(fileURLToPath(import.meta.url)),
     plugins: [[transformCommonJS, { loose: true }]],
     ast: false,

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -235,7 +235,7 @@ function buildHelper(
   );
   tree.body.push(...helper.nodes);
 
-  return babel.transformFromAst(tree, null, {
+  return babel.transformFromAstSync(tree, null, {
     filename: helperFilename,
     presets: [["@babel/preset-env", { modules: false }]],
     plugins: [

--- a/packages/babel-standalone/examples/example.htm
+++ b/packages/babel-standalone/examples/example.htm
@@ -1,48 +1,50 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <title>babel-standalone example</title>
-  </head>
-  <body>
-    Input:
-    <textarea id="input" style="width: 100%" rows="10">
+
+<head>
+  <meta charset="utf-8" />
+  <title>babel-standalone example</title>
+</head>
+
+<body>
+  Input:
+  <textarea id="input" style="width: 100%" rows="10">
 const getMessage = () => 'Hello World';
 const someDiv = <div>{getMessage()}</div>;
-</textarea
-    >
+</textarea>
 
-    Transformed code using Babel <strong id="version"></strong>:
-    <pre id="output">Loading...</pre>
+  Transformed code using Babel <strong id="version"></strong>:
+  <pre id="output">Loading...</pre>
 
-    <script src="../babel.js"></script>
-    <script>
-      console.log("Babel =", Babel);
-      document.getElementById("version").innerHTML = Babel.version;
-      var inputEl = document.getElementById("input");
-      var outputEl = document.getElementById("output");
+  <script src="../babel.js"></script>
+  <script>
+    console.log("Babel =", Babel);
+    document.getElementById("version").innerHTML = Babel.version;
+    var inputEl = document.getElementById("input");
+    var outputEl = document.getElementById("output");
 
-      function transform() {
-        try {
-          outputEl.innerHTML = Babel.transform(inputEl.value, {
-            presets: [
-              "es2015",
-              "react",
-              [
-                "stage-0",
-                {
-                  decoratorsBeforeExport: false,
-                },
-              ],
+    function transform() {
+      try {
+        outputEl.innerHTML = Babel.transformSync(inputEl.value, {
+          presets: [
+            "es2015",
+            "react",
+            [
+              "stage-0",
+              {
+                decoratorsBeforeExport: false,
+              },
             ],
-          }).code;
-        } catch (ex) {
-          outputEl.innerHTML = "ERROR: " + ex.message;
-        }
+          ],
+        }).code;
+      } catch (ex) {
+        outputEl.innerHTML = "ERROR: " + ex.message;
       }
+    }
 
-      inputEl.addEventListener("keyup", transform, false);
-      transform();
-    </script>
-  </body>
+    inputEl.addEventListener("keyup", transform, false);
+    transform();
+  </script>
+</body>
+
 </html>

--- a/packages/babel-standalone/src/index.ts
+++ b/packages/babel-standalone/src/index.ts
@@ -12,8 +12,8 @@
 /// <reference lib="dom" />
 
 import {
-  transformFromAst as babelTransformFromAst,
-  transform as babelTransform,
+  transformFromAstSync as babelTransformFromAstSync,
+  transformSync as babelTransformSync,
   buildExternalHelpers as babelBuildExternalHelpers,
 } from "@babel/core";
 import { all } from "./generated/plugins";
@@ -101,11 +101,11 @@ function processOptions(options) {
 }
 
 export function transform(code: string, options: any) {
-  return babelTransform(code, processOptions(options));
+  return babelTransformSync(code, processOptions(options));
 }
 
 export function transformFromAst(ast: any, code: string, options: any) {
-  return babelTransformFromAst(ast, code, processOptions(options));
+  return babelTransformFromAstSync(ast, code, processOptions(options));
 }
 export const availablePlugins = {};
 export const availablePresets = {};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Backports #11110, closes #11110
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Y, behind `BABEL_8_BREAKING` flag
| Minor: New Feature?      | ~~Y, deprecation message will be printed when `callback` is not supplied~~
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2440
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR backports #11110 to `main`. While fixing broken tests, I realize that this one is likely one of the most significant changes in Babel 8 as `babel.transform` is `@babel/core`'s primary programmatic interface. It seems abrupt to me if we just error out in Babel 8 without even emitting deprecation message in older Babel 7 versions, so I add warning messages and hopefully people can gracefully migrate to the `transformSync` / `transformAsync`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12695"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/77dbcb9139642ba2714ea05a392f75f9535a4175.svg" /></a>



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12695"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

