### PR TITLE
fix: add regenerate-unicode-properties to dynamicRequireTargets

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -292,6 +292,10 @@ function buildRollup(packages, targetBrowsers) {
               "packages/babel-compat-data/*.js",
               "packages/*/src/**/*.cjs",
             ],
+            dynamicRequireTargets: [
+              // https://github.com/mathiasbynens/regexpu-core/blob/ffd8fff2e31f4597f6fdfee75d5ac1c5c8111ec3/rewrite-pattern.js#L48
+              "node_modules/regenerate-unicode-properties/**",
+            ],
           }),
           rollupBabel({
             envName: babelEnvName,

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -244,7 +244,8 @@ export default function resolveChain(baseUrl, ...packages) {
   const require = createRequire(baseUrl);
 
   return packages.reduce(
-    (base, pkg) => require.resolve(pkg, { paths: [path.dirname(base)] }),
+    (base, pkg) =>
+      require.resolve(pkg + "/package.json", { paths: [path.dirname(base)] }),
     fileURLToPath(baseUrl)
   );
 }
@@ -310,7 +311,7 @@ function buildRollup(packages, targetBrowsers) {
                 import.meta.url,
                 "./packages/babel-helper-create-regexp-features-plugin",
                 "regexpu-core",
-                "regenerate-unicode-properties/package.json"
+                "regenerate-unicode-properties"
               ) + "/../**",
             ],
           }),

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -237,6 +237,18 @@ function buildBabel(exclude) {
     .pipe(gulp.dest(base));
 }
 
+/**
+ * Resolve a nested dependency starting from the given file
+ */
+export default function resolveChain(baseUrl, ...packages) {
+  const require = createRequire(baseUrl);
+
+  return packages.reduce(
+    (base, pkg) => require.resolve(pkg, { paths: [path.dirname(base)] }),
+    fileURLToPath(baseUrl)
+  );
+}
+
 // If this build is part of a pull request, include the pull request number in
 // the version number.
 let versionSuffix = "";
@@ -294,7 +306,12 @@ function buildRollup(packages, targetBrowsers) {
             ],
             dynamicRequireTargets: [
               // https://github.com/mathiasbynens/regexpu-core/blob/ffd8fff2e31f4597f6fdfee75d5ac1c5c8111ec3/rewrite-pattern.js#L48
-              "node_modules/regenerate-unicode-properties/**",
+              resolveChain(
+                import.meta.url,
+                "./packages/babel-helper-create-regexp-features-plugin",
+                "regexpu-core",
+                "regenerate-unicode-properties/package.json"
+              ) + "/../**",
             ],
           }),
           rollupBabel({

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -240,7 +240,7 @@ function buildBabel(exclude) {
 /**
  * Resolve a nested dependency starting from the given file
  */
-export default function resolveChain(baseUrl, ...packages) {
+function resolveChain(baseUrl, ...packages) {
   const require = createRequire(baseUrl);
 
   return packages.reduce(

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -217,6 +217,13 @@
           }),
         ).not.toThrow();
       });
+      it("#12815 - unicode property letter short alias should be transformed", () => {
+        expect(() =>
+          Babel.transform("/\\p{L}/u", {
+            plugins: ["proposal-unicode-property-regex"],
+          }),
+        ).not.toThrow();
+      });
     });
   },
 );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12815, closes https://github.com/babel/website/issues/2426
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The confusing error unknown `L` is thrown because Rollup complains `regenerate-unicode-properties` should be added to `dynamicRequireTargets`, which is then caught in 

https://github.com/mathiasbynens/regexpu-core/blob/ffd8fff2e31f4597f6fdfee75d5ac1c5c8111ec3/rewrite-pattern.js#L64

resulting to a complete different error message.