### PR TITLE
Register binding when transforming TSParameterProperty

### DIFF
--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.js
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.js
@@ -177,14 +177,14 @@ const rewriteReferencesVisitor = {
 
     const localName = path.node.name;
 
-    const localBinding = path.scope.getBinding(localName);
-    const rootBinding = scope.getBinding(localName);
-
-    // redeclared in this scope
-    if (rootBinding !== localBinding) return;
-
     const importData = imported.get(localName);
     if (importData) {
+      const localBinding = path.scope.getBinding(localName);
+      const rootBinding = scope.getBinding(localName);
+
+      // redeclared in this scope
+      if (rootBinding !== localBinding) return;
+
       const ref = buildImportReference(importData, path.node);
 
       // Preserve the binding location so that sourcemaps are nicer.

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -397,9 +397,13 @@ export default declare((api, opts) => {
         // We replace `TSParameterProperty` here so that transforms that
         // rely on a `Function` visitor to deal with arguments, like
         // `transform-parameters`, work properly.
-        node.params = node.params.map(p => {
-          return p.type === "TSParameterProperty" ? p.parameter : p;
-        });
+        const paramsPath = path.get("params");
+        for (const p of paramsPath) {
+          if (p.type === "TSParameterProperty") {
+            p.replaceWith(p.get("parameter"));
+            scope.registerBinding("param", p);
+          }
+        }
       },
 
       TSModuleDeclaration(path) {

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -384,13 +384,14 @@ export default declare((api, opts) => {
         });
       },
 
-      Function({ node }) {
+      Function(path) {
+        const { node, scope } = path;
         if (node.typeParameters) node.typeParameters = null;
         if (node.returnType) node.returnType = null;
 
-        const p0 = node.params[0];
-        if (p0 && t.isIdentifier(p0) && p0.name === "this") {
-          node.params.shift();
+        const params = node.params;
+        if (params.length > 0 && t.isIdentifier(params[0], { name: "this" })) {
+          params.shift();
         }
 
         // We replace `TSParameterProperty` here so that transforms that

--- a/packages/babel-plugin-transform-typescript/test/fixtures/regression/11061/input.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/regression/11061/input.mjs
@@ -1,0 +1,8 @@
+import { messaging } from 'firebase-admin'
+
+export class Something {
+  constructor(
+  	public messaging: messaging.Messaging
+  ) {
+  }
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/regression/11061/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/regression/11061/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins":["transform-typescript", "transform-classes", "transform-modules-commonjs"]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/regression/11061/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/regression/11061/output.js
@@ -1,0 +1,18 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.Something = void 0;
+
+var _firebaseAdmin = require("firebase-admin");
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+let Something = function Something(messaging) {
+  _classCallCheck(this, Something);
+
+  this.messaging = messaging;
+};
+
+exports.Something = Something;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11061 
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Although the issue #11061 is triggered from https://github.com/babel/babel/blob/c22e72eb24b9dd83d43e693067d9c856acf9977d/packages/babel-helper-module-transforms/src/rewrite-live-references.js#L180-L187

where both the local binding and root binding of `message` is `undefined` and therefore replaced by `firebaseAdmin.messging`, it should be fixed in `transform-typescript` when we transform `TSParameterProperty` to general function parameters.

I don't think the root binding of `message` should be `undefined`, too. But I prefer to fix that in another PR.