### PR TITLE
Add " 📢 Deprecation" to the changelog labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "labels": {
       "PR: Spec Compliance :eyeglasses:": ":eyeglasses: Spec Compliance",
       "PR: Breaking Change :boom:": ":boom: Breaking Change",
+      "PR: Deprecation: :loudspeaker:": ":loudspeaker: Deprecation",
       "PR: New Feature :rocket:": ":rocket: New Feature",
       "PR: Bug Fix :bug:": ":bug: Bug Fix",
       "PR: Polish :nail_care:": ":nail_care: Polish",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

For https://github.com/babel/babel/pull/12695, I realized that we had a `PR: Deprecation` label but that it isn't included in the changelog.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12698"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babel/babel.git/a6e81f03157d82e46b2aaabc255e653fe0770912.svg" /></a>

