### PR TITLE
babel-register: Don’t rewrite the cache if it’s not dirty

### DIFF
--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -13,6 +13,8 @@ const DEFAULT_FILENAME = path.join(
 const FILENAME: string = process.env.BABEL_CACHE_PATH || DEFAULT_FILENAME;
 let data: Object = {};
 
+let cacheDirty = false;
+
 let cacheDisabled = false;
 
 function isCacheDisabled() {
@@ -23,7 +25,9 @@ function isCacheDisabled() {
  */
 
 export function save() {
-  if (isCacheDisabled()) return;
+  if (isCacheDisabled() || !cacheDirty) return;
+  cacheDirty = false;
+
   let serialised: string = "{}";
 
   try {
@@ -110,6 +114,13 @@ due to a permission issue. Cache is disabled.`,
 
 export function get(): Object {
   return data;
+}
+
+/**
+ * Set the cache dirty bit.
+ */
+export function setDirty() {
+  cacheDirty = true;
 }
 
 /**

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -69,6 +69,7 @@ function compile(code, filename) {
     if (cache) {
       cache[cacheKey] = cached;
       cached.mtime = mtime(filename);
+      registerCache.setDirty();
     }
   }
 

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -30,7 +30,7 @@ function resetCache() {
 
 describe("@babel/register - caching", () => {
   describe("cache", () => {
-    let load, get, save;
+    let load, get, setDirty, save;
     let consoleWarnSpy;
 
     beforeEach(() => {
@@ -40,6 +40,7 @@ describe("@babel/register - caching", () => {
 
       load = cache.load;
       get = cache.get;
+      setDirty = cache.setDirty;
       save = cache.save;
 
       consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -73,15 +74,24 @@ describe("@babel/register - caching", () => {
       expect(get()).toEqual({});
     });
 
-    it("should create the cache on save", () => {
+    it("should not create the cache if not dirty", () => {
+      save();
+
+      expect(fs.existsSync(testCacheFilename)).toBe(false);
+      expect(get()).toEqual({});
+    });
+
+    it("should create the cache on save if dirty", () => {
+      setDirty();
       save();
 
       expect(fs.existsSync(testCacheFilename)).toBe(true);
       expect(get()).toEqual({});
     });
 
-    it("should create the cache after load", cb => {
+    it("should create the cache after dirty", cb => {
       load();
+      setDirty();
 
       process.nextTick(() => {
         expect(fs.existsSync(testCacheFilename)).toBe(true);
@@ -107,6 +117,7 @@ describe("@babel/register - caching", () => {
       writeCache({ foo: "bar" }, 0o466);
 
       load();
+      setDirty();
 
       expect(get()).toEqual({ foo: "bar" });
       process.nextTick(() => {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Fix `@babel/register` not to rewrite the cache if it’s not dirty. This saves time and avoids unnecessary SSD wear.