### PR TITLE
Do not warn for `loose` of class features in `preset-env`

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@babel/core": "workspace:*",
-    "@babel/helper-plugin-test-runner": "workspace:*"
+    "@babel/helper-plugin-test-runner": "workspace:*",
+    "@babel/preset-env": "workspace:*"
   }
 }

--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -44,7 +44,11 @@ export function createClassFeaturePlugin({
   const constantSuper = api.assumption("constantSuper");
   const noDocumentAll = api.assumption("noDocumentAll");
 
-  if (loose) {
+  if (
+    loose === true ||
+    loose ===
+      "#__internal__@babel/preset-env__prefer-true-but-false-is-ok-if-it-prevents-an-error"
+  ) {
     const explicit = [];
 
     if (setPublicClassFields !== undefined) {

--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -44,11 +44,7 @@ export function createClassFeaturePlugin({
   const constantSuper = api.assumption("constantSuper");
   const noDocumentAll = api.assumption("noDocumentAll");
 
-  if (
-    loose === true ||
-    loose ===
-      "#__internal__@babel/preset-env__prefer-true-but-false-is-ok-if-it-prevents-an-error"
-  ) {
+  if (loose === true) {
     const explicit = [];
 
     if (setPublicClassFields !== undefined) {

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/no-loose-and-assumptions-preset-env/input.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/no-loose-and-assumptions-preset-env/input.js
@@ -1,0 +1,3 @@
+class A {
+  foo;
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/no-loose-and-assumptions-preset-env/options.json
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/no-loose-and-assumptions-preset-env/options.json
@@ -1,0 +1,8 @@
+{
+  "validateLogs": true,
+  "presets": [["env", { "shippedProposals": true }]],
+  "assumptions": {
+    "setPublicClassFields": true
+  },
+  "targets": "chrome 70"
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/no-loose-and-assumptions-preset-env/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/no-loose-and-assumptions-preset-env/output.js
@@ -1,0 +1,6 @@
+class A {
+  constructor() {
+    this.foo = void 0;
+  }
+
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/no-loose-and-assumptions-preset-env/stderr.txt
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/no-loose-and-assumptions-preset-env/stderr.txt
@@ -1,10 +1,1 @@
-[proposal-class-properties]: You are using the "loose: true" option and you are explicitly setting a value for the "setPublicClassFields" assumption. The "loose" option can cause incompatibilities with the other class features plugins, so it's recommended that you replace it with the following top-level option:
-	"assumptions": {
-		"setPublicClassFields": true,
-		"privateFieldsAsProperties": true
-	}
-[proposal-private-methods]: You are using the "loose: true" option and you are explicitly setting a value for the "setPublicClassFields" assumption. The "loose" option can cause incompatibilities with the other class features plugins, so it's recommended that you replace it with the following top-level option:
-	"assumptions": {
-		"setPublicClassFields": true,
-		"privateFieldsAsProperties": true
-	}
+

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/no-loose-and-assumptions-preset-env/stderr.txt
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/no-loose-and-assumptions-preset-env/stderr.txt
@@ -1,0 +1,10 @@
+[proposal-class-properties]: You are using the "loose: true" option and you are explicitly setting a value for the "setPublicClassFields" assumption. The "loose" option can cause incompatibilities with the other class features plugins, so it's recommended that you replace it with the following top-level option:
+	"assumptions": {
+		"setPublicClassFields": true,
+		"privateFieldsAsProperties": true
+	}
+[proposal-private-methods]: You are using the "loose: true" option and you are explicitly setting a value for the "setPublicClassFields" assumption. The "loose" option can cause incompatibilities with the other class features plugins, so it's recommended that you replace it with the following top-level option:
+	"assumptions": {
+		"setPublicClassFields": true,
+		"privateFieldsAsProperties": true
+	}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions-preset-env/input.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions-preset-env/input.js
@@ -1,0 +1,3 @@
+class A {
+  foo;
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions-preset-env/options.json
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions-preset-env/options.json
@@ -1,0 +1,8 @@
+{
+  "validateLogs": true,
+  "presets": [["env", { "loose": true, "shippedProposals": true }]],
+  "assumptions": {
+    "setPublicClassFields": true
+  },
+  "targets": "chrome 70"
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions-preset-env/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions-preset-env/output.js
@@ -1,0 +1,6 @@
+class A {
+  constructor() {
+    this.foo = void 0;
+  }
+
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions-preset-env/stderr.txt
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions-preset-env/stderr.txt
@@ -1,10 +1,1 @@
-[proposal-class-properties]: You are using the "loose: true" option and you are explicitly setting a value for the "setPublicClassFields" assumption. The "loose" option can cause incompatibilities with the other class features plugins, so it's recommended that you replace it with the following top-level option:
-	"assumptions": {
-		"setPublicClassFields": true,
-		"privateFieldsAsProperties": true
-	}
-[proposal-private-methods]: You are using the "loose: true" option and you are explicitly setting a value for the "setPublicClassFields" assumption. The "loose" option can cause incompatibilities with the other class features plugins, so it's recommended that you replace it with the following top-level option:
-	"assumptions": {
-		"setPublicClassFields": true,
-		"privateFieldsAsProperties": true
-	}
+

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions-preset-env/stderr.txt
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/warn-loose-and-assumptions-preset-env/stderr.txt
@@ -1,0 +1,10 @@
+[proposal-class-properties]: You are using the "loose: true" option and you are explicitly setting a value for the "setPublicClassFields" assumption. The "loose" option can cause incompatibilities with the other class features plugins, so it's recommended that you replace it with the following top-level option:
+	"assumptions": {
+		"setPublicClassFields": true,
+		"privateFieldsAsProperties": true
+	}
+[proposal-private-methods]: You are using the "loose: true" option and you are explicitly setting a value for the "setPublicClassFields" assumption. The "loose" option can cause incompatibilities with the other class features plugins, so it's recommended that you replace it with the following top-level option:
+	"assumptions": {
+		"setPublicClassFields": true,
+		"privateFieldsAsProperties": true
+	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -429,6 +429,7 @@ __metadata:
     "@babel/helper-plugin-test-runner": "workspace:*"
     "@babel/helper-replace-supers": "workspace:^7.13.0"
     "@babel/helper-split-export-declaration": "workspace:^7.12.13"
+    "@babel/preset-env": "workspace:*"
   peerDependencies:
     "@babel/core": ^7.0.0
   languageName: unknown


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I found this while preparing https://github.com/babel/babel/pull/12897.

The first commits shows the wrong behavior, the second one fixes it.