### PR TITLE
clean up traverse scope

### DIFF
--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -246,8 +246,6 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
   },
 
   LabeledStatement(path) {
-    // @ts-expect-error todo(flow->ts): possible bug - statement might not have name and so should not be added as global
-    path.scope.getProgramParent().addGlobal(path.node);
     path.scope.getBlockParent().registerDeclaration(path);
   },
 

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -203,10 +203,7 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
     if (path.isBlockScoped()) return;
 
     // this will be hit again once we traverse into it after this iteration
-    // @ts-expect-error todo(flow->ts): might be not correct for export all declaration
-    if (path.isExportDeclaration() && path.get("declaration").isDeclaration()) {
-      return;
-    }
+    if (path.isExportDeclaration()) return;
 
     // we've ran into a declaration!
     const parent =
@@ -228,7 +225,8 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
   ExportDeclaration: {
     exit(path) {
       const { node, scope } = path;
-      // @ts-expect-error todo(flow->ts) declaration is not present on ExportAllDeclaration
+      // ExportAllDeclaration does not have `declaration`
+      if (t.isExportAllDeclaration(node)) return;
       const declar = node.declaration;
       if (t.isClassDeclaration(declar) || t.isFunctionDeclaration(declar)) {
         const id = declar.id;

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -872,7 +872,7 @@ export default class Scope {
     this.crawling = true;
     // traverse does not visit the root node, here we explicitly collect
     // root node binding info when the root is not a Program.
-    if (programParent.path !== path && collectorVisitor._exploded) {
+    if (path.type !== "Program" && collectorVisitor._exploded) {
       // @ts-expect-error when collectorVisitor is exploded, `enter` always exists
       for (const visit of collectorVisitor.enter) {
         visit(path, state);

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -279,15 +279,6 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
     }
   },
 
-  Block(path) {
-    const paths = path.get("body");
-    for (const bodyPath of paths) {
-      if (bodyPath.isFunctionDeclaration()) {
-        path.scope.getBlockParent().registerDeclaration(bodyPath);
-      }
-    }
-  },
-
   CatchClause(path) {
     path.scope.registerBinding("let", path);
   },

--- a/packages/babel-traverse/test/__snapshots__/scope.js.snap
+++ b/packages/babel-traverse/test/__snapshots__/scope.js.snap
@@ -4,11 +4,15 @@ exports[`scope duplicate bindings catch const 1`] = `"Duplicate declaration \\"e
 
 exports[`scope duplicate bindings catch let 1`] = `"Duplicate declaration \\"e\\""`;
 
+exports[`scope duplicate bindings global class/class 1`] = `"Duplicate declaration \\"foo\\""`;
+
 exports[`scope duplicate bindings global class/const 1`] = `"Duplicate declaration \\"foo\\""`;
 
 exports[`scope duplicate bindings global class/function 1`] = `"Duplicate declaration \\"foo\\""`;
 
 exports[`scope duplicate bindings global class/let 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global class/var 1`] = `"Duplicate declaration \\"foo\\""`;
 
 exports[`scope duplicate bindings global const/class 1`] = `"Duplicate declaration \\"foo\\""`;
 
@@ -33,5 +37,7 @@ exports[`scope duplicate bindings global let/function 1`] = `"Duplicate declarat
 exports[`scope duplicate bindings global let/let 1`] = `"Duplicate declaration \\"foo\\""`;
 
 exports[`scope duplicate bindings global let/var 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global var/class 1`] = `"Duplicate declaration \\"foo\\""`;
 
 exports[`scope duplicate bindings global var/let 1`] = `"Duplicate declaration \\"foo\\""`;

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -92,6 +92,82 @@ describe("scope", () => {
       });
     });
 
+    describe("import declaration", () => {
+      it.each([
+        [
+          "import default",
+          "import foo from 'foo';(foo)=>{}",
+          "foo",
+          "ImportDefaultSpecifier",
+        ],
+        [
+          "import named default",
+          "import { default as foo } from 'foo';(foo)=>{}",
+          "foo",
+          "ImportSpecifier",
+        ],
+        [
+          "import named",
+          "import { foo } from 'foo';(foo)=>{}",
+          "foo",
+          "ImportSpecifier",
+        ],
+        [
+          "import named aliased",
+          "import { _foo as foo } from 'foo';(foo)=>{}",
+          "foo",
+          "ImportSpecifier",
+        ],
+        [
+          "import namespace",
+          "import * as foo from 'foo';(foo)=>{}",
+          "foo",
+          "ImportNamespaceSpecifier",
+        ],
+      ])("%s", (testTitle, source, bindingName, bindingNodeType) => {
+        expect(
+          getPath(source, { sourceType: "module" }).scope.getBinding(
+            bindingName,
+          ).path.type,
+        ).toBe(bindingNodeType);
+      });
+    });
+
+    describe("export declaration", () => {
+      it.each([
+        [
+          "export default function",
+          "export default function foo(foo) {}",
+          "foo",
+          "FunctionDeclaration",
+        ],
+        [
+          "export default class",
+          "export default class foo extends function foo () {} {}",
+          "foo",
+          "ClassDeclaration",
+        ],
+        [
+          "export named default",
+          "export const foo = function foo(foo) {};",
+          "foo",
+          "VariableDeclarator",
+        ],
+        [
+          "export named default",
+          "export const [ { foo } ] = function foo(foo) {};",
+          "foo",
+          "VariableDeclarator",
+        ],
+      ])("%s", (testTitle, source, bindingName, bindingNodeType) => {
+        expect(
+          getPath(source, { sourceType: "module" }).scope.getBinding(
+            bindingName,
+          ).path.type,
+        ).toBe(bindingNodeType);
+      });
+    });
+
     it("variable declaration", function () {
       expect(getPath("var foo = null;").scope.getBinding("foo").path.type).toBe(
         "VariableDeclarator",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Class Id is not available in class scope after `classPath.scope.crawl()`
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This PR generally cleans up internals of traverse scope, some notable changes:
- When `scope.crawl()` is initiated from non-program scope, it will now collect the binding info from the scope path. Before this PR only function declaration will be collected, the scope path is ignored from collection. Only descendants of scope path is collected.
- Remove duplicated `Block` handler in `collectorVisitor`, it is already handled in the `BlockScoped` handler because `FunctionDeclaration` is always a `Block`.