### PR TITLE
Allow `require()` of runtime helpers in Node.js 13.2-13.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,18 +326,18 @@ jobs:
           node-version: "13.0" # quoted, otherwise it's just 13
       - name: Test Node.js 13.0
         run: yarn test:runtime:node
-      # - name: Use Node.js 13.2
-      #   uses: actions/setup-node@v2-beta
-      #   with:
-      #     node-version: 13.2
-      # - name: Test Node.js 13.2
-      #   run: yarn test:runtime:node
-      # - name: Use Node.js 13.6
-      #   uses: actions/setup-node@v2-beta
-      #   with:
-      #     node-version: 13.6
-      # - name: Test Node.js 13.6
-      #   run: yarn test:runtime:node
+      - name: Use Node.js 13.2
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: 13.2
+      - name: Test Node.js 13.2
+        run: yarn test:runtime:node
+      - name: Use Node.js 13.6
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: 13.6
+      - name: Test Node.js 13.6
+        run: yarn test:runtime:node
       - name: Use Node.js 13.7
         uses: actions/setup-node@v2-beta
         with:

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -159,13 +159,16 @@ function writeHelpers(runtimeName, { corejs } = {}) {
     // - Node.js >=13.7.0 and bundlers will succesfully load the first
     //   array entry:
     //    * Node.js will always load the CJS file
-    //    * Bundlers when using require() will load the CJS file
-    //    * Everything else will load the ESM file
-    // - Node.js <13.7.0 will fail resolving the first array entry, and will
+    //    * Modern tools when using "import" will load the ESM file
+    //    * Everything else (old tools, or requrie() in tools) will
+    //      load the CJS file
+    // - Node.js 13.2-13.7 will ignore the "node" and "import" conditions,
+    //   will fallback to "default" and load the CJS file
+    // - Node.js <13.2.0 will fail resolving the first array entry, and will
     //   fallback to the second entry (the CJS file)
     // In Babel 8 we can simplify this.
     helperSubExports[`./${helperPath}`] = [
-      { node: cjs, require: cjs, default: esm },
+      { node: cjs, import: esm, default: cjs },
       cjs,
     ];
     // For backward compatibility. We can remove this in Babel 8.

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -21,8 +21,8 @@
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof/index.js",
-        "require": "./helpers/typeof/index.js",
-        "default": "./helpers/typeof/_index.mjs"
+        "import": "./helpers/typeof/_index.mjs",
+        "default": "./helpers/typeof/index.js"
       },
       "./helpers/typeof/index.js"
     ],
@@ -30,8 +30,8 @@
     "./helpers/jsx": [
       {
         "node": "./helpers/jsx/index.js",
-        "require": "./helpers/jsx/index.js",
-        "default": "./helpers/jsx/_index.mjs"
+        "import": "./helpers/jsx/_index.mjs",
+        "default": "./helpers/jsx/index.js"
       },
       "./helpers/jsx/index.js"
     ],
@@ -39,8 +39,8 @@
     "./helpers/asyncIterator": [
       {
         "node": "./helpers/asyncIterator/index.js",
-        "require": "./helpers/asyncIterator/index.js",
-        "default": "./helpers/asyncIterator/_index.mjs"
+        "import": "./helpers/asyncIterator/_index.mjs",
+        "default": "./helpers/asyncIterator/index.js"
       },
       "./helpers/asyncIterator/index.js"
     ],
@@ -48,8 +48,8 @@
     "./helpers/AwaitValue": [
       {
         "node": "./helpers/AwaitValue/index.js",
-        "require": "./helpers/AwaitValue/index.js",
-        "default": "./helpers/AwaitValue/_index.mjs"
+        "import": "./helpers/AwaitValue/_index.mjs",
+        "default": "./helpers/AwaitValue/index.js"
       },
       "./helpers/AwaitValue/index.js"
     ],
@@ -57,8 +57,8 @@
     "./helpers/AsyncGenerator": [
       {
         "node": "./helpers/AsyncGenerator/index.js",
-        "require": "./helpers/AsyncGenerator/index.js",
-        "default": "./helpers/AsyncGenerator/_index.mjs"
+        "import": "./helpers/AsyncGenerator/_index.mjs",
+        "default": "./helpers/AsyncGenerator/index.js"
       },
       "./helpers/AsyncGenerator/index.js"
     ],
@@ -66,8 +66,8 @@
     "./helpers/wrapAsyncGenerator": [
       {
         "node": "./helpers/wrapAsyncGenerator/index.js",
-        "require": "./helpers/wrapAsyncGenerator/index.js",
-        "default": "./helpers/wrapAsyncGenerator/_index.mjs"
+        "import": "./helpers/wrapAsyncGenerator/_index.mjs",
+        "default": "./helpers/wrapAsyncGenerator/index.js"
       },
       "./helpers/wrapAsyncGenerator/index.js"
     ],
@@ -75,8 +75,8 @@
     "./helpers/awaitAsyncGenerator": [
       {
         "node": "./helpers/awaitAsyncGenerator/index.js",
-        "require": "./helpers/awaitAsyncGenerator/index.js",
-        "default": "./helpers/awaitAsyncGenerator/_index.mjs"
+        "import": "./helpers/awaitAsyncGenerator/_index.mjs",
+        "default": "./helpers/awaitAsyncGenerator/index.js"
       },
       "./helpers/awaitAsyncGenerator/index.js"
     ],
@@ -84,8 +84,8 @@
     "./helpers/asyncGeneratorDelegate": [
       {
         "node": "./helpers/asyncGeneratorDelegate/index.js",
-        "require": "./helpers/asyncGeneratorDelegate/index.js",
-        "default": "./helpers/asyncGeneratorDelegate/_index.mjs"
+        "import": "./helpers/asyncGeneratorDelegate/_index.mjs",
+        "default": "./helpers/asyncGeneratorDelegate/index.js"
       },
       "./helpers/asyncGeneratorDelegate/index.js"
     ],
@@ -93,8 +93,8 @@
     "./helpers/asyncToGenerator": [
       {
         "node": "./helpers/asyncToGenerator/index.js",
-        "require": "./helpers/asyncToGenerator/index.js",
-        "default": "./helpers/asyncToGenerator/_index.mjs"
+        "import": "./helpers/asyncToGenerator/_index.mjs",
+        "default": "./helpers/asyncToGenerator/index.js"
       },
       "./helpers/asyncToGenerator/index.js"
     ],
@@ -102,8 +102,8 @@
     "./helpers/classCallCheck": [
       {
         "node": "./helpers/classCallCheck/index.js",
-        "require": "./helpers/classCallCheck/index.js",
-        "default": "./helpers/classCallCheck/_index.mjs"
+        "import": "./helpers/classCallCheck/_index.mjs",
+        "default": "./helpers/classCallCheck/index.js"
       },
       "./helpers/classCallCheck/index.js"
     ],
@@ -111,8 +111,8 @@
     "./helpers/createClass": [
       {
         "node": "./helpers/createClass/index.js",
-        "require": "./helpers/createClass/index.js",
-        "default": "./helpers/createClass/_index.mjs"
+        "import": "./helpers/createClass/_index.mjs",
+        "default": "./helpers/createClass/index.js"
       },
       "./helpers/createClass/index.js"
     ],
@@ -120,8 +120,8 @@
     "./helpers/defineEnumerableProperties": [
       {
         "node": "./helpers/defineEnumerableProperties/index.js",
-        "require": "./helpers/defineEnumerableProperties/index.js",
-        "default": "./helpers/defineEnumerableProperties/_index.mjs"
+        "import": "./helpers/defineEnumerableProperties/_index.mjs",
+        "default": "./helpers/defineEnumerableProperties/index.js"
       },
       "./helpers/defineEnumerableProperties/index.js"
     ],
@@ -129,8 +129,8 @@
     "./helpers/defaults": [
       {
         "node": "./helpers/defaults/index.js",
-        "require": "./helpers/defaults/index.js",
-        "default": "./helpers/defaults/_index.mjs"
+        "import": "./helpers/defaults/_index.mjs",
+        "default": "./helpers/defaults/index.js"
       },
       "./helpers/defaults/index.js"
     ],
@@ -138,8 +138,8 @@
     "./helpers/defineProperty": [
       {
         "node": "./helpers/defineProperty/index.js",
-        "require": "./helpers/defineProperty/index.js",
-        "default": "./helpers/defineProperty/_index.mjs"
+        "import": "./helpers/defineProperty/_index.mjs",
+        "default": "./helpers/defineProperty/index.js"
       },
       "./helpers/defineProperty/index.js"
     ],
@@ -147,8 +147,8 @@
     "./helpers/extends": [
       {
         "node": "./helpers/extends/index.js",
-        "require": "./helpers/extends/index.js",
-        "default": "./helpers/extends/_index.mjs"
+        "import": "./helpers/extends/_index.mjs",
+        "default": "./helpers/extends/index.js"
       },
       "./helpers/extends/index.js"
     ],
@@ -156,8 +156,8 @@
     "./helpers/objectSpread": [
       {
         "node": "./helpers/objectSpread/index.js",
-        "require": "./helpers/objectSpread/index.js",
-        "default": "./helpers/objectSpread/_index.mjs"
+        "import": "./helpers/objectSpread/_index.mjs",
+        "default": "./helpers/objectSpread/index.js"
       },
       "./helpers/objectSpread/index.js"
     ],
@@ -165,8 +165,8 @@
     "./helpers/objectSpread2": [
       {
         "node": "./helpers/objectSpread2/index.js",
-        "require": "./helpers/objectSpread2/index.js",
-        "default": "./helpers/objectSpread2/_index.mjs"
+        "import": "./helpers/objectSpread2/_index.mjs",
+        "default": "./helpers/objectSpread2/index.js"
       },
       "./helpers/objectSpread2/index.js"
     ],
@@ -174,8 +174,8 @@
     "./helpers/inherits": [
       {
         "node": "./helpers/inherits/index.js",
-        "require": "./helpers/inherits/index.js",
-        "default": "./helpers/inherits/_index.mjs"
+        "import": "./helpers/inherits/_index.mjs",
+        "default": "./helpers/inherits/index.js"
       },
       "./helpers/inherits/index.js"
     ],
@@ -183,8 +183,8 @@
     "./helpers/inheritsLoose": [
       {
         "node": "./helpers/inheritsLoose/index.js",
-        "require": "./helpers/inheritsLoose/index.js",
-        "default": "./helpers/inheritsLoose/_index.mjs"
+        "import": "./helpers/inheritsLoose/_index.mjs",
+        "default": "./helpers/inheritsLoose/index.js"
       },
       "./helpers/inheritsLoose/index.js"
     ],
@@ -192,8 +192,8 @@
     "./helpers/getPrototypeOf": [
       {
         "node": "./helpers/getPrototypeOf/index.js",
-        "require": "./helpers/getPrototypeOf/index.js",
-        "default": "./helpers/getPrototypeOf/_index.mjs"
+        "import": "./helpers/getPrototypeOf/_index.mjs",
+        "default": "./helpers/getPrototypeOf/index.js"
       },
       "./helpers/getPrototypeOf/index.js"
     ],
@@ -201,8 +201,8 @@
     "./helpers/setPrototypeOf": [
       {
         "node": "./helpers/setPrototypeOf/index.js",
-        "require": "./helpers/setPrototypeOf/index.js",
-        "default": "./helpers/setPrototypeOf/_index.mjs"
+        "import": "./helpers/setPrototypeOf/_index.mjs",
+        "default": "./helpers/setPrototypeOf/index.js"
       },
       "./helpers/setPrototypeOf/index.js"
     ],
@@ -210,8 +210,8 @@
     "./helpers/isNativeReflectConstruct": [
       {
         "node": "./helpers/isNativeReflectConstruct/index.js",
-        "require": "./helpers/isNativeReflectConstruct/index.js",
-        "default": "./helpers/isNativeReflectConstruct/_index.mjs"
+        "import": "./helpers/isNativeReflectConstruct/_index.mjs",
+        "default": "./helpers/isNativeReflectConstruct/index.js"
       },
       "./helpers/isNativeReflectConstruct/index.js"
     ],
@@ -219,8 +219,8 @@
     "./helpers/construct": [
       {
         "node": "./helpers/construct/index.js",
-        "require": "./helpers/construct/index.js",
-        "default": "./helpers/construct/_index.mjs"
+        "import": "./helpers/construct/_index.mjs",
+        "default": "./helpers/construct/index.js"
       },
       "./helpers/construct/index.js"
     ],
@@ -228,8 +228,8 @@
     "./helpers/isNativeFunction": [
       {
         "node": "./helpers/isNativeFunction/index.js",
-        "require": "./helpers/isNativeFunction/index.js",
-        "default": "./helpers/isNativeFunction/_index.mjs"
+        "import": "./helpers/isNativeFunction/_index.mjs",
+        "default": "./helpers/isNativeFunction/index.js"
       },
       "./helpers/isNativeFunction/index.js"
     ],
@@ -237,8 +237,8 @@
     "./helpers/wrapNativeSuper": [
       {
         "node": "./helpers/wrapNativeSuper/index.js",
-        "require": "./helpers/wrapNativeSuper/index.js",
-        "default": "./helpers/wrapNativeSuper/_index.mjs"
+        "import": "./helpers/wrapNativeSuper/_index.mjs",
+        "default": "./helpers/wrapNativeSuper/index.js"
       },
       "./helpers/wrapNativeSuper/index.js"
     ],
@@ -246,8 +246,8 @@
     "./helpers/instanceof": [
       {
         "node": "./helpers/instanceof/index.js",
-        "require": "./helpers/instanceof/index.js",
-        "default": "./helpers/instanceof/_index.mjs"
+        "import": "./helpers/instanceof/_index.mjs",
+        "default": "./helpers/instanceof/index.js"
       },
       "./helpers/instanceof/index.js"
     ],
@@ -255,8 +255,8 @@
     "./helpers/interopRequireDefault": [
       {
         "node": "./helpers/interopRequireDefault/index.js",
-        "require": "./helpers/interopRequireDefault/index.js",
-        "default": "./helpers/interopRequireDefault/_index.mjs"
+        "import": "./helpers/interopRequireDefault/_index.mjs",
+        "default": "./helpers/interopRequireDefault/index.js"
       },
       "./helpers/interopRequireDefault/index.js"
     ],
@@ -264,8 +264,8 @@
     "./helpers/interopRequireWildcard": [
       {
         "node": "./helpers/interopRequireWildcard/index.js",
-        "require": "./helpers/interopRequireWildcard/index.js",
-        "default": "./helpers/interopRequireWildcard/_index.mjs"
+        "import": "./helpers/interopRequireWildcard/_index.mjs",
+        "default": "./helpers/interopRequireWildcard/index.js"
       },
       "./helpers/interopRequireWildcard/index.js"
     ],
