### PR TITLE
Add `#` to the private name in "write-only" errors

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -228,7 +228,7 @@ const privateNameHandlerSpec = {
         if (!getId && setId) {
           if (file.availableHelper("writeOnlyError")) {
             return t.callExpression(file.addHelper("writeOnlyError"), [
-              t.stringLiteral(name),
+              t.stringLiteral(`#${name}`),
             ]);
           }
           console.warn(

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/get-only-setter/output.js
@@ -14,7 +14,7 @@ class Cl {
       value: 0
     });
 
-    this.publicField = babelHelpers.writeOnlyError("privateFieldValue");
+    this.publicField = babelHelpers.writeOnlyError("#privateFieldValue");
   }
 
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This generates a _slightly_ better error, bu throwing `"#foo" is write-only` rather than `"foo" is write-only`, since `#` is part of the name.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12713"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/5f7b17a922ed8994a3c6b03d65a6ddd90877166b.svg" /></a>

