### PR TITLE
[internal] Use the Node.js behavior for default imports

### DIFF
--- a/lib/babel-polyfills.js.flow
+++ b/lib/babel-polyfills.js.flow
@@ -1,9 +1,9 @@
 declare module "babel-plugin-polyfill-regenerator" {
-    declare module.exports: Function;
+  declare module.exports: { default: Function };
 }
 declare module "babel-plugin-polyfill-corejs2" {
-    declare module.exports: Function;
+  declare module.exports: { default: Function };
 }
 declare module "babel-plugin-polyfill-corejs3" {
-    declare module.exports: Function;
+  declare module.exports: { default: Function };
 }

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -13,9 +13,11 @@ import assert from "assert";
 import fs from "fs";
 import path from "path";
 import vm from "vm";
-import checkDuplicatedNodes from "babel-check-duplicated-nodes";
 import QuickLRU from "quick-lru";
 import escapeRegExp from "./escape-regexp.cjs";
+
+import _checkDuplicatedNodes from "babel-check-duplicated-nodes";
+const checkDuplicatedNodes = _checkDuplicatedNodes.default;
 
 const EXTERNAL_HELPERS_VERSION = "7.100.0";
 

--- a/packages/babel-highlight/src/index.ts
+++ b/packages/babel-highlight/src/index.ts
@@ -1,7 +1,8 @@
 /// <reference path="../../../lib/third-party-libs.d.ts" />
 
-import jsTokens, * as jsTokensNs from "js-tokens";
 import type { Token, JSXToken } from "js-tokens";
+import jsTokens from "js-tokens";
+
 import {
   isStrictReservedWord,
   isKeyword,
@@ -158,9 +159,6 @@ if (process.env.BABEL_8_BREAKING) {
     }
   };
 } else {
-  // This is only available in js-tokens@4, and not in js-tokens@6
-  const { matchToToken } = jsTokensNs as any;
-
   /**
    * RegExp to test for what seems to be a JSX tag name.
    */
@@ -204,8 +202,8 @@ if (process.env.BABEL_8_BREAKING) {
 
   tokenize = function* (text: string) {
     let match;
-    while ((match = (jsTokens as any).exec(text))) {
-      const token = matchToToken(match);
+    while ((match = (jsTokens as any).default.exec(text))) {
+      const token = (jsTokens as any).matchToToken(match);
 
       yield {
         type: getTokenType(token, match.index, text),

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -5,9 +5,12 @@ import { types as t } from "@babel/core";
 import { hasMinVersion } from "./helpers";
 import getRuntimePath from "./get-runtime-path";
 
-import pluginCorejs2 from "babel-plugin-polyfill-corejs2";
-import pluginCorejs3 from "babel-plugin-polyfill-corejs3";
-import pluginRegenerator from "babel-plugin-polyfill-regenerator";
+import _pluginCorejs2 from "babel-plugin-polyfill-corejs2";
+import _pluginCorejs3 from "babel-plugin-polyfill-corejs3";
+import _pluginRegenerator from "babel-plugin-polyfill-regenerator";
+const pluginCorejs2 = _pluginCorejs2.default;
+const pluginCorejs3 = _pluginCorejs3.default;
+const pluginRegenerator = _pluginRegenerator.default;
 
 const pluginsCompat = "#__secret_key__@babel/runtime__compatibility";
 

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -16,9 +16,12 @@ import overlappingPlugins from "@babel/compat-data/overlapping-plugins";
 import removeRegeneratorEntryPlugin from "./polyfills/regenerator";
 import legacyBabelPolyfillPlugin from "./polyfills/babel-polyfill";
 
-import pluginCoreJS2 from "babel-plugin-polyfill-corejs2";
-import pluginCoreJS3 from "babel-plugin-polyfill-corejs3";
-import pluginRegenerator from "babel-plugin-polyfill-regenerator";
+import _pluginCoreJS2 from "babel-plugin-polyfill-corejs2";
+import _pluginCoreJS3 from "babel-plugin-polyfill-corejs3";
+import _pluginRegenerator from "babel-plugin-polyfill-regenerator";
+const pluginCoreJS2 = _pluginCoreJS2.default;
+const pluginCoreJS3 = _pluginCoreJS3.default;
+const pluginRegenerator = _pluginRegenerator.default;
 
 import getTargets, {
   prettifyTargets,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is another step for https://github.com/babel/babel/issues/11701.

Node.s doesn't check if `__esModule` is defined when importing a CJS module from ESM, and the `default` import is _always_ mapped to `module.exports`. This is different from how Babel handles the interop, and this PR aligns the compilation behavior to Node.js to make it easier to migrate to native ESM.

We might also consider adding this as an option to `transform-modules-commonjs`, but for now I just added a small internal plugin (not 100% compliant, because it doesn't hoist compiled imports) to our config.

When this is merged, I will open a new PR to avoid using `__dirname`/`__filename`/`require` in our sources so that we'll only be using Node.js-compliant modules.