@@ -273,8 +273,8 @@
     "./helpers/newArrowCheck": [
       {
         "node": "./helpers/newArrowCheck/index.js",
-        "require": "./helpers/newArrowCheck/index.js",
-        "default": "./helpers/newArrowCheck/_index.mjs"
+        "import": "./helpers/newArrowCheck/_index.mjs",
+        "default": "./helpers/newArrowCheck/index.js"
       },
       "./helpers/newArrowCheck/index.js"
     ],
@@ -282,8 +282,8 @@
     "./helpers/objectDestructuringEmpty": [
       {
         "node": "./helpers/objectDestructuringEmpty/index.js",
-        "require": "./helpers/objectDestructuringEmpty/index.js",
-        "default": "./helpers/objectDestructuringEmpty/_index.mjs"
+        "import": "./helpers/objectDestructuringEmpty/_index.mjs",
+        "default": "./helpers/objectDestructuringEmpty/index.js"
       },
       "./helpers/objectDestructuringEmpty/index.js"
     ],
@@ -291,8 +291,8 @@
     "./helpers/objectWithoutPropertiesLoose": [
       {
         "node": "./helpers/objectWithoutPropertiesLoose/index.js",
-        "require": "./helpers/objectWithoutPropertiesLoose/index.js",
-        "default": "./helpers/objectWithoutPropertiesLoose/_index.mjs"
+        "import": "./helpers/objectWithoutPropertiesLoose/_index.mjs",
+        "default": "./helpers/objectWithoutPropertiesLoose/index.js"
       },
       "./helpers/objectWithoutPropertiesLoose/index.js"
     ],
@@ -300,8 +300,8 @@
     "./helpers/objectWithoutProperties": [
       {
         "node": "./helpers/objectWithoutProperties/index.js",
-        "require": "./helpers/objectWithoutProperties/index.js",
-        "default": "./helpers/objectWithoutProperties/_index.mjs"
+        "import": "./helpers/objectWithoutProperties/_index.mjs",
+        "default": "./helpers/objectWithoutProperties/index.js"
       },
       "./helpers/objectWithoutProperties/index.js"
     ],
@@ -309,8 +309,8 @@
     "./helpers/assertThisInitialized": [
       {
         "node": "./helpers/assertThisInitialized/index.js",
-        "require": "./helpers/assertThisInitialized/index.js",
-        "default": "./helpers/assertThisInitialized/_index.mjs"
+        "import": "./helpers/assertThisInitialized/_index.mjs",
+        "default": "./helpers/assertThisInitialized/index.js"
       },
       "./helpers/assertThisInitialized/index.js"
     ],
@@ -318,8 +318,8 @@
     "./helpers/possibleConstructorReturn": [
       {
         "node": "./helpers/possibleConstructorReturn/index.js",
-        "require": "./helpers/possibleConstructorReturn/index.js",
-        "default": "./helpers/possibleConstructorReturn/_index.mjs"
+        "import": "./helpers/possibleConstructorReturn/_index.mjs",
+        "default": "./helpers/possibleConstructorReturn/index.js"
       },
       "./helpers/possibleConstructorReturn/index.js"
     ],
@@ -327,8 +327,8 @@
     "./helpers/createSuper": [
       {
         "node": "./helpers/createSuper/index.js",
-        "require": "./helpers/createSuper/index.js",
-        "default": "./helpers/createSuper/_index.mjs"
+        "import": "./helpers/createSuper/_index.mjs",
+        "default": "./helpers/createSuper/index.js"
       },
       "./helpers/createSuper/index.js"
     ],
@@ -336,8 +336,8 @@
     "./helpers/superPropBase": [
       {
         "node": "./helpers/superPropBase/index.js",
-        "require": "./helpers/superPropBase/index.js",
-        "default": "./helpers/superPropBase/_index.mjs"
+        "import": "./helpers/superPropBase/_index.mjs",
+        "default": "./helpers/superPropBase/index.js"
       },
       "./helpers/superPropBase/index.js"
     ],
@@ -345,8 +345,8 @@
     "./helpers/get": [
       {
         "node": "./helpers/get/index.js",
-        "require": "./helpers/get/index.js",
-        "default": "./helpers/get/_index.mjs"
+        "import": "./helpers/get/_index.mjs",
+        "default": "./helpers/get/index.js"
       },
       "./helpers/get/index.js"
     ],
@@ -354,8 +354,8 @@
     "./helpers/set": [
       {
         "node": "./helpers/set/index.js",
-        "require": "./helpers/set/index.js",
-        "default": "./helpers/set/_index.mjs"
+        "import": "./helpers/set/_index.mjs",
+        "default": "./helpers/set/index.js"
       },
       "./helpers/set/index.js"
     ],
@@ -363,8 +363,8 @@
     "./helpers/taggedTemplateLiteral": [
       {
         "node": "./helpers/taggedTemplateLiteral/index.js",
-        "require": "./helpers/taggedTemplateLiteral/index.js",
-        "default": "./helpers/taggedTemplateLiteral/_index.mjs"
+        "import": "./helpers/taggedTemplateLiteral/_index.mjs",
+        "default": "./helpers/taggedTemplateLiteral/index.js"
       },
       "./helpers/taggedTemplateLiteral/index.js"
     ],
@@ -372,8 +372,8 @@
     "./helpers/taggedTemplateLiteralLoose": [
       {
         "node": "./helpers/taggedTemplateLiteralLoose/index.js",
-        "require": "./helpers/taggedTemplateLiteralLoose/index.js",
-        "default": "./helpers/taggedTemplateLiteralLoose/_index.mjs"
+        "import": "./helpers/taggedTemplateLiteralLoose/_index.mjs",
+        "default": "./helpers/taggedTemplateLiteralLoose/index.js"
       },
       "./helpers/taggedTemplateLiteralLoose/index.js"
     ],
@@ -381,8 +381,8 @@
     "./helpers/readOnlyError": [
       {
         "node": "./helpers/readOnlyError/index.js",
-        "require": "./helpers/readOnlyError/index.js",
-        "default": "./helpers/readOnlyError/_index.mjs"
+        "import": "./helpers/readOnlyError/_index.mjs",
+        "default": "./helpers/readOnlyError/index.js"
       },
       "./helpers/readOnlyError/index.js"
     ],
@@ -390,8 +390,8 @@
     "./helpers/writeOnlyError": [
       {
         "node": "./helpers/writeOnlyError/index.js",
-        "require": "./helpers/writeOnlyError/index.js",
-        "default": "./helpers/writeOnlyError/_index.mjs"
+        "import": "./helpers/writeOnlyError/_index.mjs",
+        "default": "./helpers/writeOnlyError/index.js"
       },
       "./helpers/writeOnlyError/index.js"
     ],
@@ -399,8 +399,8 @@
     "./helpers/classNameTDZError": [
       {
         "node": "./helpers/classNameTDZError/index.js",
-        "require": "./helpers/classNameTDZError/index.js",
-        "default": "./helpers/classNameTDZError/_index.mjs"
+        "import": "./helpers/classNameTDZError/_index.mjs",
+        "default": "./helpers/classNameTDZError/index.js"
       },
       "./helpers/classNameTDZError/index.js"
     ],
@@ -408,8 +408,8 @@
     "./helpers/temporalUndefined": [
       {
         "node": "./helpers/temporalUndefined/index.js",
-        "require": "./helpers/temporalUndefined/index.js",
-        "default": "./helpers/temporalUndefined/_index.mjs"
+        "import": "./helpers/temporalUndefined/_index.mjs",
+        "default": "./helpers/temporalUndefined/index.js"
       },
       "./helpers/temporalUndefined/index.js"
     ],
@@ -417,8 +417,8 @@
     "./helpers/tdz": [
       {
         "node": "./helpers/tdz/index.js",
-        "require": "./helpers/tdz/index.js",
-        "default": "./helpers/tdz/_index.mjs"
+        "import": "./helpers/tdz/_index.mjs",
+        "default": "./helpers/tdz/index.js"
       },
       "./helpers/tdz/index.js"
     ],
@@ -426,8 +426,8 @@
     "./helpers/temporalRef": [
       {
         "node": "./helpers/temporalRef/index.js",
-        "require": "./helpers/temporalRef/index.js",
-        "default": "./helpers/temporalRef/_index.mjs"
+        "import": "./helpers/temporalRef/_index.mjs",
+        "default": "./helpers/temporalRef/index.js"
       },
       "./helpers/temporalRef/index.js"
     ],
@@ -435,8 +435,8 @@
     "./helpers/slicedToArray": [
       {
         "node": "./helpers/slicedToArray/index.js",
-        "require": "./helpers/slicedToArray/index.js",
-        "default": "./helpers/slicedToArray/_index.mjs"
+        "import": "./helpers/slicedToArray/_index.mjs",
+        "default": "./helpers/slicedToArray/index.js"
       },
       "./helpers/slicedToArray/index.js"
     ],
@@ -444,8 +444,8 @@
     "./helpers/slicedToArrayLoose": [
       {
         "node": "./helpers/slicedToArrayLoose/index.js",
-        "require": "./helpers/slicedToArrayLoose/index.js",
-        "default": "./helpers/slicedToArrayLoose/_index.mjs"
+        "import": "./helpers/slicedToArrayLoose/_index.mjs",
+        "default": "./helpers/slicedToArrayLoose/index.js"
       },
       "./helpers/slicedToArrayLoose/index.js"
     ],
@@ -453,8 +453,8 @@
     "./helpers/toArray": [
       {
         "node": "./helpers/toArray/index.js",
-        "require": "./helpers/toArray/index.js",
-        "default": "./helpers/toArray/_index.mjs"
+        "import": "./helpers/toArray/_index.mjs",
+        "default": "./helpers/toArray/index.js"
       },
       "./helpers/toArray/index.js"
     ],
@@ -462,8 +462,8 @@
     "./helpers/toConsumableArray": [
       {
         "node": "./helpers/toConsumableArray/index.js",
-        "require": "./helpers/toConsumableArray/index.js",
-        "default": "./helpers/toConsumableArray/_index.mjs"
+        "import": "./helpers/toConsumableArray/_index.mjs",
+        "default": "./helpers/toConsumableArray/index.js"
       },
       "./helpers/toConsumableArray/index.js"
     ],
@@ -471,8 +471,8 @@
     "./helpers/arrayWithoutHoles": [
       {
         "node": "./helpers/arrayWithoutHoles/index.js",
-        "require": "./helpers/arrayWithoutHoles/index.js",
-        "default": "./helpers/arrayWithoutHoles/_index.mjs"
+        "import": "./helpers/arrayWithoutHoles/_index.mjs",
+        "default": "./helpers/arrayWithoutHoles/index.js"
       },
       "./helpers/arrayWithoutHoles/index.js"
     ],
@@ -480,8 +480,8 @@
     "./helpers/arrayWithHoles": [
       {
         "node": "./helpers/arrayWithHoles/index.js",
-        "require": "./helpers/arrayWithHoles/index.js",
-        "default": "./helpers/arrayWithHoles/_index.mjs"
+        "import": "./helpers/arrayWithHoles/_index.mjs",
+        "default": "./helpers/arrayWithHoles/index.js"
       },
       "./helpers/arrayWithHoles/index.js"
     ],
@@ -489,8 +489,8 @@
     "./helpers/maybeArrayLike": [
       {
         "node": "./helpers/maybeArrayLike/index.js",
-        "require": "./helpers/maybeArrayLike/index.js",
-        "default": "./helpers/maybeArrayLike/_index.mjs"
+        "import": "./helpers/maybeArrayLike/_index.mjs",
+        "default": "./helpers/maybeArrayLike/index.js"
       },
       "./helpers/maybeArrayLike/index.js"
     ],
@@ -498,8 +498,8 @@
     "./helpers/iterableToArray": [
       {
         "node": "./helpers/iterableToArray/index.js",
-        "require": "./helpers/iterableToArray/index.js",
-        "default": "./helpers/iterableToArray/_index.mjs"
+        "import": "./helpers/iterableToArray/_index.mjs",
+        "default": "./helpers/iterableToArray/index.js"
       },
       "./helpers/iterableToArray/index.js"
     ],
@@ -507,8 +507,8 @@
     "./helpers/iterableToArrayLimit": [
       {
         "node": "./helpers/iterableToArrayLimit/index.js",
-        "require": "./helpers/iterableToArrayLimit/index.js",
-        "default": "./helpers/iterableToArrayLimit/_index.mjs"
+        "import": "./helpers/iterableToArrayLimit/_index.mjs",
+        "default": "./helpers/iterableToArrayLimit/index.js"
       },
       "./helpers/iterableToArrayLimit/index.js"
     ],
@@ -516,8 +516,8 @@
     "./helpers/iterableToArrayLimitLoose": [
       {
         "node": "./helpers/iterableToArrayLimitLoose/index.js",
-        "require": "./helpers/iterableToArrayLimitLoose/index.js",
-        "default": "./helpers/iterableToArrayLimitLoose/_index.mjs"
+        "import": "./helpers/iterableToArrayLimitLoose/_index.mjs",
+        "default": "./helpers/iterableToArrayLimitLoose/index.js"
       },
       "./helpers/iterableToArrayLimitLoose/index.js"
     ],
@@ -525,8 +525,8 @@
     "./helpers/unsupportedIterableToArray": [
       {
         "node": "./helpers/unsupportedIterableToArray/index.js",
-        "require": "./helpers/unsupportedIterableToArray/index.js",
-        "default": "./helpers/unsupportedIterableToArray/_index.mjs"
+        "import": "./helpers/unsupportedIterableToArray/_index.mjs",
+        "default": "./helpers/unsupportedIterableToArray/index.js"
       },
       "./helpers/unsupportedIterableToArray/index.js"
     ],
@@ -534,8 +534,8 @@
     "./helpers/arrayLikeToArray": [
       {
         "node": "./helpers/arrayLikeToArray/index.js",
-        "require": "./helpers/arrayLikeToArray/index.js",
-        "default": "./helpers/arrayLikeToArray/_index.mjs"
+        "import": "./helpers/arrayLikeToArray/_index.mjs",
+        "default": "./helpers/arrayLikeToArray/index.js"
       },
       "./helpers/arrayLikeToArray/index.js"
     ],
@@ -543,8 +543,8 @@
     "./helpers/nonIterableSpread": [
       {
         "node": "./helpers/nonIterableSpread/index.js",
-        "require": "./helpers/nonIterableSpread/index.js",
-        "default": "./helpers/nonIterableSpread/_index.mjs"
+        "import": "./helpers/nonIterableSpread/_index.mjs",
+        "default": "./helpers/nonIterableSpread/index.js"
       },
       "./helpers/nonIterableSpread/index.js"
     ],
