### PR TITLE
Fix class fields when `super()` is in a default param

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-complex/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-complex/input.js
@@ -1,0 +1,6 @@
+class Foo extends Bar {
+  bar = "foo";
+
+  constructor(x = test ? super() : 0) {
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-complex/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-complex/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "proposal-class-properties"
+  ]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-complex/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-complex/output.js
@@ -1,0 +1,8 @@
+class Foo extends Bar {
+  constructor(x = test ? (() => {
+    var _temp;
+
+    return _temp = super(), babelHelpers.defineProperty(this, "bar", "foo"), _temp;
+  })() : 0) {}
+
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/input.js
@@ -1,0 +1,6 @@
+class Foo extends Bar {
+  bar = "foo";
+
+  constructor(x = () => { check(super()) }) {
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "proposal-class-properties"
+  ]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/output.js
@@ -1,0 +1,8 @@
+class Foo extends Bar {
+  constructor(x = () => {
+    var _temp;
+
+    check((_temp = super(), babelHelpers.defineProperty(this, "bar", "foo"), _temp));
+  }) {}
+
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params/input.js
@@ -1,0 +1,6 @@
+class Foo extends Bar {
+  bar = "foo";
+
+  constructor(x = super()) {
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.100.0" }],
+    "proposal-class-properties"
+  ]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-super-in-default-params/output.js
@@ -1,0 +1,8 @@
+class Foo extends Bar {
+  constructor(x = (() => {
+    var _temp;
+
+    return _temp = super(), babelHelpers.defineProperty(this, "bar", "foo"), _temp;
+  })()) {}
+
+}

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -132,13 +132,12 @@ export function insertAfter(
       let { scope } = this;
 
       if (scope.path.isPattern()) {
+        t.assertExpression(node);
+
         this.replaceWith(
-          t.callExpression(
-            t.arrowFunctionExpression([], this.node as t.Expression),
-            [],
-          ),
+          t.callExpression(t.arrowFunctionExpression([], node), []),
         );
-        (this.get("callee.body") as NodePath<t.Expression>).insertAfter(nodes);
+        (this.get("callee.body") as NodePath).insertAfter(nodes);
         return [this];
       }
 

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -95,7 +95,10 @@ export function _containerInsertAfter(this: NodePath, nodes) {
  * expression, ensure that the completion record is correct by pushing the current node.
  */
 
-export function insertAfter(this: NodePath, nodes_: t.Node | t.Node[]) {
+export function insertAfter(
+  this: NodePath,
+  nodes_: t.Node | t.Node[],
+): NodePath[] {
   this._assertUnremoved();
 
   const nodes = this._verifyNodeList(nodes_);
@@ -127,6 +130,18 @@ export function insertAfter(this: NodePath, nodes_: t.Node | t.Node[]) {
     if (this.node) {
       const node = this.node as t.Expression | t.VariableDeclaration;
       let { scope } = this;
+
+      if (scope.path.isPattern()) {
+        this.replaceWith(
+          t.callExpression(
+            t.arrowFunctionExpression([], this.node as t.Expression),
+            [],
+          ),
+        );
+        (this.get("callee.body") as NodePath<t.Expression>).insertAfter(nodes);
+        return [this];
+      }
+
       // Inserting after the computed key of a method should insert the
       // temporary binding in the method's parent's scope.
       if (parentPath.isMethod({ computed: true, key: node })) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #5074
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Since this fix is at the `@babel/traverse` level, it also fixes any other usage of `insertAfter` in class parameters.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12729"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/bea63789a05c96f4e1b34e5e992a7c3e0d60eb5a.svg" /></a>

