### PR TITLE
[babel 8] type checking preset-flow options

### DIFF
--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "@babel/helper-plugin-utils": "workspace:^7.12.13",
+    "@babel/helper-validator-option": "workspace:^7.12.11",
     "@babel/plugin-transform-flow-strip-types": "workspace:^7.12.13"
   },
   "peerDependencies": {

--- a/packages/babel-preset-flow/src/index.js
+++ b/packages/babel-preset-flow/src/index.js
@@ -1,8 +1,10 @@
 import { declare } from "@babel/helper-plugin-utils";
 import transformFlowStripTypes from "@babel/plugin-transform-flow-strip-types";
+import normalizeOptions from "./normalize-options.js";
 
-export default declare((api, { all, allowDeclareFields }) => {
+export default declare((api, opts) => {
   api.assertVersion(7);
+  const { all, allowDeclareFields } = normalizeOptions(opts);
 
   return {
     plugins: [[transformFlowStripTypes, { all, allowDeclareFields }]],

--- a/packages/babel-preset-flow/src/index.js
+++ b/packages/babel-preset-flow/src/index.js
@@ -1,6 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import transformFlowStripTypes from "@babel/plugin-transform-flow-strip-types";
-import normalizeOptions from "./normalize-options.js";
+import normalizeOptions from "./normalize-options";
 
 export default declare((api, opts) => {
   api.assertVersion(7);

--- a/packages/babel-preset-flow/src/normalize-options.js
+++ b/packages/babel-preset-flow/src/normalize-options.js
@@ -2,19 +2,20 @@ import { OptionValidator } from "@babel/helper-validator-option";
 const v = new OptionValidator("@babel/preset-flow");
 
 export default function normalizeOptions(options = {}) {
-  let { all, allowDeclareFields } = options;
+  let { all } = options;
+  const { allowDeclareFields } = options;
 
   if (process.env.BABEL_8_BREAKING) {
+    v.invariant(
+      !("allowDeclareFields" in options),
+      `Since Babel 8, \`declare property: A\` is always supported, and the "allowDeclareFields" option is no longer available. Please remove it from your config.`,
+    );
     const TopLevelOptions = {
       all: "all",
-      allowDeclareFields: "allowDeclareFields",
     };
     v.validateTopLevelOptions(options, TopLevelOptions);
     all = v.validateBooleanOption(TopLevelOptions.all, options.all);
-    allowDeclareFields = v.validateBooleanOption(
-      TopLevelOptions.allowDeclareFields,
-      options.allowDeclareFields,
-    );
+    return { all };
   }
 
   return {

--- a/packages/babel-preset-flow/src/normalize-options.js
+++ b/packages/babel-preset-flow/src/normalize-options.js
@@ -1,0 +1,24 @@
+import { OptionValidator } from "@babel/helper-validator-option";
+const v = new OptionValidator("@babel/preset-flow");
+
+export default function normalizeOptions(options = {}) {
+  let { all, allowDeclareFields } = options;
+
+  if (process.env.BABEL_8_BREAKING) {
+    const TopLevelOptions = {
+      all: "all",
+      allowDeclareFields: "allowDeclareFields",
+    };
+    v.validateTopLevelOptions(options, TopLevelOptions);
+    all = v.validateBooleanOption(TopLevelOptions.all, options.all);
+    allowDeclareFields = v.validateBooleanOption(
+      TopLevelOptions.allowDeclareFields,
+      options.allowDeclareFields,
+    );
+  }
+
+  return {
+    all,
+    allowDeclareFields,
+  };
+}

--- a/packages/babel-preset-flow/src/normalize-options.js
+++ b/packages/babel-preset-flow/src/normalize-options.js
@@ -16,10 +16,10 @@ export default function normalizeOptions(options = {}) {
     v.validateTopLevelOptions(options, TopLevelOptions);
     all = v.validateBooleanOption(TopLevelOptions.all, options.all);
     return { all };
+  } else {
+    return {
+      all,
+      allowDeclareFields,
+    };
   }
-
-  return {
-    all,
-    allowDeclareFields,
-  };
 }

--- a/packages/babel-preset-flow/test/normalize-options.spec.js
+++ b/packages/babel-preset-flow/test/normalize-options.spec.js
@@ -2,20 +2,24 @@ import normalizeOptions from "../src/normalize-options";
 describe("normalize options", () => {
   (process.env.BABEL_8_BREAKING ? describe : describe.skip)("Babel 8", () => {
     it("should throw on unknown options", () => {
-      expect(() => normalizeOptions({ allowDeclareField: true }))
+      expect(() => normalizeOptions({ al: true }))
         .toThrowErrorMatchingInlineSnapshot(`
-        "@babel/preset-flow: 'allowDeclareField' is not a valid top-level option.
-        - Did you mean 'allowDeclareFields'?"
+        "@babel/preset-flow: 'al' is not a valid top-level option.
+        - Did you mean 'all'?"
       `);
     });
-    it.each(["all", "allowDeclareFields"])(
-      "should throw when `%p` is not a boolean",
-      optionName => {
-        expect(() => normalizeOptions({ [optionName]: 0 })).toThrow(
-          `@babel/preset-flow: '${optionName}' option must be a boolean.`,
-        );
-      },
-    );
+    it("should throw on Babel 7 `allowDeclareFields` option", () => {
+      expect(() =>
+        normalizeOptions({ allowDeclareFields: true }),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"@babel/preset-flow: Since Babel 8, \`declare property: A\` is always supported, and the \\"allowDeclareFields\\" option is no longer available. Please remove it from your config."`,
+      );
+    });
+    it.each(["all"])("should throw when `%p` is not a boolean", optionName => {
+      expect(() => normalizeOptions({ [optionName]: 0 })).toThrow(
+        `@babel/preset-flow: '${optionName}' option must be a boolean.`,
+      );
+    });
     it("should not throw when options is not defined", () => {
       expect(() => normalizeOptions()).not.toThrowError();
     });
@@ -23,7 +27,6 @@ describe("normalize options", () => {
       expect(normalizeOptions({})).toMatchInlineSnapshot(`
         Object {
           "all": undefined,
-          "allowDeclareFields": undefined,
         }
       `);
     });

--- a/packages/babel-preset-flow/test/normalize-options.spec.js
+++ b/packages/babel-preset-flow/test/normalize-options.spec.js
@@ -1,0 +1,52 @@
+import normalizeOptions from "../src/normalize-options";
+describe("normalize options", () => {
+  (process.env.BABEL_8_BREAKING ? describe : describe.skip)("Babel 8", () => {
+    it("should throw on unknown options", () => {
+      expect(() => normalizeOptions({ allowDeclareField: true }))
+        .toThrowErrorMatchingInlineSnapshot(`
+        "@babel/preset-flow: 'allowDeclareField' is not a valid top-level option.
+        - Did you mean 'allowDeclareFields'?"
+      `);
+    });
+    it.each(["all", "allowDeclareFields"])(
+      "should throw when `%p` is not a boolean",
+      optionName => {
+        expect(() => normalizeOptions({ [optionName]: 0 })).toThrow(
+          `@babel/preset-flow: '${optionName}' option must be a boolean.`,
+        );
+      },
+    );
+    it("should not throw when options is not defined", () => {
+      expect(() => normalizeOptions()).not.toThrowError();
+    });
+    it("default values", () => {
+      expect(normalizeOptions({})).toMatchInlineSnapshot(`
+        Object {
+          "all": undefined,
+          "allowDeclareFields": undefined,
+        }
+      `);
+    });
+  });
+  (process.env.BABEL_8_BREAKING ? describe.skip : describe)("Babel 7", () => {
+    it("should not throw on unknown options", () => {
+      expect(() =>
+        normalizeOptions({ allDeclareField: true }),
+      ).not.toThrowError();
+    });
+    it.each(["all", "allowDeclareFields"])(
+      "should not throw when `%p` is not a boolean",
+      optionName => {
+        expect(() => normalizeOptions({ [optionName]: 0 })).not.toThrowError();
+      },
+    );
+    it("default values", () => {
+      expect(normalizeOptions({})).toMatchInlineSnapshot(`
+        Object {
+          "all": undefined,
+          "allowDeclareFields": undefined,
+        }
+      `);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -851,7 +851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-option@workspace:^7.12.17, @babel/helper-validator-option@workspace:packages/babel-helper-validator-option":
+"@babel/helper-validator-option@workspace:^7.12.11, @babel/helper-validator-option@workspace:^7.12.17, @babel/helper-validator-option@workspace:packages/babel-helper-validator-option":
   version: 0.0.0-use.local
   resolution: "@babel/helper-validator-option@workspace:packages/babel-helper-validator-option"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -3169,6 +3169,7 @@ __metadata:
     "@babel/core": "workspace:*"
     "@babel/helper-plugin-test-runner": "workspace:*"
     "@babel/helper-plugin-utils": "workspace:^7.12.13"
+    "@babel/helper-validator-option": "workspace:^7.12.11"
     "@babel/plugin-transform-flow-strip-types": "workspace:^7.12.13"
   peerDependencies:
     "@babel/core": ^7.0.0-0


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Major: Breaking Change?  | Y, behind the `BABEL_8_BREAKING` flag
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | `preset-flow` now depends on `helper-validator-option`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR was derived from #10927. It focuses on checking `@babel/preset-flow` options only.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12751"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/39a4e4f5f0e9fca68e892622f6a51b39d316af1a.svg" /></a>

