### PR TITLE
[TS] Create `TSUnionType` or `TSIntersectionType` when typealias has a leading operator

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -936,9 +936,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       operator: TokenType,
     ): N.TsType {
       const node: N.TsUnionType | N.TsIntersectionType = this.startNode();
-      this.eat(operator);
+      const leadingOperator = this.eat(operator);
       let type = parseConstituentType();
-      if (this.match(operator)) {
+      if (this.match(operator) || leadingOperator) {
         const types = [type];
         while (this.eat(operator)) {
           types.push(parseConstituentType());

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -936,17 +936,16 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       operator: TokenType,
     ): N.TsType {
       const node: N.TsUnionType | N.TsIntersectionType = this.startNode();
-      const leadingOperator = this.eat(operator);
-      let type = parseConstituentType();
-      if (this.match(operator) || leadingOperator) {
-        const types = [type];
-        while (this.eat(operator)) {
-          types.push(parseConstituentType());
-        }
-        node.types = types;
-        type = this.finishNode(node, kind);
+      const hasLeadingOperator = this.eat(operator);
+      const types = [];
+      do {
+        types.push(parseConstituentType());
+      } while (this.eat(operator));
+      if (types.length === 1 && !hasLeadingOperator) {
+        return types[0];
       }
-      return type;
+      node.types = types;
+      return this.finishNode(node, kind);
     }
 
     tsParseIntersectionTypeOrHigher(): N.TsType {

--- a/packages/babel-parser/test/fixtures/typescript/types/union-intersection/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/union-intersection/input.ts
@@ -8,3 +8,4 @@ type F = number & string
 type K = | number | string
 type M = & number & string
 type N = | number
+type O = & string

--- a/packages/babel-parser/test/fixtures/typescript/types/union-intersection/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/union-intersection/input.ts
@@ -7,3 +7,4 @@ type J = number | string
 type F = number & string
 type K = | number | string
 type M = & number & string
+type N = | number

--- a/packages/babel-parser/test/fixtures/typescript/types/union-intersection/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/union-intersection/output.json
@@ -1,9 +1,9 @@
 {
   "type": "File",
-  "start":0,"end":265,"loc":{"start":{"line":1,"column":0},"end":{"line":9,"column":26}},
+  "start":0,"end":283,"loc":{"start":{"line":1,"column":0},"end":{"line":10,"column":17}},
   "program": {
     "type": "Program",
-    "start":0,"end":265,"loc":{"start":{"line":1,"column":0},"end":{"line":9,"column":26}},
+    "start":0,"end":283,"loc":{"start":{"line":1,"column":0},"end":{"line":10,"column":17}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
@@ -259,6 +259,25 @@
             {
               "type": "TSStringKeyword",
               "start":259,"end":265,"loc":{"start":{"line":9,"column":20},"end":{"line":9,"column":26}}
+            }
+          ]
+        }
+      },
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start":266,"end":283,"loc":{"start":{"line":10,"column":0},"end":{"line":10,"column":17}},
+        "id": {
+          "type": "Identifier",
+          "start":271,"end":272,"loc":{"start":{"line":10,"column":5},"end":{"line":10,"column":6},"identifierName":"N"},
+          "name": "N"
+        },
+        "typeAnnotation": {
+          "type": "TSUnionType",
+          "start":275,"end":283,"loc":{"start":{"line":10,"column":9},"end":{"line":10,"column":17}},
+          "types": [
+            {
+              "type": "TSNumberKeyword",
+              "start":277,"end":283,"loc":{"start":{"line":10,"column":11},"end":{"line":10,"column":17}}
             }
           ]
         }

--- a/packages/babel-parser/test/fixtures/typescript/types/union-intersection/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/union-intersection/output.json
@@ -1,9 +1,9 @@
 {
   "type": "File",
-  "start":0,"end":283,"loc":{"start":{"line":1,"column":0},"end":{"line":10,"column":17}},
+  "start":0,"end":301,"loc":{"start":{"line":1,"column":0},"end":{"line":11,"column":17}},
   "program": {
     "type": "Program",
-    "start":0,"end":283,"loc":{"start":{"line":1,"column":0},"end":{"line":10,"column":17}},
+    "start":0,"end":301,"loc":{"start":{"line":1,"column":0},"end":{"line":11,"column":17}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
@@ -278,6 +278,25 @@
             {
               "type": "TSNumberKeyword",
               "start":277,"end":283,"loc":{"start":{"line":10,"column":11},"end":{"line":10,"column":17}}
+            }
+          ]
+        }
+      },
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start":284,"end":301,"loc":{"start":{"line":11,"column":0},"end":{"line":11,"column":17}},
+        "id": {
+          "type": "Identifier",
+          "start":289,"end":290,"loc":{"start":{"line":11,"column":5},"end":{"line":11,"column":6},"identifierName":"O"},
+          "name": "O"
+        },
+        "typeAnnotation": {
+          "type": "TSIntersectionType",
+          "start":293,"end":301,"loc":{"start":{"line":11,"column":9},"end":{"line":11,"column":17}},
+          "types": [
+            {
+              "type": "TSStringKeyword",
+              "start":295,"end":301,"loc":{"start":{"line":11,"column":11},"end":{"line":11,"column":17}}
             }
           ]
         }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/pull/12757#issuecomment-773452013 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
If the intersection/union type has a leading `|` or `&` operator we create a `TSUnionType`/`TSIntersectionType` node even if it has just one type defined.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12758"><img src="https://gitpod.io/api/apps/github/pbs/github.com/fedeci/babel.git/16edacccf6ba24d6cffe960ef266645af021c356.svg" /></a>

