### PR TITLE
fix: create IPC channel for spawned babel-node process

### DIFF
--- a/packages/babel-node/src/babel-node.js
+++ b/packages/babel-node/src/babel-node.js
@@ -81,7 +81,7 @@ getV8Flags(function (err, v8Flags) {
 
     const child_process = require("child_process");
     const proc = child_process.spawn(process.argv[0], args, {
-      stdio: "inherit",
+      stdio: ["inherit", "inherit", "inherit", "ipc"],
     });
     proc.on("exit", function (code, signal) {
       process.on("exit", function () {

--- a/packages/babel-node/test/fixtures/babel-node/subprocess-send/in-files/payload.js
+++ b/packages/babel-node/test/fixtures/babel-node/subprocess-send/in-files/payload.js
@@ -1,0 +1,2 @@
+process.send({ hello: "world" });
+console.log("sent");

--- a/packages/babel-node/test/fixtures/babel-node/subprocess-send/options.json
+++ b/packages/babel-node/test/fixtures/babel-node/subprocess-send/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["payload.js"],
+  "stdout": "sent"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #4554 
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Per [`options.stdio` docs](https://nodejs.org/api/child_process.html#child_process_options_stdio), providing `"ipc"` as the fourth `stdio` file descriptor will instruct Node.js to create an IPC channel for sub process so that `process.send` and `process.disconnect()` is enabled.