### PR TITLE
[babel 8] Remove module-specific options from `@babel/core`

### DIFF
--- a/packages/babel-cli/src/babel/options.js
+++ b/packages/babel-cli/src/babel/options.js
@@ -98,17 +98,19 @@ commander.option(
   "The root from which all sources are relative.",
 );
 
-// Config params for certain module output formats.
-commander.option(
-  "--module-root [filename]",
-  // eslint-disable-next-line max-len
-  "Optional prefix for the AMD module formatter that will be prepended to the filename on module definitions.",
-);
-commander.option("-M, --module-ids", "Insert an explicit id for modules.");
-commander.option(
-  "--module-id [string]",
-  "Specify a custom name for module ids.",
-);
+if (!process.env.BABEL_8_BREAKING) {
+  // Config params for certain module output formats.
+  commander.option(
+    "--module-root [filename]",
+    // eslint-disable-next-line max-len
+    "Optional prefix for the AMD module formatter that will be prepended to the filename on module definitions.",
+  );
+  commander.option("-M, --module-ids", "Insert an explicit id for modules.");
+  commander.option(
+    "--module-id [string]",
+    "Specify a custom name for module ids.",
+  );
+}
 
 // "babel" command specific arguments that are not passed to @babel/core.
 commander.option(
@@ -277,9 +279,6 @@ export default function parseArgv(args: Array<string>): CmdOptions | null {
     sourceMaps: opts.sourceMaps,
     sourceFileName: opts.sourceFileName,
     sourceRoot: opts.sourceRoot,
-    moduleRoot: opts.moduleRoot,
-    moduleIds: opts.moduleIds,
-    moduleId: opts.moduleId,
 
     // Commander will default the "--no-" arguments to true, but we want to
     // leave them undefined so that @babel/core can handle the
@@ -288,6 +287,15 @@ export default function parseArgv(args: Array<string>): CmdOptions | null {
     highlightCode: opts.highlightCode === true ? undefined : opts.highlightCode,
     comments: opts.comments === true ? undefined : opts.comments,
   };
+
+  if (!process.env.BABEL_8_BREAKING) {
+    // $FlowIgnore
+    Object.assign(babelOptions, {
+      moduleRoot: opts.moduleRoot,
+      moduleIds: opts.moduleIds,
+      moduleId: opts.moduleId,
+    });
+  }
 
   // If the @babel/cli version is newer than the @babel/core version, and we have added
   // new options for @babel/core, we'll potentially get option validation errors from

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -50,7 +50,7 @@
     "@babel/code-frame": "workspace:^7.12.13",
     "@babel/generator": "workspace:^7.13.9",
     "@babel/helper-compilation-targets": "workspace:^7.13.13",
-    "@babel/helper-module-transforms": "workspace:^7.13.12",
+    "@babel/helper-module-transforms": "condition:BABEL_8_BREAKING ? : workspace:^7.13.12",
     "@babel/helpers": "workspace:^7.13.10",
     "@babel/parser": "workspace:^7.13.13",
     "@babel/template": "workspace:^7.12.13",

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -173,18 +173,6 @@ const COMMON_VALIDATORS: ValidatorSet = {
   sourceRoot: (assertString: Validator<
     $PropertyType<ValidatedOptions, "sourceRoot">,
   >),
-  getModuleId: (assertFunction: Validator<
-    $PropertyType<ValidatedOptions, "getModuleId">,
-  >),
-  moduleRoot: (assertString: Validator<
-    $PropertyType<ValidatedOptions, "moduleRoot">,
-  >),
-  moduleIds: (assertBoolean: Validator<
-    $PropertyType<ValidatedOptions, "moduleIds">,
-  >),
-  moduleId: (assertString: Validator<
-    $PropertyType<ValidatedOptions, "moduleId">,
-  >),
   parserOpts: (assertObject: Validator<
     $PropertyType<ValidatedOptions, "parserOpts">,
   >),
@@ -192,6 +180,15 @@ const COMMON_VALIDATORS: ValidatorSet = {
     $PropertyType<ValidatedOptions, "generatorOpts">,
   >),
 };
+if (!process.env.BABEL_8_BREAKING) {
+  Object.assign(COMMON_VALIDATORS, {
+    getModuleId: assertFunction,
+    moduleRoot: assertString,
+    moduleIds: assertBoolean,
+    moduleId: assertString,
+  });
+}
+
 export type InputOptions = ValidatedOptions;
 
 export type ValidatedOptions = {
@@ -252,12 +249,6 @@ export type ValidatedOptions = {
   sourceMap?: SourceMapsOption,
   sourceFileName?: string,
   sourceRoot?: string,
-
-  // AMD/UMD/SystemJS module naming options.
-  getModuleId?: Function,
-  moduleRoot?: string,
-  moduleIds?: boolean,
-  moduleId?: string,
 
   // Deprecate top level parserOpts
   parserOpts?: {},

--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -13,9 +13,9 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
     sourceType = "module",
     inputSourceMap,
     sourceMaps = !!inputSourceMap,
-
-    moduleRoot,
-    sourceRoot = moduleRoot,
+    sourceRoot = process.env.BABEL_8_BREAKING
+      ? undefined
+      : config.options.moduleRoot,
 
     sourceFileName = path.basename(filenameRelative),
 

--- a/packages/babel-core/src/transformation/plugin-pass.js
+++ b/packages/babel-core/src/transformation/plugin-pass.js
@@ -44,11 +44,14 @@ export default class PluginPass {
     return this.file.addImport();
   }
 
-  getModuleName(): ?string {
-    return this.file.getModuleName();
-  }
-
   buildCodeFrameError(node: ?NodeLocation, msg: string, Error?: typeof Error) {
     return this.file.buildCodeFrameError(node, msg, Error);
   }
+}
+
+if (!process.env.BABEL_8_BREAKING) {
+  // $FlowIgnore
+  PluginPass.prototype.getModuleName = function getModuleName(): ?string {
+    return this.file.getModuleName();
+  };
 }

--- a/packages/babel-helper-module-transforms/src/get-module-name.ts
+++ b/packages/babel-helper-module-transforms/src/get-module-name.ts
@@ -1,11 +1,24 @@
+type RootOptions = {
+  filename?: string;
+  filenameRelative?: string;
+  sourceRoot?: string;
+};
+
+type PluginOptions = {
+  moduleId?: string;
+  moduleIds?: boolean;
+  getModuleId?: (moduleName: string) => string | null | undefined;
+  moduleRoot?: string;
+};
+
 if (!process.env.BABEL_8_BREAKING) {
   const originalGetModuleName = getModuleName;
 
   // @ts-expect-error TS doesn't like reassigning a function.
   // eslint-disable-next-line no-func-assign
   getModuleName = function getModuleName(
-    rootOpts: any,
-    pluginOpts: any,
+    rootOpts: RootOptions & PluginOptions,
+    pluginOpts: PluginOptions,
   ): string | null {
     return originalGetModuleName(rootOpts, {
       moduleId: pluginOpts.moduleId ?? rootOpts.moduleId,
@@ -17,8 +30,8 @@ if (!process.env.BABEL_8_BREAKING) {
 }
 
 export default function getModuleName(
-  rootOpts: any,
-  pluginOpts: any,
+  rootOpts: RootOptions,
+  pluginOpts: PluginOptions,
 ): string | null {
   const {
     filename,

--- a/packages/babel-helper-module-transforms/src/get-module-name.ts
+++ b/packages/babel-helper-module-transforms/src/get-module-name.ts
@@ -8,10 +8,10 @@ if (!process.env.BABEL_8_BREAKING) {
     pluginOpts: any,
   ): string | null {
     return originalGetModuleName(rootOpts, {
-      moduleId: rootOpts.moduleId ?? pluginOpts.moduleId,
-      moduleIds: rootOpts.moduleIds ?? pluginOpts.moduleIds,
-      getModuleId: rootOpts.getModuleId ?? pluginOpts.getModuleId,
-      moduleRoot: rootOpts.moduleRoot ?? pluginOpts.moduleRoot,
+      moduleId: pluginOpts.moduleId ?? rootOpts.moduleId,
+      moduleIds: pluginOpts.moduleIds ?? rootOpts.moduleIds,
+      getModuleId: pluginOpts.getModuleId ?? rootOpts.getModuleId,
+      moduleRoot: pluginOpts.moduleRoot ?? rootOpts.moduleRoot,
     });
   };
 }

--- a/packages/babel-helper-module-transforms/src/get-module-name.ts
+++ b/packages/babel-helper-module-transforms/src/get-module-name.ts
@@ -1,21 +1,38 @@
+if (!process.env.BABEL_8_BREAKING) {
+  const originalGetModuleName = getModuleName;
+
+  // @ts-expect-error TS doesn't like reassigning a function.
+  // eslint-disable-next-line no-func-assign
+  getModuleName = function getModuleName(
+    rootOpts: any,
+    pluginOpts: any,
+  ): string | null {
+    return originalGetModuleName(rootOpts, {
+      moduleId: rootOpts.moduleId ?? pluginOpts.moduleId,
+      moduleIds: rootOpts.moduleIds ?? pluginOpts.moduleIds,
+      getModuleId: rootOpts.getModuleId ?? pluginOpts.getModuleId,
+      moduleRoot: rootOpts.moduleRoot ?? pluginOpts.moduleRoot,
+    });
+  };
+}
+
 export default function getModuleName(
   rootOpts: any,
   pluginOpts: any,
-): string | undefined | null {
+): string | null {
   const {
     filename,
     filenameRelative = filename,
-
-    sourceRoot = pluginOpts.moduleRoot ?? rootOpts.moduleRoot,
+    sourceRoot = pluginOpts.moduleRoot,
   } = rootOpts;
 
   const {
-    moduleId = rootOpts.moduleId,
-    moduleIds = rootOpts.moduleIds ?? !!moduleId,
+    moduleId,
+    moduleIds = !!moduleId,
 
-    getModuleId = rootOpts.getModuleId,
+    getModuleId,
 
-    moduleRoot = rootOpts.moduleRoot ?? sourceRoot,
+    moduleRoot = sourceRoot,
   } = pluginOpts;
 
   if (!moduleIds) return null;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/get-module-name-option-compat/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/get-module-name-option-compat/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "sourceType": "module",
   "moduleIds": true,
   "moduleId": "my custom module name"

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-compat/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-compat/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "sourceType": "module",
   "moduleIds": true
 }

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/get-module-name-option-compat/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/get-module-name-option-compat/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "sourceType": "module",
   "moduleIds": true,
   "moduleId": "my custom module name",

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/module-name-compat/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/module-name-compat/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "sourceType": "module",
   "moduleIds": true,
   "plugins": [["transform-modules-amd", { "loose": true }]]

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/get-module-name-option-compat/options.json
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/get-module-name-option-compat/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "moduleIds": true,
   "moduleId": "my custom module name"
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/get-module-name-option-compat/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/get-module-name-option-compat/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "sourceType": "module",
   "moduleIds": true,
   "moduleId": "my custom module name",

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global-in-namespace/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global-in-namespace/options.json
@@ -7,9 +7,9 @@
           "my custom module name": "foo.bar"
         },
         "exactGlobals": true,
-        "loose": true
+        "loose": true,
+        "moduleId": "my custom module name"
       }
     ]
-  ],
-  "moduleId": "my custom module name"
+  ]
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global-in-very-nested-namespace/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global-in-very-nested-namespace/options.json
@@ -7,9 +7,9 @@
           "my custom module name": "foo.bar.baz.qux"
         },
         "exactGlobals": true,
-        "loose": true
+        "loose": true,
+        "moduleId": "my custom module name"
       }
     ]
