### PR TITLE
Run Babel asynchronously in `@babel/register`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,9 @@ jobs:
             yarn-
       - name: Build babel artifacts
         run: |
-          BABEL_ENV=test-legacy make -j build-standalone-ci
+          make -j build-standalone-ci
         env:
+          BABEL_ENV: test-ci
           BABEL_8_BREAKING: false
           STRIP_BABEL_8_FLAG: true
       - uses: actions/upload-artifact@v2
@@ -181,10 +182,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Use Node.js 12
+      - name: Use Node.js latest
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.18 # Node.js 12 is the first LTS supported by Babel 8
+          node-version: "*"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -193,11 +194,15 @@ jobs:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('yarn.lock') }}
       - name: Install and build
-        run: make -j bootstrap
+        run:  make -j bootstrap
         env:
-          BABEL_ENV: test
+          BABEL_ENV: test-ci
           BABEL_8_BREAKING: true
           STRIP_BABEL_8_FLAG: true
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: 12.17 # Node.js 12 is the first LTS supported by Babel 8
       - name: Test
         # Hack: --color has supports-color@5 returned true for GitHub CI
         # Remove once `chalk` is bumped to 4.0.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 12, 10, 8, 6]
+        node-version: [14, 12.18, 10, 8, 6]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -184,7 +184,7 @@ jobs:
       - name: Use Node.js 12
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 12 # Node.js 12 is the first LTS supported by Babel 8
+          node-version: 12.18 # Node.js 12 is the first LTS supported by Babel 8
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -11,6 +11,7 @@ import babel from "gulp-babel";
 import camelCase from "lodash/camelCase.js";
 import fancyLog from "fancy-log";
 import filter from "gulp-filter";
+import revertPath from "gulp-revert-path";
 import gulp from "gulp";
 import { rollup } from "rollup";
 import { babel as rollupBabel } from "@rollup/plugin-babel";
@@ -228,6 +229,10 @@ function buildBabel(exclude) {
           supportsDynamicImport: true,
         },
       })
