### PR TITLE
Enable allowNamespaces in `transform-typescript` by default

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -51,6 +51,7 @@ export default declare((api, opts) => {
   const JSX_PRAGMA_REGEX = /\*?\s*@jsx((?:Frag)?)\s+([^\s]+)/;
 
   const {
+    allowNamespaces = true,
     jsxPragma = "React.createElement",
     jsxPragmaFrag = "React.Fragment",
     onlyRemoveTypeImports = false,
@@ -58,10 +59,7 @@ export default declare((api, opts) => {
 
   if (!process.env.BABEL_8_BREAKING) {
     // eslint-disable-next-line no-var
-    var { allowDeclareFields = false, allowNamespaces = false } = opts;
-  } else {
-    // eslint-disable-next-line no-var,no-redeclare
-    var { allowNamespaces = true } = opts;
+    var { allowDeclareFields = false } = opts;
   }
 
   const classMemberVisitors = {

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -53,13 +53,15 @@ export default declare((api, opts) => {
   const {
     jsxPragma = "React.createElement",
     jsxPragmaFrag = "React.Fragment",
-    allowNamespaces = false,
     onlyRemoveTypeImports = false,
   } = opts;
 
   if (!process.env.BABEL_8_BREAKING) {
     // eslint-disable-next-line no-var
-    var { allowDeclareFields = false } = opts;
+    var { allowDeclareFields = false, allowNamespaces = false } = opts;
+  } else {
+    // eslint-disable-next-line no-var,no-redeclare
+    var { allowNamespaces = true } = opts;
   }
 
   const classMemberVisitors = {

--- a/packages/babel-preset-typescript/src/normalize-options.js
+++ b/packages/babel-preset-typescript/src/normalize-options.js
@@ -2,7 +2,7 @@ import { OptionValidator } from "@babel/helper-validator-option";
 const v = new OptionValidator("@babel/preset-typescript");
 
 export default function normalizeOptions(options = {}) {
-  let { allowNamespaces, jsxPragma, onlyRemoveTypeImports } = options;
+  let { allowNamespaces = true, jsxPragma, onlyRemoveTypeImports } = options;
 
   if (process.env.BABEL_8_BREAKING) {
     const TopLevelOptions = {

--- a/packages/babel-preset-typescript/test/normalize-options.spec.js
+++ b/packages/babel-preset-typescript/test/normalize-options.spec.js
@@ -78,7 +78,7 @@ describe("normalize options", () => {
       expect(normalizeOptions({})).toMatchInlineSnapshot(`
         Object {
           "allExtensions": false,
-          "allowNamespaces": undefined,
+          "allowNamespaces": true,
           "isTSX": false,
           "jsxPragma": undefined,
           "jsxPragmaFrag": "React.Fragment",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/notes/blob/master/2019/05/21.md#prs
| Patch: Bug Fix?          |
| Major: Breaking Change?  | 
| Minor: New Feature?      | Y
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2449
| Any Dependency Changes?  |
| License                  | MIT

Unlike `useSpread` in `preset-react` which will be materialized in Babel 8, I don't think the TSNamespace feature is ready for that, but we can enable it by default in Babel 8 and gather more feedback.

Note that `allowNamespaces` has been enabled by default in `preset-typescript` (#12460), since it was extracted from `babel-8-dev`.