### PR TITLE
fix(eslint-parser): merge input `estree` options

### DIFF
--- a/eslint/babel-eslint-parser/src/configuration.js
+++ b/eslint/babel-eslint-parser/src/configuration.js
@@ -22,7 +22,7 @@ export function normalizeESLintConfig(options) {
 }
 
 /**
- * Merge the first user supplied estree plugin options to default estree plugin options
+ * Merge user supplied estree plugin options to default estree plugin options
  *
  * @param {*} babelOptions
  * @returns {Array} Merged parser plugin descriptors

--- a/eslint/babel-eslint-parser/src/configuration.js
+++ b/eslint/babel-eslint-parser/src/configuration.js
@@ -21,6 +21,26 @@ export function normalizeESLintConfig(options) {
   };
 }
 
+/**
+ * Merge the first user supplied estree plugin options to default estree plugin options
+ *
+ * @param {*} babelOptions
+ * @returns {Array} Merged parser plugin descriptors
+ */
+function getParserPlugins(babelOptions) {
+  const babelParserPlugins = babelOptions.parserOpts?.plugins ?? [];
+  // todo: enable classFeatures when it is supported by ESLint
+  const estreeOptions = { classFeatures: false };
+  for (const plugin of babelParserPlugins) {
+    if (Array.isArray(plugin) && plugin[0] === "estree") {
+      Object.assign(estreeOptions, plugin[1]);
+      break;
+    }
+  }
+  // estree must be the first parser plugin to work with other parser plugins
+  return [["estree", estreeOptions], ...babelParserPlugins];
+}
+
 export function normalizeBabelParseConfig(options) {
   const parseOptions = {
     sourceType: options.sourceType,
@@ -31,10 +51,7 @@ export function normalizeBabelParseConfig(options) {
       allowReturnOutsideFunction: true,
       allowSuperOutsideMethod: true,
       ...options.babelOptions.parserOpts,
-      plugins: [
-        ["estree", { classFeatures: false }],
-        ...(options.babelOptions.parserOpts?.plugins ?? []),
-      ],
+      plugins: getParserPlugins(options.babelOptions),
       ranges: true,
       tokens: true,
     },

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -327,6 +327,26 @@ describe("Babel and Espree", () => {
     expect(babylonAST.tokens[3].value).toEqual("#");
   });
 
+  it("parse to PropertyDeclaration when `classFeatures: true`", () => {
+    const code = "class A { #x }";
+    const babylonAST = parseForESLint(code, {
+      eslintVisitorKeys: true,
+      eslintScopeManager: true,
+      babelOptions: {
+        filename: "test.js",
+        parserOpts: {
+          plugins: [
+            ["estree", { classFeatures: true }],
+            "classPrivateProperties",
+            "classProperties",
+          ],
+        },
+      },
+    }).ast;
+    const classDeclaration = babylonAST.body[0];
+    expect(classDeclaration.body.body[0].type).toEqual("PropertyDefinition");
+  });
+
   it("empty program with line comment", () => {
     parseAndAssertSame("// single comment");
   });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `@babel/eslint-parser` users should be able to opt-in to the `classFeatures: boolean`
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In #12867 we move estree class features behind a `classFeatures: boolean` option. However it is impossible to be allowed in `@babel/eslint-parser` because Babel parser does not merge plugin options. In this PR we merge user supplied estree options to the builtin estree options defaults.

After this PR is shipped, you can specify `classFeatures` to enable estree class features implementation in `.eslintrc.js`:

```js
module.exports = {
  parser: "@babel/eslint-parser",
  babelOptions: {
    parserOpts: {
      plugins: [
        ["estree", { classFeatures: true }],
        "classPrivateProperties",
        "classProperties",
      ],
    },
  },
};

```

cc @fisker 