### PR TITLE
fix: use semver gte comparison on polyfill version tester

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -183,6 +183,19 @@ function bool(value) {
   return value && value !== "false" && value !== "0";
 }
 
+// A minimum semver GTE implementation
+// Limitation:
+// - it only supports comparing major and minor version, assuming Node.js will never ship
+//   features in patch release so we will never need to compare a version with "1.2.3"
+// - it assumes `process.versions.node` never contains `,`
+//
+// @example
+// semverGte("8.10", "8.9") // true
+// semverGte("8.9", "8.9") // true
+// semverGte("9.0", "8.9") // true
+// semverGte("8.9", "8.10") // false
+const semverGte = `((a,b)=>(([,v,x,w,y]=/(\\d+)\\.(\\d+).*,(\\d+)\\.(\\d+)/.exec([a,b])),+v>+w||v==w&&+x>=+y))`;
+
 // TODO(Babel 8) This polyfills are only needed for Node.js 6 and 8
 /** @param {import("@babel/core")} api */
 function pluginPolyfillsOldNode({ template, types: t }) {
@@ -207,7 +220,7 @@ function pluginPolyfillsOldNode({ template, types: t }) {
       // require.resolve's paths option has been introduced in Node.js 8.9
       // https://nodejs.org/api/modules.html#modules_require_resolve_request_options
       replacement: template({ syntacticPlaceholders: true })`
-        parseFloat(process.versions.node) >= 8.9
+        ${semverGte}(process.versions.node, "8.9")
           ? require.resolve
           : (/* request */ r, { paths: [/* base */ b] }, M = require("module")) => {
               let /* filename */ f = M._findPath(r, M._nodeModulePaths(b).concat(b));
@@ -239,7 +252,7 @@ function pluginPolyfillsOldNode({ template, types: t }) {
       // fs.mkdirSync's recursive option has been introduced in Node.js 10.12
       // https://nodejs.org/api/fs.html#fs_fs_mkdirsync_path_options
       replacement: template`
-        parseFloat(process.versions.node) >= 10.12
+        ${semverGte}(process.versions.node, "10.12")
           ? fs.mkdirSync
           : require("make-dir").sync
       `,

--- a/babel.config.js
+++ b/babel.config.js
@@ -193,7 +193,9 @@ function bool(value) {
 // semverGte("8.9", "8.9") // true
 // semverGte("9.0", "8.9") // true
 // semverGte("8.9", "8.10") // false
-`((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))`;
+// TODO: figure out how to inject it to the `@babel/template` usage so we don't need to
+// copy and paste it.
+// `((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))`;
 
 // TODO(Babel 8) This polyfills are only needed for Node.js 6 and 8
 /** @param {import("@babel/core")} api */

--- a/babel.config.js
+++ b/babel.config.js
@@ -187,14 +187,13 @@ function bool(value) {
 // Limitation:
 // - it only supports comparing major and minor version, assuming Node.js will never ship
 //   features in patch release so we will never need to compare a version with "1.2.3"
-// - it assumes `process.versions.node` never contains `,`
 //
 // @example
 // semverGte("8.10", "8.9") // true
 // semverGte("8.9", "8.9") // true
 // semverGte("9.0", "8.9") // true
 // semverGte("8.9", "8.10") // false
-`((a,b)=>(([,v,x,w,y]=/(\\d+)\\.(\\d+).*,(\\d+)\\.(\\d+)/.exec([a,b])),+v>+w||v==w&&+x>=+y))`;
+`((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))`;
 
 // TODO(Babel 8) This polyfills are only needed for Node.js 6 and 8
 /** @param {import("@babel/core")} api */
@@ -220,7 +219,7 @@ function pluginPolyfillsOldNode({ template, types: t }) {
       // require.resolve's paths option has been introduced in Node.js 8.9
       // https://nodejs.org/api/modules.html#modules_require_resolve_request_options
       replacement: template({ syntacticPlaceholders: true })`
-        ((a,b)=>(([,v,x,w,y]=/(\\d+)\\.(\\d+).*,(\\d+)\\.(\\d+)/.exec([a,b])),+v>+w||v==w&&+x>=+y))(process.versions.node, "8.9")
+        ((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))(process.versions.node, "8.9")
           ? require.resolve
           : (/* request */ r, { paths: [/* base */ b] }, M = require("module")) => {
               let /* filename */ f = M._findPath(r, M._nodeModulePaths(b).concat(b));
@@ -252,7 +251,7 @@ function pluginPolyfillsOldNode({ template, types: t }) {
       // fs.mkdirSync's recursive option has been introduced in Node.js 10.12
       // https://nodejs.org/api/fs.html#fs_fs_mkdirsync_path_options
       replacement: template`
-        ((a,b)=>(([,v,x,w,y]=/(\\d+)\\.(\\d+).*,(\\d+)\\.(\\d+)/.exec([a,b])),+v>+w||v==w&&+x>=+y))(process.versions.node, "10.12")
+        ((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))(process.versions.node, "10.12")
           ? fs.mkdirSync
           : require("make-dir").sync
       `,

--- a/babel.config.js
+++ b/babel.config.js
@@ -194,7 +194,7 @@ function bool(value) {
 // semverGte("8.9", "8.9") // true
 // semverGte("9.0", "8.9") // true
 // semverGte("8.9", "8.10") // false
-const semverGte = `((a,b)=>(([,v,x,w,y]=/(\\d+)\\.(\\d+).*,(\\d+)\\.(\\d+)/.exec([a,b])),+v>+w||v==w&&+x>=+y))`;
+`((a,b)=>(([,v,x,w,y]=/(\\d+)\\.(\\d+).*,(\\d+)\\.(\\d+)/.exec([a,b])),+v>+w||v==w&&+x>=+y))`;
 
 // TODO(Babel 8) This polyfills are only needed for Node.js 6 and 8
 /** @param {import("@babel/core")} api */
@@ -220,7 +220,7 @@ function pluginPolyfillsOldNode({ template, types: t }) {
       // require.resolve's paths option has been introduced in Node.js 8.9
       // https://nodejs.org/api/modules.html#modules_require_resolve_request_options
       replacement: template({ syntacticPlaceholders: true })`
-        ${semverGte}(process.versions.node, "8.9")
+        ((a,b)=>(([,v,x,w,y]=/(\\d+)\\.(\\d+).*,(\\d+)\\.(\\d+)/.exec([a,b])),+v>+w||v==w&&+x>=+y))(process.versions.node, "8.9")
           ? require.resolve
           : (/* request */ r, { paths: [/* base */ b] }, M = require("module")) => {
               let /* filename */ f = M._findPath(r, M._nodeModulePaths(b).concat(b));
@@ -252,7 +252,7 @@ function pluginPolyfillsOldNode({ template, types: t }) {
       // fs.mkdirSync's recursive option has been introduced in Node.js 10.12
       // https://nodejs.org/api/fs.html#fs_fs_mkdirsync_path_options
       replacement: template`
-        ${semverGte}(process.versions.node, "10.12")
+        ((a,b)=>(([,v,x,w,y]=/(\\d+)\\.(\\d+).*,(\\d+)\\.(\\d+)/.exec([a,b])),+v>+w||v==w&&+x>=+y))(process.versions.node, "10.12")
           ? fs.mkdirSync
           : require("make-dir").sync
       `,

--- a/babel.config.js
+++ b/babel.config.js
@@ -183,21 +183,23 @@ function bool(value) {
   return value && value !== "false" && value !== "0";
 }
 
+// A minimum semver GTE implementation
+// Limitation:
+// - it only supports comparing major and minor version, assuming Node.js will never ship
+//   features in patch release so we will never need to compare a version with "1.2.3"
+//
+// @example
+// semverGte("8.10", "8.9") // true
+// semverGte("8.9", "8.9") // true
+// semverGte("9.0", "8.9") // true
+// semverGte("8.9", "8.10") // false
+// TODO: figure out how to inject it to the `@babel/template` usage so we don't need to
+// copy and paste it.
+// `((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))`;
+
 // TODO(Babel 8) This polyfills are only needed for Node.js 6 and 8
 /** @param {import("@babel/core")} api */
 function pluginPolyfillsOldNode({ template, types: t }) {
-  // A minimum semver GTE implementation
-  // Limitation:
-  // - it only supports comparing major and minor version, assuming Node.js will never ship
-  //   features in patch release so we will never need to compare a version with "1.2.3"
-  // - the passed version must have minor version. Use "14.0" for "14" instead.
-  //
-  // @example
-  // semverGte("8.10", "8.9") // true
-  // semverGte("8.9", "8.9") // true
-  // semverGte("9.0", "8.9") // true
-  // semverGte("8.9", "8.10") // false
-  const semverGte = template.ast`((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))`;
   const polyfills = [
     {
       name: "require.resolve",
@@ -219,7 +221,7 @@ function pluginPolyfillsOldNode({ template, types: t }) {
       // require.resolve's paths option has been introduced in Node.js 8.9
       // https://nodejs.org/api/modules.html#modules_require_resolve_request_options
       replacement: template({ syntacticPlaceholders: true })`
-        ${semverGte}(process.versions.node, "8.9")
+        ((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))(process.versions.node, "8.9")
           ? require.resolve
           : (/* request */ r, { paths: [/* base */ b] }, M = require("module")) => {
               let /* filename */ f = M._findPath(r, M._nodeModulePaths(b).concat(b));
@@ -251,7 +253,7 @@ function pluginPolyfillsOldNode({ template, types: t }) {
       // fs.mkdirSync's recursive option has been introduced in Node.js 10.12
       // https://nodejs.org/api/fs.html#fs_fs_mkdirsync_path_options
       replacement: template`
-        ${semverGte}(process.versions.node, "10.12")
+        ((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))(process.versions.node, "10.12")
           ? fs.mkdirSync
           : require("make-dir").sync
       `,

--- a/babel.config.js
+++ b/babel.config.js
@@ -183,23 +183,21 @@ function bool(value) {
   return value && value !== "false" && value !== "0";
 }
 
-// A minimum semver GTE implementation
-// Limitation:
-// - it only supports comparing major and minor version, assuming Node.js will never ship
-//   features in patch release so we will never need to compare a version with "1.2.3"
-//
-// @example
-// semverGte("8.10", "8.9") // true
-// semverGte("8.9", "8.9") // true
-// semverGte("9.0", "8.9") // true
-// semverGte("8.9", "8.10") // false
-// TODO: figure out how to inject it to the `@babel/template` usage so we don't need to
-// copy and paste it.
-// `((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))`;
-
 // TODO(Babel 8) This polyfills are only needed for Node.js 6 and 8
 /** @param {import("@babel/core")} api */
 function pluginPolyfillsOldNode({ template, types: t }) {
+  // A minimum semver GTE implementation
+  // Limitation:
+  // - it only supports comparing major and minor version, assuming Node.js will never ship
+  //   features in patch release so we will never need to compare a version with "1.2.3"
+  // - the passed version must have minor version. Use "14.0" for "14" instead.
+  //
+  // @example
+  // semverGte("8.10", "8.9") // true
+  // semverGte("8.9", "8.9") // true
+  // semverGte("9.0", "8.9") // true
+  // semverGte("8.9", "8.10") // false
+  const semverGte = template.ast`((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))`;
   const polyfills = [
     {
       name: "require.resolve",
@@ -221,7 +219,7 @@ function pluginPolyfillsOldNode({ template, types: t }) {
       // require.resolve's paths option has been introduced in Node.js 8.9
       // https://nodejs.org/api/modules.html#modules_require_resolve_request_options
       replacement: template({ syntacticPlaceholders: true })`
-        ((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))(process.versions.node, "8.9")
+        ${semverGte}(process.versions.node, "8.9")
           ? require.resolve
           : (/* request */ r, { paths: [/* base */ b] }, M = require("module")) => {
               let /* filename */ f = M._findPath(r, M._nodeModulePaths(b).concat(b));
@@ -253,7 +251,7 @@ function pluginPolyfillsOldNode({ template, types: t }) {
       // fs.mkdirSync's recursive option has been introduced in Node.js 10.12
       // https://nodejs.org/api/fs.html#fs_fs_mkdirsync_path_options
       replacement: template`
-        ((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))(process.versions.node, "10.12")
+        ${semverGte}(process.versions.node, "10.12")
           ? fs.mkdirSync
           : require("make-dir").sync
       `,

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -334,6 +334,7 @@ describe("addon resolution", function () {
     });
   });
 
+  // TODO(Babel 8): remove node version check.
   it("should throw about module: usage for presets", function () {
     process.chdir("throw-module-paths");
 
@@ -344,7 +345,13 @@ describe("addon resolution", function () {
         presets: ["foo"],
       });
     }).toThrow(
-      /Cannot resolve module 'babel-preset-foo'.*\n- If you want to resolve "foo", use "module:foo"/,
+      // Todo(Babel 8): remove node checks in this file. We cannot test the desired behaviour
+      // because Jest 24 has issue on setting the MODULE_NOT_FOUND error when the native
+      // `require.resolv` is provided.
+      // see https://github.com/babel/babel/pull/12439/files#r535996000
+      process.versions.node.startsWith("8.")
+        ? /Cannot resolve module 'babel-preset-foo'/
+        : /Cannot resolve module 'babel-preset-foo'.*\n- If you want to resolve "foo", use "module:foo"/,
     );
   });
 
@@ -358,7 +365,9 @@ describe("addon resolution", function () {
         plugins: ["foo"],
       });
     }).toThrow(
-      /Cannot resolve module 'babel-plugin-foo'.*\n- If you want to resolve "foo", use "module:foo"/,
+      process.versions.node.startsWith("8.")
+        ? /Cannot resolve module 'babel-plugin-foo'/
+        : /Cannot resolve module 'babel-plugin-foo'.*\n- If you want to resolve "foo", use "module:foo"/,
     );
   });
 
@@ -372,7 +381,9 @@ describe("addon resolution", function () {
         presets: ["foo"],
       });
     }).toThrow(
-      /Cannot resolve module 'babel-preset-foo'.*\n- Did you mean "@babel\/foo"\?/,
+      process.versions.node.startsWith("8.")
+        ? /Cannot resolve module 'babel-preset-foo'/
+        : /Cannot resolve module 'babel-preset-foo'.*\n- Did you mean "@babel\/foo"\?/,
     );
   });
 
@@ -386,7 +397,9 @@ describe("addon resolution", function () {
         plugins: ["foo"],
       });
     }).toThrow(
-      /Cannot resolve module 'babel-plugin-foo'.*\n- Did you mean "@babel\/foo"\?/,
+      process.versions.node.startsWith("8.")
+        ? /Cannot resolve module 'babel-plugin-foo'/
+        : /Cannot resolve module 'babel-plugin-foo'.*\n- Did you mean "@babel\/foo"\?/,
     );
   });
 
@@ -400,7 +413,9 @@ describe("addon resolution", function () {
         presets: ["testplugin"],
       });
     }).toThrow(
-      /Cannot resolve module 'babel-preset-testplugin'.*\n- Did you accidentally pass a plugin as a preset\?/,
+      process.versions.node.startsWith("8.")
+        ? /Cannot resolve module 'babel-preset-testplugin'/
+        : /Cannot resolve module 'babel-preset-testplugin'.*\n- Did you accidentally pass a plugin as a preset\?/,
     );
   });
 
@@ -414,7 +429,9 @@ describe("addon resolution", function () {
         plugins: ["testpreset"],
       });
     }).toThrow(
-      /Cannot resolve module 'babel-plugin-testpreset'.*\n- Did you accidentally pass a preset as a plugin\?/,
+      process.versions.node.startsWith("8.")
+        ? /Cannot resolve module 'babel-plugin-testpreset'/
+        : /Cannot resolve module 'babel-plugin-testpreset'.*\n- Did you accidentally pass a preset as a plugin\?/,
     );
   });
 

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -346,8 +346,8 @@ describe("addon resolution", function () {
       });
     }).toThrow(
       // Todo(Babel 8): remove node checks in this file. We cannot test the desired behaviour
-      // because Jest 24 has issue on setting the MODULE_NOT_FOUND error when the native
-      // `require.resolv` is provided.
+      // because Jest 24 has an issue on setting the MODULE_NOT_FOUND error when the native
+      // `require.resolve` is provided.
       // see https://github.com/babel/babel/pull/12439/files#r535996000
       process.versions.node.startsWith("8.")
         ? /Cannot resolve module 'babel-preset-foo'/


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12650 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Manually tested `semverGte` with examples
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Currently we use `parseFloat` (#12458) to compare node versions and to apply polyfills conditionally, however it will fail, for example, on comparing `10.8` to `10.12`, which is the case in #12650.

The following affected packages should be republished:
- `@babel/cli`
- `@babel/node`
- `@babel/register`

We don't need to republish `@babel/transfrom-runtime` since only `scripts` is modified and we never build Babel on Node.js 10.