### PR TITLE
refactor: raise AwaitNotInAsyncContext when an AwaitExpression will be parsed

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -420,7 +420,13 @@ export default function (
               delete task.options.throws;
 
               assert.throws(runTask, function (err) {
-                return throwMsg === true || err.message.indexOf(throwMsg) >= 0;
+                assert.ok(
+                  throwMsg === true || err.message.includes(throwMsg),
+                  `
+Expected Error: ${throwMsg}
+Actual Error: ${err.message}`,
+                );
+                return true;
               });
             } else {
               if (task.exec.code) {

--- a/packages/babel-parser/src/parser/error.js
+++ b/packages/babel-parser/src/parser/error.js
@@ -16,6 +16,8 @@ type ErrorContext = {
   code?: string,
 };
 
+export type ParsingError = SyntaxError & ErrorContext;
+
 export { ErrorMessages as Errors } from "./error-message.js";
 
 export default class ParserError extends CommentsParser {

--- a/packages/babel-parser/src/parser/error.js
+++ b/packages/babel-parser/src/parser/error.js
@@ -56,21 +56,20 @@ export default class ParserError extends CommentsParser {
     errorTemplate: string,
     ...params: any
   ): Error | empty {
+    const loc = this.getLocationForPosition(pos);
+    const message =
+      errorTemplate.replace(/%(\d+)/g, (_, i: number) => params[i]) +
+      ` (${loc.line}:${loc.column})`;
     if (this.options.errorRecovery) {
-      const loc = this.getLocationForPosition(pos);
-      const message =
-        errorTemplate.replace(/%(\d+)/g, (_, i: number) => params[i]) +
-        ` (${loc.line}:${loc.column})`;
       const errors = this.state.errors;
       for (let i = errors.length - 1; i >= 0; i--) {
         const error = errors[i];
         if (error.pos === pos) {
-          Object.assign(error, { message });
-          return;
+          return Object.assign(error, { message });
         }
       }
     }
-    return this.raiseWithData(pos, undefined, errorTemplate, ...params);
+    return this._raise({ loc, pos }, message);
   }
 
   raiseWithData(

--- a/packages/babel-parser/src/parser/error.js
+++ b/packages/babel-parser/src/parser/error.js
@@ -66,6 +66,8 @@ export default class ParserError extends CommentsParser {
         const error = errors[i];
         if (error.pos === pos) {
           return Object.assign(error, { message });
+        } else if (error.pos < pos) {
+          break;
         }
       }
     }

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -534,19 +534,19 @@ export default class ExpressionParser extends LValParser {
 
     const expr = this.parseUpdate(node, update, refExpressionErrors);
 
-    const startsExpr = this.hasPlugin("v8intrinsic")
-      ? this.state.type.startsExpr
-      : this.state.type.startsExpr && !this.match(tt.modulo);
-    if (isAwait && startsExpr && !this.isAmbiguousAwait()) {
-      if (!this.state.invalidAwaitErrors.has(startPos)) {
-        this.raise(
+    if (isAwait) {
+      const startsExpr = this.hasPlugin("v8intrinsic")
+        ? this.state.type.startsExpr
+        : this.state.type.startsExpr && !this.match(tt.modulo);
+      if (startsExpr && !this.isAmbiguousAwait()) {
+        this.raiseOverwrite(
           startPos,
           this.hasPlugin("topLevelAwait")
             ? Errors.AwaitNotInAsyncContext
             : Errors.AwaitNotInAsyncFunction,
         );
+        return this.parseAwait(startPos, startLoc);
       }
-      return this.parseAwait(startPos, startLoc);
     }
 
     return expr;
@@ -2348,17 +2348,7 @@ export default class ExpressionParser extends LValParser {
       : isStrictReservedWord;
 
     if (reservedTest(word, this.inModule)) {
-      if (!this.prodParam.hasAwait && word === "await") {
-        this.raise(
-          startLoc,
-          this.hasPlugin("topLevelAwait")
-            ? Errors.AwaitNotInAsyncContext
-            : Errors.AwaitNotInAsyncFunction,
-        );
-        this.state.invalidAwaitErrors.add(startLoc);
-      } else {
-        this.raise(startLoc, Errors.UnexpectedReservedWord, word);
-      }
+      this.raise(startLoc, Errors.UnexpectedReservedWord, word);
     }
   }
 

--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -155,9 +155,6 @@ export default class State {
   // Tokens length in token store
   tokensLength: number = 0;
 
-  // Positions of invalid await errors
-  invalidAwaitErrors: Set<number> = new Set();
-
   curPosition(): Position {
     return new Position(this.curLine, this.pos - this.lineStart);
   }

--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -6,6 +6,7 @@ import { Position } from "../util/location";
 
 import { types as ct, type TokContext } from "./context";
 import { types as tt, type TokenType } from "./types";
+import type { ParsingError } from "../parser/error";
 
 type TopicContextState = {
   // When a topic binding has been currently established,
@@ -37,7 +38,7 @@ export default class State {
     this.startLoc = this.endLoc = this.curPosition();
   }
 
-  errors: SyntaxError[] = [];
+  errors: ParsingError[] = [];
 
   // Used to signify the start of a potential arrow function
   potentialArrowAt: number = -1;

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/357/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/357/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":14,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":14}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions (1:0)"
+    "SyntaxError: Unexpected reserved word 'await' (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/359/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/359/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":20,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":20}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions (1:6)"
+    "SyntaxError: Unexpected reserved word 'await' (1:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/361/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/361/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":24}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions (1:8)"
+    "SyntaxError: Unexpected reserved word 'await' (1:8)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/363/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/363/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":26}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions (1:15)"
+    "SyntaxError: Unexpected reserved word 'await' (1:15)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/365/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/365/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":19,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":19}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions (1:9)"
+    "SyntaxError: Unexpected reserved word 'await' (1:9)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/367/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/367/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":14,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":14}},
   "errors": [
-    "SyntaxError: 'await' is only allowed within async functions (1:6)"
+    "SyntaxError: Unexpected reserved word 'await' (1:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-arrow/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-arrow/options.json
@@ -2,7 +2,5 @@
   "plugins": [
     "topLevelAwait"
   ],
-  "sourceType": "module",
-  "errorRecovery": false,
-  "throws": "'await' is only allowed within async functions and at the top levels of modules (1:6)"
+  "sourceType": "module"
 }

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-arrow/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-arrow/output.json
@@ -1,0 +1,41 @@
+{
+  "type": "File",
+  "start":0,"end":14,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":14}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (1:6)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":14,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":14}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":14,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":14}},
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start":0,"end":13,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":13}},
+          "id": null,
+          "generator": false,
+          "async": false,
+          "params": [],
+          "body": {
+            "type": "AwaitExpression",
+            "start":6,"end":13,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":13}},
+            "argument": {
+              "type": "NumericLiteral",
+              "start":12,"end":13,"loc":{"start":{"line":1,"column":12},"end":{"line":1,"column":13}},
+              "extra": {
+                "rawValue": 0,
+                "raw": "0"
+              },
+              "value": 0
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-function/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-function/options.json
@@ -2,7 +2,5 @@
   "plugins": [
     "topLevelAwait"
   ],
-  "sourceType": "module",
-  "errorRecovery": false,
-  "throws": "'await' is only allowed within async functions and at the top levels of modules (2:2)"
-}
+  "sourceType": "module"
+  }

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-function/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-function/output.json
@@ -1,0 +1,52 @@
+{
+  "type": "File",
+  "start":0,"end":28,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: 'await' is only allowed within async functions and at the top levels of modules (2:2)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":28,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start":0,"end":28,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":9,"end":11,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":11},"identifierName":"fn"},
+          "name": "fn"
+        },
+        "generator": false,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start":14,"end":28,"loc":{"start":{"line":1,"column":14},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start":18,"end":26,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":10}},
+              "expression": {
+                "type": "AwaitExpression",
+                "start":18,"end":25,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":9}},
+                "argument": {
+                  "type": "NumericLiteral",
+                  "start":24,"end":25,"loc":{"start":{"line":2,"column":8},"end":{"line":2,"column":9}},
+                  "extra": {
+                    "rawValue": 0,
+                    "raw": "0"
+                  },
+                  "value": 0
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-preset-env/test/fixtures/top-level-await/unsupported/options.json
+++ b/packages/babel-preset-env/test/fixtures/top-level-await/unsupported/options.json
@@ -6,5 +6,5 @@
     "supportsTopLevelAwait": false
   },
   "presets": ["env"],
-  "throws": "'await' is only allowed within async functions (1:0)"
+  "throws": "Unexpected reserved word 'await' (1:0)"
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | See below
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When `errorRecovery` is `enabled`, Babel throws confusing `AwaitNotInAsyncContext` error `'await' is only allowed within async functions` for `function await () {}`, ([astexplorer](https://astexplorer.net/#/gist/bf42291483a02b5aec1f82d32350cf3d/c80d52e226842716b051166ef68bceac1050b73b)) However `await` here is parsed as a binding identifier, there is no AwaitExpression in the AST.

Based on #12520, we can throw `AwaitNotInAsyncContext` only before we are sure that the expression could be interpreted as an `AwaitExpression`. Therefore we can simply throw unexpected reserved word in `checkReservedWord` when we see `await` in `[~Await]` productions and script type is `module`, and then overwrite the thrown errors with `AwaitNotInAsyncContext` after we have more contextual information. In this case the `await` turns out to be a part of `AwaitExpression` because we know there is a following UpdateExpression.

However we can only achieve this on error recovery mode, in which, essentially, all errors are delayed until the AST is completely parsed. We could consider enable `errorRecovery` by default in Babel 8 because of better errors.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12716"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/afbcc3205f1cf3f4ddacdc56bd3be3f98ea7a2ba.svg" /></a>

