### PR TITLE
test: avoid deprecated jest.addMatchers

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -342,27 +342,26 @@ function normalizeOutput(code) {
   return result;
 }
 
-const toEqualFile = () => ({
-  compare: (actual, { filename, code }) => {
-    const pass = actual === code;
-    return {
-      pass,
-      message: () => {
-        const diffString = diff(code, actual, {
-          expand: false,
-        });
-        return (
-          `Expected ${filename} to match transform output.\n` +
-          `To autogenerate a passing version of this file, delete the file and re-run the tests.\n\n` +
-          `Diff:\n\n${diffString}`
-        );
-      },
-    };
-  },
-  negativeCompare: () => {
-    throw new Error("Negation unsupported");
-  },
-});
+const toEqualFile = (actual, { filename, code }) => {
+  const pass = actual === code;
+  return {
+    pass,
+    message: pass
+      ? () => {
+          throw new Error(".toEqualFile does not support negation");
+        }
+      : () => {
+          const diffString = diff(code, actual, {
+            expand: false,
+          });
+          return (
+            `Expected ${filename} to match transform output.\n` +
+            `To autogenerate a passing version of this file, delete the file and re-run the tests.\n\n` +
+            `Diff:\n\n${diffString}`
+          );
+        },
+  };
+};
 
 export default function (
   fixturesLoc: string,
@@ -377,7 +376,7 @@ export default function (
     if (suiteOpts.ignoreSuites?.includes(testSuite.title)) continue;
 
     describe(name + "/" + testSuite.title, function () {
-      jest.addMatchers({
+      expect.extend({
         toEqualFile,
       });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`jest.addMatchers` has been deprecated for ...umm, idk how long, I only recently learned it exists 😂... and is being removed in Jest 27.
Changing this now means you won't be scared by a hundred failing tests when upgrading (although there may of course be other breaking changes affecting you).
