### PR TITLE
Define fallback `exports` for `@babel/runtime` on old Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 13.1, 12, 10, 8, 6]
+        node-version: [14, 12, 10, 8, 6]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 12, 10, 8, 6]
+        node-version: [14, 13.1, 12, 10, 8, 6]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -18,411 +18,654 @@
     "regenerator-runtime": "^0.13.4"
   },
   "exports": {
-    "./helpers/typeof": {
-      "node": "./helpers/typeof/index.js",
-      "require": "./helpers/typeof/index.js",
-      "default": "./helpers/typeof/_index.mjs"
-    },
-    "./helpers/jsx": {
-      "node": "./helpers/jsx/index.js",
-      "require": "./helpers/jsx/index.js",
-      "default": "./helpers/jsx/_index.mjs"
-    },
-    "./helpers/asyncIterator": {
-      "node": "./helpers/asyncIterator/index.js",
-      "require": "./helpers/asyncIterator/index.js",
-      "default": "./helpers/asyncIterator/_index.mjs"
-    },
-    "./helpers/AwaitValue": {
-      "node": "./helpers/AwaitValue/index.js",
-      "require": "./helpers/AwaitValue/index.js",
-      "default": "./helpers/AwaitValue/_index.mjs"
-    },
-    "./helpers/AsyncGenerator": {
-      "node": "./helpers/AsyncGenerator/index.js",
-      "require": "./helpers/AsyncGenerator/index.js",
-      "default": "./helpers/AsyncGenerator/_index.mjs"
-    },
-    "./helpers/wrapAsyncGenerator": {
-      "node": "./helpers/wrapAsyncGenerator/index.js",
-      "require": "./helpers/wrapAsyncGenerator/index.js",
-      "default": "./helpers/wrapAsyncGenerator/_index.mjs"
-    },
-    "./helpers/awaitAsyncGenerator": {
-      "node": "./helpers/awaitAsyncGenerator/index.js",
-      "require": "./helpers/awaitAsyncGenerator/index.js",
-      "default": "./helpers/awaitAsyncGenerator/_index.mjs"
-    },
-    "./helpers/asyncGeneratorDelegate": {
-      "node": "./helpers/asyncGeneratorDelegate/index.js",
-      "require": "./helpers/asyncGeneratorDelegate/index.js",
-      "default": "./helpers/asyncGeneratorDelegate/_index.mjs"
-    },
-    "./helpers/asyncToGenerator": {
-      "node": "./helpers/asyncToGenerator/index.js",
-      "require": "./helpers/asyncToGenerator/index.js",
-      "default": "./helpers/asyncToGenerator/_index.mjs"
-    },
-    "./helpers/classCallCheck": {
-      "node": "./helpers/classCallCheck/index.js",
-      "require": "./helpers/classCallCheck/index.js",
-      "default": "./helpers/classCallCheck/_index.mjs"
-    },
-    "./helpers/createClass": {
-      "node": "./helpers/createClass/index.js",
-      "require": "./helpers/createClass/index.js",
-      "default": "./helpers/createClass/_index.mjs"
-    },
-    "./helpers/defineEnumerableProperties": {
-      "node": "./helpers/defineEnumerableProperties/index.js",
-      "require": "./helpers/defineEnumerableProperties/index.js",
-      "default": "./helpers/defineEnumerableProperties/_index.mjs"
-    },
-    "./helpers/defaults": {
-      "node": "./helpers/defaults/index.js",
-      "require": "./helpers/defaults/index.js",
-      "default": "./helpers/defaults/_index.mjs"
-    },
-    "./helpers/defineProperty": {
-      "node": "./helpers/defineProperty/index.js",
-      "require": "./helpers/defineProperty/index.js",
-      "default": "./helpers/defineProperty/_index.mjs"
-    },
-    "./helpers/extends": {
-      "node": "./helpers/extends/index.js",
-      "require": "./helpers/extends/index.js",
-      "default": "./helpers/extends/_index.mjs"
-    },
-    "./helpers/objectSpread": {
-      "node": "./helpers/objectSpread/index.js",
-      "require": "./helpers/objectSpread/index.js",
-      "default": "./helpers/objectSpread/_index.mjs"
-    },
-    "./helpers/objectSpread2": {
-      "node": "./helpers/objectSpread2/index.js",
-      "require": "./helpers/objectSpread2/index.js",
-      "default": "./helpers/objectSpread2/_index.mjs"
-    },
-    "./helpers/inherits": {
-      "node": "./helpers/inherits/index.js",
-      "require": "./helpers/inherits/index.js",
-      "default": "./helpers/inherits/_index.mjs"
-    },
-    "./helpers/inheritsLoose": {
-      "node": "./helpers/inheritsLoose/index.js",
-      "require": "./helpers/inheritsLoose/index.js",
-      "default": "./helpers/inheritsLoose/_index.mjs"
-    },
-    "./helpers/getPrototypeOf": {
-      "node": "./helpers/getPrototypeOf/index.js",
-      "require": "./helpers/getPrototypeOf/index.js",
-      "default": "./helpers/getPrototypeOf/_index.mjs"
-    },
-    "./helpers/setPrototypeOf": {
-      "node": "./helpers/setPrototypeOf/index.js",
-      "require": "./helpers/setPrototypeOf/index.js",
-      "default": "./helpers/setPrototypeOf/_index.mjs"
-    },
-    "./helpers/isNativeReflectConstruct": {
-      "node": "./helpers/isNativeReflectConstruct/index.js",
-      "require": "./helpers/isNativeReflectConstruct/index.js",
-      "default": "./helpers/isNativeReflectConstruct/_index.mjs"
-    },
-    "./helpers/construct": {
-      "node": "./helpers/construct/index.js",
-      "require": "./helpers/construct/index.js",
-      "default": "./helpers/construct/_index.mjs"
-    },
-    "./helpers/isNativeFunction": {
-      "node": "./helpers/isNativeFunction/index.js",
-      "require": "./helpers/isNativeFunction/index.js",
-      "default": "./helpers/isNativeFunction/_index.mjs"
-    },
-    "./helpers/wrapNativeSuper": {
-      "node": "./helpers/wrapNativeSuper/index.js",
-      "require": "./helpers/wrapNativeSuper/index.js",
-      "default": "./helpers/wrapNativeSuper/_index.mjs"
-    },
-    "./helpers/instanceof": {
-      "node": "./helpers/instanceof/index.js",
-      "require": "./helpers/instanceof/index.js",
-      "default": "./helpers/instanceof/_index.mjs"
-    },
-    "./helpers/interopRequireDefault": {
-      "node": "./helpers/interopRequireDefault/index.js",
-      "require": "./helpers/interopRequireDefault/index.js",
-      "default": "./helpers/interopRequireDefault/_index.mjs"
-    },
-    "./helpers/interopRequireWildcard": {
-      "node": "./helpers/interopRequireWildcard/index.js",
-      "require": "./helpers/interopRequireWildcard/index.js",
-      "default": "./helpers/interopRequireWildcard/_index.mjs"
-    },
-    "./helpers/newArrowCheck": {
-      "node": "./helpers/newArrowCheck/index.js",
-      "require": "./helpers/newArrowCheck/index.js",
-      "default": "./helpers/newArrowCheck/_index.mjs"
-    },
-    "./helpers/objectDestructuringEmpty": {
-      "node": "./helpers/objectDestructuringEmpty/index.js",
-      "require": "./helpers/objectDestructuringEmpty/index.js",
-      "default": "./helpers/objectDestructuringEmpty/_index.mjs"
-    },
-    "./helpers/objectWithoutPropertiesLoose": {
-      "node": "./helpers/objectWithoutPropertiesLoose/index.js",
-      "require": "./helpers/objectWithoutPropertiesLoose/index.js",
-      "default": "./helpers/objectWithoutPropertiesLoose/_index.mjs"
-    },
-    "./helpers/objectWithoutProperties": {
-      "node": "./helpers/objectWithoutProperties/index.js",
-      "require": "./helpers/objectWithoutProperties/index.js",
-      "default": "./helpers/objectWithoutProperties/_index.mjs"
-    },
-    "./helpers/assertThisInitialized": {
-      "node": "./helpers/assertThisInitialized/index.js",
-      "require": "./helpers/assertThisInitialized/index.js",
-      "default": "./helpers/assertThisInitialized/_index.mjs"
-    },
-    "./helpers/possibleConstructorReturn": {
-      "node": "./helpers/possibleConstructorReturn/index.js",
-      "require": "./helpers/possibleConstructorReturn/index.js",
-      "default": "./helpers/possibleConstructorReturn/_index.mjs"
-    },
-    "./helpers/createSuper": {
-      "node": "./helpers/createSuper/index.js",
-      "require": "./helpers/createSuper/index.js",
-      "default": "./helpers/createSuper/_index.mjs"
-    },
-    "./helpers/superPropBase": {
-      "node": "./helpers/superPropBase/index.js",
-      "require": "./helpers/superPropBase/index.js",
-      "default": "./helpers/superPropBase/_index.mjs"
-    },
-    "./helpers/get": {
-      "node": "./helpers/get/index.js",
-      "require": "./helpers/get/index.js",
-      "default": "./helpers/get/_index.mjs"
-    },
-    "./helpers/set": {
-      "node": "./helpers/set/index.js",
-      "require": "./helpers/set/index.js",
-      "default": "./helpers/set/_index.mjs"
-    },
-    "./helpers/taggedTemplateLiteral": {
-      "node": "./helpers/taggedTemplateLiteral/index.js",
-      "require": "./helpers/taggedTemplateLiteral/index.js",
-      "default": "./helpers/taggedTemplateLiteral/_index.mjs"
-    },
-    "./helpers/taggedTemplateLiteralLoose": {
-      "node": "./helpers/taggedTemplateLiteralLoose/index.js",
-      "require": "./helpers/taggedTemplateLiteralLoose/index.js",
-      "default": "./helpers/taggedTemplateLiteralLoose/_index.mjs"
-    },
-    "./helpers/readOnlyError": {
-      "node": "./helpers/readOnlyError/index.js",
-      "require": "./helpers/readOnlyError/index.js",
-      "default": "./helpers/readOnlyError/_index.mjs"
-    },
-    "./helpers/writeOnlyError": {
-      "node": "./helpers/writeOnlyError/index.js",
-      "require": "./helpers/writeOnlyError/index.js",
-      "default": "./helpers/writeOnlyError/_index.mjs"
-    },
-    "./helpers/classNameTDZError": {
-      "node": "./helpers/classNameTDZError/index.js",
-      "require": "./helpers/classNameTDZError/index.js",
-      "default": "./helpers/classNameTDZError/_index.mjs"
-    },
-    "./helpers/temporalUndefined": {
-      "node": "./helpers/temporalUndefined/index.js",
-      "require": "./helpers/temporalUndefined/index.js",
-      "default": "./helpers/temporalUndefined/_index.mjs"
-    },
-    "./helpers/tdz": {
-      "node": "./helpers/tdz/index.js",
-      "require": "./helpers/tdz/index.js",
-      "default": "./helpers/tdz/_index.mjs"
-    },
-    "./helpers/temporalRef": {
-      "node": "./helpers/temporalRef/index.js",
-      "require": "./helpers/temporalRef/index.js",
-      "default": "./helpers/temporalRef/_index.mjs"
-    },
-    "./helpers/slicedToArray": {
-      "node": "./helpers/slicedToArray/index.js",
-      "require": "./helpers/slicedToArray/index.js",
-      "default": "./helpers/slicedToArray/_index.mjs"
-    },
-    "./helpers/slicedToArrayLoose": {
-      "node": "./helpers/slicedToArrayLoose/index.js",
-      "require": "./helpers/slicedToArrayLoose/index.js",
-      "default": "./helpers/slicedToArrayLoose/_index.mjs"
-    },
-    "./helpers/toArray": {
-      "node": "./helpers/toArray/index.js",
-      "require": "./helpers/toArray/index.js",
-      "default": "./helpers/toArray/_index.mjs"
-    },
-    "./helpers/toConsumableArray": {
-      "node": "./helpers/toConsumableArray/index.js",
-      "require": "./helpers/toConsumableArray/index.js",
-      "default": "./helpers/toConsumableArray/_index.mjs"
-    },
-    "./helpers/arrayWithoutHoles": {
-      "node": "./helpers/arrayWithoutHoles/index.js",
-      "require": "./helpers/arrayWithoutHoles/index.js",
-      "default": "./helpers/arrayWithoutHoles/_index.mjs"
-    },
-    "./helpers/arrayWithHoles": {
-      "node": "./helpers/arrayWithHoles/index.js",
-      "require": "./helpers/arrayWithHoles/index.js",
-      "default": "./helpers/arrayWithHoles/_index.mjs"
-    },
-    "./helpers/maybeArrayLike": {
-      "node": "./helpers/maybeArrayLike/index.js",
-      "require": "./helpers/maybeArrayLike/index.js",
-      "default": "./helpers/maybeArrayLike/_index.mjs"
-    },
-    "./helpers/iterableToArray": {
-      "node": "./helpers/iterableToArray/index.js",
-      "require": "./helpers/iterableToArray/index.js",
-      "default": "./helpers/iterableToArray/_index.mjs"
-    },
-    "./helpers/iterableToArrayLimit": {
-      "node": "./helpers/iterableToArrayLimit/index.js",
-      "require": "./helpers/iterableToArrayLimit/index.js",
-      "default": "./helpers/iterableToArrayLimit/_index.mjs"
-    },
-    "./helpers/iterableToArrayLimitLoose": {
-      "node": "./helpers/iterableToArrayLimitLoose/index.js",
-      "require": "./helpers/iterableToArrayLimitLoose/index.js",
-      "default": "./helpers/iterableToArrayLimitLoose/_index.mjs"
-    },
-    "./helpers/unsupportedIterableToArray": {
-      "node": "./helpers/unsupportedIterableToArray/index.js",
-      "require": "./helpers/unsupportedIterableToArray/index.js",
-      "default": "./helpers/unsupportedIterableToArray/_index.mjs"
-    },
-    "./helpers/arrayLikeToArray": {
-      "node": "./helpers/arrayLikeToArray/index.js",
-      "require": "./helpers/arrayLikeToArray/index.js",
-      "default": "./helpers/arrayLikeToArray/_index.mjs"
-    },
-    "./helpers/nonIterableSpread": {
-      "node": "./helpers/nonIterableSpread/index.js",
-      "require": "./helpers/nonIterableSpread/index.js",
-      "default": "./helpers/nonIterableSpread/_index.mjs"
-    },
-    "./helpers/nonIterableRest": {
-      "node": "./helpers/nonIterableRest/index.js",
-      "require": "./helpers/nonIterableRest/index.js",
-      "default": "./helpers/nonIterableRest/_index.mjs"
-    },
-    "./helpers/createForOfIteratorHelper": {
-      "node": "./helpers/createForOfIteratorHelper/index.js",
-      "require": "./helpers/createForOfIteratorHelper/index.js",
-      "default": "./helpers/createForOfIteratorHelper/_index.mjs"
-    },
-    "./helpers/createForOfIteratorHelperLoose": {
-      "node": "./helpers/createForOfIteratorHelperLoose/index.js",
-      "require": "./helpers/createForOfIteratorHelperLoose/index.js",
-      "default": "./helpers/createForOfIteratorHelperLoose/_index.mjs"
-    },
-    "./helpers/skipFirstGeneratorNext": {
-      "node": "./helpers/skipFirstGeneratorNext/index.js",
-      "require": "./helpers/skipFirstGeneratorNext/index.js",
-      "default": "./helpers/skipFirstGeneratorNext/_index.mjs"
-    },
-    "./helpers/toPrimitive": {
-      "node": "./helpers/toPrimitive/index.js",
-      "require": "./helpers/toPrimitive/index.js",
-      "default": "./helpers/toPrimitive/_index.mjs"
-    },
-    "./helpers/toPropertyKey": {
-      "node": "./helpers/toPropertyKey/index.js",
-      "require": "./helpers/toPropertyKey/index.js",
-      "default": "./helpers/toPropertyKey/_index.mjs"
-    },
-    "./helpers/initializerWarningHelper": {
-      "node": "./helpers/initializerWarningHelper/index.js",
-      "require": "./helpers/initializerWarningHelper/index.js",
-      "default": "./helpers/initializerWarningHelper/_index.mjs"
-    },
-    "./helpers/initializerDefineProperty": {
-      "node": "./helpers/initializerDefineProperty/index.js",
-      "require": "./helpers/initializerDefineProperty/index.js",
-      "default": "./helpers/initializerDefineProperty/_index.mjs"
-    },
-    "./helpers/applyDecoratedDescriptor": {
-      "node": "./helpers/applyDecoratedDescriptor/index.js",
-      "require": "./helpers/applyDecoratedDescriptor/index.js",
-      "default": "./helpers/applyDecoratedDescriptor/_index.mjs"
-    },
-    "./helpers/classPrivateFieldLooseKey": {
-      "node": "./helpers/classPrivateFieldLooseKey/index.js",
-      "require": "./helpers/classPrivateFieldLooseKey/index.js",
-      "default": "./helpers/classPrivateFieldLooseKey/_index.mjs"
-    },
-    "./helpers/classPrivateFieldLooseBase": {
-      "node": "./helpers/classPrivateFieldLooseBase/index.js",
-      "require": "./helpers/classPrivateFieldLooseBase/index.js",
-      "default": "./helpers/classPrivateFieldLooseBase/_index.mjs"
-    },
-    "./helpers/classPrivateFieldGet": {
-      "node": "./helpers/classPrivateFieldGet/index.js",
-      "require": "./helpers/classPrivateFieldGet/index.js",
-      "default": "./helpers/classPrivateFieldGet/_index.mjs"
-    },
-    "./helpers/classPrivateFieldSet": {
-      "node": "./helpers/classPrivateFieldSet/index.js",
-      "require": "./helpers/classPrivateFieldSet/index.js",
-      "default": "./helpers/classPrivateFieldSet/_index.mjs"
-    },
-    "./helpers/classPrivateFieldDestructureSet": {
-      "node": "./helpers/classPrivateFieldDestructureSet/index.js",
-      "require": "./helpers/classPrivateFieldDestructureSet/index.js",
-      "default": "./helpers/classPrivateFieldDestructureSet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateFieldSpecGet": {
-      "node": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-      "require": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-      "default": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateFieldSpecSet": {
-      "node": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-      "require": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-      "default": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateMethodGet": {
-      "node": "./helpers/classStaticPrivateMethodGet/index.js",
-      "require": "./helpers/classStaticPrivateMethodGet/index.js",
-      "default": "./helpers/classStaticPrivateMethodGet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateMethodSet": {
-      "node": "./helpers/classStaticPrivateMethodSet/index.js",
-      "require": "./helpers/classStaticPrivateMethodSet/index.js",
-      "default": "./helpers/classStaticPrivateMethodSet/_index.mjs"
-    },
-    "./helpers/decorate": {
-      "node": "./helpers/decorate/index.js",
-      "require": "./helpers/decorate/index.js",
-      "default": "./helpers/decorate/_index.mjs"
-    },
-    "./helpers/classPrivateMethodGet": {
-      "node": "./helpers/classPrivateMethodGet/index.js",
-      "require": "./helpers/classPrivateMethodGet/index.js",
-      "default": "./helpers/classPrivateMethodGet/_index.mjs"
-    },
-    "./helpers/classPrivateMethodSet": {
-      "node": "./helpers/classPrivateMethodSet/index.js",
-      "require": "./helpers/classPrivateMethodSet/index.js",
-      "default": "./helpers/classPrivateMethodSet/_index.mjs"
-    },
-    "./helpers/wrapRegExp": {
-      "node": "./helpers/wrapRegExp/index.js",
-      "require": "./helpers/wrapRegExp/index.js",
-      "default": "./helpers/wrapRegExp/_index.mjs"
-    },
+    "./helpers/typeof": [
+      {
+        "node": "./helpers/typeof/index.js",
+        "require": "./helpers/typeof/index.js",
+        "default": "./helpers/typeof/_index.mjs"
+      },
+      "./helpers/typeof/index.js"
+    ],
+    "./helpers/jsx": [
+      {
+        "node": "./helpers/jsx/index.js",
+        "require": "./helpers/jsx/index.js",
+        "default": "./helpers/jsx/_index.mjs"
+      },
+      "./helpers/jsx/index.js"
+    ],
+    "./helpers/asyncIterator": [
+      {
+        "node": "./helpers/asyncIterator/index.js",
+        "require": "./helpers/asyncIterator/index.js",
+        "default": "./helpers/asyncIterator/_index.mjs"
+      },
+      "./helpers/asyncIterator/index.js"
+    ],
+    "./helpers/AwaitValue": [
+      {
+        "node": "./helpers/AwaitValue/index.js",
+        "require": "./helpers/AwaitValue/index.js",
+        "default": "./helpers/AwaitValue/_index.mjs"
+      },
+      "./helpers/AwaitValue/index.js"
+    ],
+    "./helpers/AsyncGenerator": [
+      {
+        "node": "./helpers/AsyncGenerator/index.js",
+        "require": "./helpers/AsyncGenerator/index.js",
+        "default": "./helpers/AsyncGenerator/_index.mjs"
+      },
+      "./helpers/AsyncGenerator/index.js"
+    ],
+    "./helpers/wrapAsyncGenerator": [
+      {
+        "node": "./helpers/wrapAsyncGenerator/index.js",
+        "require": "./helpers/wrapAsyncGenerator/index.js",
+        "default": "./helpers/wrapAsyncGenerator/_index.mjs"
+      },
+      "./helpers/wrapAsyncGenerator/index.js"
+    ],
+    "./helpers/awaitAsyncGenerator": [
+      {
+        "node": "./helpers/awaitAsyncGenerator/index.js",
+        "require": "./helpers/awaitAsyncGenerator/index.js",
+        "default": "./helpers/awaitAsyncGenerator/_index.mjs"
+      },
+      "./helpers/awaitAsyncGenerator/index.js"
+    ],
+    "./helpers/asyncGeneratorDelegate": [
+      {
+        "node": "./helpers/asyncGeneratorDelegate/index.js",
+        "require": "./helpers/asyncGeneratorDelegate/index.js",
+        "default": "./helpers/asyncGeneratorDelegate/_index.mjs"
+      },
+      "./helpers/asyncGeneratorDelegate/index.js"
+    ],
+    "./helpers/asyncToGenerator": [
+      {
+        "node": "./helpers/asyncToGenerator/index.js",
+        "require": "./helpers/asyncToGenerator/index.js",
+        "default": "./helpers/asyncToGenerator/_index.mjs"
+      },
+      "./helpers/asyncToGenerator/index.js"
+    ],
+    "./helpers/classCallCheck": [
+      {
+        "node": "./helpers/classCallCheck/index.js",
+        "require": "./helpers/classCallCheck/index.js",
+        "default": "./helpers/classCallCheck/_index.mjs"
+      },
+      "./helpers/classCallCheck/index.js"
+    ],
+    "./helpers/createClass": [
+      {
+        "node": "./helpers/createClass/index.js",
+        "require": "./helpers/createClass/index.js",
+        "default": "./helpers/createClass/_index.mjs"
+      },
+      "./helpers/createClass/index.js"
+    ],
+    "./helpers/defineEnumerableProperties": [
+      {
+        "node": "./helpers/defineEnumerableProperties/index.js",
+        "require": "./helpers/defineEnumerableProperties/index.js",
+        "default": "./helpers/defineEnumerableProperties/_index.mjs"
+      },
+      "./helpers/defineEnumerableProperties/index.js"
+    ],
+    "./helpers/defaults": [
+      {
+        "node": "./helpers/defaults/index.js",
+        "require": "./helpers/defaults/index.js",
+        "default": "./helpers/defaults/_index.mjs"
+      },
+      "./helpers/defaults/index.js"
+    ],
+    "./helpers/defineProperty": [
+      {
+        "node": "./helpers/defineProperty/index.js",
+        "require": "./helpers/defineProperty/index.js",
+        "default": "./helpers/defineProperty/_index.mjs"
+      },
+      "./helpers/defineProperty/index.js"
+    ],
+    "./helpers/extends": [
+      {
+        "node": "./helpers/extends/index.js",
+        "require": "./helpers/extends/index.js",
+        "default": "./helpers/extends/_index.mjs"
+      },
+      "./helpers/extends/index.js"
+    ],
+    "./helpers/objectSpread": [
+      {
+        "node": "./helpers/objectSpread/index.js",
+        "require": "./helpers/objectSpread/index.js",
+        "default": "./helpers/objectSpread/_index.mjs"
+      },
+      "./helpers/objectSpread/index.js"
+    ],
+    "./helpers/objectSpread2": [
+      {
+        "node": "./helpers/objectSpread2/index.js",
+        "require": "./helpers/objectSpread2/index.js",
+        "default": "./helpers/objectSpread2/_index.mjs"
+      },
+      "./helpers/objectSpread2/index.js"
+    ],
+    "./helpers/inherits": [
+      {
+        "node": "./helpers/inherits/index.js",
+        "require": "./helpers/inherits/index.js",
+        "default": "./helpers/inherits/_index.mjs"
+      },
+      "./helpers/inherits/index.js"
+    ],
+    "./helpers/inheritsLoose": [
+      {
+        "node": "./helpers/inheritsLoose/index.js",
+        "require": "./helpers/inheritsLoose/index.js",
+        "default": "./helpers/inheritsLoose/_index.mjs"
+      },
+      "./helpers/inheritsLoose/index.js"
+    ],
+    "./helpers/getPrototypeOf": [
+      {
+        "node": "./helpers/getPrototypeOf/index.js",
+        "require": "./helpers/getPrototypeOf/index.js",
+        "default": "./helpers/getPrototypeOf/_index.mjs"
+      },
+      "./helpers/getPrototypeOf/index.js"
+    ],
+    "./helpers/setPrototypeOf": [
+      {
+        "node": "./helpers/setPrototypeOf/index.js",
+        "require": "./helpers/setPrototypeOf/index.js",
+        "default": "./helpers/setPrototypeOf/_index.mjs"
+      },
+      "./helpers/setPrototypeOf/index.js"
+    ],
+    "./helpers/isNativeReflectConstruct": [
+      {
+        "node": "./helpers/isNativeReflectConstruct/index.js",
+        "require": "./helpers/isNativeReflectConstruct/index.js",
+        "default": "./helpers/isNativeReflectConstruct/_index.mjs"
+      },
+      "./helpers/isNativeReflectConstruct/index.js"
+    ],
+    "./helpers/construct": [
+      {
+        "node": "./helpers/construct/index.js",
+        "require": "./helpers/construct/index.js",
+        "default": "./helpers/construct/_index.mjs"
+      },
+      "./helpers/construct/index.js"
+    ],
+    "./helpers/isNativeFunction": [
+      {
+        "node": "./helpers/isNativeFunction/index.js",
+        "require": "./helpers/isNativeFunction/index.js",
+        "default": "./helpers/isNativeFunction/_index.mjs"
+      },
+      "./helpers/isNativeFunction/index.js"
+    ],
+    "./helpers/wrapNativeSuper": [
+      {
+        "node": "./helpers/wrapNativeSuper/index.js",
+        "require": "./helpers/wrapNativeSuper/index.js",
+        "default": "./helpers/wrapNativeSuper/_index.mjs"
+      },
+      "./helpers/wrapNativeSuper/index.js"
+    ],
+    "./helpers/instanceof": [
+      {
+        "node": "./helpers/instanceof/index.js",
+        "require": "./helpers/instanceof/index.js",
+        "default": "./helpers/instanceof/_index.mjs"
+      },
+      "./helpers/instanceof/index.js"
+    ],
+    "./helpers/interopRequireDefault": [
+      {
+        "node": "./helpers/interopRequireDefault/index.js",
+        "require": "./helpers/interopRequireDefault/index.js",
+        "default": "./helpers/interopRequireDefault/_index.mjs"
+      },
+      "./helpers/interopRequireDefault/index.js"
+    ],
+    "./helpers/interopRequireWildcard": [
+      {
+        "node": "./helpers/interopRequireWildcard/index.js",
+        "require": "./helpers/interopRequireWildcard/index.js",
+        "default": "./helpers/interopRequireWildcard/_index.mjs"
+      },
+      "./helpers/interopRequireWildcard/index.js"
+    ],
+    "./helpers/newArrowCheck": [
+      {
+        "node": "./helpers/newArrowCheck/index.js",
+        "require": "./helpers/newArrowCheck/index.js",
+        "default": "./helpers/newArrowCheck/_index.mjs"
+      },
+      "./helpers/newArrowCheck/index.js"
+    ],
+    "./helpers/objectDestructuringEmpty": [
+      {
+        "node": "./helpers/objectDestructuringEmpty/index.js",
+        "require": "./helpers/objectDestructuringEmpty/index.js",
+        "default": "./helpers/objectDestructuringEmpty/_index.mjs"
+      },
+      "./helpers/objectDestructuringEmpty/index.js"
+    ],
+    "./helpers/objectWithoutPropertiesLoose": [
+      {
+        "node": "./helpers/objectWithoutPropertiesLoose/index.js",
+        "require": "./helpers/objectWithoutPropertiesLoose/index.js",
+        "default": "./helpers/objectWithoutPropertiesLoose/_index.mjs"
+      },
+      "./helpers/objectWithoutPropertiesLoose/index.js"
+    ],
+    "./helpers/objectWithoutProperties": [
+      {
+        "node": "./helpers/objectWithoutProperties/index.js",
+        "require": "./helpers/objectWithoutProperties/index.js",
+        "default": "./helpers/objectWithoutProperties/_index.mjs"
+      },
+      "./helpers/objectWithoutProperties/index.js"
+    ],
+    "./helpers/assertThisInitialized": [
+      {
+        "node": "./helpers/assertThisInitialized/index.js",
+        "require": "./helpers/assertThisInitialized/index.js",
+        "default": "./helpers/assertThisInitialized/_index.mjs"
+      },
+      "./helpers/assertThisInitialized/index.js"
+    ],
+    "./helpers/possibleConstructorReturn": [
+      {
+        "node": "./helpers/possibleConstructorReturn/index.js",
+        "require": "./helpers/possibleConstructorReturn/index.js",
+        "default": "./helpers/possibleConstructorReturn/_index.mjs"
+      },
+      "./helpers/possibleConstructorReturn/index.js"
+    ],
+    "./helpers/createSuper": [
+      {
+        "node": "./helpers/createSuper/index.js",
+        "require": "./helpers/createSuper/index.js",
+        "default": "./helpers/createSuper/_index.mjs"
+      },
+      "./helpers/createSuper/index.js"
+    ],
+    "./helpers/superPropBase": [
+      {
+        "node": "./helpers/superPropBase/index.js",
+        "require": "./helpers/superPropBase/index.js",
+        "default": "./helpers/superPropBase/_index.mjs"
+      },
+      "./helpers/superPropBase/index.js"
+    ],
+    "./helpers/get": [
+      {
+        "node": "./helpers/get/index.js",
+        "require": "./helpers/get/index.js",
+        "default": "./helpers/get/_index.mjs"
+      },
+      "./helpers/get/index.js"
+    ],
+    "./helpers/set": [
+      {
+        "node": "./helpers/set/index.js",
+        "require": "./helpers/set/index.js",
+        "default": "./helpers/set/_index.mjs"
+      },
+      "./helpers/set/index.js"
+    ],
+    "./helpers/taggedTemplateLiteral": [
+      {
+        "node": "./helpers/taggedTemplateLiteral/index.js",
+        "require": "./helpers/taggedTemplateLiteral/index.js",
+        "default": "./helpers/taggedTemplateLiteral/_index.mjs"
+      },
+      "./helpers/taggedTemplateLiteral/index.js"
+    ],
+    "./helpers/taggedTemplateLiteralLoose": [
+      {
+        "node": "./helpers/taggedTemplateLiteralLoose/index.js",
+        "require": "./helpers/taggedTemplateLiteralLoose/index.js",
+        "default": "./helpers/taggedTemplateLiteralLoose/_index.mjs"
+      },
+      "./helpers/taggedTemplateLiteralLoose/index.js"
+    ],
+    "./helpers/readOnlyError": [
+      {
+        "node": "./helpers/readOnlyError/index.js",
+        "require": "./helpers/readOnlyError/index.js",
+        "default": "./helpers/readOnlyError/_index.mjs"
+      },
+      "./helpers/readOnlyError/index.js"
+    ],
+    "./helpers/writeOnlyError": [
+      {
+        "node": "./helpers/writeOnlyError/index.js",
+        "require": "./helpers/writeOnlyError/index.js",
+        "default": "./helpers/writeOnlyError/_index.mjs"
+      },
+      "./helpers/writeOnlyError/index.js"
+    ],
+    "./helpers/classNameTDZError": [
+      {
+        "node": "./helpers/classNameTDZError/index.js",
+        "require": "./helpers/classNameTDZError/index.js",
+        "default": "./helpers/classNameTDZError/_index.mjs"
+      },
+      "./helpers/classNameTDZError/index.js"
+    ],
+    "./helpers/temporalUndefined": [
+      {
+        "node": "./helpers/temporalUndefined/index.js",
+        "require": "./helpers/temporalUndefined/index.js",
+        "default": "./helpers/temporalUndefined/_index.mjs"
+      },
+      "./helpers/temporalUndefined/index.js"
+    ],
+    "./helpers/tdz": [
+      {
+        "node": "./helpers/tdz/index.js",
+        "require": "./helpers/tdz/index.js",
+        "default": "./helpers/tdz/_index.mjs"
+      },
+      "./helpers/tdz/index.js"
+    ],
+    "./helpers/temporalRef": [
+      {
+        "node": "./helpers/temporalRef/index.js",
+        "require": "./helpers/temporalRef/index.js",
+        "default": "./helpers/temporalRef/_index.mjs"
+      },
+      "./helpers/temporalRef/index.js"
+    ],
+    "./helpers/slicedToArray": [
+      {
+        "node": "./helpers/slicedToArray/index.js",
+        "require": "./helpers/slicedToArray/index.js",
+        "default": "./helpers/slicedToArray/_index.mjs"
+      },
+      "./helpers/slicedToArray/index.js"
+    ],
+    "./helpers/slicedToArrayLoose": [
+      {
+        "node": "./helpers/slicedToArrayLoose/index.js",
+        "require": "./helpers/slicedToArrayLoose/index.js",
+        "default": "./helpers/slicedToArrayLoose/_index.mjs"
+      },
+      "./helpers/slicedToArrayLoose/index.js"
+    ],
+    "./helpers/toArray": [
+      {
+        "node": "./helpers/toArray/index.js",
+        "require": "./helpers/toArray/index.js",
+        "default": "./helpers/toArray/_index.mjs"
+      },
+      "./helpers/toArray/index.js"
+    ],
+    "./helpers/toConsumableArray": [
+      {
+        "node": "./helpers/toConsumableArray/index.js",
+        "require": "./helpers/toConsumableArray/index.js",
+        "default": "./helpers/toConsumableArray/_index.mjs"
+      },
+      "./helpers/toConsumableArray/index.js"
+    ],
+    "./helpers/arrayWithoutHoles": [
+      {
+        "node": "./helpers/arrayWithoutHoles/index.js",
+        "require": "./helpers/arrayWithoutHoles/index.js",
+        "default": "./helpers/arrayWithoutHoles/_index.mjs"
+      },
+      "./helpers/arrayWithoutHoles/index.js"
+    ],
+    "./helpers/arrayWithHoles": [
+      {
+        "node": "./helpers/arrayWithHoles/index.js",
+        "require": "./helpers/arrayWithHoles/index.js",
+        "default": "./helpers/arrayWithHoles/_index.mjs"
+      },
+      "./helpers/arrayWithHoles/index.js"
+    ],
+    "./helpers/maybeArrayLike": [
+      {
+        "node": "./helpers/maybeArrayLike/index.js",
+        "require": "./helpers/maybeArrayLike/index.js",
+        "default": "./helpers/maybeArrayLike/_index.mjs"
+      },
+      "./helpers/maybeArrayLike/index.js"
+    ],
+    "./helpers/iterableToArray": [
+      {
+        "node": "./helpers/iterableToArray/index.js",
+        "require": "./helpers/iterableToArray/index.js",
+        "default": "./helpers/iterableToArray/_index.mjs"
+      },
+      "./helpers/iterableToArray/index.js"
+    ],
+    "./helpers/iterableToArrayLimit": [
+      {
+        "node": "./helpers/iterableToArrayLimit/index.js",
+        "require": "./helpers/iterableToArrayLimit/index.js",
+        "default": "./helpers/iterableToArrayLimit/_index.mjs"
+      },
+      "./helpers/iterableToArrayLimit/index.js"
+    ],
+    "./helpers/iterableToArrayLimitLoose": [
+      {
+        "node": "./helpers/iterableToArrayLimitLoose/index.js",
+        "require": "./helpers/iterableToArrayLimitLoose/index.js",
+        "default": "./helpers/iterableToArrayLimitLoose/_index.mjs"
+      },
+      "./helpers/iterableToArrayLimitLoose/index.js"
+    ],
+    "./helpers/unsupportedIterableToArray": [
+      {
+        "node": "./helpers/unsupportedIterableToArray/index.js",
+        "require": "./helpers/unsupportedIterableToArray/index.js",
+        "default": "./helpers/unsupportedIterableToArray/_index.mjs"
+      },
+      "./helpers/unsupportedIterableToArray/index.js"
+    ],
+    "./helpers/arrayLikeToArray": [
+      {
+        "node": "./helpers/arrayLikeToArray/index.js",
+        "require": "./helpers/arrayLikeToArray/index.js",
+        "default": "./helpers/arrayLikeToArray/_index.mjs"
+      },
+      "./helpers/arrayLikeToArray/index.js"
+    ],
+    "./helpers/nonIterableSpread": [
+      {
+        "node": "./helpers/nonIterableSpread/index.js",
+        "require": "./helpers/nonIterableSpread/index.js",
+        "default": "./helpers/nonIterableSpread/_index.mjs"
+      },
+      "./helpers/nonIterableSpread/index.js"
+    ],
+    "./helpers/nonIterableRest": [
+      {
+        "node": "./helpers/nonIterableRest/index.js",
+        "require": "./helpers/nonIterableRest/index.js",
+        "default": "./helpers/nonIterableRest/_index.mjs"
+      },
+      "./helpers/nonIterableRest/index.js"
+    ],
+    "./helpers/createForOfIteratorHelper": [
+      {
+        "node": "./helpers/createForOfIteratorHelper/index.js",
+        "require": "./helpers/createForOfIteratorHelper/index.js",
+        "default": "./helpers/createForOfIteratorHelper/_index.mjs"
+      },
+      "./helpers/createForOfIteratorHelper/index.js"
+    ],
+    "./helpers/createForOfIteratorHelperLoose": [
+      {
+        "node": "./helpers/createForOfIteratorHelperLoose/index.js",
+        "require": "./helpers/createForOfIteratorHelperLoose/index.js",
+        "default": "./helpers/createForOfIteratorHelperLoose/_index.mjs"
+      },
+      "./helpers/createForOfIteratorHelperLoose/index.js"
+    ],
+    "./helpers/skipFirstGeneratorNext": [
+      {
+        "node": "./helpers/skipFirstGeneratorNext/index.js",
+        "require": "./helpers/skipFirstGeneratorNext/index.js",
+        "default": "./helpers/skipFirstGeneratorNext/_index.mjs"
+      },
+      "./helpers/skipFirstGeneratorNext/index.js"
+    ],
+    "./helpers/toPrimitive": [
+      {
+        "node": "./helpers/toPrimitive/index.js",
+        "require": "./helpers/toPrimitive/index.js",
+        "default": "./helpers/toPrimitive/_index.mjs"
+      },
+      "./helpers/toPrimitive/index.js"
+    ],
+    "./helpers/toPropertyKey": [
+      {
+        "node": "./helpers/toPropertyKey/index.js",
+        "require": "./helpers/toPropertyKey/index.js",
+        "default": "./helpers/toPropertyKey/_index.mjs"
+      },
+      "./helpers/toPropertyKey/index.js"
+    ],
+    "./helpers/initializerWarningHelper": [
+      {
+        "node": "./helpers/initializerWarningHelper/index.js",
+        "require": "./helpers/initializerWarningHelper/index.js",
+        "default": "./helpers/initializerWarningHelper/_index.mjs"
+      },
+      "./helpers/initializerWarningHelper/index.js"
+    ],
+    "./helpers/initializerDefineProperty": [
+      {
+        "node": "./helpers/initializerDefineProperty/index.js",
+        "require": "./helpers/initializerDefineProperty/index.js",
+        "default": "./helpers/initializerDefineProperty/_index.mjs"
+      },
+      "./helpers/initializerDefineProperty/index.js"
+    ],
+    "./helpers/applyDecoratedDescriptor": [
+      {
+        "node": "./helpers/applyDecoratedDescriptor/index.js",
+        "require": "./helpers/applyDecoratedDescriptor/index.js",
+        "default": "./helpers/applyDecoratedDescriptor/_index.mjs"
+      },
+      "./helpers/applyDecoratedDescriptor/index.js"
+    ],
+    "./helpers/classPrivateFieldLooseKey": [
+      {
+        "node": "./helpers/classPrivateFieldLooseKey/index.js",
+        "require": "./helpers/classPrivateFieldLooseKey/index.js",
+        "default": "./helpers/classPrivateFieldLooseKey/_index.mjs"
+      },
+      "./helpers/classPrivateFieldLooseKey/index.js"
+    ],
+    "./helpers/classPrivateFieldLooseBase": [
+      {
+        "node": "./helpers/classPrivateFieldLooseBase/index.js",
+        "require": "./helpers/classPrivateFieldLooseBase/index.js",
+        "default": "./helpers/classPrivateFieldLooseBase/_index.mjs"
+      },
+      "./helpers/classPrivateFieldLooseBase/index.js"
+    ],
+    "./helpers/classPrivateFieldGet": [
+      {
+        "node": "./helpers/classPrivateFieldGet/index.js",
+        "require": "./helpers/classPrivateFieldGet/index.js",
+        "default": "./helpers/classPrivateFieldGet/_index.mjs"
+      },
+      "./helpers/classPrivateFieldGet/index.js"
+    ],
+    "./helpers/classPrivateFieldSet": [
+      {
+        "node": "./helpers/classPrivateFieldSet/index.js",
+        "require": "./helpers/classPrivateFieldSet/index.js",
+        "default": "./helpers/classPrivateFieldSet/_index.mjs"
+      },
+      "./helpers/classPrivateFieldSet/index.js"
+    ],
+    "./helpers/classPrivateFieldDestructureSet": [
+      {
+        "node": "./helpers/classPrivateFieldDestructureSet/index.js",
+        "require": "./helpers/classPrivateFieldDestructureSet/index.js",
+        "default": "./helpers/classPrivateFieldDestructureSet/_index.mjs"
+      },
+      "./helpers/classPrivateFieldDestructureSet/index.js"
+    ],
+    "./helpers/classStaticPrivateFieldSpecGet": [
+      {
+        "node": "./helpers/classStaticPrivateFieldSpecGet/index.js",
+        "require": "./helpers/classStaticPrivateFieldSpecGet/index.js",
+        "default": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateFieldSpecGet/index.js"
+    ],
+    "./helpers/classStaticPrivateFieldSpecSet": [
+      {
+        "node": "./helpers/classStaticPrivateFieldSpecSet/index.js",
+        "require": "./helpers/classStaticPrivateFieldSpecSet/index.js",
+        "default": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateFieldSpecSet/index.js"
+    ],
+    "./helpers/classStaticPrivateMethodGet": [
+      {
+        "node": "./helpers/classStaticPrivateMethodGet/index.js",
+        "require": "./helpers/classStaticPrivateMethodGet/index.js",
+        "default": "./helpers/classStaticPrivateMethodGet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateMethodGet/index.js"
+    ],
+    "./helpers/classStaticPrivateMethodSet": [
+      {
+        "node": "./helpers/classStaticPrivateMethodSet/index.js",
+        "require": "./helpers/classStaticPrivateMethodSet/index.js",
+        "default": "./helpers/classStaticPrivateMethodSet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateMethodSet/index.js"
+    ],
+    "./helpers/decorate": [
+      {
+        "node": "./helpers/decorate/index.js",
+        "require": "./helpers/decorate/index.js",
+        "default": "./helpers/decorate/_index.mjs"
+      },
+      "./helpers/decorate/index.js"
+    ],
+    "./helpers/classPrivateMethodGet": [
+      {
+        "node": "./helpers/classPrivateMethodGet/index.js",
+        "require": "./helpers/classPrivateMethodGet/index.js",
+        "default": "./helpers/classPrivateMethodGet/_index.mjs"
+      },
+      "./helpers/classPrivateMethodGet/index.js"
+    ],
+    "./helpers/classPrivateMethodSet": [
+      {
+        "node": "./helpers/classPrivateMethodSet/index.js",
+        "require": "./helpers/classPrivateMethodSet/index.js",
+        "default": "./helpers/classPrivateMethodSet/_index.mjs"
+      },
+      "./helpers/classPrivateMethodSet/index.js"
+    ],
+    "./helpers/wrapRegExp": [
+      {
+        "node": "./helpers/wrapRegExp/index.js",
+        "require": "./helpers/wrapRegExp/index.js",
+        "default": "./helpers/wrapRegExp/_index.mjs"
+      },
+      "./helpers/wrapRegExp/index.js"
+    ],
     "./package": "./package.json",
     "./package.json": "./package.json",
     "./regenerator": "./regenerator/index.js",

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -17,411 +17,654 @@
     "regenerator-runtime": "^0.13.4"
   },
   "exports": {
-    "./helpers/typeof": {
-      "node": "./helpers/typeof/index.js",
-      "require": "./helpers/typeof/index.js",
-      "default": "./helpers/typeof/_index.mjs"
-    },
-    "./helpers/jsx": {
-      "node": "./helpers/jsx/index.js",
-      "require": "./helpers/jsx/index.js",
-      "default": "./helpers/jsx/_index.mjs"
-    },
-    "./helpers/asyncIterator": {
-      "node": "./helpers/asyncIterator/index.js",
-      "require": "./helpers/asyncIterator/index.js",
-      "default": "./helpers/asyncIterator/_index.mjs"
-    },
-    "./helpers/AwaitValue": {
-      "node": "./helpers/AwaitValue/index.js",
-      "require": "./helpers/AwaitValue/index.js",
-      "default": "./helpers/AwaitValue/_index.mjs"
-    },
-    "./helpers/AsyncGenerator": {
-      "node": "./helpers/AsyncGenerator/index.js",
-      "require": "./helpers/AsyncGenerator/index.js",
-      "default": "./helpers/AsyncGenerator/_index.mjs"
-    },
-    "./helpers/wrapAsyncGenerator": {
-      "node": "./helpers/wrapAsyncGenerator/index.js",
-      "require": "./helpers/wrapAsyncGenerator/index.js",
-      "default": "./helpers/wrapAsyncGenerator/_index.mjs"
-    },
-    "./helpers/awaitAsyncGenerator": {
-      "node": "./helpers/awaitAsyncGenerator/index.js",
-      "require": "./helpers/awaitAsyncGenerator/index.js",
-      "default": "./helpers/awaitAsyncGenerator/_index.mjs"
-    },
-    "./helpers/asyncGeneratorDelegate": {
-      "node": "./helpers/asyncGeneratorDelegate/index.js",
-      "require": "./helpers/asyncGeneratorDelegate/index.js",
-      "default": "./helpers/asyncGeneratorDelegate/_index.mjs"
-    },
-    "./helpers/asyncToGenerator": {
-      "node": "./helpers/asyncToGenerator/index.js",
-      "require": "./helpers/asyncToGenerator/index.js",
-      "default": "./helpers/asyncToGenerator/_index.mjs"
-    },
-    "./helpers/classCallCheck": {
-      "node": "./helpers/classCallCheck/index.js",
-      "require": "./helpers/classCallCheck/index.js",
-      "default": "./helpers/classCallCheck/_index.mjs"
-    },
-    "./helpers/createClass": {
-      "node": "./helpers/createClass/index.js",
-      "require": "./helpers/createClass/index.js",
-      "default": "./helpers/createClass/_index.mjs"
-    },
-    "./helpers/defineEnumerableProperties": {
-      "node": "./helpers/defineEnumerableProperties/index.js",
-      "require": "./helpers/defineEnumerableProperties/index.js",
-      "default": "./helpers/defineEnumerableProperties/_index.mjs"
-    },
-    "./helpers/defaults": {
-      "node": "./helpers/defaults/index.js",
-      "require": "./helpers/defaults/index.js",
-      "default": "./helpers/defaults/_index.mjs"
-    },
-    "./helpers/defineProperty": {
-      "node": "./helpers/defineProperty/index.js",
-      "require": "./helpers/defineProperty/index.js",
-      "default": "./helpers/defineProperty/_index.mjs"
-    },
-    "./helpers/extends": {
-      "node": "./helpers/extends/index.js",
-      "require": "./helpers/extends/index.js",
-      "default": "./helpers/extends/_index.mjs"
-    },
-    "./helpers/objectSpread": {
-      "node": "./helpers/objectSpread/index.js",
-      "require": "./helpers/objectSpread/index.js",
-      "default": "./helpers/objectSpread/_index.mjs"
-    },
-    "./helpers/objectSpread2": {
-      "node": "./helpers/objectSpread2/index.js",
-      "require": "./helpers/objectSpread2/index.js",
-      "default": "./helpers/objectSpread2/_index.mjs"
-    },
-    "./helpers/inherits": {
-      "node": "./helpers/inherits/index.js",
-      "require": "./helpers/inherits/index.js",
-      "default": "./helpers/inherits/_index.mjs"
-    },
-    "./helpers/inheritsLoose": {
-      "node": "./helpers/inheritsLoose/index.js",
-      "require": "./helpers/inheritsLoose/index.js",
-      "default": "./helpers/inheritsLoose/_index.mjs"
-    },
-    "./helpers/getPrototypeOf": {
-      "node": "./helpers/getPrototypeOf/index.js",
-      "require": "./helpers/getPrototypeOf/index.js",
-      "default": "./helpers/getPrototypeOf/_index.mjs"
-    },
-    "./helpers/setPrototypeOf": {
-      "node": "./helpers/setPrototypeOf/index.js",
-      "require": "./helpers/setPrototypeOf/index.js",
-      "default": "./helpers/setPrototypeOf/_index.mjs"
-    },
-    "./helpers/isNativeReflectConstruct": {
-      "node": "./helpers/isNativeReflectConstruct/index.js",
-      "require": "./helpers/isNativeReflectConstruct/index.js",
-      "default": "./helpers/isNativeReflectConstruct/_index.mjs"
-    },
-    "./helpers/construct": {
-      "node": "./helpers/construct/index.js",
-      "require": "./helpers/construct/index.js",
-      "default": "./helpers/construct/_index.mjs"
-    },
-    "./helpers/isNativeFunction": {
-      "node": "./helpers/isNativeFunction/index.js",
-      "require": "./helpers/isNativeFunction/index.js",
-      "default": "./helpers/isNativeFunction/_index.mjs"
-    },
-    "./helpers/wrapNativeSuper": {
-      "node": "./helpers/wrapNativeSuper/index.js",
-      "require": "./helpers/wrapNativeSuper/index.js",
-      "default": "./helpers/wrapNativeSuper/_index.mjs"
-    },
-    "./helpers/instanceof": {
-      "node": "./helpers/instanceof/index.js",
-      "require": "./helpers/instanceof/index.js",
-      "default": "./helpers/instanceof/_index.mjs"
-    },
-    "./helpers/interopRequireDefault": {
-      "node": "./helpers/interopRequireDefault/index.js",
-      "require": "./helpers/interopRequireDefault/index.js",
-      "default": "./helpers/interopRequireDefault/_index.mjs"
-    },
-    "./helpers/interopRequireWildcard": {
-      "node": "./helpers/interopRequireWildcard/index.js",
-      "require": "./helpers/interopRequireWildcard/index.js",
-      "default": "./helpers/interopRequireWildcard/_index.mjs"
-    },
-    "./helpers/newArrowCheck": {
-      "node": "./helpers/newArrowCheck/index.js",
-      "require": "./helpers/newArrowCheck/index.js",
-      "default": "./helpers/newArrowCheck/_index.mjs"
-    },
-    "./helpers/objectDestructuringEmpty": {
-      "node": "./helpers/objectDestructuringEmpty/index.js",
-      "require": "./helpers/objectDestructuringEmpty/index.js",
-      "default": "./helpers/objectDestructuringEmpty/_index.mjs"
-    },
-    "./helpers/objectWithoutPropertiesLoose": {
-      "node": "./helpers/objectWithoutPropertiesLoose/index.js",
-      "require": "./helpers/objectWithoutPropertiesLoose/index.js",
-      "default": "./helpers/objectWithoutPropertiesLoose/_index.mjs"
-    },
-    "./helpers/objectWithoutProperties": {
-      "node": "./helpers/objectWithoutProperties/index.js",
-      "require": "./helpers/objectWithoutProperties/index.js",
-      "default": "./helpers/objectWithoutProperties/_index.mjs"
-    },
-    "./helpers/assertThisInitialized": {
-      "node": "./helpers/assertThisInitialized/index.js",
-      "require": "./helpers/assertThisInitialized/index.js",
-      "default": "./helpers/assertThisInitialized/_index.mjs"
-    },
-    "./helpers/possibleConstructorReturn": {
-      "node": "./helpers/possibleConstructorReturn/index.js",
-      "require": "./helpers/possibleConstructorReturn/index.js",
-      "default": "./helpers/possibleConstructorReturn/_index.mjs"
-    },
-    "./helpers/createSuper": {
-      "node": "./helpers/createSuper/index.js",
-      "require": "./helpers/createSuper/index.js",
-      "default": "./helpers/createSuper/_index.mjs"
-    },
-    "./helpers/superPropBase": {
-      "node": "./helpers/superPropBase/index.js",
-      "require": "./helpers/superPropBase/index.js",
-      "default": "./helpers/superPropBase/_index.mjs"
-    },
-    "./helpers/get": {
-      "node": "./helpers/get/index.js",
-      "require": "./helpers/get/index.js",
-      "default": "./helpers/get/_index.mjs"
-    },
-    "./helpers/set": {
-      "node": "./helpers/set/index.js",
-      "require": "./helpers/set/index.js",
-      "default": "./helpers/set/_index.mjs"
-    },
-    "./helpers/taggedTemplateLiteral": {
-      "node": "./helpers/taggedTemplateLiteral/index.js",
-      "require": "./helpers/taggedTemplateLiteral/index.js",
-      "default": "./helpers/taggedTemplateLiteral/_index.mjs"
-    },
-    "./helpers/taggedTemplateLiteralLoose": {
-      "node": "./helpers/taggedTemplateLiteralLoose/index.js",
-      "require": "./helpers/taggedTemplateLiteralLoose/index.js",
-      "default": "./helpers/taggedTemplateLiteralLoose/_index.mjs"
-    },
-    "./helpers/readOnlyError": {
-      "node": "./helpers/readOnlyError/index.js",
-      "require": "./helpers/readOnlyError/index.js",
-      "default": "./helpers/readOnlyError/_index.mjs"
-    },
-    "./helpers/writeOnlyError": {
-      "node": "./helpers/writeOnlyError/index.js",
-      "require": "./helpers/writeOnlyError/index.js",
-      "default": "./helpers/writeOnlyError/_index.mjs"
-    },
-    "./helpers/classNameTDZError": {
-      "node": "./helpers/classNameTDZError/index.js",
-      "require": "./helpers/classNameTDZError/index.js",
-      "default": "./helpers/classNameTDZError/_index.mjs"
-    },
-    "./helpers/temporalUndefined": {
-      "node": "./helpers/temporalUndefined/index.js",
-      "require": "./helpers/temporalUndefined/index.js",
-      "default": "./helpers/temporalUndefined/_index.mjs"
-    },
-    "./helpers/tdz": {
-      "node": "./helpers/tdz/index.js",
-      "require": "./helpers/tdz/index.js",
-      "default": "./helpers/tdz/_index.mjs"
-    },
-    "./helpers/temporalRef": {
-      "node": "./helpers/temporalRef/index.js",
-      "require": "./helpers/temporalRef/index.js",
-      "default": "./helpers/temporalRef/_index.mjs"
-    },
-    "./helpers/slicedToArray": {
-      "node": "./helpers/slicedToArray/index.js",
-      "require": "./helpers/slicedToArray/index.js",
-      "default": "./helpers/slicedToArray/_index.mjs"
-    },
-    "./helpers/slicedToArrayLoose": {
-      "node": "./helpers/slicedToArrayLoose/index.js",
-      "require": "./helpers/slicedToArrayLoose/index.js",
-      "default": "./helpers/slicedToArrayLoose/_index.mjs"
-    },
-    "./helpers/toArray": {
-      "node": "./helpers/toArray/index.js",
-      "require": "./helpers/toArray/index.js",
-      "default": "./helpers/toArray/_index.mjs"
-    },
-    "./helpers/toConsumableArray": {
-      "node": "./helpers/toConsumableArray/index.js",
-      "require": "./helpers/toConsumableArray/index.js",
-      "default": "./helpers/toConsumableArray/_index.mjs"
-    },
-    "./helpers/arrayWithoutHoles": {
-      "node": "./helpers/arrayWithoutHoles/index.js",
-      "require": "./helpers/arrayWithoutHoles/index.js",
-      "default": "./helpers/arrayWithoutHoles/_index.mjs"
-    },
-    "./helpers/arrayWithHoles": {
-      "node": "./helpers/arrayWithHoles/index.js",
-      "require": "./helpers/arrayWithHoles/index.js",
-      "default": "./helpers/arrayWithHoles/_index.mjs"
-    },
-    "./helpers/maybeArrayLike": {
-      "node": "./helpers/maybeArrayLike/index.js",
-      "require": "./helpers/maybeArrayLike/index.js",
-      "default": "./helpers/maybeArrayLike/_index.mjs"
-    },
-    "./helpers/iterableToArray": {
-      "node": "./helpers/iterableToArray/index.js",
-      "require": "./helpers/iterableToArray/index.js",
-      "default": "./helpers/iterableToArray/_index.mjs"
-    },
-    "./helpers/iterableToArrayLimit": {
-      "node": "./helpers/iterableToArrayLimit/index.js",
-      "require": "./helpers/iterableToArrayLimit/index.js",
-      "default": "./helpers/iterableToArrayLimit/_index.mjs"
-    },
-    "./helpers/iterableToArrayLimitLoose": {
-      "node": "./helpers/iterableToArrayLimitLoose/index.js",
-      "require": "./helpers/iterableToArrayLimitLoose/index.js",
-      "default": "./helpers/iterableToArrayLimitLoose/_index.mjs"
-    },
-    "./helpers/unsupportedIterableToArray": {
-      "node": "./helpers/unsupportedIterableToArray/index.js",
-      "require": "./helpers/unsupportedIterableToArray/index.js",
-      "default": "./helpers/unsupportedIterableToArray/_index.mjs"
-    },
-    "./helpers/arrayLikeToArray": {
-      "node": "./helpers/arrayLikeToArray/index.js",
-      "require": "./helpers/arrayLikeToArray/index.js",
-      "default": "./helpers/arrayLikeToArray/_index.mjs"
-    },
-    "./helpers/nonIterableSpread": {
-      "node": "./helpers/nonIterableSpread/index.js",
-      "require": "./helpers/nonIterableSpread/index.js",
-      "default": "./helpers/nonIterableSpread/_index.mjs"
-    },
-    "./helpers/nonIterableRest": {
-      "node": "./helpers/nonIterableRest/index.js",
-      "require": "./helpers/nonIterableRest/index.js",
-      "default": "./helpers/nonIterableRest/_index.mjs"
-    },
-    "./helpers/createForOfIteratorHelper": {
-      "node": "./helpers/createForOfIteratorHelper/index.js",
-      "require": "./helpers/createForOfIteratorHelper/index.js",
-      "default": "./helpers/createForOfIteratorHelper/_index.mjs"
-    },
-    "./helpers/createForOfIteratorHelperLoose": {
-      "node": "./helpers/createForOfIteratorHelperLoose/index.js",
-      "require": "./helpers/createForOfIteratorHelperLoose/index.js",
-      "default": "./helpers/createForOfIteratorHelperLoose/_index.mjs"
-    },
-    "./helpers/skipFirstGeneratorNext": {
-      "node": "./helpers/skipFirstGeneratorNext/index.js",
-      "require": "./helpers/skipFirstGeneratorNext/index.js",
-      "default": "./helpers/skipFirstGeneratorNext/_index.mjs"
-    },
-    "./helpers/toPrimitive": {
-      "node": "./helpers/toPrimitive/index.js",
-      "require": "./helpers/toPrimitive/index.js",
-      "default": "./helpers/toPrimitive/_index.mjs"
-    },
-    "./helpers/toPropertyKey": {
-      "node": "./helpers/toPropertyKey/index.js",
-      "require": "./helpers/toPropertyKey/index.js",
-      "default": "./helpers/toPropertyKey/_index.mjs"
-    },
-    "./helpers/initializerWarningHelper": {
-      "node": "./helpers/initializerWarningHelper/index.js",
-      "require": "./helpers/initializerWarningHelper/index.js",
-      "default": "./helpers/initializerWarningHelper/_index.mjs"
-    },
-    "./helpers/initializerDefineProperty": {
-      "node": "./helpers/initializerDefineProperty/index.js",
-      "require": "./helpers/initializerDefineProperty/index.js",
-      "default": "./helpers/initializerDefineProperty/_index.mjs"
-    },
-    "./helpers/applyDecoratedDescriptor": {
-      "node": "./helpers/applyDecoratedDescriptor/index.js",
-      "require": "./helpers/applyDecoratedDescriptor/index.js",
-      "default": "./helpers/applyDecoratedDescriptor/_index.mjs"
-    },
-    "./helpers/classPrivateFieldLooseKey": {
-      "node": "./helpers/classPrivateFieldLooseKey/index.js",
-      "require": "./helpers/classPrivateFieldLooseKey/index.js",
-      "default": "./helpers/classPrivateFieldLooseKey/_index.mjs"
-    },
-    "./helpers/classPrivateFieldLooseBase": {
-      "node": "./helpers/classPrivateFieldLooseBase/index.js",
-      "require": "./helpers/classPrivateFieldLooseBase/index.js",
-      "default": "./helpers/classPrivateFieldLooseBase/_index.mjs"
-    },
-    "./helpers/classPrivateFieldGet": {
-      "node": "./helpers/classPrivateFieldGet/index.js",
-      "require": "./helpers/classPrivateFieldGet/index.js",
-      "default": "./helpers/classPrivateFieldGet/_index.mjs"
-    },
-    "./helpers/classPrivateFieldSet": {
-      "node": "./helpers/classPrivateFieldSet/index.js",
-      "require": "./helpers/classPrivateFieldSet/index.js",
-      "default": "./helpers/classPrivateFieldSet/_index.mjs"
-    },
-    "./helpers/classPrivateFieldDestructureSet": {
-      "node": "./helpers/classPrivateFieldDestructureSet/index.js",
-      "require": "./helpers/classPrivateFieldDestructureSet/index.js",
-      "default": "./helpers/classPrivateFieldDestructureSet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateFieldSpecGet": {
-      "node": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-      "require": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-      "default": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateFieldSpecSet": {
-      "node": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-      "require": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-      "default": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateMethodGet": {
-      "node": "./helpers/classStaticPrivateMethodGet/index.js",
-      "require": "./helpers/classStaticPrivateMethodGet/index.js",
-      "default": "./helpers/classStaticPrivateMethodGet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateMethodSet": {
-      "node": "./helpers/classStaticPrivateMethodSet/index.js",
-      "require": "./helpers/classStaticPrivateMethodSet/index.js",
-      "default": "./helpers/classStaticPrivateMethodSet/_index.mjs"
-    },
-    "./helpers/decorate": {
-      "node": "./helpers/decorate/index.js",
-      "require": "./helpers/decorate/index.js",
-      "default": "./helpers/decorate/_index.mjs"
-    },
-    "./helpers/classPrivateMethodGet": {
-      "node": "./helpers/classPrivateMethodGet/index.js",
-      "require": "./helpers/classPrivateMethodGet/index.js",
-      "default": "./helpers/classPrivateMethodGet/_index.mjs"
-    },
-    "./helpers/classPrivateMethodSet": {
-      "node": "./helpers/classPrivateMethodSet/index.js",
-      "require": "./helpers/classPrivateMethodSet/index.js",
-      "default": "./helpers/classPrivateMethodSet/_index.mjs"
-    },
-    "./helpers/wrapRegExp": {
-      "node": "./helpers/wrapRegExp/index.js",
-      "require": "./helpers/wrapRegExp/index.js",
-      "default": "./helpers/wrapRegExp/_index.mjs"
-    },
+    "./helpers/typeof": [
+      {
+        "node": "./helpers/typeof/index.js",
+        "require": "./helpers/typeof/index.js",
+        "default": "./helpers/typeof/_index.mjs"
+      },
+      "./helpers/typeof/index.js"
+    ],
+    "./helpers/jsx": [
+      {
+        "node": "./helpers/jsx/index.js",
+        "require": "./helpers/jsx/index.js",
+        "default": "./helpers/jsx/_index.mjs"
+      },
+      "./helpers/jsx/index.js"
+    ],
+    "./helpers/asyncIterator": [
+      {
+        "node": "./helpers/asyncIterator/index.js",
+        "require": "./helpers/asyncIterator/index.js",
+        "default": "./helpers/asyncIterator/_index.mjs"
+      },
+      "./helpers/asyncIterator/index.js"
+    ],
+    "./helpers/AwaitValue": [
+      {
+        "node": "./helpers/AwaitValue/index.js",
+        "require": "./helpers/AwaitValue/index.js",
+        "default": "./helpers/AwaitValue/_index.mjs"
+      },
+      "./helpers/AwaitValue/index.js"
+    ],
+    "./helpers/AsyncGenerator": [
+      {
+        "node": "./helpers/AsyncGenerator/index.js",
+        "require": "./helpers/AsyncGenerator/index.js",
+        "default": "./helpers/AsyncGenerator/_index.mjs"
+      },
+      "./helpers/AsyncGenerator/index.js"
+    ],
+    "./helpers/wrapAsyncGenerator": [
+      {
+        "node": "./helpers/wrapAsyncGenerator/index.js",
+        "require": "./helpers/wrapAsyncGenerator/index.js",
+        "default": "./helpers/wrapAsyncGenerator/_index.mjs"
+      },
+      "./helpers/wrapAsyncGenerator/index.js"
+    ],
+    "./helpers/awaitAsyncGenerator": [
+      {
+        "node": "./helpers/awaitAsyncGenerator/index.js",
+        "require": "./helpers/awaitAsyncGenerator/index.js",
+        "default": "./helpers/awaitAsyncGenerator/_index.mjs"
+      },
+      "./helpers/awaitAsyncGenerator/index.js"
+    ],
+    "./helpers/asyncGeneratorDelegate": [
+      {
+        "node": "./helpers/asyncGeneratorDelegate/index.js",
+        "require": "./helpers/asyncGeneratorDelegate/index.js",
+        "default": "./helpers/asyncGeneratorDelegate/_index.mjs"
+      },
+      "./helpers/asyncGeneratorDelegate/index.js"
+    ],
+    "./helpers/asyncToGenerator": [
+      {
+        "node": "./helpers/asyncToGenerator/index.js",
+        "require": "./helpers/asyncToGenerator/index.js",
+        "default": "./helpers/asyncToGenerator/_index.mjs"
+      },
+      "./helpers/asyncToGenerator/index.js"
+    ],
+    "./helpers/classCallCheck": [
+      {
+        "node": "./helpers/classCallCheck/index.js",
+        "require": "./helpers/classCallCheck/index.js",
+        "default": "./helpers/classCallCheck/_index.mjs"
+      },
+      "./helpers/classCallCheck/index.js"
+    ],
+    "./helpers/createClass": [
+      {
+        "node": "./helpers/createClass/index.js",
+        "require": "./helpers/createClass/index.js",
+        "default": "./helpers/createClass/_index.mjs"
+      },
+      "./helpers/createClass/index.js"
+    ],
+    "./helpers/defineEnumerableProperties": [
+      {
+        "node": "./helpers/defineEnumerableProperties/index.js",
+        "require": "./helpers/defineEnumerableProperties/index.js",
+        "default": "./helpers/defineEnumerableProperties/_index.mjs"
+      },
+      "./helpers/defineEnumerableProperties/index.js"
+    ],
+    "./helpers/defaults": [
+      {
+        "node": "./helpers/defaults/index.js",
+        "require": "./helpers/defaults/index.js",
+        "default": "./helpers/defaults/_index.mjs"
+      },
+      "./helpers/defaults/index.js"
+    ],
+    "./helpers/defineProperty": [
+      {
+        "node": "./helpers/defineProperty/index.js",
+        "require": "./helpers/defineProperty/index.js",
+        "default": "./helpers/defineProperty/_index.mjs"
+      },
+      "./helpers/defineProperty/index.js"
+    ],
+    "./helpers/extends": [
+      {
+        "node": "./helpers/extends/index.js",
+        "require": "./helpers/extends/index.js",
+        "default": "./helpers/extends/_index.mjs"
+      },
+      "./helpers/extends/index.js"
+    ],
+    "./helpers/objectSpread": [
+      {
+        "node": "./helpers/objectSpread/index.js",
+        "require": "./helpers/objectSpread/index.js",
+        "default": "./helpers/objectSpread/_index.mjs"
+      },
+      "./helpers/objectSpread/index.js"
+    ],
+    "./helpers/objectSpread2": [
+      {
+        "node": "./helpers/objectSpread2/index.js",
+        "require": "./helpers/objectSpread2/index.js",
+        "default": "./helpers/objectSpread2/_index.mjs"
+      },
+      "./helpers/objectSpread2/index.js"
+    ],
+    "./helpers/inherits": [
+      {
+        "node": "./helpers/inherits/index.js",
+        "require": "./helpers/inherits/index.js",
+        "default": "./helpers/inherits/_index.mjs"
+      },
+      "./helpers/inherits/index.js"
+    ],
+    "./helpers/inheritsLoose": [
+      {
+        "node": "./helpers/inheritsLoose/index.js",
+        "require": "./helpers/inheritsLoose/index.js",
+        "default": "./helpers/inheritsLoose/_index.mjs"
+      },
+      "./helpers/inheritsLoose/index.js"
+    ],
+    "./helpers/getPrototypeOf": [
+      {
+        "node": "./helpers/getPrototypeOf/index.js",
+        "require": "./helpers/getPrototypeOf/index.js",
+        "default": "./helpers/getPrototypeOf/_index.mjs"
+      },
+      "./helpers/getPrototypeOf/index.js"
+    ],
+    "./helpers/setPrototypeOf": [
+      {
+        "node": "./helpers/setPrototypeOf/index.js",
+        "require": "./helpers/setPrototypeOf/index.js",
+        "default": "./helpers/setPrototypeOf/_index.mjs"
+      },
+      "./helpers/setPrototypeOf/index.js"
+    ],
+    "./helpers/isNativeReflectConstruct": [
+      {
+        "node": "./helpers/isNativeReflectConstruct/index.js",
+        "require": "./helpers/isNativeReflectConstruct/index.js",
+        "default": "./helpers/isNativeReflectConstruct/_index.mjs"
+      },
+      "./helpers/isNativeReflectConstruct/index.js"
+    ],
+    "./helpers/construct": [
+      {
+        "node": "./helpers/construct/index.js",
+        "require": "./helpers/construct/index.js",
+        "default": "./helpers/construct/_index.mjs"
+      },
+      "./helpers/construct/index.js"
+    ],
+    "./helpers/isNativeFunction": [
+      {
+        "node": "./helpers/isNativeFunction/index.js",
+        "require": "./helpers/isNativeFunction/index.js",
+        "default": "./helpers/isNativeFunction/_index.mjs"
+      },
+      "./helpers/isNativeFunction/index.js"
+    ],
+    "./helpers/wrapNativeSuper": [
+      {
+        "node": "./helpers/wrapNativeSuper/index.js",
+        "require": "./helpers/wrapNativeSuper/index.js",
+        "default": "./helpers/wrapNativeSuper/_index.mjs"
+      },
+      "./helpers/wrapNativeSuper/index.js"
+    ],
+    "./helpers/instanceof": [
+      {
+        "node": "./helpers/instanceof/index.js",
+        "require": "./helpers/instanceof/index.js",
+        "default": "./helpers/instanceof/_index.mjs"
+      },
+      "./helpers/instanceof/index.js"
+    ],
+    "./helpers/interopRequireDefault": [
+      {
+        "node": "./helpers/interopRequireDefault/index.js",
+        "require": "./helpers/interopRequireDefault/index.js",
+        "default": "./helpers/interopRequireDefault/_index.mjs"
+      },
+      "./helpers/interopRequireDefault/index.js"
+    ],
+    "./helpers/interopRequireWildcard": [
+      {
+        "node": "./helpers/interopRequireWildcard/index.js",
+        "require": "./helpers/interopRequireWildcard/index.js",
+        "default": "./helpers/interopRequireWildcard/_index.mjs"
+      },
+      "./helpers/interopRequireWildcard/index.js"
+    ],
+    "./helpers/newArrowCheck": [
+      {
+        "node": "./helpers/newArrowCheck/index.js",
+        "require": "./helpers/newArrowCheck/index.js",
+        "default": "./helpers/newArrowCheck/_index.mjs"
+      },
+      "./helpers/newArrowCheck/index.js"
+    ],
+    "./helpers/objectDestructuringEmpty": [
+      {
+        "node": "./helpers/objectDestructuringEmpty/index.js",
+        "require": "./helpers/objectDestructuringEmpty/index.js",
+        "default": "./helpers/objectDestructuringEmpty/_index.mjs"
+      },
+      "./helpers/objectDestructuringEmpty/index.js"
+    ],
+    "./helpers/objectWithoutPropertiesLoose": [
+      {
+        "node": "./helpers/objectWithoutPropertiesLoose/index.js",
+        "require": "./helpers/objectWithoutPropertiesLoose/index.js",
+        "default": "./helpers/objectWithoutPropertiesLoose/_index.mjs"
+      },
+      "./helpers/objectWithoutPropertiesLoose/index.js"
+    ],
+    "./helpers/objectWithoutProperties": [
+      {
+        "node": "./helpers/objectWithoutProperties/index.js",
+        "require": "./helpers/objectWithoutProperties/index.js",
+        "default": "./helpers/objectWithoutProperties/_index.mjs"
+      },
+      "./helpers/objectWithoutProperties/index.js"
+    ],
+    "./helpers/assertThisInitialized": [
+      {
+        "node": "./helpers/assertThisInitialized/index.js",
+        "require": "./helpers/assertThisInitialized/index.js",
+        "default": "./helpers/assertThisInitialized/_index.mjs"
+      },
+      "./helpers/assertThisInitialized/index.js"
+    ],
+    "./helpers/possibleConstructorReturn": [
+      {
+        "node": "./helpers/possibleConstructorReturn/index.js",
+        "require": "./helpers/possibleConstructorReturn/index.js",
+        "default": "./helpers/possibleConstructorReturn/_index.mjs"
+      },
+      "./helpers/possibleConstructorReturn/index.js"
+    ],
+    "./helpers/createSuper": [
+      {
+        "node": "./helpers/createSuper/index.js",
+        "require": "./helpers/createSuper/index.js",
+        "default": "./helpers/createSuper/_index.mjs"
+      },
+      "./helpers/createSuper/index.js"
+    ],
+    "./helpers/superPropBase": [
+      {
+        "node": "./helpers/superPropBase/index.js",
+        "require": "./helpers/superPropBase/index.js",
+        "default": "./helpers/superPropBase/_index.mjs"
+      },
+      "./helpers/superPropBase/index.js"
+    ],
+    "./helpers/get": [
+      {
+        "node": "./helpers/get/index.js",
+        "require": "./helpers/get/index.js",
+        "default": "./helpers/get/_index.mjs"
+      },
+      "./helpers/get/index.js"
+    ],
+    "./helpers/set": [
+      {
+        "node": "./helpers/set/index.js",
+        "require": "./helpers/set/index.js",
+        "default": "./helpers/set/_index.mjs"
+      },
+      "./helpers/set/index.js"
+    ],
+    "./helpers/taggedTemplateLiteral": [
+      {
+        "node": "./helpers/taggedTemplateLiteral/index.js",
+        "require": "./helpers/taggedTemplateLiteral/index.js",
+        "default": "./helpers/taggedTemplateLiteral/_index.mjs"
+      },
+      "./helpers/taggedTemplateLiteral/index.js"
+    ],
+    "./helpers/taggedTemplateLiteralLoose": [
+      {
+        "node": "./helpers/taggedTemplateLiteralLoose/index.js",
+        "require": "./helpers/taggedTemplateLiteralLoose/index.js",
+        "default": "./helpers/taggedTemplateLiteralLoose/_index.mjs"
+      },
+      "./helpers/taggedTemplateLiteralLoose/index.js"
+    ],
+    "./helpers/readOnlyError": [
+      {
+        "node": "./helpers/readOnlyError/index.js",
+        "require": "./helpers/readOnlyError/index.js",
+        "default": "./helpers/readOnlyError/_index.mjs"
+      },
+      "./helpers/readOnlyError/index.js"
+    ],
+    "./helpers/writeOnlyError": [
+      {
+        "node": "./helpers/writeOnlyError/index.js",
+        "require": "./helpers/writeOnlyError/index.js",
+        "default": "./helpers/writeOnlyError/_index.mjs"
+      },
+      "./helpers/writeOnlyError/index.js"
+    ],
+    "./helpers/classNameTDZError": [
+      {
+        "node": "./helpers/classNameTDZError/index.js",
+        "require": "./helpers/classNameTDZError/index.js",
+        "default": "./helpers/classNameTDZError/_index.mjs"
+      },
+      "./helpers/classNameTDZError/index.js"
+    ],
+    "./helpers/temporalUndefined": [
+      {
+        "node": "./helpers/temporalUndefined/index.js",
+        "require": "./helpers/temporalUndefined/index.js",
+        "default": "./helpers/temporalUndefined/_index.mjs"
+      },
+      "./helpers/temporalUndefined/index.js"
+    ],
+    "./helpers/tdz": [
+      {
+        "node": "./helpers/tdz/index.js",
+        "require": "./helpers/tdz/index.js",
+        "default": "./helpers/tdz/_index.mjs"
+      },
+      "./helpers/tdz/index.js"
+    ],
+    "./helpers/temporalRef": [
+      {
+        "node": "./helpers/temporalRef/index.js",
+        "require": "./helpers/temporalRef/index.js",
+        "default": "./helpers/temporalRef/_index.mjs"
+      },
+      "./helpers/temporalRef/index.js"
+    ],
+    "./helpers/slicedToArray": [
+      {
+        "node": "./helpers/slicedToArray/index.js",
+        "require": "./helpers/slicedToArray/index.js",
+        "default": "./helpers/slicedToArray/_index.mjs"
+      },
+      "./helpers/slicedToArray/index.js"
+    ],
+    "./helpers/slicedToArrayLoose": [
+      {
+        "node": "./helpers/slicedToArrayLoose/index.js",
+        "require": "./helpers/slicedToArrayLoose/index.js",
+        "default": "./helpers/slicedToArrayLoose/_index.mjs"
+      },
+      "./helpers/slicedToArrayLoose/index.js"
+    ],
+    "./helpers/toArray": [
+      {
+        "node": "./helpers/toArray/index.js",
+        "require": "./helpers/toArray/index.js",
+        "default": "./helpers/toArray/_index.mjs"
+      },
+      "./helpers/toArray/index.js"
+    ],
+    "./helpers/toConsumableArray": [
+      {
+        "node": "./helpers/toConsumableArray/index.js",
+        "require": "./helpers/toConsumableArray/index.js",
+        "default": "./helpers/toConsumableArray/_index.mjs"
+      },
+      "./helpers/toConsumableArray/index.js"
+    ],
+    "./helpers/arrayWithoutHoles": [
+      {
+        "node": "./helpers/arrayWithoutHoles/index.js",
+        "require": "./helpers/arrayWithoutHoles/index.js",
+        "default": "./helpers/arrayWithoutHoles/_index.mjs"
+      },
+      "./helpers/arrayWithoutHoles/index.js"
+    ],
+    "./helpers/arrayWithHoles": [
+      {
+        "node": "./helpers/arrayWithHoles/index.js",
+        "require": "./helpers/arrayWithHoles/index.js",
+        "default": "./helpers/arrayWithHoles/_index.mjs"
+      },
+      "./helpers/arrayWithHoles/index.js"
+    ],
+    "./helpers/maybeArrayLike": [
+      {
+        "node": "./helpers/maybeArrayLike/index.js",
+        "require": "./helpers/maybeArrayLike/index.js",
+        "default": "./helpers/maybeArrayLike/_index.mjs"
+      },
+      "./helpers/maybeArrayLike/index.js"
+    ],
+    "./helpers/iterableToArray": [
+      {
+        "node": "./helpers/iterableToArray/index.js",
+        "require": "./helpers/iterableToArray/index.js",
+        "default": "./helpers/iterableToArray/_index.mjs"
+      },
+      "./helpers/iterableToArray/index.js"
+    ],
+    "./helpers/iterableToArrayLimit": [
+      {
+        "node": "./helpers/iterableToArrayLimit/index.js",
+        "require": "./helpers/iterableToArrayLimit/index.js",
+        "default": "./helpers/iterableToArrayLimit/_index.mjs"
+      },
+      "./helpers/iterableToArrayLimit/index.js"
+    ],
+    "./helpers/iterableToArrayLimitLoose": [
+      {
+        "node": "./helpers/iterableToArrayLimitLoose/index.js",
+        "require": "./helpers/iterableToArrayLimitLoose/index.js",
+        "default": "./helpers/iterableToArrayLimitLoose/_index.mjs"
+      },
+      "./helpers/iterableToArrayLimitLoose/index.js"
+    ],
+    "./helpers/unsupportedIterableToArray": [
+      {
+        "node": "./helpers/unsupportedIterableToArray/index.js",
+        "require": "./helpers/unsupportedIterableToArray/index.js",
+        "default": "./helpers/unsupportedIterableToArray/_index.mjs"
+      },
+      "./helpers/unsupportedIterableToArray/index.js"
+    ],
+    "./helpers/arrayLikeToArray": [
+      {
+        "node": "./helpers/arrayLikeToArray/index.js",
+        "require": "./helpers/arrayLikeToArray/index.js",
+        "default": "./helpers/arrayLikeToArray/_index.mjs"
+      },
+      "./helpers/arrayLikeToArray/index.js"
+    ],
+    "./helpers/nonIterableSpread": [
+      {
+        "node": "./helpers/nonIterableSpread/index.js",
+        "require": "./helpers/nonIterableSpread/index.js",
+        "default": "./helpers/nonIterableSpread/_index.mjs"
+      },
+      "./helpers/nonIterableSpread/index.js"
+    ],
+    "./helpers/nonIterableRest": [
+      {
+        "node": "./helpers/nonIterableRest/index.js",
+        "require": "./helpers/nonIterableRest/index.js",
+        "default": "./helpers/nonIterableRest/_index.mjs"
+      },
+      "./helpers/nonIterableRest/index.js"
+    ],
+    "./helpers/createForOfIteratorHelper": [
+      {
+        "node": "./helpers/createForOfIteratorHelper/index.js",
+        "require": "./helpers/createForOfIteratorHelper/index.js",
+        "default": "./helpers/createForOfIteratorHelper/_index.mjs"
+      },
+      "./helpers/createForOfIteratorHelper/index.js"
+    ],
+    "./helpers/createForOfIteratorHelperLoose": [
+      {
+        "node": "./helpers/createForOfIteratorHelperLoose/index.js",
+        "require": "./helpers/createForOfIteratorHelperLoose/index.js",
+        "default": "./helpers/createForOfIteratorHelperLoose/_index.mjs"
+      },
+      "./helpers/createForOfIteratorHelperLoose/index.js"
+    ],
+    "./helpers/skipFirstGeneratorNext": [
+      {
+        "node": "./helpers/skipFirstGeneratorNext/index.js",
+        "require": "./helpers/skipFirstGeneratorNext/index.js",
+        "default": "./helpers/skipFirstGeneratorNext/_index.mjs"
+      },
+      "./helpers/skipFirstGeneratorNext/index.js"
+    ],
+    "./helpers/toPrimitive": [
+      {
+        "node": "./helpers/toPrimitive/index.js",
+        "require": "./helpers/toPrimitive/index.js",
+        "default": "./helpers/toPrimitive/_index.mjs"
+      },
+      "./helpers/toPrimitive/index.js"
+    ],
+    "./helpers/toPropertyKey": [
+      {
+        "node": "./helpers/toPropertyKey/index.js",
+        "require": "./helpers/toPropertyKey/index.js",
+        "default": "./helpers/toPropertyKey/_index.mjs"
+      },
+      "./helpers/toPropertyKey/index.js"
+    ],
+    "./helpers/initializerWarningHelper": [
+      {
+        "node": "./helpers/initializerWarningHelper/index.js",
+        "require": "./helpers/initializerWarningHelper/index.js",
+        "default": "./helpers/initializerWarningHelper/_index.mjs"
+      },
+      "./helpers/initializerWarningHelper/index.js"
+    ],
+    "./helpers/initializerDefineProperty": [
+      {
+        "node": "./helpers/initializerDefineProperty/index.js",
+        "require": "./helpers/initializerDefineProperty/index.js",
+        "default": "./helpers/initializerDefineProperty/_index.mjs"
+      },
+      "./helpers/initializerDefineProperty/index.js"
+    ],
+    "./helpers/applyDecoratedDescriptor": [
+      {
+        "node": "./helpers/applyDecoratedDescriptor/index.js",
+        "require": "./helpers/applyDecoratedDescriptor/index.js",
+        "default": "./helpers/applyDecoratedDescriptor/_index.mjs"
+      },
+      "./helpers/applyDecoratedDescriptor/index.js"
+    ],
+    "./helpers/classPrivateFieldLooseKey": [
+      {
+        "node": "./helpers/classPrivateFieldLooseKey/index.js",
+        "require": "./helpers/classPrivateFieldLooseKey/index.js",
+        "default": "./helpers/classPrivateFieldLooseKey/_index.mjs"
+      },
+      "./helpers/classPrivateFieldLooseKey/index.js"
+    ],
+    "./helpers/classPrivateFieldLooseBase": [
+      {
+        "node": "./helpers/classPrivateFieldLooseBase/index.js",
+        "require": "./helpers/classPrivateFieldLooseBase/index.js",
+        "default": "./helpers/classPrivateFieldLooseBase/_index.mjs"
+      },
+      "./helpers/classPrivateFieldLooseBase/index.js"
+    ],
+    "./helpers/classPrivateFieldGet": [
+      {
+        "node": "./helpers/classPrivateFieldGet/index.js",
+        "require": "./helpers/classPrivateFieldGet/index.js",
+        "default": "./helpers/classPrivateFieldGet/_index.mjs"
+      },
+      "./helpers/classPrivateFieldGet/index.js"
+    ],
+    "./helpers/classPrivateFieldSet": [
+      {
+        "node": "./helpers/classPrivateFieldSet/index.js",
+        "require": "./helpers/classPrivateFieldSet/index.js",
+        "default": "./helpers/classPrivateFieldSet/_index.mjs"
+      },
+      "./helpers/classPrivateFieldSet/index.js"
+    ],
+    "./helpers/classPrivateFieldDestructureSet": [
+      {
+        "node": "./helpers/classPrivateFieldDestructureSet/index.js",
+        "require": "./helpers/classPrivateFieldDestructureSet/index.js",
+        "default": "./helpers/classPrivateFieldDestructureSet/_index.mjs"
+      },
+      "./helpers/classPrivateFieldDestructureSet/index.js"
+    ],
+    "./helpers/classStaticPrivateFieldSpecGet": [
+      {
+        "node": "./helpers/classStaticPrivateFieldSpecGet/index.js",
+        "require": "./helpers/classStaticPrivateFieldSpecGet/index.js",
+        "default": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateFieldSpecGet/index.js"
+    ],
+    "./helpers/classStaticPrivateFieldSpecSet": [
+      {
+        "node": "./helpers/classStaticPrivateFieldSpecSet/index.js",
+        "require": "./helpers/classStaticPrivateFieldSpecSet/index.js",
+        "default": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateFieldSpecSet/index.js"
+    ],
+    "./helpers/classStaticPrivateMethodGet": [
+      {
+        "node": "./helpers/classStaticPrivateMethodGet/index.js",
+        "require": "./helpers/classStaticPrivateMethodGet/index.js",
+        "default": "./helpers/classStaticPrivateMethodGet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateMethodGet/index.js"
+    ],
+    "./helpers/classStaticPrivateMethodSet": [
+      {
+        "node": "./helpers/classStaticPrivateMethodSet/index.js",
+        "require": "./helpers/classStaticPrivateMethodSet/index.js",
+        "default": "./helpers/classStaticPrivateMethodSet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateMethodSet/index.js"
+    ],
+    "./helpers/decorate": [
+      {
+        "node": "./helpers/decorate/index.js",
+        "require": "./helpers/decorate/index.js",
+        "default": "./helpers/decorate/_index.mjs"
+      },
+      "./helpers/decorate/index.js"
+    ],
+    "./helpers/classPrivateMethodGet": [
+      {
+        "node": "./helpers/classPrivateMethodGet/index.js",
+        "require": "./helpers/classPrivateMethodGet/index.js",
+        "default": "./helpers/classPrivateMethodGet/_index.mjs"
+      },
+      "./helpers/classPrivateMethodGet/index.js"
+    ],
+    "./helpers/classPrivateMethodSet": [
+      {
+        "node": "./helpers/classPrivateMethodSet/index.js",
+        "require": "./helpers/classPrivateMethodSet/index.js",
+        "default": "./helpers/classPrivateMethodSet/_index.mjs"
+      },
+      "./helpers/classPrivateMethodSet/index.js"
+    ],
+    "./helpers/wrapRegExp": [
+      {
+        "node": "./helpers/wrapRegExp/index.js",
+        "require": "./helpers/wrapRegExp/index.js",
+        "default": "./helpers/wrapRegExp/_index.mjs"
+      },
+      "./helpers/wrapRegExp/index.js"
+    ],
     "./package": "./package.json",
     "./package.json": "./package.json",
     "./regenerator": "./regenerator/index.js",

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -17,411 +17,654 @@
     "regenerator-runtime": "^0.13.4"
   },
   "exports": {
-    "./helpers/typeof": {
-      "node": "./helpers/typeof/index.js",
-      "require": "./helpers/typeof/index.js",
-      "default": "./helpers/typeof/_index.mjs"
-    },
-    "./helpers/jsx": {
-      "node": "./helpers/jsx/index.js",
-      "require": "./helpers/jsx/index.js",
-      "default": "./helpers/jsx/_index.mjs"
-    },
-    "./helpers/asyncIterator": {
-      "node": "./helpers/asyncIterator/index.js",
-      "require": "./helpers/asyncIterator/index.js",
-      "default": "./helpers/asyncIterator/_index.mjs"
-    },
-    "./helpers/AwaitValue": {
-      "node": "./helpers/AwaitValue/index.js",
-      "require": "./helpers/AwaitValue/index.js",
-      "default": "./helpers/AwaitValue/_index.mjs"
-    },
-    "./helpers/AsyncGenerator": {
-      "node": "./helpers/AsyncGenerator/index.js",
-      "require": "./helpers/AsyncGenerator/index.js",
-      "default": "./helpers/AsyncGenerator/_index.mjs"
-    },
-    "./helpers/wrapAsyncGenerator": {
-      "node": "./helpers/wrapAsyncGenerator/index.js",
-      "require": "./helpers/wrapAsyncGenerator/index.js",
-      "default": "./helpers/wrapAsyncGenerator/_index.mjs"
-    },
-    "./helpers/awaitAsyncGenerator": {
-      "node": "./helpers/awaitAsyncGenerator/index.js",
-      "require": "./helpers/awaitAsyncGenerator/index.js",
-      "default": "./helpers/awaitAsyncGenerator/_index.mjs"
-    },
-    "./helpers/asyncGeneratorDelegate": {
-      "node": "./helpers/asyncGeneratorDelegate/index.js",
-      "require": "./helpers/asyncGeneratorDelegate/index.js",
-      "default": "./helpers/asyncGeneratorDelegate/_index.mjs"
-    },
-    "./helpers/asyncToGenerator": {
-      "node": "./helpers/asyncToGenerator/index.js",
-      "require": "./helpers/asyncToGenerator/index.js",
-      "default": "./helpers/asyncToGenerator/_index.mjs"
-    },
-    "./helpers/classCallCheck": {
-      "node": "./helpers/classCallCheck/index.js",
-      "require": "./helpers/classCallCheck/index.js",
-      "default": "./helpers/classCallCheck/_index.mjs"
-    },
-    "./helpers/createClass": {
-      "node": "./helpers/createClass/index.js",
-      "require": "./helpers/createClass/index.js",
-      "default": "./helpers/createClass/_index.mjs"
-    },
-    "./helpers/defineEnumerableProperties": {
-      "node": "./helpers/defineEnumerableProperties/index.js",
-      "require": "./helpers/defineEnumerableProperties/index.js",
-      "default": "./helpers/defineEnumerableProperties/_index.mjs"
-    },
-    "./helpers/defaults": {
-      "node": "./helpers/defaults/index.js",
-      "require": "./helpers/defaults/index.js",
-      "default": "./helpers/defaults/_index.mjs"
-    },
-    "./helpers/defineProperty": {
-      "node": "./helpers/defineProperty/index.js",
-      "require": "./helpers/defineProperty/index.js",
-      "default": "./helpers/defineProperty/_index.mjs"
-    },
-    "./helpers/extends": {
-      "node": "./helpers/extends/index.js",
-      "require": "./helpers/extends/index.js",
-      "default": "./helpers/extends/_index.mjs"
-    },
-    "./helpers/objectSpread": {
-      "node": "./helpers/objectSpread/index.js",
-      "require": "./helpers/objectSpread/index.js",
-      "default": "./helpers/objectSpread/_index.mjs"
-    },
-    "./helpers/objectSpread2": {
-      "node": "./helpers/objectSpread2/index.js",
-      "require": "./helpers/objectSpread2/index.js",
-      "default": "./helpers/objectSpread2/_index.mjs"
-    },
-    "./helpers/inherits": {
-      "node": "./helpers/inherits/index.js",
-      "require": "./helpers/inherits/index.js",
-      "default": "./helpers/inherits/_index.mjs"
-    },
-    "./helpers/inheritsLoose": {
-      "node": "./helpers/inheritsLoose/index.js",
-      "require": "./helpers/inheritsLoose/index.js",
-      "default": "./helpers/inheritsLoose/_index.mjs"
-    },
-    "./helpers/getPrototypeOf": {
-      "node": "./helpers/getPrototypeOf/index.js",
-      "require": "./helpers/getPrototypeOf/index.js",
-      "default": "./helpers/getPrototypeOf/_index.mjs"
-    },
-    "./helpers/setPrototypeOf": {
-      "node": "./helpers/setPrototypeOf/index.js",
-      "require": "./helpers/setPrototypeOf/index.js",
-      "default": "./helpers/setPrototypeOf/_index.mjs"
-    },
-    "./helpers/isNativeReflectConstruct": {
-      "node": "./helpers/isNativeReflectConstruct/index.js",
-      "require": "./helpers/isNativeReflectConstruct/index.js",
-      "default": "./helpers/isNativeReflectConstruct/_index.mjs"
-    },
-    "./helpers/construct": {
-      "node": "./helpers/construct/index.js",
-      "require": "./helpers/construct/index.js",
-      "default": "./helpers/construct/_index.mjs"
-    },
-    "./helpers/isNativeFunction": {
-      "node": "./helpers/isNativeFunction/index.js",
-      "require": "./helpers/isNativeFunction/index.js",
-      "default": "./helpers/isNativeFunction/_index.mjs"
-    },
-    "./helpers/wrapNativeSuper": {
-      "node": "./helpers/wrapNativeSuper/index.js",
-      "require": "./helpers/wrapNativeSuper/index.js",
-      "default": "./helpers/wrapNativeSuper/_index.mjs"
-    },
-    "./helpers/instanceof": {
-      "node": "./helpers/instanceof/index.js",
-      "require": "./helpers/instanceof/index.js",
-      "default": "./helpers/instanceof/_index.mjs"
-    },
-    "./helpers/interopRequireDefault": {
-      "node": "./helpers/interopRequireDefault/index.js",
-      "require": "./helpers/interopRequireDefault/index.js",
-      "default": "./helpers/interopRequireDefault/_index.mjs"
-    },
-    "./helpers/interopRequireWildcard": {
-      "node": "./helpers/interopRequireWildcard/index.js",
-      "require": "./helpers/interopRequireWildcard/index.js",
-      "default": "./helpers/interopRequireWildcard/_index.mjs"
-    },
-    "./helpers/newArrowCheck": {
-      "node": "./helpers/newArrowCheck/index.js",
-      "require": "./helpers/newArrowCheck/index.js",
-      "default": "./helpers/newArrowCheck/_index.mjs"
-    },
-    "./helpers/objectDestructuringEmpty": {
-      "node": "./helpers/objectDestructuringEmpty/index.js",
-      "require": "./helpers/objectDestructuringEmpty/index.js",
-      "default": "./helpers/objectDestructuringEmpty/_index.mjs"
-    },
-    "./helpers/objectWithoutPropertiesLoose": {
-      "node": "./helpers/objectWithoutPropertiesLoose/index.js",
-      "require": "./helpers/objectWithoutPropertiesLoose/index.js",
-      "default": "./helpers/objectWithoutPropertiesLoose/_index.mjs"
-    },
-    "./helpers/objectWithoutProperties": {
-      "node": "./helpers/objectWithoutProperties/index.js",
-      "require": "./helpers/objectWithoutProperties/index.js",
-      "default": "./helpers/objectWithoutProperties/_index.mjs"
-    },
-    "./helpers/assertThisInitialized": {
-      "node": "./helpers/assertThisInitialized/index.js",
-      "require": "./helpers/assertThisInitialized/index.js",
-      "default": "./helpers/assertThisInitialized/_index.mjs"
-    },
-    "./helpers/possibleConstructorReturn": {
-      "node": "./helpers/possibleConstructorReturn/index.js",
-      "require": "./helpers/possibleConstructorReturn/index.js",
-      "default": "./helpers/possibleConstructorReturn/_index.mjs"
-    },
-    "./helpers/createSuper": {
-      "node": "./helpers/createSuper/index.js",
-      "require": "./helpers/createSuper/index.js",
-      "default": "./helpers/createSuper/_index.mjs"
-    },
-    "./helpers/superPropBase": {
-      "node": "./helpers/superPropBase/index.js",
-      "require": "./helpers/superPropBase/index.js",
-      "default": "./helpers/superPropBase/_index.mjs"
-    },
-    "./helpers/get": {
-      "node": "./helpers/get/index.js",
-      "require": "./helpers/get/index.js",
-      "default": "./helpers/get/_index.mjs"
-    },
-    "./helpers/set": {
-      "node": "./helpers/set/index.js",
-      "require": "./helpers/set/index.js",
-      "default": "./helpers/set/_index.mjs"
-    },
-    "./helpers/taggedTemplateLiteral": {
-      "node": "./helpers/taggedTemplateLiteral/index.js",
-      "require": "./helpers/taggedTemplateLiteral/index.js",
-      "default": "./helpers/taggedTemplateLiteral/_index.mjs"
-    },
-    "./helpers/taggedTemplateLiteralLoose": {
-      "node": "./helpers/taggedTemplateLiteralLoose/index.js",
-      "require": "./helpers/taggedTemplateLiteralLoose/index.js",
-      "default": "./helpers/taggedTemplateLiteralLoose/_index.mjs"
-    },
-    "./helpers/readOnlyError": {
-      "node": "./helpers/readOnlyError/index.js",
-      "require": "./helpers/readOnlyError/index.js",
-      "default": "./helpers/readOnlyError/_index.mjs"
-    },
-    "./helpers/writeOnlyError": {
-      "node": "./helpers/writeOnlyError/index.js",
-      "require": "./helpers/writeOnlyError/index.js",
-      "default": "./helpers/writeOnlyError/_index.mjs"
-    },
-    "./helpers/classNameTDZError": {
-      "node": "./helpers/classNameTDZError/index.js",
-      "require": "./helpers/classNameTDZError/index.js",
-      "default": "./helpers/classNameTDZError/_index.mjs"
-    },
-    "./helpers/temporalUndefined": {
-      "node": "./helpers/temporalUndefined/index.js",
-      "require": "./helpers/temporalUndefined/index.js",
-      "default": "./helpers/temporalUndefined/_index.mjs"
-    },
-    "./helpers/tdz": {
-      "node": "./helpers/tdz/index.js",
-      "require": "./helpers/tdz/index.js",
-      "default": "./helpers/tdz/_index.mjs"
-    },
-    "./helpers/temporalRef": {
-      "node": "./helpers/temporalRef/index.js",
-      "require": "./helpers/temporalRef/index.js",
-      "default": "./helpers/temporalRef/_index.mjs"
-    },
-    "./helpers/slicedToArray": {
-      "node": "./helpers/slicedToArray/index.js",
-      "require": "./helpers/slicedToArray/index.js",
-      "default": "./helpers/slicedToArray/_index.mjs"
-    },
-    "./helpers/slicedToArrayLoose": {
-      "node": "./helpers/slicedToArrayLoose/index.js",
-      "require": "./helpers/slicedToArrayLoose/index.js",
-      "default": "./helpers/slicedToArrayLoose/_index.mjs"
-    },
-    "./helpers/toArray": {
-      "node": "./helpers/toArray/index.js",
-      "require": "./helpers/toArray/index.js",
-      "default": "./helpers/toArray/_index.mjs"
-    },
-    "./helpers/toConsumableArray": {
-      "node": "./helpers/toConsumableArray/index.js",
-      "require": "./helpers/toConsumableArray/index.js",
-      "default": "./helpers/toConsumableArray/_index.mjs"
-    },
-    "./helpers/arrayWithoutHoles": {
-      "node": "./helpers/arrayWithoutHoles/index.js",
-      "require": "./helpers/arrayWithoutHoles/index.js",
-      "default": "./helpers/arrayWithoutHoles/_index.mjs"
-    },
-    "./helpers/arrayWithHoles": {
-      "node": "./helpers/arrayWithHoles/index.js",
-      "require": "./helpers/arrayWithHoles/index.js",
-      "default": "./helpers/arrayWithHoles/_index.mjs"
-    },
-    "./helpers/maybeArrayLike": {
-      "node": "./helpers/maybeArrayLike/index.js",
-      "require": "./helpers/maybeArrayLike/index.js",
-      "default": "./helpers/maybeArrayLike/_index.mjs"
-    },
-    "./helpers/iterableToArray": {
-      "node": "./helpers/iterableToArray/index.js",
-      "require": "./helpers/iterableToArray/index.js",
-      "default": "./helpers/iterableToArray/_index.mjs"
-    },
-    "./helpers/iterableToArrayLimit": {
-      "node": "./helpers/iterableToArrayLimit/index.js",
-      "require": "./helpers/iterableToArrayLimit/index.js",
-      "default": "./helpers/iterableToArrayLimit/_index.mjs"
-    },
-    "./helpers/iterableToArrayLimitLoose": {
-      "node": "./helpers/iterableToArrayLimitLoose/index.js",
-      "require": "./helpers/iterableToArrayLimitLoose/index.js",
-      "default": "./helpers/iterableToArrayLimitLoose/_index.mjs"
-    },
-    "./helpers/unsupportedIterableToArray": {
-      "node": "./helpers/unsupportedIterableToArray/index.js",
-      "require": "./helpers/unsupportedIterableToArray/index.js",
-      "default": "./helpers/unsupportedIterableToArray/_index.mjs"
-    },
-    "./helpers/arrayLikeToArray": {
-      "node": "./helpers/arrayLikeToArray/index.js",
-      "require": "./helpers/arrayLikeToArray/index.js",
-      "default": "./helpers/arrayLikeToArray/_index.mjs"
-    },
-    "./helpers/nonIterableSpread": {
-      "node": "./helpers/nonIterableSpread/index.js",
-      "require": "./helpers/nonIterableSpread/index.js",
-      "default": "./helpers/nonIterableSpread/_index.mjs"
-    },
-    "./helpers/nonIterableRest": {
-      "node": "./helpers/nonIterableRest/index.js",
-      "require": "./helpers/nonIterableRest/index.js",
-      "default": "./helpers/nonIterableRest/_index.mjs"
-    },
-    "./helpers/createForOfIteratorHelper": {
-      "node": "./helpers/createForOfIteratorHelper/index.js",
-      "require": "./helpers/createForOfIteratorHelper/index.js",
-      "default": "./helpers/createForOfIteratorHelper/_index.mjs"
-    },
-    "./helpers/createForOfIteratorHelperLoose": {
-      "node": "./helpers/createForOfIteratorHelperLoose/index.js",
-      "require": "./helpers/createForOfIteratorHelperLoose/index.js",
-      "default": "./helpers/createForOfIteratorHelperLoose/_index.mjs"
-    },
-    "./helpers/skipFirstGeneratorNext": {
-      "node": "./helpers/skipFirstGeneratorNext/index.js",
-      "require": "./helpers/skipFirstGeneratorNext/index.js",
-      "default": "./helpers/skipFirstGeneratorNext/_index.mjs"
-    },
-    "./helpers/toPrimitive": {
-      "node": "./helpers/toPrimitive/index.js",
-      "require": "./helpers/toPrimitive/index.js",
-      "default": "./helpers/toPrimitive/_index.mjs"
-    },
-    "./helpers/toPropertyKey": {
-      "node": "./helpers/toPropertyKey/index.js",
-      "require": "./helpers/toPropertyKey/index.js",
-      "default": "./helpers/toPropertyKey/_index.mjs"
-    },
-    "./helpers/initializerWarningHelper": {
-      "node": "./helpers/initializerWarningHelper/index.js",
-      "require": "./helpers/initializerWarningHelper/index.js",
-      "default": "./helpers/initializerWarningHelper/_index.mjs"
-    },
-    "./helpers/initializerDefineProperty": {
-      "node": "./helpers/initializerDefineProperty/index.js",
-      "require": "./helpers/initializerDefineProperty/index.js",
-      "default": "./helpers/initializerDefineProperty/_index.mjs"
-    },
-    "./helpers/applyDecoratedDescriptor": {
-      "node": "./helpers/applyDecoratedDescriptor/index.js",
-      "require": "./helpers/applyDecoratedDescriptor/index.js",
-      "default": "./helpers/applyDecoratedDescriptor/_index.mjs"
-    },
-    "./helpers/classPrivateFieldLooseKey": {
-      "node": "./helpers/classPrivateFieldLooseKey/index.js",
-      "require": "./helpers/classPrivateFieldLooseKey/index.js",
-      "default": "./helpers/classPrivateFieldLooseKey/_index.mjs"
-    },
-    "./helpers/classPrivateFieldLooseBase": {
-      "node": "./helpers/classPrivateFieldLooseBase/index.js",
-      "require": "./helpers/classPrivateFieldLooseBase/index.js",
-      "default": "./helpers/classPrivateFieldLooseBase/_index.mjs"
-    },
-    "./helpers/classPrivateFieldGet": {
-      "node": "./helpers/classPrivateFieldGet/index.js",
-      "require": "./helpers/classPrivateFieldGet/index.js",
-      "default": "./helpers/classPrivateFieldGet/_index.mjs"
-    },
-    "./helpers/classPrivateFieldSet": {
-      "node": "./helpers/classPrivateFieldSet/index.js",
-      "require": "./helpers/classPrivateFieldSet/index.js",
-      "default": "./helpers/classPrivateFieldSet/_index.mjs"
-    },
-    "./helpers/classPrivateFieldDestructureSet": {
-      "node": "./helpers/classPrivateFieldDestructureSet/index.js",
-      "require": "./helpers/classPrivateFieldDestructureSet/index.js",
-      "default": "./helpers/classPrivateFieldDestructureSet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateFieldSpecGet": {
-      "node": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-      "require": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-      "default": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateFieldSpecSet": {
-      "node": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-      "require": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-      "default": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateMethodGet": {
-      "node": "./helpers/classStaticPrivateMethodGet/index.js",
-      "require": "./helpers/classStaticPrivateMethodGet/index.js",
-      "default": "./helpers/classStaticPrivateMethodGet/_index.mjs"
-    },
-    "./helpers/classStaticPrivateMethodSet": {
-      "node": "./helpers/classStaticPrivateMethodSet/index.js",
-      "require": "./helpers/classStaticPrivateMethodSet/index.js",
-      "default": "./helpers/classStaticPrivateMethodSet/_index.mjs"
-    },
-    "./helpers/decorate": {
-      "node": "./helpers/decorate/index.js",
-      "require": "./helpers/decorate/index.js",
-      "default": "./helpers/decorate/_index.mjs"
-    },
-    "./helpers/classPrivateMethodGet": {
-      "node": "./helpers/classPrivateMethodGet/index.js",
-      "require": "./helpers/classPrivateMethodGet/index.js",
-      "default": "./helpers/classPrivateMethodGet/_index.mjs"
-    },
-    "./helpers/classPrivateMethodSet": {
-      "node": "./helpers/classPrivateMethodSet/index.js",
-      "require": "./helpers/classPrivateMethodSet/index.js",
-      "default": "./helpers/classPrivateMethodSet/_index.mjs"
-    },
-    "./helpers/wrapRegExp": {
-      "node": "./helpers/wrapRegExp/index.js",
-      "require": "./helpers/wrapRegExp/index.js",
-      "default": "./helpers/wrapRegExp/_index.mjs"
-    },
+    "./helpers/typeof": [
+      {
+        "node": "./helpers/typeof/index.js",
+        "require": "./helpers/typeof/index.js",
+        "default": "./helpers/typeof/_index.mjs"
+      },
+      "./helpers/typeof/index.js"
+    ],
+    "./helpers/jsx": [
+      {
+        "node": "./helpers/jsx/index.js",
+        "require": "./helpers/jsx/index.js",
+        "default": "./helpers/jsx/_index.mjs"
+      },
+      "./helpers/jsx/index.js"
+    ],
+    "./helpers/asyncIterator": [
+      {
+        "node": "./helpers/asyncIterator/index.js",
+        "require": "./helpers/asyncIterator/index.js",
+        "default": "./helpers/asyncIterator/_index.mjs"
+      },
+      "./helpers/asyncIterator/index.js"
+    ],
+    "./helpers/AwaitValue": [
+      {
+        "node": "./helpers/AwaitValue/index.js",
+        "require": "./helpers/AwaitValue/index.js",
+        "default": "./helpers/AwaitValue/_index.mjs"
+      },
+      "./helpers/AwaitValue/index.js"
+    ],
+    "./helpers/AsyncGenerator": [
+      {
+        "node": "./helpers/AsyncGenerator/index.js",
+        "require": "./helpers/AsyncGenerator/index.js",
+        "default": "./helpers/AsyncGenerator/_index.mjs"
+      },
+      "./helpers/AsyncGenerator/index.js"
+    ],
+    "./helpers/wrapAsyncGenerator": [
+      {
+        "node": "./helpers/wrapAsyncGenerator/index.js",
+        "require": "./helpers/wrapAsyncGenerator/index.js",
+        "default": "./helpers/wrapAsyncGenerator/_index.mjs"
+      },
+      "./helpers/wrapAsyncGenerator/index.js"
+    ],
+    "./helpers/awaitAsyncGenerator": [
+      {
+        "node": "./helpers/awaitAsyncGenerator/index.js",
+        "require": "./helpers/awaitAsyncGenerator/index.js",
+        "default": "./helpers/awaitAsyncGenerator/_index.mjs"
+      },
+      "./helpers/awaitAsyncGenerator/index.js"
+    ],
+    "./helpers/asyncGeneratorDelegate": [
+      {
+        "node": "./helpers/asyncGeneratorDelegate/index.js",
+        "require": "./helpers/asyncGeneratorDelegate/index.js",
+        "default": "./helpers/asyncGeneratorDelegate/_index.mjs"
+      },
+      "./helpers/asyncGeneratorDelegate/index.js"
+    ],
+    "./helpers/asyncToGenerator": [
+      {
+        "node": "./helpers/asyncToGenerator/index.js",
+        "require": "./helpers/asyncToGenerator/index.js",
+        "default": "./helpers/asyncToGenerator/_index.mjs"
+      },
+      "./helpers/asyncToGenerator/index.js"
+    ],
+    "./helpers/classCallCheck": [
+      {
+        "node": "./helpers/classCallCheck/index.js",
+        "require": "./helpers/classCallCheck/index.js",
+        "default": "./helpers/classCallCheck/_index.mjs"
+      },
+      "./helpers/classCallCheck/index.js"
+    ],
+    "./helpers/createClass": [
+      {
+        "node": "./helpers/createClass/index.js",
+        "require": "./helpers/createClass/index.js",
+        "default": "./helpers/createClass/_index.mjs"
+      },
+      "./helpers/createClass/index.js"
+    ],
+    "./helpers/defineEnumerableProperties": [
+      {
+        "node": "./helpers/defineEnumerableProperties/index.js",
+        "require": "./helpers/defineEnumerableProperties/index.js",
+        "default": "./helpers/defineEnumerableProperties/_index.mjs"
+      },
+      "./helpers/defineEnumerableProperties/index.js"
+    ],
+    "./helpers/defaults": [
+      {
+        "node": "./helpers/defaults/index.js",
+        "require": "./helpers/defaults/index.js",
+        "default": "./helpers/defaults/_index.mjs"
+      },
+      "./helpers/defaults/index.js"
+    ],
+    "./helpers/defineProperty": [
+      {
+        "node": "./helpers/defineProperty/index.js",
+        "require": "./helpers/defineProperty/index.js",
+        "default": "./helpers/defineProperty/_index.mjs"
+      },
+      "./helpers/defineProperty/index.js"
+    ],
+    "./helpers/extends": [
+      {
+        "node": "./helpers/extends/index.js",
+        "require": "./helpers/extends/index.js",
+        "default": "./helpers/extends/_index.mjs"
+      },
+      "./helpers/extends/index.js"
+    ],
+    "./helpers/objectSpread": [
+      {
+        "node": "./helpers/objectSpread/index.js",
+        "require": "./helpers/objectSpread/index.js",
+        "default": "./helpers/objectSpread/_index.mjs"
+      },
+      "./helpers/objectSpread/index.js"
+    ],
+    "./helpers/objectSpread2": [
+      {
+        "node": "./helpers/objectSpread2/index.js",
+        "require": "./helpers/objectSpread2/index.js",
+        "default": "./helpers/objectSpread2/_index.mjs"
+      },
+      "./helpers/objectSpread2/index.js"
+    ],
+    "./helpers/inherits": [
+      {
+        "node": "./helpers/inherits/index.js",
+        "require": "./helpers/inherits/index.js",
+        "default": "./helpers/inherits/_index.mjs"
+      },
+      "./helpers/inherits/index.js"
+    ],
+    "./helpers/inheritsLoose": [
+      {
+        "node": "./helpers/inheritsLoose/index.js",
+        "require": "./helpers/inheritsLoose/index.js",
+        "default": "./helpers/inheritsLoose/_index.mjs"
+      },
+      "./helpers/inheritsLoose/index.js"
+    ],
+    "./helpers/getPrototypeOf": [
+      {
+        "node": "./helpers/getPrototypeOf/index.js",
+        "require": "./helpers/getPrototypeOf/index.js",
+        "default": "./helpers/getPrototypeOf/_index.mjs"
+      },
+      "./helpers/getPrototypeOf/index.js"
+    ],
+    "./helpers/setPrototypeOf": [
+      {
+        "node": "./helpers/setPrototypeOf/index.js",
+        "require": "./helpers/setPrototypeOf/index.js",
+        "default": "./helpers/setPrototypeOf/_index.mjs"
+      },
+      "./helpers/setPrototypeOf/index.js"
+    ],
+    "./helpers/isNativeReflectConstruct": [
+      {
+        "node": "./helpers/isNativeReflectConstruct/index.js",
+        "require": "./helpers/isNativeReflectConstruct/index.js",
+        "default": "./helpers/isNativeReflectConstruct/_index.mjs"
+      },
+      "./helpers/isNativeReflectConstruct/index.js"
+    ],
+    "./helpers/construct": [
+      {
+        "node": "./helpers/construct/index.js",
+        "require": "./helpers/construct/index.js",
+        "default": "./helpers/construct/_index.mjs"
+      },
+      "./helpers/construct/index.js"
+    ],
+    "./helpers/isNativeFunction": [
+      {
+        "node": "./helpers/isNativeFunction/index.js",
+        "require": "./helpers/isNativeFunction/index.js",
+        "default": "./helpers/isNativeFunction/_index.mjs"
+      },
+      "./helpers/isNativeFunction/index.js"
+    ],
+    "./helpers/wrapNativeSuper": [
+      {
+        "node": "./helpers/wrapNativeSuper/index.js",
+        "require": "./helpers/wrapNativeSuper/index.js",
+        "default": "./helpers/wrapNativeSuper/_index.mjs"
+      },
+      "./helpers/wrapNativeSuper/index.js"
+    ],
+    "./helpers/instanceof": [
+      {
+        "node": "./helpers/instanceof/index.js",
+        "require": "./helpers/instanceof/index.js",
+        "default": "./helpers/instanceof/_index.mjs"
+      },
+      "./helpers/instanceof/index.js"
+    ],
+    "./helpers/interopRequireDefault": [
+      {
+        "node": "./helpers/interopRequireDefault/index.js",
+        "require": "./helpers/interopRequireDefault/index.js",
+        "default": "./helpers/interopRequireDefault/_index.mjs"
+      },
+      "./helpers/interopRequireDefault/index.js"
+    ],
+    "./helpers/interopRequireWildcard": [
+      {
+        "node": "./helpers/interopRequireWildcard/index.js",
+        "require": "./helpers/interopRequireWildcard/index.js",
+        "default": "./helpers/interopRequireWildcard/_index.mjs"
+      },
+      "./helpers/interopRequireWildcard/index.js"
+    ],
+    "./helpers/newArrowCheck": [
+      {
+        "node": "./helpers/newArrowCheck/index.js",
+        "require": "./helpers/newArrowCheck/index.js",
+        "default": "./helpers/newArrowCheck/_index.mjs"
+      },
+      "./helpers/newArrowCheck/index.js"
+    ],
+    "./helpers/objectDestructuringEmpty": [
+      {
+        "node": "./helpers/objectDestructuringEmpty/index.js",
+        "require": "./helpers/objectDestructuringEmpty/index.js",
+        "default": "./helpers/objectDestructuringEmpty/_index.mjs"
+      },
+      "./helpers/objectDestructuringEmpty/index.js"
+    ],
+    "./helpers/objectWithoutPropertiesLoose": [
+      {
+        "node": "./helpers/objectWithoutPropertiesLoose/index.js",
+        "require": "./helpers/objectWithoutPropertiesLoose/index.js",
+        "default": "./helpers/objectWithoutPropertiesLoose/_index.mjs"
+      },
+      "./helpers/objectWithoutPropertiesLoose/index.js"
+    ],
+    "./helpers/objectWithoutProperties": [
+      {
+        "node": "./helpers/objectWithoutProperties/index.js",
+        "require": "./helpers/objectWithoutProperties/index.js",
+        "default": "./helpers/objectWithoutProperties/_index.mjs"
+      },
+      "./helpers/objectWithoutProperties/index.js"
+    ],
+    "./helpers/assertThisInitialized": [
+      {
+        "node": "./helpers/assertThisInitialized/index.js",
+        "require": "./helpers/assertThisInitialized/index.js",
+        "default": "./helpers/assertThisInitialized/_index.mjs"
+      },
+      "./helpers/assertThisInitialized/index.js"
+    ],
+    "./helpers/possibleConstructorReturn": [
+      {
+        "node": "./helpers/possibleConstructorReturn/index.js",
+        "require": "./helpers/possibleConstructorReturn/index.js",
+        "default": "./helpers/possibleConstructorReturn/_index.mjs"
+      },
+      "./helpers/possibleConstructorReturn/index.js"
+    ],
+    "./helpers/createSuper": [
+      {
+        "node": "./helpers/createSuper/index.js",
+        "require": "./helpers/createSuper/index.js",
+        "default": "./helpers/createSuper/_index.mjs"
+      },
+      "./helpers/createSuper/index.js"
+    ],
+    "./helpers/superPropBase": [
+      {
+        "node": "./helpers/superPropBase/index.js",
+        "require": "./helpers/superPropBase/index.js",
+        "default": "./helpers/superPropBase/_index.mjs"
+      },
+      "./helpers/superPropBase/index.js"
+    ],
+    "./helpers/get": [
+      {
+        "node": "./helpers/get/index.js",
+        "require": "./helpers/get/index.js",
+        "default": "./helpers/get/_index.mjs"
+      },
+      "./helpers/get/index.js"
+    ],
+    "./helpers/set": [
+      {
+        "node": "./helpers/set/index.js",
+        "require": "./helpers/set/index.js",
+        "default": "./helpers/set/_index.mjs"
+      },
+      "./helpers/set/index.js"
+    ],
+    "./helpers/taggedTemplateLiteral": [
+      {
+        "node": "./helpers/taggedTemplateLiteral/index.js",
+        "require": "./helpers/taggedTemplateLiteral/index.js",
+        "default": "./helpers/taggedTemplateLiteral/_index.mjs"
+      },
+      "./helpers/taggedTemplateLiteral/index.js"
+    ],
+    "./helpers/taggedTemplateLiteralLoose": [
+      {
+        "node": "./helpers/taggedTemplateLiteralLoose/index.js",
+        "require": "./helpers/taggedTemplateLiteralLoose/index.js",
+        "default": "./helpers/taggedTemplateLiteralLoose/_index.mjs"
+      },
+      "./helpers/taggedTemplateLiteralLoose/index.js"
+    ],
+    "./helpers/readOnlyError": [
+      {
+        "node": "./helpers/readOnlyError/index.js",
+        "require": "./helpers/readOnlyError/index.js",
+        "default": "./helpers/readOnlyError/_index.mjs"
+      },
+      "./helpers/readOnlyError/index.js"
+    ],
+    "./helpers/writeOnlyError": [
+      {
+        "node": "./helpers/writeOnlyError/index.js",
+        "require": "./helpers/writeOnlyError/index.js",
+        "default": "./helpers/writeOnlyError/_index.mjs"
+      },
+      "./helpers/writeOnlyError/index.js"
+    ],
+    "./helpers/classNameTDZError": [
+      {
+        "node": "./helpers/classNameTDZError/index.js",
+        "require": "./helpers/classNameTDZError/index.js",
+        "default": "./helpers/classNameTDZError/_index.mjs"
+      },
+      "./helpers/classNameTDZError/index.js"
+    ],
+    "./helpers/temporalUndefined": [
+      {
+        "node": "./helpers/temporalUndefined/index.js",
+        "require": "./helpers/temporalUndefined/index.js",
+        "default": "./helpers/temporalUndefined/_index.mjs"
+      },
+      "./helpers/temporalUndefined/index.js"
+    ],
+    "./helpers/tdz": [
+      {
+        "node": "./helpers/tdz/index.js",
+        "require": "./helpers/tdz/index.js",
+        "default": "./helpers/tdz/_index.mjs"
+      },
+      "./helpers/tdz/index.js"
+    ],
+    "./helpers/temporalRef": [
+      {
+        "node": "./helpers/temporalRef/index.js",
+        "require": "./helpers/temporalRef/index.js",
+        "default": "./helpers/temporalRef/_index.mjs"
+      },
+      "./helpers/temporalRef/index.js"
+    ],
+    "./helpers/slicedToArray": [
+      {
+        "node": "./helpers/slicedToArray/index.js",
+        "require": "./helpers/slicedToArray/index.js",
+        "default": "./helpers/slicedToArray/_index.mjs"
+      },
+      "./helpers/slicedToArray/index.js"
+    ],
+    "./helpers/slicedToArrayLoose": [
+      {
+        "node": "./helpers/slicedToArrayLoose/index.js",
+        "require": "./helpers/slicedToArrayLoose/index.js",
+        "default": "./helpers/slicedToArrayLoose/_index.mjs"
+      },
+      "./helpers/slicedToArrayLoose/index.js"
+    ],
+    "./helpers/toArray": [
+      {
+        "node": "./helpers/toArray/index.js",
+        "require": "./helpers/toArray/index.js",
+        "default": "./helpers/toArray/_index.mjs"
+      },
+      "./helpers/toArray/index.js"
+    ],
+    "./helpers/toConsumableArray": [
+      {
+        "node": "./helpers/toConsumableArray/index.js",
+        "require": "./helpers/toConsumableArray/index.js",
+        "default": "./helpers/toConsumableArray/_index.mjs"
+      },
+      "./helpers/toConsumableArray/index.js"
+    ],
+    "./helpers/arrayWithoutHoles": [
+      {
+        "node": "./helpers/arrayWithoutHoles/index.js",
+        "require": "./helpers/arrayWithoutHoles/index.js",
+        "default": "./helpers/arrayWithoutHoles/_index.mjs"
+      },
+      "./helpers/arrayWithoutHoles/index.js"
+    ],
+    "./helpers/arrayWithHoles": [
+      {
+        "node": "./helpers/arrayWithHoles/index.js",
+        "require": "./helpers/arrayWithHoles/index.js",
+        "default": "./helpers/arrayWithHoles/_index.mjs"
+      },
+      "./helpers/arrayWithHoles/index.js"
+    ],
+    "./helpers/maybeArrayLike": [
+      {
+        "node": "./helpers/maybeArrayLike/index.js",
+        "require": "./helpers/maybeArrayLike/index.js",
+        "default": "./helpers/maybeArrayLike/_index.mjs"
+      },
+      "./helpers/maybeArrayLike/index.js"
+    ],
+    "./helpers/iterableToArray": [
+      {
+        "node": "./helpers/iterableToArray/index.js",
+        "require": "./helpers/iterableToArray/index.js",
+        "default": "./helpers/iterableToArray/_index.mjs"
+      },
+      "./helpers/iterableToArray/index.js"
+    ],
+    "./helpers/iterableToArrayLimit": [
+      {
+        "node": "./helpers/iterableToArrayLimit/index.js",
+        "require": "./helpers/iterableToArrayLimit/index.js",
+        "default": "./helpers/iterableToArrayLimit/_index.mjs"
+      },
+      "./helpers/iterableToArrayLimit/index.js"
+    ],
+    "./helpers/iterableToArrayLimitLoose": [
+      {
+        "node": "./helpers/iterableToArrayLimitLoose/index.js",
+        "require": "./helpers/iterableToArrayLimitLoose/index.js",
+        "default": "./helpers/iterableToArrayLimitLoose/_index.mjs"
+      },
+      "./helpers/iterableToArrayLimitLoose/index.js"
+    ],
+    "./helpers/unsupportedIterableToArray": [
+      {
+        "node": "./helpers/unsupportedIterableToArray/index.js",
+        "require": "./helpers/unsupportedIterableToArray/index.js",
+        "default": "./helpers/unsupportedIterableToArray/_index.mjs"
+      },
+      "./helpers/unsupportedIterableToArray/index.js"
+    ],
+    "./helpers/arrayLikeToArray": [
+      {
+        "node": "./helpers/arrayLikeToArray/index.js",
+        "require": "./helpers/arrayLikeToArray/index.js",
+        "default": "./helpers/arrayLikeToArray/_index.mjs"
+      },
+      "./helpers/arrayLikeToArray/index.js"
+    ],
+    "./helpers/nonIterableSpread": [
+      {
+        "node": "./helpers/nonIterableSpread/index.js",
+        "require": "./helpers/nonIterableSpread/index.js",
+        "default": "./helpers/nonIterableSpread/_index.mjs"
+      },
+      "./helpers/nonIterableSpread/index.js"
+    ],
+    "./helpers/nonIterableRest": [
+      {
+        "node": "./helpers/nonIterableRest/index.js",
+        "require": "./helpers/nonIterableRest/index.js",
+        "default": "./helpers/nonIterableRest/_index.mjs"
+      },
+      "./helpers/nonIterableRest/index.js"
+    ],
+    "./helpers/createForOfIteratorHelper": [
+      {
+        "node": "./helpers/createForOfIteratorHelper/index.js",
+        "require": "./helpers/createForOfIteratorHelper/index.js",
+        "default": "./helpers/createForOfIteratorHelper/_index.mjs"
+      },
+      "./helpers/createForOfIteratorHelper/index.js"
+    ],
+    "./helpers/createForOfIteratorHelperLoose": [
+      {
+        "node": "./helpers/createForOfIteratorHelperLoose/index.js",
+        "require": "./helpers/createForOfIteratorHelperLoose/index.js",
+        "default": "./helpers/createForOfIteratorHelperLoose/_index.mjs"
+      },
+      "./helpers/createForOfIteratorHelperLoose/index.js"
+    ],
+    "./helpers/skipFirstGeneratorNext": [
+      {
+        "node": "./helpers/skipFirstGeneratorNext/index.js",
+        "require": "./helpers/skipFirstGeneratorNext/index.js",
+        "default": "./helpers/skipFirstGeneratorNext/_index.mjs"
+      },
+      "./helpers/skipFirstGeneratorNext/index.js"
+    ],
+    "./helpers/toPrimitive": [
+      {
+        "node": "./helpers/toPrimitive/index.js",
+        "require": "./helpers/toPrimitive/index.js",
+        "default": "./helpers/toPrimitive/_index.mjs"
+      },
+      "./helpers/toPrimitive/index.js"
+    ],
+    "./helpers/toPropertyKey": [
+      {
+        "node": "./helpers/toPropertyKey/index.js",
+        "require": "./helpers/toPropertyKey/index.js",
+        "default": "./helpers/toPropertyKey/_index.mjs"
+      },
+      "./helpers/toPropertyKey/index.js"
+    ],
+    "./helpers/initializerWarningHelper": [
+      {
+        "node": "./helpers/initializerWarningHelper/index.js",
+        "require": "./helpers/initializerWarningHelper/index.js",
+        "default": "./helpers/initializerWarningHelper/_index.mjs"
+      },
+      "./helpers/initializerWarningHelper/index.js"
+    ],
+    "./helpers/initializerDefineProperty": [
+      {
+        "node": "./helpers/initializerDefineProperty/index.js",
+        "require": "./helpers/initializerDefineProperty/index.js",
+        "default": "./helpers/initializerDefineProperty/_index.mjs"
+      },
+      "./helpers/initializerDefineProperty/index.js"
+    ],
+    "./helpers/applyDecoratedDescriptor": [
+      {
+        "node": "./helpers/applyDecoratedDescriptor/index.js",
+        "require": "./helpers/applyDecoratedDescriptor/index.js",
+        "default": "./helpers/applyDecoratedDescriptor/_index.mjs"
+      },
+      "./helpers/applyDecoratedDescriptor/index.js"
+    ],
+    "./helpers/classPrivateFieldLooseKey": [
+      {
+        "node": "./helpers/classPrivateFieldLooseKey/index.js",
+        "require": "./helpers/classPrivateFieldLooseKey/index.js",
+        "default": "./helpers/classPrivateFieldLooseKey/_index.mjs"
+      },
+      "./helpers/classPrivateFieldLooseKey/index.js"
+    ],
+    "./helpers/classPrivateFieldLooseBase": [
+      {
+        "node": "./helpers/classPrivateFieldLooseBase/index.js",
+        "require": "./helpers/classPrivateFieldLooseBase/index.js",
+        "default": "./helpers/classPrivateFieldLooseBase/_index.mjs"
+      },
+      "./helpers/classPrivateFieldLooseBase/index.js"
+    ],
+    "./helpers/classPrivateFieldGet": [
+      {
+        "node": "./helpers/classPrivateFieldGet/index.js",
+        "require": "./helpers/classPrivateFieldGet/index.js",
+        "default": "./helpers/classPrivateFieldGet/_index.mjs"
+      },
+      "./helpers/classPrivateFieldGet/index.js"
+    ],
+    "./helpers/classPrivateFieldSet": [
+      {
+        "node": "./helpers/classPrivateFieldSet/index.js",
+        "require": "./helpers/classPrivateFieldSet/index.js",
+        "default": "./helpers/classPrivateFieldSet/_index.mjs"
+      },
+      "./helpers/classPrivateFieldSet/index.js"
+    ],
+    "./helpers/classPrivateFieldDestructureSet": [
+      {
+        "node": "./helpers/classPrivateFieldDestructureSet/index.js",
+        "require": "./helpers/classPrivateFieldDestructureSet/index.js",
+        "default": "./helpers/classPrivateFieldDestructureSet/_index.mjs"
+      },
+      "./helpers/classPrivateFieldDestructureSet/index.js"
+    ],
+    "./helpers/classStaticPrivateFieldSpecGet": [
+      {
+        "node": "./helpers/classStaticPrivateFieldSpecGet/index.js",
+        "require": "./helpers/classStaticPrivateFieldSpecGet/index.js",
+        "default": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateFieldSpecGet/index.js"
+    ],
+    "./helpers/classStaticPrivateFieldSpecSet": [
+      {
+        "node": "./helpers/classStaticPrivateFieldSpecSet/index.js",
+        "require": "./helpers/classStaticPrivateFieldSpecSet/index.js",
+        "default": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateFieldSpecSet/index.js"
+    ],
+    "./helpers/classStaticPrivateMethodGet": [
+      {
+        "node": "./helpers/classStaticPrivateMethodGet/index.js",
+        "require": "./helpers/classStaticPrivateMethodGet/index.js",
+        "default": "./helpers/classStaticPrivateMethodGet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateMethodGet/index.js"
+    ],
+    "./helpers/classStaticPrivateMethodSet": [
+      {
+        "node": "./helpers/classStaticPrivateMethodSet/index.js",
+        "require": "./helpers/classStaticPrivateMethodSet/index.js",
+        "default": "./helpers/classStaticPrivateMethodSet/_index.mjs"
+      },
+      "./helpers/classStaticPrivateMethodSet/index.js"
+    ],
+    "./helpers/decorate": [
+      {
+        "node": "./helpers/decorate/index.js",
+        "require": "./helpers/decorate/index.js",
+        "default": "./helpers/decorate/_index.mjs"
+      },
+      "./helpers/decorate/index.js"
+    ],
+    "./helpers/classPrivateMethodGet": [
+      {
+        "node": "./helpers/classPrivateMethodGet/index.js",
+        "require": "./helpers/classPrivateMethodGet/index.js",
+        "default": "./helpers/classPrivateMethodGet/_index.mjs"
+      },
+      "./helpers/classPrivateMethodGet/index.js"
+    ],
+    "./helpers/classPrivateMethodSet": [
+      {
+        "node": "./helpers/classPrivateMethodSet/index.js",
+        "require": "./helpers/classPrivateMethodSet/index.js",
+        "default": "./helpers/classPrivateMethodSet/_index.mjs"
+      },
+      "./helpers/classPrivateMethodSet/index.js"
+    ],
+    "./helpers/wrapRegExp": [
+      {
+        "node": "./helpers/wrapRegExp/index.js",
+        "require": "./helpers/wrapRegExp/index.js",
+        "default": "./helpers/wrapRegExp/_index.mjs"
+      },
+      "./helpers/wrapRegExp/index.js"
+    ],
     "./package": "./package.json",
     "./package.json": "./package.json",
     "./regenerator": "./regenerator/index.js",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12871
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Conditional exports have been introduced in Node.js 13.7.0. Previous Node.js versions still read the `exports` field in `package.json` but throw when they see conditions.

This PR adds a fallback (using the array exports "syntax"): older Node.js versions will fail loading the conditional exports, and fallback to the second array entry.
There is [comment in the build script](https://github.com/babel/babel/pull/12877/files#diff-1a33067593da7fc235661f175965fbb22715fbe76fde5ae41e1bd39afdcb4469R156-R166) that explains it.

@guybedford I'm sorry to ping you, but I just learned this by experimenting and reading the docs. Is my understanding correct? :sweat_smile: 