@@ -552,8 +552,8 @@
     "./helpers/nonIterableRest": [
       {
         "node": "./helpers/nonIterableRest/index.js",
-        "require": "./helpers/nonIterableRest/index.js",
-        "default": "./helpers/nonIterableRest/_index.mjs"
+        "import": "./helpers/nonIterableRest/_index.mjs",
+        "default": "./helpers/nonIterableRest/index.js"
       },
       "./helpers/nonIterableRest/index.js"
     ],
@@ -561,8 +561,8 @@
     "./helpers/createForOfIteratorHelper": [
       {
         "node": "./helpers/createForOfIteratorHelper/index.js",
-        "require": "./helpers/createForOfIteratorHelper/index.js",
-        "default": "./helpers/createForOfIteratorHelper/_index.mjs"
+        "import": "./helpers/createForOfIteratorHelper/_index.mjs",
+        "default": "./helpers/createForOfIteratorHelper/index.js"
       },
       "./helpers/createForOfIteratorHelper/index.js"
     ],
@@ -570,8 +570,8 @@
     "./helpers/createForOfIteratorHelperLoose": [
       {
         "node": "./helpers/createForOfIteratorHelperLoose/index.js",
-        "require": "./helpers/createForOfIteratorHelperLoose/index.js",
-        "default": "./helpers/createForOfIteratorHelperLoose/_index.mjs"
+        "import": "./helpers/createForOfIteratorHelperLoose/_index.mjs",
+        "default": "./helpers/createForOfIteratorHelperLoose/index.js"
       },
       "./helpers/createForOfIteratorHelperLoose/index.js"
     ],
@@ -579,8 +579,8 @@
     "./helpers/skipFirstGeneratorNext": [
       {
         "node": "./helpers/skipFirstGeneratorNext/index.js",
-        "require": "./helpers/skipFirstGeneratorNext/index.js",
-        "default": "./helpers/skipFirstGeneratorNext/_index.mjs"
+        "import": "./helpers/skipFirstGeneratorNext/_index.mjs",
+        "default": "./helpers/skipFirstGeneratorNext/index.js"
       },
       "./helpers/skipFirstGeneratorNext/index.js"
     ],
@@ -588,8 +588,8 @@
     "./helpers/toPrimitive": [
       {
         "node": "./helpers/toPrimitive/index.js",
-        "require": "./helpers/toPrimitive/index.js",
-        "default": "./helpers/toPrimitive/_index.mjs"
+        "import": "./helpers/toPrimitive/_index.mjs",
+        "default": "./helpers/toPrimitive/index.js"
       },
       "./helpers/toPrimitive/index.js"
     ],
@@ -597,8 +597,8 @@
     "./helpers/toPropertyKey": [
       {
         "node": "./helpers/toPropertyKey/index.js",
-        "require": "./helpers/toPropertyKey/index.js",
-        "default": "./helpers/toPropertyKey/_index.mjs"
+        "import": "./helpers/toPropertyKey/_index.mjs",
+        "default": "./helpers/toPropertyKey/index.js"
       },
       "./helpers/toPropertyKey/index.js"
     ],
@@ -606,8 +606,8 @@
     "./helpers/initializerWarningHelper": [
       {
         "node": "./helpers/initializerWarningHelper/index.js",
-        "require": "./helpers/initializerWarningHelper/index.js",
-        "default": "./helpers/initializerWarningHelper/_index.mjs"
+        "import": "./helpers/initializerWarningHelper/_index.mjs",
+        "default": "./helpers/initializerWarningHelper/index.js"
       },
       "./helpers/initializerWarningHelper/index.js"
     ],
@@ -615,8 +615,8 @@
     "./helpers/initializerDefineProperty": [
       {
         "node": "./helpers/initializerDefineProperty/index.js",
-        "require": "./helpers/initializerDefineProperty/index.js",
-        "default": "./helpers/initializerDefineProperty/_index.mjs"
+        "import": "./helpers/initializerDefineProperty/_index.mjs",
+        "default": "./helpers/initializerDefineProperty/index.js"
       },
       "./helpers/initializerDefineProperty/index.js"
     ],
@@ -624,8 +624,8 @@
     "./helpers/applyDecoratedDescriptor": [
       {
         "node": "./helpers/applyDecoratedDescriptor/index.js",
-        "require": "./helpers/applyDecoratedDescriptor/index.js",
-        "default": "./helpers/applyDecoratedDescriptor/_index.mjs"
+        "import": "./helpers/applyDecoratedDescriptor/_index.mjs",
+        "default": "./helpers/applyDecoratedDescriptor/index.js"
       },
       "./helpers/applyDecoratedDescriptor/index.js"
     ],
@@ -633,8 +633,8 @@
     "./helpers/classPrivateFieldLooseKey": [
       {
         "node": "./helpers/classPrivateFieldLooseKey/index.js",
-        "require": "./helpers/classPrivateFieldLooseKey/index.js",
-        "default": "./helpers/classPrivateFieldLooseKey/_index.mjs"
+        "import": "./helpers/classPrivateFieldLooseKey/_index.mjs",
+        "default": "./helpers/classPrivateFieldLooseKey/index.js"
       },
       "./helpers/classPrivateFieldLooseKey/index.js"
     ],
@@ -642,8 +642,8 @@
     "./helpers/classPrivateFieldLooseBase": [
       {
         "node": "./helpers/classPrivateFieldLooseBase/index.js",
-        "require": "./helpers/classPrivateFieldLooseBase/index.js",
-        "default": "./helpers/classPrivateFieldLooseBase/_index.mjs"
+        "import": "./helpers/classPrivateFieldLooseBase/_index.mjs",
+        "default": "./helpers/classPrivateFieldLooseBase/index.js"
       },
       "./helpers/classPrivateFieldLooseBase/index.js"
     ],
@@ -651,8 +651,8 @@
     "./helpers/classPrivateFieldGet": [
       {
         "node": "./helpers/classPrivateFieldGet/index.js",
-        "require": "./helpers/classPrivateFieldGet/index.js",
-        "default": "./helpers/classPrivateFieldGet/_index.mjs"
+        "import": "./helpers/classPrivateFieldGet/_index.mjs",
+        "default": "./helpers/classPrivateFieldGet/index.js"
       },
       "./helpers/classPrivateFieldGet/index.js"
     ],
@@ -660,8 +660,8 @@
     "./helpers/classPrivateFieldSet": [
       {
         "node": "./helpers/classPrivateFieldSet/index.js",
-        "require": "./helpers/classPrivateFieldSet/index.js",
-        "default": "./helpers/classPrivateFieldSet/_index.mjs"
+        "import": "./helpers/classPrivateFieldSet/_index.mjs",
+        "default": "./helpers/classPrivateFieldSet/index.js"
       },
       "./helpers/classPrivateFieldSet/index.js"
     ],
@@ -669,8 +669,8 @@
     "./helpers/classPrivateFieldDestructureSet": [
       {
         "node": "./helpers/classPrivateFieldDestructureSet/index.js",
-        "require": "./helpers/classPrivateFieldDestructureSet/index.js",
-        "default": "./helpers/classPrivateFieldDestructureSet/_index.mjs"
+        "import": "./helpers/classPrivateFieldDestructureSet/_index.mjs",
+        "default": "./helpers/classPrivateFieldDestructureSet/index.js"
       },
       "./helpers/classPrivateFieldDestructureSet/index.js"
     ],
@@ -678,8 +678,8 @@
     "./helpers/classStaticPrivateFieldSpecGet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-        "require": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-        "default": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs"
+        "import": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs",
+        "default": "./helpers/classStaticPrivateFieldSpecGet/index.js"
       },
       "./helpers/classStaticPrivateFieldSpecGet/index.js"
     ],
@@ -687,8 +687,8 @@
     "./helpers/classStaticPrivateFieldSpecSet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-        "require": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-        "default": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs"
+        "import": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs",
+        "default": "./helpers/classStaticPrivateFieldSpecSet/index.js"
       },
       "./helpers/classStaticPrivateFieldSpecSet/index.js"
     ],
@@ -696,8 +696,8 @@
     "./helpers/classStaticPrivateMethodGet": [
       {
         "node": "./helpers/classStaticPrivateMethodGet/index.js",
-        "require": "./helpers/classStaticPrivateMethodGet/index.js",
-        "default": "./helpers/classStaticPrivateMethodGet/_index.mjs"
+        "import": "./helpers/classStaticPrivateMethodGet/_index.mjs",
+        "default": "./helpers/classStaticPrivateMethodGet/index.js"
       },
       "./helpers/classStaticPrivateMethodGet/index.js"
     ],
@@ -705,8 +705,8 @@
     "./helpers/classStaticPrivateMethodSet": [
       {
         "node": "./helpers/classStaticPrivateMethodSet/index.js",
-        "require": "./helpers/classStaticPrivateMethodSet/index.js",
-        "default": "./helpers/classStaticPrivateMethodSet/_index.mjs"
+        "import": "./helpers/classStaticPrivateMethodSet/_index.mjs",
+        "default": "./helpers/classStaticPrivateMethodSet/index.js"
       },
       "./helpers/classStaticPrivateMethodSet/index.js"
     ],
@@ -714,8 +714,8 @@
     "./helpers/decorate": [
       {
         "node": "./helpers/decorate/index.js",
-        "require": "./helpers/decorate/index.js",
-        "default": "./helpers/decorate/_index.mjs"
+        "import": "./helpers/decorate/_index.mjs",
+        "default": "./helpers/decorate/index.js"
       },
       "./helpers/decorate/index.js"
     ],
@@ -723,8 +723,8 @@
     "./helpers/classPrivateMethodGet": [
       {
         "node": "./helpers/classPrivateMethodGet/index.js",
-        "require": "./helpers/classPrivateMethodGet/index.js",
-        "default": "./helpers/classPrivateMethodGet/_index.mjs"
+        "import": "./helpers/classPrivateMethodGet/_index.mjs",
+        "default": "./helpers/classPrivateMethodGet/index.js"
       },
       "./helpers/classPrivateMethodGet/index.js"
     ],
@@ -732,8 +732,8 @@
     "./helpers/classPrivateMethodSet": [
       {
         "node": "./helpers/classPrivateMethodSet/index.js",
-        "require": "./helpers/classPrivateMethodSet/index.js",
-        "default": "./helpers/classPrivateMethodSet/_index.mjs"
+        "import": "./helpers/classPrivateMethodSet/_index.mjs",
+        "default": "./helpers/classPrivateMethodSet/index.js"
       },
       "./helpers/classPrivateMethodSet/index.js"
     ],
@@ -741,8 +741,8 @@
     "./helpers/wrapRegExp": [
       {
         "node": "./helpers/wrapRegExp/index.js",
-        "require": "./helpers/wrapRegExp/index.js",
-        "default": "./helpers/wrapRegExp/_index.mjs"
+        "import": "./helpers/wrapRegExp/_index.mjs",
+        "default": "./helpers/wrapRegExp/index.js"
       },
       "./helpers/wrapRegExp/index.js"
     ],

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -20,8 +20,8 @@
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof/index.js",
-        "require": "./helpers/typeof/index.js",
-        "default": "./helpers/typeof/_index.mjs"
+        "import": "./helpers/typeof/_index.mjs",
+        "default": "./helpers/typeof/index.js"
       },
       "./helpers/typeof/index.js"
     ],
@@ -29,8 +29,8 @@
     "./helpers/jsx": [
       {
         "node": "./helpers/jsx/index.js",
-        "require": "./helpers/jsx/index.js",
-        "default": "./helpers/jsx/_index.mjs"
+        "import": "./helpers/jsx/_index.mjs",
+        "default": "./helpers/jsx/index.js"
       },
       "./helpers/jsx/index.js"
     ],
@@ -38,8 +38,8 @@
     "./helpers/asyncIterator": [
       {
         "node": "./helpers/asyncIterator/index.js",
-        "require": "./helpers/asyncIterator/index.js",
-        "default": "./helpers/asyncIterator/_index.mjs"
+        "import": "./helpers/asyncIterator/_index.mjs",
+        "default": "./helpers/asyncIterator/index.js"
       },
       "./helpers/asyncIterator/index.js"
     ],
@@ -47,8 +47,8 @@
     "./helpers/AwaitValue": [
       {
         "node": "./helpers/AwaitValue/index.js",
-        "require": "./helpers/AwaitValue/index.js",
-        "default": "./helpers/AwaitValue/_index.mjs"
+        "import": "./helpers/AwaitValue/_index.mjs",
+        "default": "./helpers/AwaitValue/index.js"
       },
       "./helpers/AwaitValue/index.js"
     ],
@@ -56,8 +56,8 @@
     "./helpers/AsyncGenerator": [
       {
         "node": "./helpers/AsyncGenerator/index.js",
-        "require": "./helpers/AsyncGenerator/index.js",
-        "default": "./helpers/AsyncGenerator/_index.mjs"
+        "import": "./helpers/AsyncGenerator/_index.mjs",
+        "default": "./helpers/AsyncGenerator/index.js"
       },
       "./helpers/AsyncGenerator/index.js"
     ],
@@ -65,8 +65,8 @@
     "./helpers/wrapAsyncGenerator": [
       {
         "node": "./helpers/wrapAsyncGenerator/index.js",
-        "require": "./helpers/wrapAsyncGenerator/index.js",
-        "default": "./helpers/wrapAsyncGenerator/_index.mjs"
+        "import": "./helpers/wrapAsyncGenerator/_index.mjs",
+        "default": "./helpers/wrapAsyncGenerator/index.js"
       },
       "./helpers/wrapAsyncGenerator/index.js"
     ],
@@ -74,8 +74,8 @@
     "./helpers/awaitAsyncGenerator": [
       {
         "node": "./helpers/awaitAsyncGenerator/index.js",
-        "require": "./helpers/awaitAsyncGenerator/index.js",
-        "default": "./helpers/awaitAsyncGenerator/_index.mjs"
+        "import": "./helpers/awaitAsyncGenerator/_index.mjs",
+        "default": "./helpers/awaitAsyncGenerator/index.js"
       },
       "./helpers/awaitAsyncGenerator/index.js"
     ],
@@ -83,8 +83,8 @@
     "./helpers/asyncGeneratorDelegate": [
       {
         "node": "./helpers/asyncGeneratorDelegate/index.js",
-        "require": "./helpers/asyncGeneratorDelegate/index.js",
-        "default": "./helpers/asyncGeneratorDelegate/_index.mjs"
+        "import": "./helpers/asyncGeneratorDelegate/_index.mjs",
+        "default": "./helpers/asyncGeneratorDelegate/index.js"
       },
       "./helpers/asyncGeneratorDelegate/index.js"
     ],
@@ -92,8 +92,8 @@
     "./helpers/asyncToGenerator": [
       {
         "node": "./helpers/asyncToGenerator/index.js",
-        "require": "./helpers/asyncToGenerator/index.js",
-        "default": "./helpers/asyncToGenerator/_index.mjs"
+        "import": "./helpers/asyncToGenerator/_index.mjs",
+        "default": "./helpers/asyncToGenerator/index.js"
       },
       "./helpers/asyncToGenerator/index.js"
     ],
