### PR TITLE
Support destructuring variable declarator within TS namespace

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/namespace.js
+++ b/packages/babel-plugin-transform-typescript/src/namespace.js
@@ -130,11 +130,15 @@ function handleNested(path, t, node, parentExport) {
       case "ClassDeclaration":
         names.add(subNode.id.name);
         continue;
-      case "VariableDeclaration":
-        for (const variable of subNode.declarations) {
-          names.add(variable.id.name);
+      case "VariableDeclaration": {
+        const bindingIdentifiers = Object.values(
+          t.getBindingIdentifiers(subNode),
+        );
+        for (const id of bindingIdentifiers) {
+          names.add(id.name);
         }
         continue;
+      }
       default:
         // Neither named declaration nor export, continue to next item.
         continue;

--- a/packages/babel-plugin-transform-typescript/src/namespace.js
+++ b/packages/babel-plugin-transform-typescript/src/namespace.js
@@ -1,4 +1,4 @@
-import { template } from "@babel/core";
+import { template, types as t } from "@babel/core";
 
 export default function transpileNamespace(path, t, allowNamespaces) {
   if (path.node.declare || path.node.id.type === "StringLiteral") {
@@ -44,6 +44,36 @@ function getDeclaration(t, name) {
 
 function getMemberExpression(t, name, itemName) {
   return t.memberExpression(t.identifier(name), t.identifier(itemName));
+}
+
+/**
+ * Convert export const foo = 1 to Namepsace.foo = 1;
+ *
+ * @param {t.VariableDeclaration} node given variable declaration, e.g. `const foo = 1`
+ * @param {string} name the generated unique namespace member name
+ * @param {*} hub An instance implements HubInterface defined in `@babel/traverse` that can throw a code frame error
+ */
+function handleVariableDeclaration(
+  node: t.VariableDeclaration,
+  name: string,
+  hub: any,
+): t.Statement[] {
+  if (node.kind !== "const") {
+    throw hub.file.buildCodeFrameError(
+      node,
+      "Namespaces exporting non-const are not supported by Babel." +
+        " Change to const or see:" +
+        " https://babeljs.io/docs/en/babel-plugin-transform-typescript",
+    );
+  }
+  for (const declarator of node.declarations) {
+    declarator.init = t.assignmentExpression(
+      "=",
+      getMemberExpression(t, name, declarator.id.name),
+      declarator.init,
+    );
+  }
+  return [node];
 }
 
 function handleNested(path, t, node, parentExport) {
@@ -111,24 +141,16 @@ function handleNested(path, t, node, parentExport) {
         );
         break;
       }
-      case "VariableDeclaration":
-        if (subNode.declaration.kind !== "const") {
-          throw path.hub.file.buildCodeFrameError(
-            subNode.declaration,
-            "Namespaces exporting non-const are not supported by Babel." +
-              " Change to const or see:" +
-              " https://babeljs.io/docs/en/babel-plugin-transform-typescript",
-          );
-        }
-        for (const variable of subNode.declaration.declarations) {
-          variable.init = t.assignmentExpression(
-            "=",
-            getMemberExpression(t, name, variable.id.name),
-            variable.init,
-          );
-        }
-        namespaceTopLevel[i] = subNode.declaration;
+      case "VariableDeclaration": {
+        const nodes = handleVariableDeclaration(
+          subNode.declaration,
+          name,
+          path.hub,
+        );
+        namespaceTopLevel.splice(i, nodes.length, ...nodes);
+        i += nodes.length - 1;
         break;
+      }
       case "TSModuleDeclaration": {
         const transformed = handleNested(
           path,

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/namespace-nested-module/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/namespace-nested-module/input.ts
@@ -1,0 +1,6 @@
+namespace N {
+  const M1 = {}
+  export module M1 {}
+  const { M2 } = {}
+  export module M2 {}
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/namespace-nested-module/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/namespace-nested-module/output.mjs
@@ -1,0 +1,13 @@
+let N;
+
+(function (_N) {
+  const M1 = {};
+
+  (function (_M) {})(M1 || (M1 = _N.M1 || (_N.M1 = {})));
+
+  const {
+    M2
+  } = {};
+
+  (function (_M2) {})(M2 || (M2 = _N.M2 || (_N.M2 = {})));
+})(N || (N = {}));

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-destructuring/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-destructuring/input.ts
@@ -1,0 +1,6 @@
+class C { }
+namespace N {
+  export const { a } = C;
+  export const [ b ] = C;
+  export const [ { a: [{ b: c }] }] = A, { a: { b: { d = 1 } } = {}, ...e } = C;
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-destructuring/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-destructuring/output.mjs
@@ -1,0 +1,24 @@
+class C {}
+
+let N;
+
+(function (_N) {
+  const {
+    a
+  } = C;
+  _N.a = a;
+  const [{
+    a: [{
+      b: c
+    }]
+  }] = A,
+        {
+    a: {
+      b: {
+        d = 1
+      }
+    } = {},
+    ...e
+  } = C;
+  _N.e = e, _N.c = c, _N.d = d;
+})(N || (N = {}));


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11461
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR should be reviewed by commits. It supports general declarator via `t.getBindingIdentifiers`. The following snippet
```ts
namespace Foo
{
    export const {a, b} = obj
}
```
is now transformed to
```js
let Foo;

(function (_Foo) {
  const {a, b} = obj;
  _Foo.a = a, _Foo.b = b;
})(Foo || (Foo = {}));
```
Unlike TypeScript which also [transpiles](https://www.typescriptlang.org/play?target=99#code/HYQwtgpgzgDiDGEAEAxA9mgsAKAN46UKQgA8Y0AnAFyXjWChtxABokAjAXyQF4k12AKxycgA) patterns even if we target to `ESNext`, Babel does not transpile and instead it will delegate to `@babel/plugin-transform-destructuring` for further transpilation if required.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/12760"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/7ba47251ce7d9ba826d2ba147fcb197099ee43d7.svg" /></a>

