### PR TITLE
Add `es6.array.slice` in corejs2 builtins

### DIFF
--- a/packages/babel-compat-data/data/corejs2-built-ins.json
+++ b/packages/babel-compat-data/data/corejs2-built-ins.json
@@ -1,4 +1,15 @@
 {
+  "es6.array.concat": {
+    "chrome": "51",
+    "opera": "38",
+    "edge": "15",
+    "firefox": "48",
+    "safari": "10",
+    "node": "6.5",
+    "ios": "10",
+    "samsung": "5",
+    "electron": "1.2"
+  },
   "es6.array.copy-within": {
     "chrome": "45",
     "opera": "32",
@@ -36,18 +47,15 @@
     "electron": "0.31"
   },
   "es6.array.filter": {
-    "chrome": "5",
-    "opera": "10.10",
-    "edge": "12",
-    "firefox": "2",
-    "safari": "3.1",
-    "node": "0.10",
-    "ie": "9",
-    "android": "4",
-    "ios": "6",
-    "phantom": "2",
-    "samsung": "1",
-    "electron": "0.20"
+    "chrome": "51",
+    "opera": "38",
+    "edge": "13",
+    "firefox": "48",
+    "safari": "10",
+    "node": "6.5",
+    "ios": "10",
+    "samsung": "5",
+    "electron": "1.2"
   },
   "es6.array.find": {
     "chrome": "45",
@@ -172,18 +180,15 @@
     "electron": "0.20"
   },
   "es6.array.map": {
-    "chrome": "5",
-    "opera": "10.10",
-    "edge": "12",
-    "firefox": "2",
-    "safari": "3.1",
-    "node": "0.10",
-    "ie": "9",
-    "android": "4",
-    "ios": "6",
-    "phantom": "2",
-    "samsung": "1",
-    "electron": "0.20"
+    "chrome": "51",
+    "opera": "38",
+    "edge": "13",
+    "firefox": "48",
+    "safari": "10",
+    "node": "6.5",
+    "ios": "10",
+    "samsung": "5",
+    "electron": "1.2"
   },
   "es6.array.of": {
     "chrome": "45",
@@ -262,6 +267,17 @@
     "electron": "3.0"
   },
   "es6.array.species": {
+    "chrome": "51",
+    "opera": "38",
+    "edge": "13",
+    "firefox": "48",
+    "safari": "10",
+    "node": "6.5",
+    "ios": "10",
+    "samsung": "5",
+    "electron": "1.2"
+  },
+  "es6.array.splice": {
     "chrome": "51",
     "opera": "38",
     "edge": "13",

--- a/packages/babel-compat-data/data/corejs2-built-ins.json
+++ b/packages/babel-compat-data/data/corejs2-built-ins.json
@@ -850,6 +850,17 @@
     "samsung": "4",
     "electron": "0.30"
   },
+  "es6.array.slice": {
+    "chrome": "1",
+    "edge": "12",
+    "firefox": "1",
+    "ie":"4",
+    "ios": "1",
+    "node": "0.10.0",
+    "opera": "4",
+    "safari": "1",
+    "samsung": "1.0"
+  },
   "es6.object.to-string": {
     "chrome": "57",
     "opera": "44",

--- a/packages/babel-compat-data/data/corejs2-built-ins.json
+++ b/packages/babel-compat-data/data/corejs2-built-ins.json
@@ -224,6 +224,17 @@
     "samsung": "1",
     "electron": "0.20"
   },
+  "es6.array.slice": {
+    "chrome": "51",
+    "opera": "38",
+    "edge": "13",
+    "firefox": "48",
+    "safari": "10",
+    "node": "6.5",
+    "ios": "10",
+    "samsung": "5",
+    "electron": "1.2"
+  },
   "es6.array.some": {
     "chrome": "5",
     "opera": "10.10",
@@ -849,17 +860,6 @@
     "ios": "9",
     "samsung": "4",
     "electron": "0.30"
-  },
-  "es6.array.slice": {
-    "chrome": "1",
-    "edge": "12",
-    "firefox": "1",
-    "ie":"4",
-    "ios": "1",
-    "node": "0.10.0",
-    "opera": "4",
-    "safari": "1",
-    "samsung": "1.0"
   },
   "es6.object.to-string": {
     "chrome": "57",

--- a/packages/babel-compat-data/scripts/data/corejs2-built-in-features.js
+++ b/packages/babel-compat-data/scripts/data/corejs2-built-in-features.js
@@ -27,13 +27,12 @@ const typedArrayMethods = [
 ];
 
 module.exports = {
-  // compat-table missing babel6 mapping
-  // "es6.array.concat": {
-  //   features: [
-  //     "well-known symbols / Symbol.isConcatSpreadable",
-  //     "well-known symbols / Symbol.species, Array.prototype.concat",
-  //   ]
-  // },
+  "es6.array.concat": {
+    features: [
+      "well-known symbols / Symbol.isConcatSpreadable",
+      "well-known symbols / Symbol.species, Array.prototype.concat",
+    ],
+  },
   "es6.array.copy-within":
     "Array.prototype methods / Array.prototype.copyWithin",
   "es6.array.every": "Array methods / Array.prototype.every",
@@ -41,8 +40,7 @@ module.exports = {
   "es6.array.filter": {
     features: [
       "Array methods / Array.prototype.filter",
-      // compat-table missing babel6 mapping
-      // "well-known symbols / Symbol.species, Array.prototype.filter",
+      "well-known symbols / Symbol.species, Array.prototype.filter",
     ],
   },
   "es6.array.find": "Array.prototype methods / Array.prototype.find",
@@ -66,8 +64,7 @@ module.exports = {
   "es6.array.map": {
     features: [
       "Array methods / Array.prototype.map",
-      // compat-table missing babel6 mapping
-      // "well-known symbols / Symbol.species, Array.prototype.map",
+      "well-known symbols / Symbol.species, Array.prototype.map",
     ],
   },
   "es6.array.of": "Array static methods / Array.of",
@@ -78,8 +75,8 @@ module.exports = {
   "es6.array.some": "Array methods / Array.prototype.some",
   "es6.array.sort": "Array methods / Array.prototype.sort",
   "es6.array.species": "Array static methods / Array[Symbol.species]",
-  // compat-table missing babel6 mapping
-  //"es6.array.splice": "well-known symbols / Symbol.species, Array.prototype.splice",
+  "es6.array.splice":
+    "well-known symbols / Symbol.species, Array.prototype.splice",
 
   "es6.date.now": "Date methods / Date.now",
   "es6.date.to-iso-string": "Date methods / Date.prototype.toISOString",

--- a/packages/babel-compat-data/scripts/data/corejs2-built-in-features.js
+++ b/packages/babel-compat-data/scripts/data/corejs2-built-in-features.js
@@ -73,8 +73,8 @@ module.exports = {
   "es6.array.of": "Array static methods / Array.of",
   "es6.array.reduce": "Array methods / Array.prototype.reduce",
   "es6.array.reduce-right": "Array methods / Array.prototype.reduceRight",
-  // compat-table missing babel6 mapping
-  // "es6.array.slice": "well-known symbols / Symbol.species, Array.prototype.slice",
+  "es6.array.slice":
+    "well-known symbols / Symbol.species, Array.prototype.slice",
   "es6.array.some": "Array methods / Array.prototype.some",
   "es6.array.sort": "Array methods / Array.prototype.sort",
   "es6.array.species": "Array static methods / Array[Symbol.species]",

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/helper-module-imports": "workspace:^7.12.13",
     "@babel/helper-plugin-utils": "workspace:^7.13.0",
-    "babel-plugin-polyfill-corejs2": "^0.1.2",
+    "babel-plugin-polyfill-corejs2": "^0.1.4",
     "babel-plugin-polyfill-corejs3": "^0.1.2",
     "babel-plugin-polyfill-regenerator": "^0.1.1",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : 7.0.0"

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -79,7 +79,7 @@
     "@babel/plugin-transform-unicode-regex": "workspace:^7.12.13",
     "@babel/preset-modules": "^0.1.3",
     "@babel/types": "workspace:^7.13.0",
-    "babel-plugin-polyfill-corejs2": "^0.1.2",
+    "babel-plugin-polyfill-corejs2": "^0.1.4",
     "babel-plugin-polyfill-corejs3": "^0.1.2",
     "babel-plugin-polyfill-regenerator": "^0.1.1",
     "core-js-compat": "^3.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2705,7 +2705,7 @@ __metadata:
     "@babel/runtime-corejs3": "workspace:*"
     "@babel/template": "workspace:*"
     "@babel/types": "workspace:*"
-    babel-plugin-polyfill-corejs2: ^0.1.3
+    babel-plugin-polyfill-corejs2: ^0.1.4
     babel-plugin-polyfill-corejs3: ^0.1.3
     babel-plugin-polyfill-regenerator: ^0.1.2
     make-dir: ^2.1.0
@@ -3070,7 +3070,7 @@ __metadata:
     "@babel/plugin-transform-unicode-regex": "workspace:^7.12.13"
     "@babel/preset-modules": ^0.1.3
     "@babel/types": "workspace:^7.13.0"
-    babel-plugin-polyfill-corejs2: ^0.1.3
+    babel-plugin-polyfill-corejs2: ^0.1.4
     babel-plugin-polyfill-corejs3: ^0.1.3
     babel-plugin-polyfill-regenerator: ^0.1.2
     core-js-compat: ^3.9.0
@@ -4790,16 +4790,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs2@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "babel-plugin-polyfill-corejs2@npm:0.1.3"
+"babel-plugin-polyfill-corejs2@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "babel-plugin-polyfill-corejs2@npm:0.1.4"
   dependencies:
     "@babel/compat-data": ^7.11.0
     "@babel/helper-define-polyfill-provider": ^0.1.1
     semver: ^6.1.1
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 3e3283140d42cc2612d17f1f461d854ed02feb5f01ba6a32342721595228d7ec412dde866fa23970fd39712ae2a2c8f769e8027daa6a1a5a5733fb217bc803dd
+  checksum: 1b878ddf67114299b01cd76d80b23f7db462b42bf98d953f0a6297f80f16311197e6ff80a45f834c1b374d23ac7bf53ce2837d410877cf860fd6c213ecde739c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12859 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix          |
| Tests Added + Pass?      | Yes|
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | N/A |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


This polyfill  (es6.array.slice)[https://github.com/zloirock/core-js/blob/v2/modules/es6.array.slice.js]  is present in `corejs2` but missing in the `compat-data` package.
This introduces the error `Internal error in the corejs2 provider: unknown polyfill "es6.array.slice"`