### PR TITLE
Polish `@babel/node` REPL

### DIFF
--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -219,6 +219,7 @@ function replStart() {
     output: process.stdout,
     eval: replEval,
     useGlobal: true,
+    preview: true,
   });
 }
 

--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -213,7 +213,7 @@ function requireArgs() {
 }
 
 function replStart() {
-  repl.start({
+  const replServer = repl.start({
     prompt: "babel > ",
     input: process.stdin,
     output: process.stdout,
@@ -221,6 +221,11 @@ function replStart() {
     useGlobal: true,
     preview: true,
   });
+  if (process.env.BABEL_8_BREAKING) {
+    replServer.setupHistory(process.env.NODE_REPL_HISTORY, () => {});
+  } else {
+    replServer.setupHistory?.(process.env.NODE_REPL_HISTORY, () => {});
+  }
 }
 
 function replEval(code, context, filename, callback) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10739
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR polishes the `@babel/node` REPL.
- Toggled on `preview: true` REPL options: it will output the preview (like Chrome DevTools did) of evaluation result on supported node.js version (v13.4.0, v12.17.0)
- setup history from `process.env.NODE_REPL_HISOTRY`, if it is not given, Node.js will default to `~/.node_repl_history` (v11.10.0). Although we could implement REPL history support for lower versions, I don't think it is worthy since Babel 8 will drop Node < 12 support. Thanks for @0xdevalias offering a detailed report (#10739) on this feature!

I marked this PR as Polish because there is no new options/methods added.