### PR TITLE
Remove the cross-platform absolute path check

### DIFF
--- a/packages/babel-core/src/config/files/plugins.js
+++ b/packages/babel-core/src/config/files/plugins.js
@@ -5,13 +5,12 @@
  */
 
 import buildDebug from "debug";
-import path from "path";
 
 const debug = buildDebug("babel:config:loading:files:plugins");
 
 const EXACT_RE = /^module:/;
-const BABEL_PLUGIN_PREFIX_RE = /^(?!@|module:|[^/]+\/|babel-plugin-)/;
-const BABEL_PRESET_PREFIX_RE = /^(?!@|module:|[^/]+\/|babel-preset-)/;
+const BABEL_PLUGIN_PREFIX_RE = /^(?!@|module:|.*\/|babel-plugin-)/;
+const BABEL_PRESET_PREFIX_RE = /^(?!@|module:|.*\/|babel-preset-)/;
 const BABEL_PLUGIN_ORG_RE = /^(@babel\/)(?!plugin-|[^/]+\/)/;
 const BABEL_PRESET_ORG_RE = /^(@babel\/)(?!preset-|[^/]+\/)/;
 const OTHER_PLUGIN_ORG_RE = /^(@(?!babel\/)[^/]+\/)(?![^/]*babel-plugin(?:-|\/|$)|[^/]+\/)/;
@@ -59,7 +58,7 @@ export function loadPreset(
 
 function standardizeName(type: "plugin" | "preset", name: string) {
   // Let absolute and relative paths through.
-  if (path.isAbsolute(name)) return name;
+  if (name[0] === "/") return name;
 
   const isPreset = type === "preset";
 


### PR DESCRIPTION
An absolute CommonJS module identifier is [defined to be](https://nodejs.org/api/modules.html#modules_all_together) one that starts with '/'. CommonJS module identifiers are platform independent. That is, they are the same on every platform. Hence, there is no need for a cross-platform absolute path check to determine if a CommonJS module identifier represents an absolute module path or not.

This change also simplifies some of the regexes since the case of starting with '/' is handled by the first conditional in 'standardizeName'.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12719"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ugultopu/babel.git/e49b0e86192452ce4e6ae7c4d8b370068d0a9cb4.svg" /></a>