-  ],
-  "moduleId": "my custom module name"
+  ]
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global/options.json
@@ -7,9 +7,9 @@
           "my custom module name": "baz"
         },
         "exactGlobals": true,
-        "loose": true
+        "loose": true,
+        "moduleId": "my custom module name"
       }
     ]
-  ],
-  "moduleId": "my custom module name"
+  ]
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id/options.json
@@ -1,5 +1,4 @@
 {
   "sourceType": "module",
-  "moduleId": "MyLib",
-  "plugins": [["transform-modules-umd", { "loose": true }]]
+  "plugins": [["transform-modules-umd", { "loose": true, "moduleId": "MyLib" }]]
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-name-compat/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-name-compat/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "sourceType": "module",
   "moduleIds": true,
   "plugins": [["transform-modules-umd", { "loose": true }]]

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-name-with-overridden-global-compat/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-name-with-overridden-global-compat/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     [
       "transform-modules-umd",

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/get-module-name-option-compat/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/get-module-name-option-compat/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "sourceType": "module",
   "moduleIds": true,
   "moduleId": "my custom module name"

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-namespace/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-namespace/options.json
@@ -6,9 +6,9 @@
         "globals": {
           "my custom module name": "foo.bar"
         },
-        "exactGlobals": true
+        "exactGlobals": true,
+        "moduleId": "my custom module name"
       }
     ]
