### PR TITLE
fix(ts): allow abstract methods with `export default abstract class`

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2085,8 +2085,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (this.isAbstractClass()) {
         const cls = this.startNode();
         this.next(); // Skip "abstract"
-        this.parseClass(cls, true, true);
         cls.abstract = true;
+        this.parseClass(cls, true, true);
         return cls;
       }
 

--- a/packages/babel-parser/test/fixtures/typescript/class/abstract/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/abstract/input.ts
@@ -5,3 +5,4 @@ export abstract class C3 {}
 export default abstract class { }
 export default abstract class C4 { }
 // `abstract class` is not valid as an expression.
+export default abstract class C5 { abstract foo(): void; }

--- a/packages/babel-parser/test/fixtures/typescript/class/abstract/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/abstract/output.json
@@ -1,9 +1,9 @@
 {
   "type": "File",
-  "start":0,"end":254,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":50}},
+  "start":0,"end":313,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":58}},
   "program": {
     "type": "Program",
-    "start":0,"end":254,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":50}},
+    "start":0,"end":313,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":58}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
@@ -43,6 +43,13 @@
       {
         "type": "ExportNamedDeclaration",
         "start":50,"end":77,"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":27}},
+        "trailingComments": [
+          {
+            "type": "CommentLine",
+            "value": " `export abstract class {}` is not valid TypeScript.",
+            "start":78,"end":132,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":54}}
+          }
+        ],
         "exportKind": "value",
         "specifiers": [],
         "source": null,
@@ -61,46 +68,47 @@
             "start":75,"end":77,"loc":{"start":{"line":3,"column":25},"end":{"line":3,"column":27}},
             "body": []
           }
-        },
-        "trailingComments": [
-          {
-            "type": "CommentLine",
-            "value": " `export abstract class {}` is not valid TypeScript.",
-            "start":78,"end":132,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":54}}
-          }
-        ]
+        }
       },
       {
         "type": "ExportDefaultDeclaration",
         "start":133,"end":166,"loc":{"start":{"line":5,"column":0},"end":{"line":5,"column":33}},
-        "exportKind": "value",
-        "declaration": {
-          "type": "ClassDeclaration",
-          "start":148,"end":166,"loc":{"start":{"line":5,"column":15},"end":{"line":5,"column":33}},
-          "id": null,
-          "superClass": null,
-          "body": {
-            "type": "ClassBody",
-            "start":163,"end":166,"loc":{"start":{"line":5,"column":30},"end":{"line":5,"column":33}},
-            "body": []
-          },
-          "abstract": true
-        },
         "leadingComments": [
           {
             "type": "CommentLine",
             "value": " `export abstract class {}` is not valid TypeScript.",
             "start":78,"end":132,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":54}}
           }
-        ]
+        ],
+        "exportKind": "value",
+        "declaration": {
+          "type": "ClassDeclaration",
+          "start":148,"end":166,"loc":{"start":{"line":5,"column":15},"end":{"line":5,"column":33}},
+          "abstract": true,
+          "id": null,
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "start":163,"end":166,"loc":{"start":{"line":5,"column":30},"end":{"line":5,"column":33}},
+            "body": []
+          }
+        }
       },
       {
         "type": "ExportDefaultDeclaration",
         "start":167,"end":203,"loc":{"start":{"line":6,"column":0},"end":{"line":6,"column":36}},
+        "trailingComments": [
+          {
+            "type": "CommentLine",
+            "value": " `abstract class` is not valid as an expression.",
+            "start":204,"end":254,"loc":{"start":{"line":7,"column":0},"end":{"line":7,"column":50}}
+          }
+        ],
         "exportKind": "value",
         "declaration": {
           "type": "ClassDeclaration",
           "start":182,"end":203,"loc":{"start":{"line":6,"column":15},"end":{"line":6,"column":36}},
+          "abstract": true,
           "id": {
             "type": "Identifier",
             "start":197,"end":199,"loc":{"start":{"line":6,"column":30},"end":{"line":6,"column":32},"identifierName":"C4"},
@@ -111,16 +119,62 @@
             "type": "ClassBody",
             "start":200,"end":203,"loc":{"start":{"line":6,"column":33},"end":{"line":6,"column":36}},
             "body": []
-          },
-          "abstract": true
-        },
-        "trailingComments": [
+          }
+        }
+      },
+      {
+        "type": "ExportDefaultDeclaration",
+        "start":255,"end":313,"loc":{"start":{"line":8,"column":0},"end":{"line":8,"column":58}},
+        "leadingComments": [
           {
             "type": "CommentLine",
             "value": " `abstract class` is not valid as an expression.",
             "start":204,"end":254,"loc":{"start":{"line":7,"column":0},"end":{"line":7,"column":50}}
           }
-        ]
+        ],
+        "exportKind": "value",
+        "declaration": {
+          "type": "ClassDeclaration",
+          "start":270,"end":313,"loc":{"start":{"line":8,"column":15},"end":{"line":8,"column":58}},
+          "abstract": true,
+          "id": {
+            "type": "Identifier",
+            "start":285,"end":287,"loc":{"start":{"line":8,"column":30},"end":{"line":8,"column":32},"identifierName":"C5"},
+            "name": "C5"
+          },
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "start":288,"end":313,"loc":{"start":{"line":8,"column":33},"end":{"line":8,"column":58}},
+            "body": [
+              {
+                "type": "TSDeclareMethod",
+                "start":290,"end":311,"loc":{"start":{"line":8,"column":35},"end":{"line":8,"column":56}},
+                "abstract": true,
+                "static": false,
+                "key": {
+                  "type": "Identifier",
+                  "start":299,"end":302,"loc":{"start":{"line":8,"column":44},"end":{"line":8,"column":47},"identifierName":"foo"},
+                  "name": "foo"
+                },
+                "computed": false,
+                "kind": "method",
+                "id": null,
+                "generator": false,
+                "async": false,
+                "params": [],
+                "returnType": {
+                  "type": "TSTypeAnnotation",
+                  "start":304,"end":310,"loc":{"start":{"line":8,"column":49},"end":{"line":8,"column":55}},
+                  "typeAnnotation": {
+                    "type": "TSVoidKeyword",
+                    "start":306,"end":310,"loc":{"start":{"line":8,"column":51},"end":{"line":8,"column":55}}
+                  }
+                }
+              }
+            ]
+          }
+        }
       }
     ],
     "directives": []


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12745  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Assign `abstract` property to the class node before calling `parseClass` in `parseExportDefaultExpression`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12748"><img src="https://gitpod.io/api/apps/github/pbs/github.com/fedeci/babel.git/e7fbb098bad2442d7e6ff292f10dd2993ec64902.svg" /></a>

