### PR TITLE
[internal] Keep the `.cjs` extension when compiling source files

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -11,6 +11,7 @@ import babel from "gulp-babel";
 import camelCase from "lodash/camelCase.js";
 import fancyLog from "fancy-log";
 import filter from "gulp-filter";
+import revertPath from "gulp-revert-path";
 import gulp from "gulp";
 import { rollup } from "rollup";
 import { babel as rollupBabel } from "@rollup/plugin-babel";
@@ -228,6 +229,10 @@ function buildBabel(exclude) {
           supportsDynamicImport: true,
         },
       })
+    )
+    .pipe(
+      // gulp-babel always converts the extension to .js, but we want to keep the original one
+      revertPath()
     )
     .pipe(
       // Passing 'file.relative' because newer() above uses a relative

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gulp-filter": "^5.1.0",
     "gulp-newer": "^1.0.0",
     "gulp-plumber": "^1.2.1",
+    "gulp-revert-path": "^2.0.0",
     "husky": "^3.0.0",
     "jest": "^26.6.1",
     "lint-staged": "^9.2.0",

--- a/packages/babel-core/src/config/pattern-to-regex.js
+++ b/packages/babel-core/src/config/pattern-to-regex.js
@@ -2,7 +2,7 @@
 import path from "path";
 
 // $FlowIgnore
-import escapeRegExp from "./helpers/escape-regexp";
+import escapeRegExp from "./helpers/escape-regexp.cjs";
 
 const sep = `\\${path.sep}`;
 const endSep = `(?:${sep}|$)`;

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -15,7 +15,7 @@ import path from "path";
 import vm from "vm";
 import checkDuplicatedNodes from "babel-check-duplicated-nodes";
 import QuickLRU from "quick-lru";
-import escapeRegExp from "./escape-regexp";
+import escapeRegExp from "./escape-regexp.cjs";
 
 const cachedScripts = new QuickLRU({ maxSize: 10 });
 const contextModuleCache = new WeakMap();

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -7,7 +7,7 @@ import { addHook } from "pirates";
 import fs from "fs";
 import path from "path";
 import Module from "module";
-import escapeRegExp from "./escape-regexp";
+import escapeRegExp from "./escape-regexp.cjs";
 
 const maps = {};
 let transformOpts = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4851,6 +4851,7 @@ __metadata:
     gulp-filter: ^5.1.0
     gulp-newer: ^1.0.0
     gulp-plumber: ^1.2.1
+    gulp-revert-path: ^2.0.0
     husky: ^3.0.0
     jest: ^26.6.1
     lint-staged: ^9.2.0
@@ -7719,6 +7720,15 @@ fsevents@^1.2.7:
     plugin-error: ^0.1.2
     through2: ^2.0.3
   checksum: 1c1cad8ddc0c578784641684e9dd4cad3b35a102a358e15fe04a1cd82fb1d0c88bf9ed44e3cbf1abadad7d2c8f402b23570e923283522a08e61843d07d4fdf6a
+  languageName: node
+  linkType: hard
+
+"gulp-revert-path@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "gulp-revert-path@npm:2.0.0"
+  dependencies:
+    through2: ^2.0.0
+  checksum: c2b01db2942c084f8cb11cecff22663a3ab894cdf43daed601bdaa9c713797e11739415b46f18342171fb0c65c1fe57d18dd40f93da403002e99f453b5661d77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Extracted from https://github.com/babel/babel/pull/12814. With this PR, our gulp setup will transform the input files extensions as follows:
- `.ts` -> `.js`
- `.d.ts` -> `.d.ts`
- `.js` -> `.js`
- `.cjs` -> `.cjs`
- `.mjs` -> `.mjs`

This is needed because, when preparing our code base for the ESM switch, we need to make sure that some files (`.cjs`) only contain CJS and aren't interpreted as ESM if we add `"type": "module"` to `package.json` files.

Fyi, I opened babel/gulp-babel#211 to discuss making this an option of `gulp-babel`.