@@ -101,8 +101,8 @@
     "./helpers/classCallCheck": [
       {
         "node": "./helpers/classCallCheck/index.js",
-        "require": "./helpers/classCallCheck/index.js",
-        "default": "./helpers/classCallCheck/_index.mjs"
+        "import": "./helpers/classCallCheck/_index.mjs",
+        "default": "./helpers/classCallCheck/index.js"
       },
       "./helpers/classCallCheck/index.js"
     ],
@@ -110,8 +110,8 @@
     "./helpers/createClass": [
       {
         "node": "./helpers/createClass/index.js",
-        "require": "./helpers/createClass/index.js",
-        "default": "./helpers/createClass/_index.mjs"
+        "import": "./helpers/createClass/_index.mjs",
+        "default": "./helpers/createClass/index.js"
       },
       "./helpers/createClass/index.js"
     ],
@@ -119,8 +119,8 @@
     "./helpers/defineEnumerableProperties": [
       {
         "node": "./helpers/defineEnumerableProperties/index.js",
-        "require": "./helpers/defineEnumerableProperties/index.js",
-        "default": "./helpers/defineEnumerableProperties/_index.mjs"
+        "import": "./helpers/defineEnumerableProperties/_index.mjs",
+        "default": "./helpers/defineEnumerableProperties/index.js"
       },
       "./helpers/defineEnumerableProperties/index.js"
     ],
@@ -128,8 +128,8 @@
     "./helpers/defaults": [
       {
         "node": "./helpers/defaults/index.js",
-        "require": "./helpers/defaults/index.js",
-        "default": "./helpers/defaults/_index.mjs"
+        "import": "./helpers/defaults/_index.mjs",
+        "default": "./helpers/defaults/index.js"
       },
       "./helpers/defaults/index.js"
     ],
@@ -137,8 +137,8 @@
     "./helpers/defineProperty": [
       {
         "node": "./helpers/defineProperty/index.js",
-        "require": "./helpers/defineProperty/index.js",
-        "default": "./helpers/defineProperty/_index.mjs"
+        "import": "./helpers/defineProperty/_index.mjs",
+        "default": "./helpers/defineProperty/index.js"
       },
       "./helpers/defineProperty/index.js"
     ],
@@ -146,8 +146,8 @@
     "./helpers/extends": [
       {
         "node": "./helpers/extends/index.js",
-        "require": "./helpers/extends/index.js",
-        "default": "./helpers/extends/_index.mjs"
+        "import": "./helpers/extends/_index.mjs",
+        "default": "./helpers/extends/index.js"
       },
       "./helpers/extends/index.js"
     ],
@@ -155,8 +155,8 @@
     "./helpers/objectSpread": [
       {
         "node": "./helpers/objectSpread/index.js",
-        "require": "./helpers/objectSpread/index.js",
-        "default": "./helpers/objectSpread/_index.mjs"
+        "import": "./helpers/objectSpread/_index.mjs",
+        "default": "./helpers/objectSpread/index.js"
       },
       "./helpers/objectSpread/index.js"
     ],
@@ -164,8 +164,8 @@
     "./helpers/objectSpread2": [
       {
         "node": "./helpers/objectSpread2/index.js",
-        "require": "./helpers/objectSpread2/index.js",
-        "default": "./helpers/objectSpread2/_index.mjs"
+        "import": "./helpers/objectSpread2/_index.mjs",
+        "default": "./helpers/objectSpread2/index.js"
       },
       "./helpers/objectSpread2/index.js"
     ],
@@ -173,8 +173,8 @@
     "./helpers/inherits": [
       {
         "node": "./helpers/inherits/index.js",
-        "require": "./helpers/inherits/index.js",
-        "default": "./helpers/inherits/_index.mjs"
+        "import": "./helpers/inherits/_index.mjs",
+        "default": "./helpers/inherits/index.js"
       },
       "./helpers/inherits/index.js"
     ],
@@ -182,8 +182,8 @@
     "./helpers/inheritsLoose": [
       {
         "node": "./helpers/inheritsLoose/index.js",
-        "require": "./helpers/inheritsLoose/index.js",
-        "default": "./helpers/inheritsLoose/_index.mjs"
+        "import": "./helpers/inheritsLoose/_index.mjs",
+        "default": "./helpers/inheritsLoose/index.js"
       },
       "./helpers/inheritsLoose/index.js"
     ],
@@ -191,8 +191,8 @@
     "./helpers/getPrototypeOf": [
       {
         "node": "./helpers/getPrototypeOf/index.js",
-        "require": "./helpers/getPrototypeOf/index.js",
-        "default": "./helpers/getPrototypeOf/_index.mjs"
+        "import": "./helpers/getPrototypeOf/_index.mjs",
+        "default": "./helpers/getPrototypeOf/index.js"
       },
       "./helpers/getPrototypeOf/index.js"
     ],
@@ -200,8 +200,8 @@
     "./helpers/setPrototypeOf": [
       {
         "node": "./helpers/setPrototypeOf/index.js",
-        "require": "./helpers/setPrototypeOf/index.js",
-        "default": "./helpers/setPrototypeOf/_index.mjs"
+        "import": "./helpers/setPrototypeOf/_index.mjs",
+        "default": "./helpers/setPrototypeOf/index.js"
       },
       "./helpers/setPrototypeOf/index.js"
     ],
@@ -209,8 +209,8 @@
     "./helpers/isNativeReflectConstruct": [
       {
         "node": "./helpers/isNativeReflectConstruct/index.js",
-        "require": "./helpers/isNativeReflectConstruct/index.js",
-        "default": "./helpers/isNativeReflectConstruct/_index.mjs"
+        "import": "./helpers/isNativeReflectConstruct/_index.mjs",
+        "default": "./helpers/isNativeReflectConstruct/index.js"
       },
       "./helpers/isNativeReflectConstruct/index.js"
     ],
@@ -218,8 +218,8 @@
     "./helpers/construct": [
       {
         "node": "./helpers/construct/index.js",
-        "require": "./helpers/construct/index.js",
-        "default": "./helpers/construct/_index.mjs"
+        "import": "./helpers/construct/_index.mjs",
+        "default": "./helpers/construct/index.js"
       },
       "./helpers/construct/index.js"
     ],
@@ -227,8 +227,8 @@
     "./helpers/isNativeFunction": [
       {
         "node": "./helpers/isNativeFunction/index.js",
-        "require": "./helpers/isNativeFunction/index.js",
-        "default": "./helpers/isNativeFunction/_index.mjs"
+        "import": "./helpers/isNativeFunction/_index.mjs",
+        "default": "./helpers/isNativeFunction/index.js"
       },
       "./helpers/isNativeFunction/index.js"
     ],
@@ -236,8 +236,8 @@
     "./helpers/wrapNativeSuper": [
       {
         "node": "./helpers/wrapNativeSuper/index.js",
-        "require": "./helpers/wrapNativeSuper/index.js",
-        "default": "./helpers/wrapNativeSuper/_index.mjs"
+        "import": "./helpers/wrapNativeSuper/_index.mjs",
+        "default": "./helpers/wrapNativeSuper/index.js"
       },
       "./helpers/wrapNativeSuper/index.js"
     ],
@@ -245,8 +245,8 @@
     "./helpers/instanceof": [
       {
         "node": "./helpers/instanceof/index.js",
-        "require": "./helpers/instanceof/index.js",
-        "default": "./helpers/instanceof/_index.mjs"
+        "import": "./helpers/instanceof/_index.mjs",
+        "default": "./helpers/instanceof/index.js"
       },
       "./helpers/instanceof/index.js"
     ],
@@ -254,8 +254,8 @@
     "./helpers/interopRequireDefault": [
       {
         "node": "./helpers/interopRequireDefault/index.js",
-        "require": "./helpers/interopRequireDefault/index.js",
-        "default": "./helpers/interopRequireDefault/_index.mjs"
+        "import": "./helpers/interopRequireDefault/_index.mjs",
+        "default": "./helpers/interopRequireDefault/index.js"
       },
       "./helpers/interopRequireDefault/index.js"
     ],
@@ -263,8 +263,8 @@
     "./helpers/interopRequireWildcard": [
       {
         "node": "./helpers/interopRequireWildcard/index.js",
-        "require": "./helpers/interopRequireWildcard/index.js",
-        "default": "./helpers/interopRequireWildcard/_index.mjs"
+        "import": "./helpers/interopRequireWildcard/_index.mjs",
+        "default": "./helpers/interopRequireWildcard/index.js"
       },
       "./helpers/interopRequireWildcard/index.js"
     ],
@@ -272,8 +272,8 @@
     "./helpers/newArrowCheck": [
       {
         "node": "./helpers/newArrowCheck/index.js",
-        "require": "./helpers/newArrowCheck/index.js",
-        "default": "./helpers/newArrowCheck/_index.mjs"
+        "import": "./helpers/newArrowCheck/_index.mjs",
+        "default": "./helpers/newArrowCheck/index.js"
       },
       "./helpers/newArrowCheck/index.js"
     ],
@@ -281,8 +281,8 @@
     "./helpers/objectDestructuringEmpty": [
       {
         "node": "./helpers/objectDestructuringEmpty/index.js",
-        "require": "./helpers/objectDestructuringEmpty/index.js",
-        "default": "./helpers/objectDestructuringEmpty/_index.mjs"
+        "import": "./helpers/objectDestructuringEmpty/_index.mjs",
+        "default": "./helpers/objectDestructuringEmpty/index.js"
       },
       "./helpers/objectDestructuringEmpty/index.js"
     ],
@@ -290,8 +290,8 @@
     "./helpers/objectWithoutPropertiesLoose": [
       {
         "node": "./helpers/objectWithoutPropertiesLoose/index.js",
-        "require": "./helpers/objectWithoutPropertiesLoose/index.js",
-        "default": "./helpers/objectWithoutPropertiesLoose/_index.mjs"
+        "import": "./helpers/objectWithoutPropertiesLoose/_index.mjs",
+        "default": "./helpers/objectWithoutPropertiesLoose/index.js"
       },
       "./helpers/objectWithoutPropertiesLoose/index.js"
     ],
@@ -299,8 +299,8 @@
     "./helpers/objectWithoutProperties": [
       {
         "node": "./helpers/objectWithoutProperties/index.js",
-        "require": "./helpers/objectWithoutProperties/index.js",
-        "default": "./helpers/objectWithoutProperties/_index.mjs"
+        "import": "./helpers/objectWithoutProperties/_index.mjs",
+        "default": "./helpers/objectWithoutProperties/index.js"
       },
       "./helpers/objectWithoutProperties/index.js"
     ],
@@ -308,8 +308,8 @@
     "./helpers/assertThisInitialized": [
       {
         "node": "./helpers/assertThisInitialized/index.js",
-        "require": "./helpers/assertThisInitialized/index.js",
-        "default": "./helpers/assertThisInitialized/_index.mjs"
+        "import": "./helpers/assertThisInitialized/_index.mjs",
+        "default": "./helpers/assertThisInitialized/index.js"
       },
       "./helpers/assertThisInitialized/index.js"
     ],
@@ -317,8 +317,8 @@
     "./helpers/possibleConstructorReturn": [
       {
         "node": "./helpers/possibleConstructorReturn/index.js",
-        "require": "./helpers/possibleConstructorReturn/index.js",
-        "default": "./helpers/possibleConstructorReturn/_index.mjs"
+        "import": "./helpers/possibleConstructorReturn/_index.mjs",
+        "default": "./helpers/possibleConstructorReturn/index.js"
       },
       "./helpers/possibleConstructorReturn/index.js"
     ],
@@ -326,8 +326,8 @@
     "./helpers/createSuper": [
       {
         "node": "./helpers/createSuper/index.js",
-        "require": "./helpers/createSuper/index.js",
-        "default": "./helpers/createSuper/_index.mjs"
+        "import": "./helpers/createSuper/_index.mjs",
+        "default": "./helpers/createSuper/index.js"
       },
       "./helpers/createSuper/index.js"
     ],
@@ -335,8 +335,8 @@
     "./helpers/superPropBase": [
       {
         "node": "./helpers/superPropBase/index.js",
-        "require": "./helpers/superPropBase/index.js",
-        "default": "./helpers/superPropBase/_index.mjs"
+        "import": "./helpers/superPropBase/_index.mjs",
+        "default": "./helpers/superPropBase/index.js"
       },
       "./helpers/superPropBase/index.js"
     ],
@@ -344,8 +344,8 @@
     "./helpers/get": [
       {
         "node": "./helpers/get/index.js",
-        "require": "./helpers/get/index.js",
-        "default": "./helpers/get/_index.mjs"
+        "import": "./helpers/get/_index.mjs",
+        "default": "./helpers/get/index.js"
       },
       "./helpers/get/index.js"
     ],
@@ -353,8 +353,8 @@
     "./helpers/set": [
       {
         "node": "./helpers/set/index.js",
-        "require": "./helpers/set/index.js",
-        "default": "./helpers/set/_index.mjs"
+        "import": "./helpers/set/_index.mjs",
+        "default": "./helpers/set/index.js"
       },
       "./helpers/set/index.js"
     ],
@@ -362,8 +362,8 @@
     "./helpers/taggedTemplateLiteral": [
       {
         "node": "./helpers/taggedTemplateLiteral/index.js",
-        "require": "./helpers/taggedTemplateLiteral/index.js",
-        "default": "./helpers/taggedTemplateLiteral/_index.mjs"
+        "import": "./helpers/taggedTemplateLiteral/_index.mjs",
+        "default": "./helpers/taggedTemplateLiteral/index.js"
       },
       "./helpers/taggedTemplateLiteral/index.js"
     ],
@@ -371,8 +371,8 @@
     "./helpers/taggedTemplateLiteralLoose": [
       {
         "node": "./helpers/taggedTemplateLiteralLoose/index.js",
-        "require": "./helpers/taggedTemplateLiteralLoose/index.js",
-        "default": "./helpers/taggedTemplateLiteralLoose/_index.mjs"
+        "import": "./helpers/taggedTemplateLiteralLoose/_index.mjs",
+        "default": "./helpers/taggedTemplateLiteralLoose/index.js"
       },
       "./helpers/taggedTemplateLiteralLoose/index.js"
     ],
@@ -380,8 +380,8 @@
     "./helpers/readOnlyError": [
       {
         "node": "./helpers/readOnlyError/index.js",
-        "require": "./helpers/readOnlyError/index.js",
-        "default": "./helpers/readOnlyError/_index.mjs"
+        "import": "./helpers/readOnlyError/_index.mjs",
+        "default": "./helpers/readOnlyError/index.js"
       },
       "./helpers/readOnlyError/index.js"
     ],
