### PR TITLE
Evaluate object and initializer when setting a private method

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -299,8 +299,11 @@ const privateNameHandlerSpec = {
           value,
         ]);
       }
-      return t.callExpression(file.addHelper("readOnlyError"), [
-        t.stringLiteral(`#${name}`),
+      return t.sequenceExpression([
+        value,
+        t.callExpression(file.addHelper("readOnlyError"), [
+          t.stringLiteral(`#${name}`),
+        ]),
       ]);
     }
     return t.callExpression(file.addHelper("classPrivateFieldSet"), [

--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -300,6 +300,7 @@ const privateNameHandlerSpec = {
         ]);
       }
       return t.sequenceExpression([
+        this.receiver(member),
         value,
         t.callExpression(file.addHelper("readOnlyError"), [
           t.stringLiteral(`#${name}`),

--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -232,8 +232,11 @@ const privateNameHandlerSpec = {
       if (isAccessor) {
         if (!getId && setId) {
           if (file.availableHelper("writeOnlyError")) {
-            return t.callExpression(file.addHelper("writeOnlyError"), [
-              t.stringLiteral(`#${name}`),
+            return t.sequenceExpression([
+              this.receiver(member),
+              t.callExpression(file.addHelper("writeOnlyError"), [
+                t.stringLiteral(`#${name}`),
+              ]),
             ]);
           }
           console.warn(

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/reassignment/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/reassignment/exec.js
@@ -1,10 +1,10 @@
 let counter = 0;
 class Foo {
   constructor() {
-    this.#privateMethod = ++counter;
+    this.#privateFieldValue = ++counter;
   }
 
-  #privateMethod() {
+  get #privateFieldValue() {
     return 42;
   }
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/reassignment/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/reassignment/input.js
@@ -1,0 +1,10 @@
+let counter = 0;
+class Foo {
+  constructor() {
+    this.#privateFieldValue = ++counter;
+  }
+
+  get #privateFieldValue() {
+    return 42;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/reassignment/output.js
@@ -1,0 +1,18 @@
+var counter = 0;
+
+var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _privateFieldValue, {
+      get: _get_privateFieldValue,
+      set: void 0
+    });
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = ++counter;
+  }
+
+}
+
+var _get_privateFieldValue = function () {
+  return 42;
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/get-only-setter/output.js
@@ -14,7 +14,7 @@ class Cl {
       value: 0
     });
 
-    this.publicField = babelHelpers.writeOnlyError("#privateFieldValue");
+    this.publicField = (this, babelHelpers.writeOnlyError("#privateFieldValue"));
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/exec.js
@@ -1,10 +1,10 @@
 let counter = 0;
 class Foo {
   constructor() {
-    this.#privateMethod = ++counter;
+    this.#privateFieldValue = ++counter;
   }
 
-  #privateMethod() {
+  get #privateFieldValue() {
     return 42;
   }
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/exec.js
@@ -1,7 +1,12 @@
-let counter = 0;
+let results = [];
 class Foo {
   constructor() {
-    this.#privateFieldValue = ++counter;
+    this.self.#privateFieldValue = results.push(2);
+  }
+
+  get self() {
+    results.push(1);
+    return this;
   }
 
   get #privateFieldValue() {
@@ -9,5 +14,5 @@ class Foo {
   }
 }
 
-expect(() => new Foo).toThrow();
-expect(counter).toBe(1);
+expect(() => new Foo).toThrow(TypeError);
+expect(results).toStrictEqual([1, 2]);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/input.js
@@ -1,0 +1,10 @@
+let counter = 0;
+class Foo {
+  constructor() {
+    this.#privateFieldValue = ++counter;
+  }
+
+  get #privateFieldValue() {
+    return 42;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/input.js
@@ -1,7 +1,12 @@
-let counter = 0;
+let results = [];
 class Foo {
   constructor() {
-    this.#privateFieldValue = ++counter;
+    this.self.#privateFieldValue = results.push(2);
+  }
+
+  get self() {
+    results.push(1);
+    return this;
   }
 
   get #privateFieldValue() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/output.js
@@ -1,4 +1,4 @@
-var counter = 0;
+var results = [];
 
 var _privateFieldValue = new WeakMap();
 
@@ -9,7 +9,12 @@ class Foo {
       set: void 0
     });
 
-    babelHelpers.classPrivateMethodSet(++counter);
+    this.self, results.push(2), babelHelpers.readOnlyError("#privateFieldValue");
+  }
+
+  get self() {
+    results.push(1);
+    return this;
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/output.js
@@ -1,0 +1,19 @@
+var counter = 0;
+
+var _privateFieldValue = new WeakMap();
+
+class Foo {
+  constructor() {
+    _privateFieldValue.set(this, {
+      get: _get_privateFieldValue,
+      set: void 0
+    });
+
+    babelHelpers.classPrivateMethodSet(++counter);
+  }
+
+}
+
+var _get_privateFieldValue = function () {
+  return 42;
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/exec.js
@@ -1,12 +1,19 @@
 class Cl {
   #privateField = 0;
+  counter = 0;
 
   get #privateFieldValue() {
     return this.#privateField;
   }
 
+  get self() {
+    this.counter++;
+    return this;
+  }
+
   constructor() {
-    expect(() => this.#privateFieldValue = 1).toThrow(TypeError);
+    expect(() => this.self.#privateFieldValue = 1).toThrow(TypeError);
+    expect(this.counter).toBe(1);
   }
 }
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/input.js
@@ -1,11 +1,19 @@
 class Cl {
   #privateField = 0;
+  counter = 0;
 
   get #privateFieldValue() {
     return this.#privateField;
   }
 
+  get self() {
+    this.counter++;
+    return this;
+  }
+
   constructor() {
-    this.#privateFieldValue = 1;
+    this.self.#privateFieldValue = 1
   }
 }
+
+const cl = new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
@@ -14,7 +14,7 @@ class Cl {
       value: 0
     });
 
-    babelHelpers.readOnlyError("#privateFieldValue");
+    1, babelHelpers.readOnlyError("#privateFieldValue");
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
@@ -14,7 +14,7 @@ class Cl {
       value: 0
     });
 
-    1, babelHelpers.readOnlyError("#privateFieldValue");
+    this, 1, babelHelpers.readOnlyError("#privateFieldValue");
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
@@ -3,6 +3,11 @@ var _privateField = new WeakMap();
 var _privateFieldValue = new WeakMap();
 
 class Cl {
+  get self() {
+    this.counter++;
+    return this;
+  }
+
   constructor() {
     _privateFieldValue.set(this, {
       get: _get_privateFieldValue,
@@ -14,7 +19,8 @@ class Cl {
       value: 0
     });
 
-    this, 1, babelHelpers.readOnlyError("#privateFieldValue");
+    babelHelpers.defineProperty(this, "counter", 0);
+    this.self, 1, babelHelpers.readOnlyError("#privateFieldValue");
   }
 
 }
@@ -22,3 +28,5 @@ class Cl {
 var _get_privateFieldValue = function () {
   return babelHelpers.classPrivateFieldGet(this, _privateField);
 };
+
+var cl = new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/exec.js
@@ -1,0 +1,16 @@
+let counter = 0;
+class Foo {
+  constructor() {
+    this.#privateMethod = ++counter;
+  }
+
+  #privateMethod() {
+    return 42;
+  }
+}
+
+try {
+  new Foo;
+} catch {
+  expect(counter).toBe(1);
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/exec.js
@@ -11,6 +11,6 @@ class Foo {
 
 try {
   new Foo;
-} catch {
+} catch (e) {
   expect(counter).toBe(1);
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/input.js
@@ -1,0 +1,10 @@
+let counter = 0;
+class Foo {
+  constructor() {
+    this.#privateMethod = ++counter;
+  }
+
+  #privateMethod() {
+    return 42;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/output.js
@@ -1,0 +1,17 @@
+var counter = 0;
+
+var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+    babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod] = ++counter;
+  }
+
+}
+
+var _privateMethod2 = function _privateMethod2() {
+  return 42;
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/exec.js
@@ -1,9 +1,15 @@
 class A {
+  counter = 0;
   #method() {}
+  self() {
+    this.counter++;
+    return this;
+  }
 
-  run() {
-    this.#method = 2;
+  constructor() {
+    expect(() => this.self().#method = 2).toThrow(TypeError);
+    expect(this.counter).toBe(1);
   }
 }
 
-expect(() => new A().run()).toThrow(TypeError);
+new A;

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/input.js
@@ -1,7 +1,12 @@
 class A {
+  counter = 0;
   #method() {}
+  self() {
+    this.counter++;
+    return this;
+  }
 
-  run() {
-    this.#method = 2;
+  constructor() {
+    this.self().#method = 2;
   }
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
@@ -6,7 +6,7 @@ class A {
   }
 
   run() {
-    2, babelHelpers.readOnlyError("#method");
+    this, 2, babelHelpers.readOnlyError("#method");
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
@@ -1,12 +1,16 @@
 var _method = new WeakSet();
 
 class A {
-  constructor() {
-    _method.add(this);
+  self() {
+    this.counter++;
+    return this;
   }
 
-  run() {
-    this, 2, babelHelpers.readOnlyError("#method");
+  constructor() {
+    _method.add(this);
+
+    babelHelpers.defineProperty(this, "counter", 0);
+    this.self(), 2, babelHelpers.readOnlyError("#method");
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
@@ -6,7 +6,7 @@ class A {
   }
 
   run() {
-    babelHelpers.readOnlyError("#method");
+    2, babelHelpers.readOnlyError("#method");
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/exec.js
@@ -1,0 +1,16 @@
+let counter = 0;
+class Foo {
+  constructor() {
+    this.#privateMethod = ++counter;
+  }
+
+  #privateMethod() {
+    return 42;
+  }
+}
+
+try {
+  new Foo;
+} catch {
+  expect(counter).toBe(1);
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/exec.js
@@ -9,8 +9,5 @@ class Foo {
   }
 }
 
-try {
-  new Foo;
-} catch (e) {
-  expect(counter).toBe(1);
-}
+expect(() => new Foo).toThrow();
+expect(counter).toBe(1);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/exec.js
@@ -11,6 +11,6 @@ class Foo {
 
 try {
   new Foo;
-} catch {
+} catch (e) {
   expect(counter).toBe(1);
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/exec.js
@@ -1,13 +1,18 @@
-let counter = 0;
+let results = [];
 class Foo {
   constructor() {
-    this.#privateMethod = ++counter;
+    this.self.#privateFieldValue = results.push(2);
   }
 
-  #privateMethod() {
+  get self() {
+    results.push(1);
+    return this;
+  }
+
+  #privateFieldValue() {
     return 42;
   }
 }
 
-expect(() => new Foo).toThrow();
-expect(counter).toBe(1);
+expect(() => new Foo).toThrow(TypeError);
+expect(results).toStrictEqual([1, 2]);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/input.js
@@ -1,0 +1,10 @@
+let counter = 0;
+class Foo {
+  constructor() {
+    this.#privateMethod = ++counter;
+  }
+
+  #privateMethod() {
+    return 42;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/input.js
@@ -1,10 +1,15 @@
-let counter = 0;
+let results = [];
 class Foo {
   constructor() {
-    this.#privateMethod = ++counter;
+    this.self.#privateFieldValue = results.push(2);
   }
 
-  #privateMethod() {
+  get self() {
+    results.push(1);
+    return this;
+  }
+
+  #privateFieldValue() {
     return 42;
   }
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/output.js
@@ -1,16 +1,21 @@
-var counter = 0;
+var results = [];
 
-var _privateMethod = new WeakSet();
+var _privateFieldValue = new WeakSet();
 
 class Foo {
   constructor() {
-    _privateMethod.add(this);
+    _privateFieldValue.add(this);
 
-    ++counter, babelHelpers.readOnlyError("#privateMethod");
+    this.self, results.push(2), babelHelpers.readOnlyError("#privateFieldValue");
+  }
+
+  get self() {
+    results.push(1);
+    return this;
   }
 
 }
 
-var _privateMethod2 = function _privateMethod2() {
+var _privateFieldValue2 = function _privateFieldValue2() {
   return 42;
 };

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/output.js
@@ -1,0 +1,16 @@
+var counter = 0;
+
+var _privateMethod = new WeakSet();
+
+class Foo {
+  constructor() {
+    _privateMethod.add(this);
+
+    ++counter, babelHelpers.readOnlyError("#privateMethod");
+  }
+
+}
+
+var _privateMethod2 = function _privateMethod2() {
+  return 42;
+};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12705 
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Pass down `value` to the argument of `classPrivateMethodSet` so it will always be evaluated before a runtime error is thrown.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12707"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/5e73971082ad674595fed1c98f35f8438bb460f7.svg" /></a>

