### PR TITLE
Throw when compiling spread in `super()` but not classes

### DIFF
--- a/packages/babel-plugin-transform-spread/src/index.js
+++ b/packages/babel-plugin-transform-spread/src/index.js
@@ -97,7 +97,12 @@ export default declare((api, options) => {
 
         const calleePath = skipTransparentExprWrappers(path.get("callee"));
 
-        if (calleePath.isSuper()) return;
+        if (calleePath.isSuper()) {
+          throw path.buildCodeFrameError(
+            "It's not possible to compile spread arguments in `super()` without compiling classes.\n" +
+              "Please add '@babel/plugin-transform-classes' to your Babel configuration.",
+          );
+        }
 
         let contextLiteral = scope.buildUndefinedNode();
 

--- a/packages/babel-plugin-transform-spread/src/index.js
+++ b/packages/babel-plugin-transform-spread/src/index.js
@@ -98,6 +98,7 @@ export default declare((api, options) => {
         const calleePath = skipTransparentExprWrappers(path.get("callee"));
 
         if (calleePath.isSuper()) {
+          // NOTE: spread and classes have almost the same compat data, so this is very unlikely to happen in practice.
           throw path.buildCodeFrameError(
             "It's not possible to compile spread arguments in `super()` without compiling classes.\n" +
               "Please add '@babel/plugin-transform-classes' to your Babel configuration.",

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-after/input.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-after/input.js
@@ -1,0 +1,5 @@
+class A extends B {
+  constructor() {
+    super(...foo);
+  }
+}

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-after/options.json
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-after/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "transform-spread",
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-after/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-after/output.js
@@ -1,0 +1,14 @@
+let A = /*#__PURE__*/function (_B) {
+  "use strict";
+
+  babelHelpers.inherits(A, _B);
+
+  var _super = babelHelpers.createSuper(A);
+
+  function A() {
+    babelHelpers.classCallCheck(this, A);
+    return _super.call.apply(_super, [this].concat(babelHelpers.toConsumableArray(foo)));
+  }
+
+  return A;
+}(B);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-before/input.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-before/input.js
@@ -1,0 +1,5 @@
+class A extends B {
+  constructor() {
+    super(...foo);
+  }
+}

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-before/options.json
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-before/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "transform-classes",
+    "transform-spread"
+  ]
+}

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-before/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-before/output.js
@@ -1,0 +1,14 @@
+let A = /*#__PURE__*/function (_B) {
+  "use strict";
+
+  babelHelpers.inherits(A, _B);
+
+  var _super = babelHelpers.createSuper(A);
+
+  function A() {
+    babelHelpers.classCallCheck(this, A);
+    return _super.call.apply(_super, [this].concat(babelHelpers.toConsumableArray(foo)));
+  }
+
+  return A;
+}(B);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/super-no-classes-plugin/input.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/super-no-classes-plugin/input.js
@@ -1,0 +1,5 @@
+class A extends B {
+  constructor() {
+    super(...foo);
+  }
+}

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/super-no-classes-plugin/options.json
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/super-no-classes-plugin/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "transform-spread"
+  ],
+  "throws": "It's not possible to compile spread arguments in `super()` without compiling classes."
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes #4375, closes #4254
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Babel already generates invalid code (it leaves `...` even if it's a syntax error in older browsers), so it's better to throw an explicit error explaining how to fix it.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12722"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/cbd87e0abba922452eb1a93a7e314ac4100b7659.svg" /></a>