@@ -389,8 +389,8 @@
     "./helpers/writeOnlyError": [
       {
         "node": "./helpers/writeOnlyError/index.js",
-        "require": "./helpers/writeOnlyError/index.js",
-        "default": "./helpers/writeOnlyError/_index.mjs"
+        "import": "./helpers/writeOnlyError/_index.mjs",
+        "default": "./helpers/writeOnlyError/index.js"
       },
       "./helpers/writeOnlyError/index.js"
     ],
@@ -398,8 +398,8 @@
     "./helpers/classNameTDZError": [
       {
         "node": "./helpers/classNameTDZError/index.js",
-        "require": "./helpers/classNameTDZError/index.js",
-        "default": "./helpers/classNameTDZError/_index.mjs"
+        "import": "./helpers/classNameTDZError/_index.mjs",
+        "default": "./helpers/classNameTDZError/index.js"
       },
       "./helpers/classNameTDZError/index.js"
     ],
@@ -407,8 +407,8 @@
     "./helpers/temporalUndefined": [
       {
         "node": "./helpers/temporalUndefined/index.js",
-        "require": "./helpers/temporalUndefined/index.js",
-        "default": "./helpers/temporalUndefined/_index.mjs"
+        "import": "./helpers/temporalUndefined/_index.mjs",
+        "default": "./helpers/temporalUndefined/index.js"
       },
       "./helpers/temporalUndefined/index.js"
     ],
@@ -416,8 +416,8 @@
     "./helpers/tdz": [
       {
         "node": "./helpers/tdz/index.js",
-        "require": "./helpers/tdz/index.js",
-        "default": "./helpers/tdz/_index.mjs"
+        "import": "./helpers/tdz/_index.mjs",
+        "default": "./helpers/tdz/index.js"
       },
       "./helpers/tdz/index.js"
     ],
@@ -425,8 +425,8 @@
     "./helpers/temporalRef": [
       {
         "node": "./helpers/temporalRef/index.js",
-        "require": "./helpers/temporalRef/index.js",
-        "default": "./helpers/temporalRef/_index.mjs"
+        "import": "./helpers/temporalRef/_index.mjs",
+        "default": "./helpers/temporalRef/index.js"
       },
       "./helpers/temporalRef/index.js"
     ],
@@ -434,8 +434,8 @@
     "./helpers/slicedToArray": [
       {
         "node": "./helpers/slicedToArray/index.js",
-        "require": "./helpers/slicedToArray/index.js",
-        "default": "./helpers/slicedToArray/_index.mjs"
+        "import": "./helpers/slicedToArray/_index.mjs",
+        "default": "./helpers/slicedToArray/index.js"
       },
       "./helpers/slicedToArray/index.js"
     ],
@@ -443,8 +443,8 @@
     "./helpers/slicedToArrayLoose": [
       {
         "node": "./helpers/slicedToArrayLoose/index.js",
-        "require": "./helpers/slicedToArrayLoose/index.js",
-        "default": "./helpers/slicedToArrayLoose/_index.mjs"
+        "import": "./helpers/slicedToArrayLoose/_index.mjs",
+        "default": "./helpers/slicedToArrayLoose/index.js"
       },
       "./helpers/slicedToArrayLoose/index.js"
     ],
@@ -452,8 +452,8 @@
     "./helpers/toArray": [
       {
         "node": "./helpers/toArray/index.js",
-        "require": "./helpers/toArray/index.js",
-        "default": "./helpers/toArray/_index.mjs"
+        "import": "./helpers/toArray/_index.mjs",
+        "default": "./helpers/toArray/index.js"
       },
       "./helpers/toArray/index.js"
     ],
@@ -461,8 +461,8 @@
     "./helpers/toConsumableArray": [
       {
         "node": "./helpers/toConsumableArray/index.js",
-        "require": "./helpers/toConsumableArray/index.js",
-        "default": "./helpers/toConsumableArray/_index.mjs"
+        "import": "./helpers/toConsumableArray/_index.mjs",
+        "default": "./helpers/toConsumableArray/index.js"
       },
       "./helpers/toConsumableArray/index.js"
     ],
@@ -470,8 +470,8 @@
     "./helpers/arrayWithoutHoles": [
       {
         "node": "./helpers/arrayWithoutHoles/index.js",
-        "require": "./helpers/arrayWithoutHoles/index.js",
-        "default": "./helpers/arrayWithoutHoles/_index.mjs"
+        "import": "./helpers/arrayWithoutHoles/_index.mjs",
+        "default": "./helpers/arrayWithoutHoles/index.js"
       },
       "./helpers/arrayWithoutHoles/index.js"
     ],
@@ -479,8 +479,8 @@
     "./helpers/arrayWithHoles": [
       {
         "node": "./helpers/arrayWithHoles/index.js",
-        "require": "./helpers/arrayWithHoles/index.js",
-        "default": "./helpers/arrayWithHoles/_index.mjs"
+        "import": "./helpers/arrayWithHoles/_index.mjs",
+        "default": "./helpers/arrayWithHoles/index.js"
       },
       "./helpers/arrayWithHoles/index.js"
     ],
@@ -488,8 +488,8 @@
     "./helpers/maybeArrayLike": [
       {
         "node": "./helpers/maybeArrayLike/index.js",
-        "require": "./helpers/maybeArrayLike/index.js",
-        "default": "./helpers/maybeArrayLike/_index.mjs"
+        "import": "./helpers/maybeArrayLike/_index.mjs",
+        "default": "./helpers/maybeArrayLike/index.js"
       },
       "./helpers/maybeArrayLike/index.js"
     ],
@@ -497,8 +497,8 @@
     "./helpers/iterableToArray": [
       {
         "node": "./helpers/iterableToArray/index.js",
-        "require": "./helpers/iterableToArray/index.js",
-        "default": "./helpers/iterableToArray/_index.mjs"
+        "import": "./helpers/iterableToArray/_index.mjs",
+        "default": "./helpers/iterableToArray/index.js"
       },
       "./helpers/iterableToArray/index.js"
     ],
@@ -506,8 +506,8 @@
     "./helpers/iterableToArrayLimit": [
       {
         "node": "./helpers/iterableToArrayLimit/index.js",
-        "require": "./helpers/iterableToArrayLimit/index.js",
-        "default": "./helpers/iterableToArrayLimit/_index.mjs"
+        "import": "./helpers/iterableToArrayLimit/_index.mjs",
+        "default": "./helpers/iterableToArrayLimit/index.js"
       },
       "./helpers/iterableToArrayLimit/index.js"
     ],
@@ -515,8 +515,8 @@
     "./helpers/iterableToArrayLimitLoose": [
       {
         "node": "./helpers/iterableToArrayLimitLoose/index.js",
-        "require": "./helpers/iterableToArrayLimitLoose/index.js",
-        "default": "./helpers/iterableToArrayLimitLoose/_index.mjs"
+        "import": "./helpers/iterableToArrayLimitLoose/_index.mjs",
+        "default": "./helpers/iterableToArrayLimitLoose/index.js"
       },
       "./helpers/iterableToArrayLimitLoose/index.js"
     ],
@@ -524,8 +524,8 @@
     "./helpers/unsupportedIterableToArray": [
       {
         "node": "./helpers/unsupportedIterableToArray/index.js",
-        "require": "./helpers/unsupportedIterableToArray/index.js",
-        "default": "./helpers/unsupportedIterableToArray/_index.mjs"
+        "import": "./helpers/unsupportedIterableToArray/_index.mjs",
+        "default": "./helpers/unsupportedIterableToArray/index.js"
       },
       "./helpers/unsupportedIterableToArray/index.js"
     ],
@@ -533,8 +533,8 @@
     "./helpers/arrayLikeToArray": [
       {
         "node": "./helpers/arrayLikeToArray/index.js",
-        "require": "./helpers/arrayLikeToArray/index.js",
-        "default": "./helpers/arrayLikeToArray/_index.mjs"
+        "import": "./helpers/arrayLikeToArray/_index.mjs",
+        "default": "./helpers/arrayLikeToArray/index.js"
       },
       "./helpers/arrayLikeToArray/index.js"
     ],
@@ -542,8 +542,8 @@
     "./helpers/nonIterableSpread": [
       {
         "node": "./helpers/nonIterableSpread/index.js",
-        "require": "./helpers/nonIterableSpread/index.js",
-        "default": "./helpers/nonIterableSpread/_index.mjs"
+        "import": "./helpers/nonIterableSpread/_index.mjs",
+        "default": "./helpers/nonIterableSpread/index.js"
       },
       "./helpers/nonIterableSpread/index.js"
     ],
@@ -551,8 +551,8 @@
     "./helpers/nonIterableRest": [
       {
         "node": "./helpers/nonIterableRest/index.js",
-        "require": "./helpers/nonIterableRest/index.js",
-        "default": "./helpers/nonIterableRest/_index.mjs"
+        "import": "./helpers/nonIterableRest/_index.mjs",
+        "default": "./helpers/nonIterableRest/index.js"
       },
       "./helpers/nonIterableRest/index.js"
     ],
@@ -560,8 +560,8 @@
     "./helpers/createForOfIteratorHelper": [
       {
         "node": "./helpers/createForOfIteratorHelper/index.js",
-        "require": "./helpers/createForOfIteratorHelper/index.js",
-        "default": "./helpers/createForOfIteratorHelper/_index.mjs"
+        "import": "./helpers/createForOfIteratorHelper/_index.mjs",
+        "default": "./helpers/createForOfIteratorHelper/index.js"
       },
       "./helpers/createForOfIteratorHelper/index.js"
     ],
@@ -569,8 +569,8 @@
     "./helpers/createForOfIteratorHelperLoose": [
       {
         "node": "./helpers/createForOfIteratorHelperLoose/index.js",
-        "require": "./helpers/createForOfIteratorHelperLoose/index.js",
-        "default": "./helpers/createForOfIteratorHelperLoose/_index.mjs"
+        "import": "./helpers/createForOfIteratorHelperLoose/_index.mjs",
+        "default": "./helpers/createForOfIteratorHelperLoose/index.js"
       },
       "./helpers/createForOfIteratorHelperLoose/index.js"
     ],
@@ -578,8 +578,8 @@
     "./helpers/skipFirstGeneratorNext": [
       {
         "node": "./helpers/skipFirstGeneratorNext/index.js",
-        "require": "./helpers/skipFirstGeneratorNext/index.js",
-        "default": "./helpers/skipFirstGeneratorNext/_index.mjs"
+        "import": "./helpers/skipFirstGeneratorNext/_index.mjs",
+        "default": "./helpers/skipFirstGeneratorNext/index.js"
       },
       "./helpers/skipFirstGeneratorNext/index.js"
     ],
@@ -587,8 +587,8 @@
     "./helpers/toPrimitive": [
       {
         "node": "./helpers/toPrimitive/index.js",
-        "require": "./helpers/toPrimitive/index.js",
-        "default": "./helpers/toPrimitive/_index.mjs"
+        "import": "./helpers/toPrimitive/_index.mjs",
+        "default": "./helpers/toPrimitive/index.js"
       },
       "./helpers/toPrimitive/index.js"
     ],
@@ -596,8 +596,8 @@
     "./helpers/toPropertyKey": [
       {
         "node": "./helpers/toPropertyKey/index.js",
-        "require": "./helpers/toPropertyKey/index.js",
-        "default": "./helpers/toPropertyKey/_index.mjs"
+        "import": "./helpers/toPropertyKey/_index.mjs",
+        "default": "./helpers/toPropertyKey/index.js"
       },
       "./helpers/toPropertyKey/index.js"
     ],
@@ -605,8 +605,8 @@
     "./helpers/initializerWarningHelper": [
       {
         "node": "./helpers/initializerWarningHelper/index.js",
-        "require": "./helpers/initializerWarningHelper/index.js",
-        "default": "./helpers/initializerWarningHelper/_index.mjs"
+        "import": "./helpers/initializerWarningHelper/_index.mjs",
+        "default": "./helpers/initializerWarningHelper/index.js"
       },
       "./helpers/initializerWarningHelper/index.js"
     ],
@@ -614,8 +614,8 @@
     "./helpers/initializerDefineProperty": [
       {
         "node": "./helpers/initializerDefineProperty/index.js",
-        "require": "./helpers/initializerDefineProperty/index.js",
-        "default": "./helpers/initializerDefineProperty/_index.mjs"
+        "import": "./helpers/initializerDefineProperty/_index.mjs",
+        "default": "./helpers/initializerDefineProperty/index.js"
       },
       "./helpers/initializerDefineProperty/index.js"
     ],
@@ -623,8 +623,8 @@
     "./helpers/applyDecoratedDescriptor": [
       {
         "node": "./helpers/applyDecoratedDescriptor/index.js",
-        "require": "./helpers/applyDecoratedDescriptor/index.js",
-        "default": "./helpers/applyDecoratedDescriptor/_index.mjs"
+        "import": "./helpers/applyDecoratedDescriptor/_index.mjs",
+        "default": "./helpers/applyDecoratedDescriptor/index.js"
       },
       "./helpers/applyDecoratedDescriptor/index.js"
     ],
@@ -632,8 +632,8 @@
     "./helpers/classPrivateFieldLooseKey": [
       {
         "node": "./helpers/classPrivateFieldLooseKey/index.js",
-        "require": "./helpers/classPrivateFieldLooseKey/index.js",
-        "default": "./helpers/classPrivateFieldLooseKey/_index.mjs"
+        "import": "./helpers/classPrivateFieldLooseKey/_index.mjs",
+        "default": "./helpers/classPrivateFieldLooseKey/index.js"
       },
       "./helpers/classPrivateFieldLooseKey/index.js"
     ],
@@ -641,8 +641,8 @@
     "./helpers/classPrivateFieldLooseBase": [
       {
         "node": "./helpers/classPrivateFieldLooseBase/index.js",
-        "require": "./helpers/classPrivateFieldLooseBase/index.js",
-        "default": "./helpers/classPrivateFieldLooseBase/_index.mjs"
+        "import": "./helpers/classPrivateFieldLooseBase/_index.mjs",
+        "default": "./helpers/classPrivateFieldLooseBase/index.js"
       },
       "./helpers/classPrivateFieldLooseBase/index.js"
     ],
@@ -650,8 +650,8 @@
     "./helpers/classPrivateFieldGet": [
       {
         "node": "./helpers/classPrivateFieldGet/index.js",
-        "require": "./helpers/classPrivateFieldGet/index.js",
-        "default": "./helpers/classPrivateFieldGet/_index.mjs"
+        "import": "./helpers/classPrivateFieldGet/_index.mjs",
+        "default": "./helpers/classPrivateFieldGet/index.js"
       },
       "./helpers/classPrivateFieldGet/index.js"
     ],
