### PR TITLE
Don't use `useESModules` in `@babel/runtime` build script

### DIFF
--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -230,10 +230,7 @@ function buildHelper(
       ],
     ],
     plugins: [
-      [
-        transformRuntime,
-        { corejs, useESModules: esm, version: runtimeVersion },
-      ],
+      [transformRuntime, { corejs, version: runtimeVersion }],
       buildRuntimeRewritePlugin(runtimeName, helperName),
       esm ? null : addDefaultCJSExport,
     ].filter(Boolean),


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Removes warning in `make bootstrap`
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We are using `@babel/plugin-transform-runtime` from the monorepo itself to build `@babel/runtime`, so after https://github.com/babel/babel/pull/12632 `useESModules` is not needed anymore.

This doesn't change the committed helpers (https://github.com/babel/babel/tree/main/packages/babel-runtime/helpers), as expected.