### PR TITLE
Remove workaround for #12567 in e2e Jest tests

### DIFF
--- a/scripts/integration-tests/e2e-jest.sh
+++ b/scripts/integration-tests/e2e-jest.sh
@@ -37,13 +37,6 @@ python --version
 #                                   TEST                                       #
 #==============================================================================#
 
-# Workaround for https://github.com/babel/babel/pull/12567
-node -e '
-  let snapshots = fs.readFileSync("packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap", "utf8");
-  snapshots = snapshots.replace(/(?<!^<dim>.*)\| <\/>/gm, "|<\/> ");
-  fs.writeFileSync("packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap", snapshots);
-'
-
 if [ "$BABEL_8_BREAKING" = true ] ; then
   # This option is removed in Babel 8
   sed -i 's/allowDeclareFields: true,\?/\/* allowDeclareFields: true *\//g' babel.config.js


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Not needed after https://github.com/facebook/jest/pull/11048. Thanks @SimenB for reminding us about it!

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12749"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nicolo-ribaudo/babel.git/99af65fc7f6bcf87f1c18614a727c0824abc62eb.svg" /></a>