@@ -659,8 +659,8 @@
     "./helpers/classPrivateFieldSet": [
       {
         "node": "./helpers/classPrivateFieldSet/index.js",
-        "require": "./helpers/classPrivateFieldSet/index.js",
-        "default": "./helpers/classPrivateFieldSet/_index.mjs"
+        "import": "./helpers/classPrivateFieldSet/_index.mjs",
+        "default": "./helpers/classPrivateFieldSet/index.js"
       },
       "./helpers/classPrivateFieldSet/index.js"
     ],
@@ -668,8 +668,8 @@
     "./helpers/classPrivateFieldDestructureSet": [
       {
         "node": "./helpers/classPrivateFieldDestructureSet/index.js",
-        "require": "./helpers/classPrivateFieldDestructureSet/index.js",
-        "default": "./helpers/classPrivateFieldDestructureSet/_index.mjs"
+        "import": "./helpers/classPrivateFieldDestructureSet/_index.mjs",
+        "default": "./helpers/classPrivateFieldDestructureSet/index.js"
       },
       "./helpers/classPrivateFieldDestructureSet/index.js"
     ],
@@ -677,8 +677,8 @@
     "./helpers/classStaticPrivateFieldSpecGet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-        "require": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-        "default": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs"
+        "import": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs",
+        "default": "./helpers/classStaticPrivateFieldSpecGet/index.js"
       },
       "./helpers/classStaticPrivateFieldSpecGet/index.js"
     ],
@@ -686,8 +686,8 @@
     "./helpers/classStaticPrivateFieldSpecSet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-        "require": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-        "default": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs"
+        "import": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs",
+        "default": "./helpers/classStaticPrivateFieldSpecSet/index.js"
       },
       "./helpers/classStaticPrivateFieldSpecSet/index.js"
     ],
@@ -695,8 +695,8 @@
     "./helpers/classStaticPrivateMethodGet": [
       {
         "node": "./helpers/classStaticPrivateMethodGet/index.js",
-        "require": "./helpers/classStaticPrivateMethodGet/index.js",
-        "default": "./helpers/classStaticPrivateMethodGet/_index.mjs"
+        "import": "./helpers/classStaticPrivateMethodGet/_index.mjs",
+        "default": "./helpers/classStaticPrivateMethodGet/index.js"
       },
       "./helpers/classStaticPrivateMethodGet/index.js"
     ],
@@ -704,8 +704,8 @@
     "./helpers/classStaticPrivateMethodSet": [
       {
         "node": "./helpers/classStaticPrivateMethodSet/index.js",
-        "require": "./helpers/classStaticPrivateMethodSet/index.js",
-        "default": "./helpers/classStaticPrivateMethodSet/_index.mjs"
+        "import": "./helpers/classStaticPrivateMethodSet/_index.mjs",
+        "default": "./helpers/classStaticPrivateMethodSet/index.js"
       },
       "./helpers/classStaticPrivateMethodSet/index.js"
     ],
@@ -713,8 +713,8 @@
     "./helpers/decorate": [
       {
         "node": "./helpers/decorate/index.js",
-        "require": "./helpers/decorate/index.js",
-        "default": "./helpers/decorate/_index.mjs"
+        "import": "./helpers/decorate/_index.mjs",
+        "default": "./helpers/decorate/index.js"
       },
       "./helpers/decorate/index.js"
     ],
@@ -722,8 +722,8 @@
     "./helpers/classPrivateMethodGet": [
       {
         "node": "./helpers/classPrivateMethodGet/index.js",
-        "require": "./helpers/classPrivateMethodGet/index.js",
-        "default": "./helpers/classPrivateMethodGet/_index.mjs"
+        "import": "./helpers/classPrivateMethodGet/_index.mjs",
+        "default": "./helpers/classPrivateMethodGet/index.js"
       },
       "./helpers/classPrivateMethodGet/index.js"
     ],
@@ -731,8 +731,8 @@
     "./helpers/classPrivateMethodSet": [
       {
         "node": "./helpers/classPrivateMethodSet/index.js",
-        "require": "./helpers/classPrivateMethodSet/index.js",
-        "default": "./helpers/classPrivateMethodSet/_index.mjs"
+        "import": "./helpers/classPrivateMethodSet/_index.mjs",
+        "default": "./helpers/classPrivateMethodSet/index.js"
       },
       "./helpers/classPrivateMethodSet/index.js"
     ],
@@ -740,8 +740,8 @@
     "./helpers/wrapRegExp": [
       {
         "node": "./helpers/wrapRegExp/index.js",
-        "require": "./helpers/wrapRegExp/index.js",
-        "default": "./helpers/wrapRegExp/_index.mjs"
+        "import": "./helpers/wrapRegExp/_index.mjs",
+        "default": "./helpers/wrapRegExp/index.js"
       },
       "./helpers/wrapRegExp/index.js"
     ],

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -20,8 +20,8 @@
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof/index.js",
-        "require": "./helpers/typeof/index.js",
-        "default": "./helpers/typeof/_index.mjs"
+        "import": "./helpers/typeof/_index.mjs",
+        "default": "./helpers/typeof/index.js"
       },
       "./helpers/typeof/index.js"
     ],
@@ -29,8 +29,8 @@
     "./helpers/jsx": [
       {
         "node": "./helpers/jsx/index.js",
-        "require": "./helpers/jsx/index.js",
-        "default": "./helpers/jsx/_index.mjs"
+        "import": "./helpers/jsx/_index.mjs",
+        "default": "./helpers/jsx/index.js"
       },
       "./helpers/jsx/index.js"
     ],
@@ -38,8 +38,8 @@
     "./helpers/asyncIterator": [
       {
         "node": "./helpers/asyncIterator/index.js",
-        "require": "./helpers/asyncIterator/index.js",
-        "default": "./helpers/asyncIterator/_index.mjs"
+        "import": "./helpers/asyncIterator/_index.mjs",
+        "default": "./helpers/asyncIterator/index.js"
       },
       "./helpers/asyncIterator/index.js"
     ],
@@ -47,8 +47,8 @@
     "./helpers/AwaitValue": [
       {
         "node": "./helpers/AwaitValue/index.js",
-        "require": "./helpers/AwaitValue/index.js",
-        "default": "./helpers/AwaitValue/_index.mjs"
+        "import": "./helpers/AwaitValue/_index.mjs",
+        "default": "./helpers/AwaitValue/index.js"
       },
       "./helpers/AwaitValue/index.js"
     ],
@@ -56,8 +56,8 @@
     "./helpers/AsyncGenerator": [
       {
         "node": "./helpers/AsyncGenerator/index.js",
-        "require": "./helpers/AsyncGenerator/index.js",
-        "default": "./helpers/AsyncGenerator/_index.mjs"
+        "import": "./helpers/AsyncGenerator/_index.mjs",
+        "default": "./helpers/AsyncGenerator/index.js"
       },
       "./helpers/AsyncGenerator/index.js"
     ],
@@ -65,8 +65,8 @@
     "./helpers/wrapAsyncGenerator": [
       {
         "node": "./helpers/wrapAsyncGenerator/index.js",
-        "require": "./helpers/wrapAsyncGenerator/index.js",
-        "default": "./helpers/wrapAsyncGenerator/_index.mjs"
+        "import": "./helpers/wrapAsyncGenerator/_index.mjs",
+        "default": "./helpers/wrapAsyncGenerator/index.js"
       },
       "./helpers/wrapAsyncGenerator/index.js"
     ],
@@ -74,8 +74,8 @@
     "./helpers/awaitAsyncGenerator": [
       {
         "node": "./helpers/awaitAsyncGenerator/index.js",
-        "require": "./helpers/awaitAsyncGenerator/index.js",
-        "default": "./helpers/awaitAsyncGenerator/_index.mjs"
+        "import": "./helpers/awaitAsyncGenerator/_index.mjs",
+        "default": "./helpers/awaitAsyncGenerator/index.js"
       },
       "./helpers/awaitAsyncGenerator/index.js"
     ],
@@ -83,8 +83,8 @@
     "./helpers/asyncGeneratorDelegate": [
       {
         "node": "./helpers/asyncGeneratorDelegate/index.js",
-        "require": "./helpers/asyncGeneratorDelegate/index.js",
-        "default": "./helpers/asyncGeneratorDelegate/_index.mjs"
+        "import": "./helpers/asyncGeneratorDelegate/_index.mjs",
+        "default": "./helpers/asyncGeneratorDelegate/index.js"
       },
       "./helpers/asyncGeneratorDelegate/index.js"
     ],
@@ -92,8 +92,8 @@
     "./helpers/asyncToGenerator": [
       {
         "node": "./helpers/asyncToGenerator/index.js",
-        "require": "./helpers/asyncToGenerator/index.js",
-        "default": "./helpers/asyncToGenerator/_index.mjs"
+        "import": "./helpers/asyncToGenerator/_index.mjs",
+        "default": "./helpers/asyncToGenerator/index.js"
       },
       "./helpers/asyncToGenerator/index.js"
     ],
@@ -101,8 +101,8 @@
     "./helpers/classCallCheck": [
       {
         "node": "./helpers/classCallCheck/index.js",
-        "require": "./helpers/classCallCheck/index.js",
-        "default": "./helpers/classCallCheck/_index.mjs"
+        "import": "./helpers/classCallCheck/_index.mjs",
+        "default": "./helpers/classCallCheck/index.js"
       },
       "./helpers/classCallCheck/index.js"
     ],
@@ -110,8 +110,8 @@
     "./helpers/createClass": [
       {
         "node": "./helpers/createClass/index.js",
-        "require": "./helpers/createClass/index.js",
-        "default": "./helpers/createClass/_index.mjs"
+        "import": "./helpers/createClass/_index.mjs",
+        "default": "./helpers/createClass/index.js"
       },
       "./helpers/createClass/index.js"
     ],
@@ -119,8 +119,8 @@
     "./helpers/defineEnumerableProperties": [
       {
         "node": "./helpers/defineEnumerableProperties/index.js",
-        "require": "./helpers/defineEnumerableProperties/index.js",
-        "default": "./helpers/defineEnumerableProperties/_index.mjs"
+        "import": "./helpers/defineEnumerableProperties/_index.mjs",
+        "default": "./helpers/defineEnumerableProperties/index.js"
       },
       "./helpers/defineEnumerableProperties/index.js"
     ],
@@ -128,8 +128,8 @@
     "./helpers/defaults": [
       {
         "node": "./helpers/defaults/index.js",
-        "require": "./helpers/defaults/index.js",
-        "default": "./helpers/defaults/_index.mjs"
+        "import": "./helpers/defaults/_index.mjs",
+        "default": "./helpers/defaults/index.js"
       },
       "./helpers/defaults/index.js"
     ],
@@ -137,8 +137,8 @@
     "./helpers/defineProperty": [
       {
         "node": "./helpers/defineProperty/index.js",
-        "require": "./helpers/defineProperty/index.js",
-        "default": "./helpers/defineProperty/_index.mjs"
+        "import": "./helpers/defineProperty/_index.mjs",
+        "default": "./helpers/defineProperty/index.js"
       },
       "./helpers/defineProperty/index.js"
     ],
@@ -146,8 +146,8 @@
     "./helpers/extends": [
       {
         "node": "./helpers/extends/index.js",
-        "require": "./helpers/extends/index.js",
-        "default": "./helpers/extends/_index.mjs"
+        "import": "./helpers/extends/_index.mjs",
+        "default": "./helpers/extends/index.js"
       },
       "./helpers/extends/index.js"
     ],
@@ -155,8 +155,8 @@
     "./helpers/objectSpread": [
       {
         "node": "./helpers/objectSpread/index.js",
-        "require": "./helpers/objectSpread/index.js",
-        "default": "./helpers/objectSpread/_index.mjs"
+        "import": "./helpers/objectSpread/_index.mjs",
+        "default": "./helpers/objectSpread/index.js"
       },
       "./helpers/objectSpread/index.js"
     ],
@@ -164,8 +164,8 @@
     "./helpers/objectSpread2": [
       {
         "node": "./helpers/objectSpread2/index.js",
-        "require": "./helpers/objectSpread2/index.js",
-        "default": "./helpers/objectSpread2/_index.mjs"
+        "import": "./helpers/objectSpread2/_index.mjs",
+        "default": "./helpers/objectSpread2/index.js"
       },
       "./helpers/objectSpread2/index.js"
     ],
@@ -173,8 +173,8 @@
     "./helpers/inherits": [
       {
         "node": "./helpers/inherits/index.js",
-        "require": "./helpers/inherits/index.js",
-        "default": "./helpers/inherits/_index.mjs"
+        "import": "./helpers/inherits/_index.mjs",
+        "default": "./helpers/inherits/index.js"
       },
       "./helpers/inherits/index.js"
     ],
@@ -182,8 +182,8 @@
     "./helpers/inheritsLoose": [
       {
         "node": "./helpers/inheritsLoose/index.js",
-        "require": "./helpers/inheritsLoose/index.js",
-        "default": "./helpers/inheritsLoose/_index.mjs"
+        "import": "./helpers/inheritsLoose/_index.mjs",
+        "default": "./helpers/inheritsLoose/index.js"
       },
       "./helpers/inheritsLoose/index.js"
     ],
@@ -191,8 +191,8 @@
     "./helpers/getPrototypeOf": [
       {
         "node": "./helpers/getPrototypeOf/index.js",
-        "require": "./helpers/getPrototypeOf/index.js",
-        "default": "./helpers/getPrototypeOf/_index.mjs"
+        "import": "./helpers/getPrototypeOf/_index.mjs",
+        "default": "./helpers/getPrototypeOf/index.js"
       },
       "./helpers/getPrototypeOf/index.js"
     ],
@@ -200,8 +200,8 @@
     "./helpers/setPrototypeOf": [
       {
         "node": "./helpers/setPrototypeOf/index.js",
-        "require": "./helpers/setPrototypeOf/index.js",
-        "default": "./helpers/setPrototypeOf/_index.mjs"
+        "import": "./helpers/setPrototypeOf/_index.mjs",
+        "default": "./helpers/setPrototypeOf/index.js"
       },
       "./helpers/setPrototypeOf/index.js"
     ],
@@ -209,8 +209,8 @@
     "./helpers/isNativeReflectConstruct": [
       {
         "node": "./helpers/isNativeReflectConstruct/index.js",
-        "require": "./helpers/isNativeReflectConstruct/index.js",
-        "default": "./helpers/isNativeReflectConstruct/_index.mjs"
+        "import": "./helpers/isNativeReflectConstruct/_index.mjs",
+        "default": "./helpers/isNativeReflectConstruct/index.js"
       },
       "./helpers/isNativeReflectConstruct/index.js"
     ],
@@ -218,8 +218,8 @@
     "./helpers/construct": [
       {
         "node": "./helpers/construct/index.js",
-        "require": "./helpers/construct/index.js",
-        "default": "./helpers/construct/_index.mjs"
+        "import": "./helpers/construct/_index.mjs",
+        "default": "./helpers/construct/index.js"
       },
       "./helpers/construct/index.js"
     ],
