### PR TITLE
Fix "Add to CHANGELOG.md" commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,7 @@ jobs:
     outputs:
       is-main: ${{ steps.is-main.outputs.result == 1 }}
       changelog: ${{ steps.changelog.outputs.changelog }}
+      version: ${{ steps.tags.outputs.new }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -179,7 +180,7 @@ jobs:
         run: |
           git add CHANGELOG.md
           git -c user.name="Babel Bot" -c user.email="babel-bot@users.noreply.github.com" \
-            commit -m "Add ${{ steps.tags.outputs.new }} to CHANGELOG.md [skip ci]" --no-verify --quiet
+            commit -m "Add ${{ needs.github-release.outputs.version }} to CHANGELOG.md [skip ci]" --no-verify --quiet
 
       - name: Push to GitHub
         run: |


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I noticed one more minor problem in the release action: the "Add X to CHANGELOG.md" commit message doesn't include the version.

- New (wrong) commit: https://github.com/babel/babel/commit/4e2f8301dc963063985991b5f6cc2bbd1542cff3
- Old (correct) commit: https://github.com/babel/babel/commit/a038d787c616fdc6cef93cfe0e87d4aba85405d3