+    )
+    .pipe(
+      // gulp-babel always converts the extension to .js, but we want to keep the original one
+      revertPath()
     )
     .pipe(
       // Passing 'file.relative' because newer() above uses a relative

--- a/babel.config.js
+++ b/babel.config.js
@@ -26,7 +26,7 @@ module.exports = function (api) {
 
   let transformRuntimeOptions;
 
-  const nodeVersion = "6.9";
+  const nodeVersion = bool(process.env.BABEL_8_BREAKING) ? "12.17" : "6.9";
   // The vast majority of our src files are modules, but we use
   // unambiguous to keep things simple until we get around to renaming
   // the modules to be more easily distinguished from CommonJS
@@ -57,7 +57,7 @@ module.exports = function (api) {
       if (env === "rollup") envOpts.targets = { node: nodeVersion };
       needsPolyfillsForOldNode = true;
       break;
-    case "test-legacy": // In test-legacy environment, we build babel on latest node but test on minimum supported legacy versions
+    case "test-ci": // In test-ci environment, we build babel on latest node but test on minimum supported legacy versions
     case "production":
       // Config during builds before publish.
       envOpts.targets = {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gulp-filter": "^5.1.0",
     "gulp-newer": "^1.0.0",
     "gulp-plumber": "^1.2.1",
+    "gulp-revert-path": "^2.0.0",
     "husky": "^3.0.0",
     "jest": "^26.6.1",
     "lint-staged": "^9.2.0",

--- a/packages/babel-core/src/config/pattern-to-regex.js
+++ b/packages/babel-core/src/config/pattern-to-regex.js
@@ -2,7 +2,7 @@
 import path from "path";
 
 // $FlowIgnore
-import escapeRegExp from "./helpers/escape-regexp";
+import escapeRegExp from "./helpers/escape-regexp.cjs";
 
 const sep = `\\${path.sep}`;
 const endSep = `(?:${sep}|$)`;

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -16,7 +16,7 @@ import vm from "vm";
 import checkDuplicatedNodes from "babel-check-duplicated-nodes";
 import QuickLRU from "quick-lru";
 import diff from "jest-diff";
-import escapeRegExp from "./escape-regexp";
+import escapeRegExp from "./escape-regexp.cjs";
 
 const cachedScripts = new QuickLRU({ maxSize: 10 });
 const contextModuleCache = new WeakMap();

--- a/packages/babel-register/async.js
+++ b/packages/babel-register/async.js
@@ -1,0 +1,1 @@
+module.exports = require("./lib/async/index.cjs");

--- a/packages/babel-register/src/async/hook.cjs
+++ b/packages/babel-register/src/async/hook.cjs
@@ -1,0 +1,135 @@
+"use strict";
+
+const sourceMapSupport = require("source-map-support");
+const { addHook } = require("pirates");
+const fs = require("fs");
+const path = require("path");
+const { DEFAULT_EXTENSIONS } = require("@babel/core");
+
+const escapeRegExp = require("../escape-regexp.cjs");
+const registerCache = require("../cache");
+const worker = require("./worker-interface.cjs");
+
+const maps = {};
+let transformOpts = {};
+let piratesRevert = null;
+
+function installSourceMapSupport() {
+  sourceMapSupport.install({
+    handleUncaughtExceptions: false,
+    environment: "node",
+    retrieveSourceMap(source) {
+      const map = maps && maps[source];
+      if (map) {
+        return {
+          url: null,
+          map: map,
+        };
+      } else {
+        return null;
+      }
+    },
+  });
+}
+
+let cache;
+
+function mtime(filename) {
+  return +fs.statSync(filename).mtime;
+}
+
+function compile(code, filename) {
+  // merge in base options and resolve all the plugins and presets relative to this file
+
+  const ref = worker.loadOptions(filename, transformOpts);
+
+  // Bail out ASAP if the file has been ignored.
+  if (!ref) return code;
+
+  const { cacheKey, optionsId } = ref;
+
+  let cached = cache && cache[cacheKey];
+
+  if (!cached || cached.mtime !== mtime(filename)) {
+    cached = worker.compile(code, optionsId);
+
+    if (cache) {
+      cache[cacheKey] = cached;
+      cached.mtime = mtime(filename);
+      registerCache.setDirty();
+    }
+  }
+
+  if (cached.map) {
+    if (Object.keys(maps).length === 0) {
+      installSourceMapSupport();
+    }
+    maps[filename] = cached.map;
+  }
+
+  return cached.code;
+}
+
+function hookExtensions(exts) {
+  if (piratesRevert) piratesRevert();
+  piratesRevert = addHook(compile, { exts, ignoreNodeModules: false });
+}
+
+exports.revert = function revert() {
+  if (piratesRevert) piratesRevert();
+};
+
+exports.register = function register(opts?: Object = {}) {
+  // Clone to avoid mutating the arguments object with the 'delete's below.
+  opts = {
+    ...opts,
+  };
+  hookExtensions(opts.extensions || DEFAULT_EXTENSIONS);
+
+  if (opts.cache === false && cache) {
+    registerCache.clear();
+    cache = null;
+  } else if (opts.cache !== false && !cache) {
+    registerCache.load();
+    cache = registerCache.get();
+  }
+
+  delete opts.extensions;
+  delete opts.cache;
+
+  transformOpts = {
+    ...opts,
+    caller: {
+      name: "@babel/register",
+      ...(opts.caller || {}),
+    },
+  };
+
+  let { cwd = "." } = transformOpts;
+
+  // Ensure that the working directory is resolved up front so that
+  // things don't break if it changes later.
+  cwd = transformOpts.cwd = path.resolve(cwd);
+
+  if (transformOpts.ignore === undefined && transformOpts.only === undefined) {
+    transformOpts.only = [
+      // Only compile things inside the current working directory.
+      // $FlowIgnore
+      new RegExp("^" + escapeRegExp(cwd), "i"),
+    ];
+    transformOpts.ignore = [
+      // Ignore any node_modules inside the current working directory.
+      new RegExp(
+        "^" +
+          // $FlowIgnore
+          escapeRegExp(cwd) +
+          "(?:" +
+          path.sep +
+          ".*)?" +
+          // $FlowIgnore
+          escapeRegExp(path.sep + "node_modules" + path.sep),
+        "i"
+      ),
+    ];
+  }
+};

--- a/packages/babel-register/src/async/index.cjs
+++ b/packages/babel-register/src/async/index.cjs
@@ -1,0 +1,18 @@
+"use strict";
+
+/**
+ * This file wraps the compiled ES6 module implementation of register so
+ * that it can be used both from a standard CommonJS environment, and also
+ * from a compiled Babel import.
+ */
+
+const { register, revert } = require("./hook.cjs");
+
+exports = module.exports = function (...args) {
+  return register(...args);
+};
+exports.__esModule = true;
+exports.default = exports;
+exports.revert = revert;
+
+register();

--- a/packages/babel-register/src/async/worker-interface.cjs
+++ b/packages/babel-register/src/async/worker-interface.cjs
@@ -1,0 +1,69 @@
+"use strict";
+
+const [major, minor] = process.versions.node.split(".");
+if (
+  +major < 12 ||
+  (+major === 12 && +minor < 17) ||
+  (+major === 13 && +minor < 2)
+) {
+  throw new Error("@babel/runtime/async requires Node.js ^12.17 || >= 13.2");
+}
+
+const {
+  Worker,
+  MessageChannel,
+  receiveMessageOnPort,
+  SHARE_ENV,
+} = require("worker_threads");
+const assert = require("assert");
+
+let worker;
+let signal;
+let channel;
+
+function messageSync(message, transfer) {
+  Atomics.store(signal, 0, 0);
+  worker.postMessage(message, transfer);
+  Atomics.wait(signal, 0, 0);
+
+  const response = receiveMessageOnPort(channel.port2).message;
+  if (response.type === "error") throw response.error;
+  return response;
+}
+
+function init() {
+  worker = new Worker(__dirname + "/worker.cjs", { env: SHARE_ENV });
+  signal = new Int32Array(new SharedArrayBuffer(4));
+  channel = new MessageChannel();
+
+  messageSync({ type: "init", signal, port: channel.port1 }, [channel.port1]);
+
+  worker.unref();
+  channel.port2.unref();
+}
+
+exports.loadOptions = function message(filename, opts) {
+  if (!worker) init();
+
+  const result = messageSync({ type: "loadOptions", filename, opts });
+
+  if (result.type === "ignored") return null;
+  assert.strictEqual(result.type, "cacheKey");
+
+  return { cacheKey: result.cacheKey, optionsId: result.optionsId };
+};
+
+exports.compile = function message(code, optionsId) {
+  if (!worker) init();
+
+  const result = messageSync({
+    type: "compile",
+    optionsId,
+    // code could be a buffer
+    code: code.toString(),
+  });
+
+  assert.strictEqual(result.type, "result");
+
+  return { code: result.code, map: result.map };
+};

--- a/packages/babel-register/src/async/worker.cjs
+++ b/packages/babel-register/src/async/worker.cjs
@@ -1,0 +1,95 @@
+"use strict";
+
+const path = require("path");
+const { parentPort } = require("worker_threads");
+
+const babelP = import("@babel/core");
+
+let signal, port;
+
+const loadedOptions = new Map();
+let nextLoadedOptionsId = 0n;
+
+function assertInitialized() {
+  if (!signal) {
+    throw new Error("@babel/register worker has not been initialized yet.");
+  }
+}
+
+const handlers = {
+  init(message) {
+    if (signal) {
+      throw new Error("@babel/register worker has already been initialized.");
+    }
+
+    ({ signal, port } = message);
+
+    return { type: "initialized" };
+  },
+  async loadOptions(message) {
+    assertInitialized();
+
+    const { default: babel } = await babelP;
+
+    const opts = await babel.loadOptionsAsync({
+      // sourceRoot can be overwritten
+      sourceRoot: path.dirname(message.filename) + path.sep,
+      ...message.opts,
+      filename: message.filename,
+    });
+
+    if (!opts) return { type: "ignored" };
+
+    let cacheKey = `${JSON.stringify(opts)}:${babel.version}`;
+
+    const env = babel.getEnv(false);
+    if (env) cacheKey += `:${env}`;
+
+    const optionsId = nextLoadedOptionsId++;
+    loadedOptions.set(optionsId, opts);
+
+    return { type: "cacheKey", cacheKey, optionsId };
+  },
+  async compile(message) {
+    assertInitialized();
+
+    const { default: babel } = await babelP;
+
+    const { code, optionsId } = message;
+    if (!loadedOptions.has(optionsId)) {
+      throw new Error(`Unkwown options id: ${optionsId}`);
+    }
+
+    const opts = loadedOptions.get(optionsId);
+    loadedOptions.delete(optionsId);
+
+    const result = await babel.transformAsync(code, {
+      ...opts,
+      sourceMaps: opts.sourceMaps === undefined ? "both" : opts.sourceMaps,
+      ast: false,
+    });
+
+    return { type: "result", code: result.code, map: result.map };
+  },
+  __default__(message) {
+    throw new Error("Unknown message: " + message.type);
+  },
+};
+
+parentPort.addListener("message", async message => {
+  try {
+    const handler = handlers[message.type] || handlers.__default__;
+    const result = await handler(message);
+    send(result);
+  } catch (error) {
+    send({ type: "error", error });
+  }
+});
+
+function send(message) {
+  port.postMessage(message);
+  // Change the value of signal[0] to 1
+  Atomics.store(signal, 0, 1);
+  // This will unlock the main thread when we notify it
+  Atomics.notify(signal, 0);
+}

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -7,7 +7,7 @@ import { addHook } from "pirates";
 import fs from "fs";
 import path from "path";
 import Module from "module";
-import escapeRegExp from "./escape-regexp";
+import escapeRegExp from "./escape-regexp.cjs";
 
 const maps = {};
 let transformOpts = {};

--- a/packages/babel-register/test/async.js
+++ b/packages/babel-register/test/async.js
@@ -1,0 +1,260 @@
+import fs from "fs";
+import path from "path";
+import child from "child_process";
+
+let currentHook;
+let currentOptions;
+let sourceMapSupport = false;
+
+const registerFile = require.resolve("../async.js");
+const testCacheFilename = path.join(__dirname, ".babel");
+const testFile = require.resolve("./fixtures/babelrc/es2015");
+const testFileContent = fs.readFileSync(testFile);
+const sourceMapTestFile = require.resolve("./fixtures/source-map/index");
+const sourceMapNestedTestFile = require.resolve(
+  "./fixtures/source-map/foo/bar",
+);
+const internalModulesTestFile = require.resolve(
+  "./fixtures/internal-modules/index",
+);
+
+jest.mock("pirates", () => {
+  return {
+    addHook(hook, opts) {
+      currentHook = hook;
+      currentOptions = opts;
+
+      return () => {
+        currentHook = null;
+        currentOptions = null;
+      };
+    },
+  };
+});
+
+jest.mock("source-map-support", () => {
+  return {
+    install() {
+      sourceMapSupport = true;
+    },
+  };
+});
+
+const defaultOptions = {
+  exts: [".js", ".jsx", ".es6", ".es", ".mjs"],
+  ignoreNodeModules: false,
+};
+
+function cleanCache() {
+  try {
+    fs.unlinkSync(testCacheFilename);
+  } catch (e) {
+    // It is convenient to always try to clear
+  }
+}
+
+function resetCache() {
+  process.env.BABEL_CACHE_PATH = null;
+}
+
+const describeGe12 =
+  parseInt(process.versions.node) >= 12 ? describe : describe.skip;
+
+describeGe12("@babel/register/async", function () {
+  let babelRegister;
+
+  function setupRegister(config = { babelrc: false }) {
+    process.env.BABEL_CACHE_PATH = testCacheFilename;
+    config = {
+      cwd: path.dirname(testFile),
+      ...config,
+    };
+
+    babelRegister = require(registerFile);
+    babelRegister.default(config);
+  }
+
+  function revertRegister() {
+    if (babelRegister) {
+      babelRegister.revert();
+      delete require.cache[registerFile];
+      babelRegister = null;
+    }
+    cleanCache();
+  }
+
+  afterEach(async () => {
+    // @babel/register saves the cache on process.nextTick.
+    // We need to wait for at least one tick so that when jest
+    // tears down the testing environment @babel/register has
+    // already finished.
+    await new Promise(setImmediate);
+
+    revertRegister();
+    currentHook = null;
+    currentOptions = null;
+    sourceMapSupport = false;
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    resetCache();
+  });
+
+  test("registers hook correctly", () => {
+    setupRegister();
+
+    expect(typeof currentHook).toBe("function");
+    expect(currentOptions).toEqual(defaultOptions);
+  });
+
+  test("unregisters hook correctly", () => {
+    setupRegister();
+    revertRegister();
+
+    expect(currentHook).toBeNull();
+    expect(currentOptions).toBeNull();
+  });
+
+  test("installs source map support by default", () => {
+    setupRegister();
+
+    currentHook("const a = 1;", testFile);
+
+    expect(sourceMapSupport).toBe(true);
+  });
+
+  test("installs source map support when requested", () => {
+    setupRegister({
+      babelrc: false,
+      sourceMaps: true,
+    });
+
+    currentHook("const a = 1;", testFile);
+
+    expect(sourceMapSupport).toBe(true);
+  });
+
+  test("does not install source map support if asked not to", () => {
+    setupRegister({
+      babelrc: false,
+      sourceMaps: false,
+    });
+
+    currentHook("const a = 1;", testFile);
+
+    expect(sourceMapSupport).toBe(false);
+  });
+
+  it("returns concatenatable sourceRoot and sources", callback => {
+    // The Source Maps R3 standard https://sourcemaps.info/spec.html states
+    // that `sourceRoot` is “prepended to the individual entries in the
+    // ‘source’ field.” If `sources` contains file names, and `sourceRoot`
+    // is intended to refer to a directory but doesn’t end with a trailing
+    // slash, any consumers of the source map are in for a bad day.
+    //
+    // The underlying problem seems to only get triggered if one file
+    // requires() another with @babel/register active, and I couldn’t get
+    // that working inside a test, possibly because of jest’s mocking
+    // hooks, so we spawn a separate process.
+
+    spawnNode(["-r", registerFile, sourceMapTestFile], output => {
+      let err;
+
+      try {
+        const sourceMap = JSON.parse(output);
+        expect(sourceMap.map.sourceRoot + sourceMap.map.sources[0]).toBe(
+          sourceMapNestedTestFile,
+        );
+      } catch (e) {
+        err = e;
+      }
+
+      callback(err);
+    });
+  });
+
+  test("hook transpiles with config", () => {
+    setupRegister({
+      babelrc: false,
+      sourceMaps: false,
+      plugins: ["@babel/transform-modules-commonjs"],
+    });
+
+    const result = currentHook(testFileContent, testFile);
+
+    expect(result).toBe('"use strict";\n\nrequire("assert");');
+  });
+
+  test("hook transpiles with babelrc", () => {
+    setupRegister({
+      babelrc: true,
+      sourceMaps: false,
+    });
+
+    const result = currentHook(testFileContent, testFile);
+
+    expect(result).toBe('"use strict";\n\nrequire("assert");');
+  });
+
+  test("hook supports .mjs config files", () => {
+    const mjsConfigTestFile = require.resolve(
+      "./fixtures/mjs-config/babel.config.mjs",
+    );
+    const mjsTestFile = require.resolve("./fixtures/mjs-config/es2015.js");
+    const mjsTestFileContent = fs.readFileSync(mjsTestFile);
+    const cwd = path.dirname(mjsConfigTestFile);
+
+    setupRegister({
+      configFile: mjsConfigTestFile,
+      babelrc: false,
+      sourceMaps: false,
+      cwd,
+    });
+
+    const result = currentHook(mjsTestFileContent, mjsTestFile);
+
+    expect(result).toBe('"use strict";\n\nrequire("assert");');
+  });
+
+  test("transforms modules used within register", callback => {
+    // Need a clean environment without `convert-source-map`
+    // and `lodash/isPlainObject` already in the require cache,
+    // so we spawn a separate process
+
+    spawnNode([internalModulesTestFile], output => {
+      let err;
+
+      try {
+        const { convertSourceMap, isPlainObject } = JSON.parse(output);
+        expect(convertSourceMap).toMatch("/* transformed */");
+        expect(isPlainObject).toMatch("/* transformed */");
+      } catch (e) {
+        err = e;
+      }
+
+      callback(err);
+    });
+  });
+});
+
+function spawnNode(args, callback) {
+  const spawn = child.spawn(process.execPath, args, { cwd: __dirname });
+
+  let output = "";
+
+  for (const stream of [spawn.stderr, spawn.stdout]) {
+    stream.on("data", chunk => {
+      output += chunk;
+    });
+  }
+
+  spawn.on("close", function () {
+    output = output.replace(
+      /\(node:\d+\) ExperimentalWarning: The ESM module loader is experimental\./g,
+      "",
+    );
+
+    callback(output);
+  });
+}

--- a/packages/babel-register/test/fixtures/mjs-config/babel.config.mjs
+++ b/packages/babel-register/test/fixtures/mjs-config/babel.config.mjs
@@ -1,0 +1,3 @@
+export default {
+    plugins: ["@babel/plugin-transform-modules-commonjs"]
+};

--- a/packages/babel-register/test/fixtures/mjs-config/es2015.js
+++ b/packages/babel-register/test/fixtures/mjs-config/es2015.js
@@ -1,0 +1,1 @@
+import "assert";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4882,6 +4882,7 @@ __metadata:
     gulp-filter: ^5.1.0
     gulp-newer: ^1.0.0
     gulp-plumber: ^1.2.1
+    gulp-revert-path: ^2.0.0
     husky: ^3.0.0
     jest: ^26.6.1
     lint-staged: ^9.2.0
@@ -7757,6 +7758,15 @@ fsevents@^1.2.7:
     plugin-error: ^0.1.2
     through2: ^2.0.3
   checksum: 1c1cad8ddc0c578784641684e9dd4cad3b35a102a358e15fe04a1cd82fb1d0c88bf9ed44e3cbf1abadad7d2c8f402b23570e923283522a08e61843d07d4fdf6a
+  languageName: node
+  linkType: hard
+
+"gulp-revert-path@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "gulp-revert-path@npm:2.0.0"
+  dependencies:
+    through2: ^2.0.0
+  checksum: c2b01db2942c084f8cb11cecff22663a3ab894cdf43daed601bdaa9c713797e11739415b46f18342171fb0c65c1fe57d18dd40f93da403002e99f453b5661d77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Require hooks must run synchronously, but Babel might need to run asynchronously (for example, if there is a `.mjs` config file or plugin).

While it's currently possible to stick to a sync solution (you just need to use a JSON or CJS config file), if we release Babel as ESM it will be impossible to `require("@babel/core")` synchronously before registering the require hook.
We could "solve" it by asking our users to do
```js
import("@babel/register").then(() => require("./entry-point"));
```
instead of
```js
require("@babel/register");
require("./entry-point");
```

but that doesn't solve the problem when using the `node -r` option (https://github.com/babel/babel/issues/11701#issuecomment-780200445).

This PR avoid the problem by moving the compilation to a worker, so that we can load and run Babel asynchronously.

It should be almost 100% backward compatible, except that:
1. It won't be possible to pass function plugins to `@babel/register`'s options, because they aren't serializable. This can be easily solved by moving the plugins to a config file.
2. It requires Node.js ^12.7 (which has `receiveMessageOnPort` support). I set the minimun requirement to ^12.17, which is the version with native ESM support.

I introduced this new implementation at `@babel/register/async` so that we don't introduce breaking changes, but it should become the default in Babel 8.