@@ -227,8 +227,8 @@
     "./helpers/isNativeFunction": [
       {
         "node": "./helpers/isNativeFunction/index.js",
-        "require": "./helpers/isNativeFunction/index.js",
-        "default": "./helpers/isNativeFunction/_index.mjs"
+        "import": "./helpers/isNativeFunction/_index.mjs",
+        "default": "./helpers/isNativeFunction/index.js"
       },
       "./helpers/isNativeFunction/index.js"
     ],
@@ -236,8 +236,8 @@
     "./helpers/wrapNativeSuper": [
       {
         "node": "./helpers/wrapNativeSuper/index.js",
-        "require": "./helpers/wrapNativeSuper/index.js",
-        "default": "./helpers/wrapNativeSuper/_index.mjs"
+        "import": "./helpers/wrapNativeSuper/_index.mjs",
+        "default": "./helpers/wrapNativeSuper/index.js"
       },
       "./helpers/wrapNativeSuper/index.js"
     ],
@@ -245,8 +245,8 @@
     "./helpers/instanceof": [
       {
         "node": "./helpers/instanceof/index.js",
-        "require": "./helpers/instanceof/index.js",
-        "default": "./helpers/instanceof/_index.mjs"
+        "import": "./helpers/instanceof/_index.mjs",
+        "default": "./helpers/instanceof/index.js"
       },
       "./helpers/instanceof/index.js"
     ],
@@ -254,8 +254,8 @@
     "./helpers/interopRequireDefault": [
       {
         "node": "./helpers/interopRequireDefault/index.js",
-        "require": "./helpers/interopRequireDefault/index.js",
-        "default": "./helpers/interopRequireDefault/_index.mjs"
+        "import": "./helpers/interopRequireDefault/_index.mjs",
+        "default": "./helpers/interopRequireDefault/index.js"
       },
       "./helpers/interopRequireDefault/index.js"
     ],
@@ -263,8 +263,8 @@
     "./helpers/interopRequireWildcard": [
       {
         "node": "./helpers/interopRequireWildcard/index.js",
-        "require": "./helpers/interopRequireWildcard/index.js",
-        "default": "./helpers/interopRequireWildcard/_index.mjs"
+        "import": "./helpers/interopRequireWildcard/_index.mjs",
+        "default": "./helpers/interopRequireWildcard/index.js"
       },
       "./helpers/interopRequireWildcard/index.js"
     ],
@@ -272,8 +272,8 @@
     "./helpers/newArrowCheck": [
       {
         "node": "./helpers/newArrowCheck/index.js",
-        "require": "./helpers/newArrowCheck/index.js",
-        "default": "./helpers/newArrowCheck/_index.mjs"
+        "import": "./helpers/newArrowCheck/_index.mjs",
+        "default": "./helpers/newArrowCheck/index.js"
       },
       "./helpers/newArrowCheck/index.js"
     ],
@@ -281,8 +281,8 @@
     "./helpers/objectDestructuringEmpty": [
       {
         "node": "./helpers/objectDestructuringEmpty/index.js",
-        "require": "./helpers/objectDestructuringEmpty/index.js",
-        "default": "./helpers/objectDestructuringEmpty/_index.mjs"
+        "import": "./helpers/objectDestructuringEmpty/_index.mjs",
+        "default": "./helpers/objectDestructuringEmpty/index.js"
       },
       "./helpers/objectDestructuringEmpty/index.js"
     ],
@@ -290,8 +290,8 @@
     "./helpers/objectWithoutPropertiesLoose": [
       {
         "node": "./helpers/objectWithoutPropertiesLoose/index.js",
-        "require": "./helpers/objectWithoutPropertiesLoose/index.js",
-        "default": "./helpers/objectWithoutPropertiesLoose/_index.mjs"
+        "import": "./helpers/objectWithoutPropertiesLoose/_index.mjs",
+        "default": "./helpers/objectWithoutPropertiesLoose/index.js"
       },
       "./helpers/objectWithoutPropertiesLoose/index.js"
     ],
@@ -299,8 +299,8 @@
     "./helpers/objectWithoutProperties": [
       {
         "node": "./helpers/objectWithoutProperties/index.js",
-        "require": "./helpers/objectWithoutProperties/index.js",
-        "default": "./helpers/objectWithoutProperties/_index.mjs"
+        "import": "./helpers/objectWithoutProperties/_index.mjs",
+        "default": "./helpers/objectWithoutProperties/index.js"
       },
       "./helpers/objectWithoutProperties/index.js"
     ],
@@ -308,8 +308,8 @@
     "./helpers/assertThisInitialized": [
       {
         "node": "./helpers/assertThisInitialized/index.js",
-        "require": "./helpers/assertThisInitialized/index.js",
-        "default": "./helpers/assertThisInitialized/_index.mjs"
+        "import": "./helpers/assertThisInitialized/_index.mjs",
+        "default": "./helpers/assertThisInitialized/index.js"
       },
       "./helpers/assertThisInitialized/index.js"
     ],
@@ -317,8 +317,8 @@
     "./helpers/possibleConstructorReturn": [
       {
         "node": "./helpers/possibleConstructorReturn/index.js",
-        "require": "./helpers/possibleConstructorReturn/index.js",
-        "default": "./helpers/possibleConstructorReturn/_index.mjs"
+        "import": "./helpers/possibleConstructorReturn/_index.mjs",
+        "default": "./helpers/possibleConstructorReturn/index.js"
       },
       "./helpers/possibleConstructorReturn/index.js"
     ],
@@ -326,8 +326,8 @@
     "./helpers/createSuper": [
       {
         "node": "./helpers/createSuper/index.js",
-        "require": "./helpers/createSuper/index.js",
-        "default": "./helpers/createSuper/_index.mjs"
+        "import": "./helpers/createSuper/_index.mjs",
+        "default": "./helpers/createSuper/index.js"
       },
       "./helpers/createSuper/index.js"
     ],
@@ -335,8 +335,8 @@
     "./helpers/superPropBase": [
       {
         "node": "./helpers/superPropBase/index.js",
-        "require": "./helpers/superPropBase/index.js",
-        "default": "./helpers/superPropBase/_index.mjs"
+        "import": "./helpers/superPropBase/_index.mjs",
+        "default": "./helpers/superPropBase/index.js"
       },
       "./helpers/superPropBase/index.js"
     ],
@@ -344,8 +344,8 @@
     "./helpers/get": [
       {
         "node": "./helpers/get/index.js",
-        "require": "./helpers/get/index.js",
-        "default": "./helpers/get/_index.mjs"
+        "import": "./helpers/get/_index.mjs",
+        "default": "./helpers/get/index.js"
       },
       "./helpers/get/index.js"
     ],
@@ -353,8 +353,8 @@
     "./helpers/set": [
       {
         "node": "./helpers/set/index.js",
-        "require": "./helpers/set/index.js",
-        "default": "./helpers/set/_index.mjs"
+        "import": "./helpers/set/_index.mjs",
+        "default": "./helpers/set/index.js"
       },
       "./helpers/set/index.js"
     ],
@@ -362,8 +362,8 @@
     "./helpers/taggedTemplateLiteral": [
       {
         "node": "./helpers/taggedTemplateLiteral/index.js",
-        "require": "./helpers/taggedTemplateLiteral/index.js",
-        "default": "./helpers/taggedTemplateLiteral/_index.mjs"
+        "import": "./helpers/taggedTemplateLiteral/_index.mjs",
+        "default": "./helpers/taggedTemplateLiteral/index.js"
       },
       "./helpers/taggedTemplateLiteral/index.js"
     ],
@@ -371,8 +371,8 @@
     "./helpers/taggedTemplateLiteralLoose": [
       {
         "node": "./helpers/taggedTemplateLiteralLoose/index.js",
-        "require": "./helpers/taggedTemplateLiteralLoose/index.js",
-        "default": "./helpers/taggedTemplateLiteralLoose/_index.mjs"
+        "import": "./helpers/taggedTemplateLiteralLoose/_index.mjs",
+        "default": "./helpers/taggedTemplateLiteralLoose/index.js"
       },
       "./helpers/taggedTemplateLiteralLoose/index.js"
     ],
@@ -380,8 +380,8 @@
     "./helpers/readOnlyError": [
       {
         "node": "./helpers/readOnlyError/index.js",
-        "require": "./helpers/readOnlyError/index.js",
-        "default": "./helpers/readOnlyError/_index.mjs"
+        "import": "./helpers/readOnlyError/_index.mjs",
+        "default": "./helpers/readOnlyError/index.js"
       },
       "./helpers/readOnlyError/index.js"
     ],
@@ -389,8 +389,8 @@
     "./helpers/writeOnlyError": [
       {
         "node": "./helpers/writeOnlyError/index.js",
-        "require": "./helpers/writeOnlyError/index.js",
-        "default": "./helpers/writeOnlyError/_index.mjs"
+        "import": "./helpers/writeOnlyError/_index.mjs",
+        "default": "./helpers/writeOnlyError/index.js"
       },
       "./helpers/writeOnlyError/index.js"
     ],
@@ -398,8 +398,8 @@
     "./helpers/classNameTDZError": [
       {
         "node": "./helpers/classNameTDZError/index.js",
-        "require": "./helpers/classNameTDZError/index.js",
-        "default": "./helpers/classNameTDZError/_index.mjs"
+        "import": "./helpers/classNameTDZError/_index.mjs",
+        "default": "./helpers/classNameTDZError/index.js"
       },
       "./helpers/classNameTDZError/index.js"
     ],
@@ -407,8 +407,8 @@
     "./helpers/temporalUndefined": [
       {
         "node": "./helpers/temporalUndefined/index.js",
-        "require": "./helpers/temporalUndefined/index.js",
-        "default": "./helpers/temporalUndefined/_index.mjs"
+        "import": "./helpers/temporalUndefined/_index.mjs",
+        "default": "./helpers/temporalUndefined/index.js"
       },
       "./helpers/temporalUndefined/index.js"
     ],
@@ -416,8 +416,8 @@
     "./helpers/tdz": [
       {
         "node": "./helpers/tdz/index.js",
-        "require": "./helpers/tdz/index.js",
-        "default": "./helpers/tdz/_index.mjs"
+        "import": "./helpers/tdz/_index.mjs",
+        "default": "./helpers/tdz/index.js"
       },
       "./helpers/tdz/index.js"
     ],
@@ -425,8 +425,8 @@
     "./helpers/temporalRef": [
       {
         "node": "./helpers/temporalRef/index.js",
-        "require": "./helpers/temporalRef/index.js",
-        "default": "./helpers/temporalRef/_index.mjs"
+        "import": "./helpers/temporalRef/_index.mjs",
+        "default": "./helpers/temporalRef/index.js"
       },
       "./helpers/temporalRef/index.js"
     ],
@@ -434,8 +434,8 @@
     "./helpers/slicedToArray": [
       {
         "node": "./helpers/slicedToArray/index.js",
-        "require": "./helpers/slicedToArray/index.js",
-        "default": "./helpers/slicedToArray/_index.mjs"
+        "import": "./helpers/slicedToArray/_index.mjs",
+        "default": "./helpers/slicedToArray/index.js"
       },
       "./helpers/slicedToArray/index.js"
     ],
@@ -443,8 +443,8 @@
     "./helpers/slicedToArrayLoose": [
       {
         "node": "./helpers/slicedToArrayLoose/index.js",
-        "require": "./helpers/slicedToArrayLoose/index.js",
-        "default": "./helpers/slicedToArrayLoose/_index.mjs"
+        "import": "./helpers/slicedToArrayLoose/_index.mjs",
+        "default": "./helpers/slicedToArrayLoose/index.js"
       },
       "./helpers/slicedToArrayLoose/index.js"
     ],
@@ -452,8 +452,8 @@
     "./helpers/toArray": [
       {
         "node": "./helpers/toArray/index.js",
-        "require": "./helpers/toArray/index.js",
-        "default": "./helpers/toArray/_index.mjs"
+        "import": "./helpers/toArray/_index.mjs",
+        "default": "./helpers/toArray/index.js"
       },
       "./helpers/toArray/index.js"
     ],
@@ -461,8 +461,8 @@
     "./helpers/toConsumableArray": [
       {
         "node": "./helpers/toConsumableArray/index.js",
-        "require": "./helpers/toConsumableArray/index.js",
-        "default": "./helpers/toConsumableArray/_index.mjs"
+        "import": "./helpers/toConsumableArray/_index.mjs",
+        "default": "./helpers/toConsumableArray/index.js"
       },
       "./helpers/toConsumableArray/index.js"
     ],
@@ -470,8 +470,8 @@
     "./helpers/arrayWithoutHoles": [
       {
         "node": "./helpers/arrayWithoutHoles/index.js",
-        "require": "./helpers/arrayWithoutHoles/index.js",
-        "default": "./helpers/arrayWithoutHoles/_index.mjs"
+        "import": "./helpers/arrayWithoutHoles/_index.mjs",
+        "default": "./helpers/arrayWithoutHoles/index.js"
       },
       "./helpers/arrayWithoutHoles/index.js"
     ],
@@ -479,8 +479,8 @@
     "./helpers/arrayWithHoles": [
       {
         "node": "./helpers/arrayWithHoles/index.js",
-        "require": "./helpers/arrayWithHoles/index.js",
-        "default": "./helpers/arrayWithHoles/_index.mjs"
+        "import": "./helpers/arrayWithHoles/_index.mjs",
+        "default": "./helpers/arrayWithHoles/index.js"
       },
       "./helpers/arrayWithHoles/index.js"
     ],
@@ -488,8 +488,8 @@
     "./helpers/maybeArrayLike": [
       {
         "node": "./helpers/maybeArrayLike/index.js",
-        "require": "./helpers/maybeArrayLike/index.js",
-        "default": "./helpers/maybeArrayLike/_index.mjs"
+        "import": "./helpers/maybeArrayLike/_index.mjs",
+        "default": "./helpers/maybeArrayLike/index.js"
       },
       "./helpers/maybeArrayLike/index.js"
     ],
@@ -497,8 +497,8 @@
     "./helpers/iterableToArray": [
       {
         "node": "./helpers/iterableToArray/index.js",
-        "require": "./helpers/iterableToArray/index.js",
-        "default": "./helpers/iterableToArray/_index.mjs"
+        "import": "./helpers/iterableToArray/_index.mjs",
+        "default": "./helpers/iterableToArray/index.js"
       },
       "./helpers/iterableToArray/index.js"
     ],
@@ -506,8 +506,8 @@
     "./helpers/iterableToArrayLimit": [
       {
         "node": "./helpers/iterableToArrayLimit/index.js",
-        "require": "./helpers/iterableToArrayLimit/index.js",
-        "default": "./helpers/iterableToArrayLimit/_index.mjs"
+        "import": "./helpers/iterableToArrayLimit/_index.mjs",
+        "default": "./helpers/iterableToArrayLimit/index.js"
       },
       "./helpers/iterableToArrayLimit/index.js"
     ],
