### PR TITLE
Reuse the `readOnlyError` helper for private methods

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -294,7 +294,9 @@ const privateNameHandlerSpec = {
           value,
         ]);
       }
-      return t.callExpression(file.addHelper("classPrivateMethodSet"), []);
+      return t.callExpression(file.addHelper("readOnlyError"), [
+        t.stringLiteral(`#${name}`),
+      ]);
     }
     return t.callExpression(file.addHelper("classPrivateFieldSet"), [
       this.receiver(member),

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -2092,11 +2092,14 @@ helpers.classPrivateMethodGet = helper("7.1.6")`
   }
 `;
 
-helpers.classPrivateMethodSet = helper("7.1.6")`
-  export default function _classPrivateMethodSet() {
-    throw new TypeError("attempted to reassign private method");
-  }
-`;
+if (!process.env.BABEL_8_BREAKING) {
+  // Use readOnlyError instead
+  helpers.classPrivateMethodSet = helper("7.1.6")`
+    export default function _classPrivateMethodSet() {
+      throw new TypeError("attempted to reassign private method");
+    }
+  `;
+}
 
 helpers.wrapRegExp = helper("7.2.6")`
   import wrapNativeSuper from "wrapNativeSuper";

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
@@ -14,7 +14,7 @@ class Cl {
       value: 0
     });
 
-    babelHelpers.classPrivateMethodSet();
+    babelHelpers.readOnlyError("#privateFieldValue");
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/exec.js
@@ -1,0 +1,9 @@
+class A {
+  #method() {}
+
+  run() {
+    this.#method = 2;
+  }
+}
+
+expect(() => new A().run()).toThrow(TypeError);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/input.js
@@ -1,0 +1,7 @@
+class A {
+  #method() {}
+
+  run() {
+    this.#method = 2;
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
@@ -1,0 +1,14 @@
+var _method = new WeakSet();
+
+class A {
+  constructor() {
+    _method.add(this);
+  }
+
+  run() {
+    babelHelpers.readOnlyError("#method");
+  }
+
+}
+
+var _method2 = function _method2() {};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

While reviewing https://github.com/babel/babel/pull/12707, I noticed that `classPrivateMethodSet` is basically the same as `readOnlyError` except that it doesn't say exactly _what_ cannot be reassigned.

The `readOnlyError` helper will throw something like `"#foo" is read-only"`, which is also more correct when reassigning a private getter (since it's not technically a method). Also, we avoid injecting two different helpers in the generated bundle.

This PR also removes `classPrivateMethodSet` for Babel 8.