-  ],
-  "moduleId": "my custom module name"
+  ]
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-very-nested-namespace/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-very-nested-namespace/options.json
@@ -6,9 +6,9 @@
         "globals": {
           "my custom module name": "foo.bar.baz.qux"
         },
-        "exactGlobals": true
+        "exactGlobals": true,
+        "moduleId": "my custom module name"
       }
     ]
-  ],
-  "moduleId": "my custom module name"
+  ]
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global/options.json
@@ -6,9 +6,9 @@
         "globals": {
           "my custom module name": "baz"
         },
-        "exactGlobals": true
+        "exactGlobals": true,
+        "moduleId": "my custom module name"
       }
     ]
-  ],
-  "moduleId": "my custom module name"
+  ]
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id/options.json
@@ -1,4 +1,7 @@
 {
   "sourceType": "module",
-  "moduleId": "MyLib"
+  "plugins": [
+    "external-helpers",
+    ["transform-modules-umd", { "moduleId": "MyLib" }]
+  ]
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id/options.json
@@ -1,7 +1,4 @@
 {
   "sourceType": "module",
-  "plugins": [
-    "external-helpers",
-    ["transform-modules-umd", { "moduleId": "MyLib" }]
-  ]
+  "plugins": [["transform-modules-umd", { "moduleId": "MyLib" }]]
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-name-compat/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-name-compat/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "sourceType": "module",
   "moduleIds": true
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-name-with-overridden-global-compat/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-name-with-overridden-global-compat/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     [
       "transform-modules-umd",

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,7 +204,7 @@ __metadata:
     "@babel/code-frame": "workspace:^7.12.13"
     "@babel/generator": "workspace:^7.13.9"
     "@babel/helper-compilation-targets": "workspace:^7.13.13"
-    "@babel/helper-module-transforms": "workspace:^7.13.12"
+    "@babel/helper-module-transforms": "condition:BABEL_8_BREAKING ? : workspace:^7.13.12"
     "@babel/helper-transform-fixture-test-runner": "workspace:*"
     "@babel/helpers": "workspace:^7.13.10"
     "@babel/parser": "workspace:^7.13.13"
@@ -639,6 +639,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@babel/helper-module-transforms-BABEL_8_BREAKING-false@npm:@babel/helper-module-transforms@workspace:^7.13.12, @babel/helper-module-transforms@workspace:^7.13.0, @babel/helper-module-transforms@workspace:packages/babel-helper-module-transforms":
+  version: 0.0.0-use.local
+  resolution: "@babel/helper-module-transforms@workspace:packages/babel-helper-module-transforms"
+  dependencies:
+    "@babel/helper-module-imports": "workspace:^7.13.12"
+    "@babel/helper-replace-supers": "workspace:^7.13.12"
+    "@babel/helper-simple-access": "workspace:^7.13.12"
+    "@babel/helper-split-export-declaration": "workspace:^7.12.13"
+    "@babel/helper-validator-identifier": "workspace:^7.12.11"
+    "@babel/template": "workspace:^7.12.13"
+    "@babel/traverse": "workspace:^7.13.0"
+    "@babel/types": "workspace:^7.13.12"
+  languageName: unknown
+  linkType: soft
+
+"@babel/helper-module-transforms@condition:BABEL_8_BREAKING ? : workspace:^7.13.12":
+  version: 0.0.0-condition-130862
+  resolution: "@babel/helper-module-transforms@condition:BABEL_8_BREAKING?:workspace:^7.13.12#130862"
+  dependencies:
+    "@babel/helper-module-transforms-BABEL_8_BREAKING-false": "npm:@babel/helper-module-transforms@workspace:^7.13.12"
+  checksum: 099f985d9558228aa29430a51630015ea02a47f2714cc392f0105921e768c4998a70686942c51defe174cd5ed9f221ab0e4505a611f40e7a68158748c4bbfb8e
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.12.1, @babel/helper-module-transforms@npm:^7.12.13, @babel/helper-module-transforms@npm:^7.13.0":
   version: 7.13.0
   resolution: "@babel/helper-module-transforms@npm:7.13.0"
@@ -655,21 +679,6 @@ __metadata:
   checksum: b7e45c67eeaca488fa7a7bb0afebaec25b91f94cb04d32229ef799bd3a31ef5b566737fefd139b20c6525817528816e43bf492372c77e352e2a0e4d03b1fe21b
   languageName: node
   linkType: hard
-
-"@babel/helper-module-transforms@workspace:^7.13.0, @babel/helper-module-transforms@workspace:^7.13.12, @babel/helper-module-transforms@workspace:packages/babel-helper-module-transforms":
-  version: 0.0.0-use.local
-  resolution: "@babel/helper-module-transforms@workspace:packages/babel-helper-module-transforms"
-  dependencies:
-    "@babel/helper-module-imports": "workspace:^7.13.12"
-    "@babel/helper-replace-supers": "workspace:^7.13.12"
-    "@babel/helper-simple-access": "workspace:^7.13.12"
-    "@babel/helper-split-export-declaration": "workspace:^7.12.13"
-    "@babel/helper-validator-identifier": "workspace:^7.12.11"
-    "@babel/template": "workspace:^7.12.13"
-    "@babel/traverse": "workspace:^7.13.0"
-    "@babel/types": "workspace:^7.13.12"
-  languageName: unknown
-  linkType: soft
 
 "@babel/helper-optimise-call-expression@npm:^7.12.13":
   version: 7.12.13


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/5473
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes, behind `BABEL_8_BREAKING`
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We added these options to the various modules plugins in Babel 7.9.0 (https://github.com/babel/babel/pull/11194), and we can now remove them from `@babel/core`.

The first two commits update the two Yarn plugins that we use, to add them support for the `workspace:` protocol nested inside the `condition:` protocol. I tested them locally and they seem to work, but I'm marking this as draft until the e2e tests pass.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12724"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/1e3ec25ab2c9e7518557a19bfbf1aa3766357bfd.svg" /></a>