@@ -515,8 +515,8 @@
     "./helpers/iterableToArrayLimitLoose": [
       {
         "node": "./helpers/iterableToArrayLimitLoose/index.js",
-        "require": "./helpers/iterableToArrayLimitLoose/index.js",
-        "default": "./helpers/iterableToArrayLimitLoose/_index.mjs"
+        "import": "./helpers/iterableToArrayLimitLoose/_index.mjs",
+        "default": "./helpers/iterableToArrayLimitLoose/index.js"
       },
       "./helpers/iterableToArrayLimitLoose/index.js"
     ],
@@ -524,8 +524,8 @@
     "./helpers/unsupportedIterableToArray": [
       {
         "node": "./helpers/unsupportedIterableToArray/index.js",
-        "require": "./helpers/unsupportedIterableToArray/index.js",
-        "default": "./helpers/unsupportedIterableToArray/_index.mjs"
+        "import": "./helpers/unsupportedIterableToArray/_index.mjs",
+        "default": "./helpers/unsupportedIterableToArray/index.js"
       },
       "./helpers/unsupportedIterableToArray/index.js"
     ],
@@ -533,8 +533,8 @@
     "./helpers/arrayLikeToArray": [
       {
         "node": "./helpers/arrayLikeToArray/index.js",
-        "require": "./helpers/arrayLikeToArray/index.js",
-        "default": "./helpers/arrayLikeToArray/_index.mjs"
+        "import": "./helpers/arrayLikeToArray/_index.mjs",
+        "default": "./helpers/arrayLikeToArray/index.js"
       },
       "./helpers/arrayLikeToArray/index.js"
     ],
@@ -542,8 +542,8 @@
     "./helpers/nonIterableSpread": [
       {
         "node": "./helpers/nonIterableSpread/index.js",
-        "require": "./helpers/nonIterableSpread/index.js",
-        "default": "./helpers/nonIterableSpread/_index.mjs"
+        "import": "./helpers/nonIterableSpread/_index.mjs",
+        "default": "./helpers/nonIterableSpread/index.js"
       },
       "./helpers/nonIterableSpread/index.js"
     ],
@@ -551,8 +551,8 @@
     "./helpers/nonIterableRest": [
       {
         "node": "./helpers/nonIterableRest/index.js",
-        "require": "./helpers/nonIterableRest/index.js",
-        "default": "./helpers/nonIterableRest/_index.mjs"
+        "import": "./helpers/nonIterableRest/_index.mjs",
+        "default": "./helpers/nonIterableRest/index.js"
       },
       "./helpers/nonIterableRest/index.js"
     ],
@@ -560,8 +560,8 @@
     "./helpers/createForOfIteratorHelper": [
       {
         "node": "./helpers/createForOfIteratorHelper/index.js",
-        "require": "./helpers/createForOfIteratorHelper/index.js",
-        "default": "./helpers/createForOfIteratorHelper/_index.mjs"
+        "import": "./helpers/createForOfIteratorHelper/_index.mjs",
+        "default": "./helpers/createForOfIteratorHelper/index.js"
       },
       "./helpers/createForOfIteratorHelper/index.js"
     ],
@@ -569,8 +569,8 @@
     "./helpers/createForOfIteratorHelperLoose": [
       {
         "node": "./helpers/createForOfIteratorHelperLoose/index.js",
-        "require": "./helpers/createForOfIteratorHelperLoose/index.js",
-        "default": "./helpers/createForOfIteratorHelperLoose/_index.mjs"
+        "import": "./helpers/createForOfIteratorHelperLoose/_index.mjs",
+        "default": "./helpers/createForOfIteratorHelperLoose/index.js"
       },
       "./helpers/createForOfIteratorHelperLoose/index.js"
     ],
@@ -578,8 +578,8 @@
     "./helpers/skipFirstGeneratorNext": [
       {
         "node": "./helpers/skipFirstGeneratorNext/index.js",
-        "require": "./helpers/skipFirstGeneratorNext/index.js",
-        "default": "./helpers/skipFirstGeneratorNext/_index.mjs"
+        "import": "./helpers/skipFirstGeneratorNext/_index.mjs",
+        "default": "./helpers/skipFirstGeneratorNext/index.js"
       },
       "./helpers/skipFirstGeneratorNext/index.js"
     ],
@@ -587,8 +587,8 @@
     "./helpers/toPrimitive": [
       {
         "node": "./helpers/toPrimitive/index.js",
-        "require": "./helpers/toPrimitive/index.js",
-        "default": "./helpers/toPrimitive/_index.mjs"
+        "import": "./helpers/toPrimitive/_index.mjs",
+        "default": "./helpers/toPrimitive/index.js"
       },
       "./helpers/toPrimitive/index.js"
     ],
@@ -596,8 +596,8 @@
     "./helpers/toPropertyKey": [
       {
         "node": "./helpers/toPropertyKey/index.js",
-        "require": "./helpers/toPropertyKey/index.js",
-        "default": "./helpers/toPropertyKey/_index.mjs"
+        "import": "./helpers/toPropertyKey/_index.mjs",
+        "default": "./helpers/toPropertyKey/index.js"
       },
       "./helpers/toPropertyKey/index.js"
     ],
@@ -605,8 +605,8 @@
     "./helpers/initializerWarningHelper": [
       {
         "node": "./helpers/initializerWarningHelper/index.js",
-        "require": "./helpers/initializerWarningHelper/index.js",
-        "default": "./helpers/initializerWarningHelper/_index.mjs"
+        "import": "./helpers/initializerWarningHelper/_index.mjs",
+        "default": "./helpers/initializerWarningHelper/index.js"
       },
       "./helpers/initializerWarningHelper/index.js"
     ],
@@ -614,8 +614,8 @@
     "./helpers/initializerDefineProperty": [
       {
         "node": "./helpers/initializerDefineProperty/index.js",
-        "require": "./helpers/initializerDefineProperty/index.js",
-        "default": "./helpers/initializerDefineProperty/_index.mjs"
+        "import": "./helpers/initializerDefineProperty/_index.mjs",
+        "default": "./helpers/initializerDefineProperty/index.js"
       },
       "./helpers/initializerDefineProperty/index.js"
     ],
@@ -623,8 +623,8 @@
     "./helpers/applyDecoratedDescriptor": [
       {
         "node": "./helpers/applyDecoratedDescriptor/index.js",
-        "require": "./helpers/applyDecoratedDescriptor/index.js",
-        "default": "./helpers/applyDecoratedDescriptor/_index.mjs"
+        "import": "./helpers/applyDecoratedDescriptor/_index.mjs",
+        "default": "./helpers/applyDecoratedDescriptor/index.js"
       },
       "./helpers/applyDecoratedDescriptor/index.js"
     ],
@@ -632,8 +632,8 @@
     "./helpers/classPrivateFieldLooseKey": [
       {
         "node": "./helpers/classPrivateFieldLooseKey/index.js",
-        "require": "./helpers/classPrivateFieldLooseKey/index.js",
-        "default": "./helpers/classPrivateFieldLooseKey/_index.mjs"
+        "import": "./helpers/classPrivateFieldLooseKey/_index.mjs",
+        "default": "./helpers/classPrivateFieldLooseKey/index.js"
       },
       "./helpers/classPrivateFieldLooseKey/index.js"
     ],
@@ -641,8 +641,8 @@
     "./helpers/classPrivateFieldLooseBase": [
       {
         "node": "./helpers/classPrivateFieldLooseBase/index.js",
-        "require": "./helpers/classPrivateFieldLooseBase/index.js",
-        "default": "./helpers/classPrivateFieldLooseBase/_index.mjs"
+        "import": "./helpers/classPrivateFieldLooseBase/_index.mjs",
+        "default": "./helpers/classPrivateFieldLooseBase/index.js"
       },
       "./helpers/classPrivateFieldLooseBase/index.js"
     ],
@@ -650,8 +650,8 @@
     "./helpers/classPrivateFieldGet": [
       {
         "node": "./helpers/classPrivateFieldGet/index.js",
-        "require": "./helpers/classPrivateFieldGet/index.js",
-        "default": "./helpers/classPrivateFieldGet/_index.mjs"
+        "import": "./helpers/classPrivateFieldGet/_index.mjs",
+        "default": "./helpers/classPrivateFieldGet/index.js"
       },
       "./helpers/classPrivateFieldGet/index.js"
     ],
@@ -659,8 +659,8 @@
     "./helpers/classPrivateFieldSet": [
       {
         "node": "./helpers/classPrivateFieldSet/index.js",
-        "require": "./helpers/classPrivateFieldSet/index.js",
-        "default": "./helpers/classPrivateFieldSet/_index.mjs"
+        "import": "./helpers/classPrivateFieldSet/_index.mjs",
+        "default": "./helpers/classPrivateFieldSet/index.js"
       },
       "./helpers/classPrivateFieldSet/index.js"
     ],
@@ -668,8 +668,8 @@
     "./helpers/classPrivateFieldDestructureSet": [
       {
         "node": "./helpers/classPrivateFieldDestructureSet/index.js",
-        "require": "./helpers/classPrivateFieldDestructureSet/index.js",
-        "default": "./helpers/classPrivateFieldDestructureSet/_index.mjs"
+        "import": "./helpers/classPrivateFieldDestructureSet/_index.mjs",
+        "default": "./helpers/classPrivateFieldDestructureSet/index.js"
       },
       "./helpers/classPrivateFieldDestructureSet/index.js"
     ],
@@ -677,8 +677,8 @@
     "./helpers/classStaticPrivateFieldSpecGet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-        "require": "./helpers/classStaticPrivateFieldSpecGet/index.js",
-        "default": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs"
+        "import": "./helpers/classStaticPrivateFieldSpecGet/_index.mjs",
+        "default": "./helpers/classStaticPrivateFieldSpecGet/index.js"
       },
       "./helpers/classStaticPrivateFieldSpecGet/index.js"
     ],
@@ -686,8 +686,8 @@
     "./helpers/classStaticPrivateFieldSpecSet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-        "require": "./helpers/classStaticPrivateFieldSpecSet/index.js",
-        "default": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs"
+        "import": "./helpers/classStaticPrivateFieldSpecSet/_index.mjs",
+        "default": "./helpers/classStaticPrivateFieldSpecSet/index.js"
       },
       "./helpers/classStaticPrivateFieldSpecSet/index.js"
     ],
@@ -695,8 +695,8 @@
     "./helpers/classStaticPrivateMethodGet": [
       {
         "node": "./helpers/classStaticPrivateMethodGet/index.js",
-        "require": "./helpers/classStaticPrivateMethodGet/index.js",
-        "default": "./helpers/classStaticPrivateMethodGet/_index.mjs"
+        "import": "./helpers/classStaticPrivateMethodGet/_index.mjs",
+        "default": "./helpers/classStaticPrivateMethodGet/index.js"
       },
       "./helpers/classStaticPrivateMethodGet/index.js"
     ],
@@ -704,8 +704,8 @@
     "./helpers/classStaticPrivateMethodSet": [
       {
         "node": "./helpers/classStaticPrivateMethodSet/index.js",
-        "require": "./helpers/classStaticPrivateMethodSet/index.js",
-        "default": "./helpers/classStaticPrivateMethodSet/_index.mjs"
+        "import": "./helpers/classStaticPrivateMethodSet/_index.mjs",
+        "default": "./helpers/classStaticPrivateMethodSet/index.js"
       },
       "./helpers/classStaticPrivateMethodSet/index.js"
     ],
@@ -713,8 +713,8 @@
     "./helpers/decorate": [
       {
         "node": "./helpers/decorate/index.js",
-        "require": "./helpers/decorate/index.js",
-        "default": "./helpers/decorate/_index.mjs"
+        "import": "./helpers/decorate/_index.mjs",
+        "default": "./helpers/decorate/index.js"
       },
       "./helpers/decorate/index.js"
     ],
@@ -722,8 +722,8 @@
     "./helpers/classPrivateMethodGet": [
       {
         "node": "./helpers/classPrivateMethodGet/index.js",
-        "require": "./helpers/classPrivateMethodGet/index.js",
-        "default": "./helpers/classPrivateMethodGet/_index.mjs"
+        "import": "./helpers/classPrivateMethodGet/_index.mjs",
+        "default": "./helpers/classPrivateMethodGet/index.js"
       },
       "./helpers/classPrivateMethodGet/index.js"
     ],
@@ -731,8 +731,8 @@
     "./helpers/classPrivateMethodSet": [
       {
         "node": "./helpers/classPrivateMethodSet/index.js",
-        "require": "./helpers/classPrivateMethodSet/index.js",
-        "default": "./helpers/classPrivateMethodSet/_index.mjs"
+        "import": "./helpers/classPrivateMethodSet/_index.mjs",
+        "default": "./helpers/classPrivateMethodSet/index.js"
       },
       "./helpers/classPrivateMethodSet/index.js"
     ],
@@ -740,8 +740,8 @@
     "./helpers/wrapRegExp": [
       {
         "node": "./helpers/wrapRegExp/index.js",
-        "require": "./helpers/wrapRegExp/index.js",
-        "default": "./helpers/wrapRegExp/_index.mjs"
+        "import": "./helpers/wrapRegExp/_index.mjs",
+        "default": "./helpers/wrapRegExp/index.js"
       },
       "./helpers/wrapRegExp/index.js"
     ],

--- a/test/runtime-integration/expected-cjs-absolute-13.2.txt
+++ b/test/runtime-integration/expected-cjs-absolute-13.2.txt
@@ -1,0 +1,9 @@
+================= require - auto ====================
+typeof objectWithoutProperties: function
+typeof objectWithoutProperties.default: function
+obj: { b: 2, [Symbol(Symbol.toStringTag)]: 5 }
+================= require - esm =====================
+Error: Must use import to load ES Module: <ROOT>/packages/babel-runtime/helpers/esm/toPrimitive.js
+=============== require - corejs ====================
+typeof Set: function
+arr: 1,2,3

--- a/test/runtime-integration/node.cjs
+++ b/test/runtime-integration/node.cjs
@@ -22,6 +22,8 @@ const expectedCjsAbsolute =
     ? "expected-cjs-absolute-10.txt"
     : major === 13 && minor <= 1
     ? "expected-cjs-absolute-13.0.txt"
+    : major === 13 && minor <= 3
+    ? "expected-cjs-absolute-13.2.txt"
     : "expected-cjs-absolute.txt";
 
 test(


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/12889
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR restores compatibility with Node.js 13.2-13.6.

We now have tests for every Node.js versions where there were ESM-related changes and for Webpack/Rollup, so I'm confident that these changes don't break anything.

The fix is based on https://twitter.com/ljharb/status/1364324634540142596.