### PR TITLE
fix(ts): include `asserts` in `TSTypePredicate` location

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1069,6 +1069,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             node.asserts = true;
             thisTypePredicate = this.finishNode(node, "TSTypePredicate");
           } else {
+            this.resetStartLocationFromNode(thisTypePredicate, node);
             (thisTypePredicate: N.TsTypePredicate).asserts = true;
           }
           t.typeAnnotation = thisTypePredicate;

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-this-with-predicate/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-this-with-predicate/output.json
@@ -40,7 +40,7 @@
                 "start":21,"end":42,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":30}},
                 "typeAnnotation": {
                   "type": "TSTypePredicate",
-                  "start":31,"end":42,"loc":{"start":{"line":2,"column":19},"end":{"line":2,"column":30}},
+                  "start":23,"end":42,"loc":{"start":{"line":2,"column":11},"end":{"line":2,"column":30}},
                   "parameterName": {
                     "type": "TSThisType",
                     "start":31,"end":35,"loc":{"start":{"line":2,"column":19},"end":{"line":2,"column":23}}
@@ -86,7 +86,7 @@
                   "start":58,"end":79,"loc":{"start":{"line":3,"column":12},"end":{"line":3,"column":33}},
                   "typeAnnotation": {
                     "type": "TSTypePredicate",
-                    "start":68,"end":79,"loc":{"start":{"line":3,"column":22},"end":{"line":3,"column":33}},
+                    "start":60,"end":79,"loc":{"start":{"line":3,"column":14},"end":{"line":3,"column":33}},
                     "parameterName": {
                       "type": "TSThisType",
                       "start":68,"end":72,"loc":{"start":{"line":3,"column":22},"end":{"line":3,"column":26}}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12761  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The location of the node created before eating `asserts` is assigned to the returned `typePredicate`.