### PR TITLE
Fix Module not found: Error: Can't resolve 'core-js/modules/es6.array.concat.js' with compat-data@7.13.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "glob-watcher/chokidar": "npm:^3.4.0",
     "@types/babel__core": "link:./nope",
     "@types/babel__traverse": "link:./nope",
-    "@babel/parser/@babel/types": "workspace:*"
+    "@babel/parser/@babel/types": "workspace:*",
+    "babel-plugin-polyfill-corejs2/@babel/compat-data": "workspace:*"
   },
   "engines": {
     "node": ">= 6.9.0",

--- a/packages/babel-compat-data/data/corejs2-built-ins.json
+++ b/packages/babel-compat-data/data/corejs2-built-ins.json
@@ -1,15 +1,4 @@
 {
-  "es6.array.concat": {
-    "chrome": "51",
-    "opera": "38",
-    "edge": "15",
-    "firefox": "48",
-    "safari": "10",
-    "node": "6.5",
-    "ios": "10",
-    "samsung": "5",
-    "electron": "1.2"
-  },
   "es6.array.copy-within": {
     "chrome": "45",
     "opera": "32",
@@ -267,17 +256,6 @@
     "electron": "3.0"
   },
   "es6.array.species": {
-    "chrome": "51",
-    "opera": "38",
-    "edge": "13",
-    "firefox": "48",
-    "safari": "10",
-    "node": "6.5",
-    "ios": "10",
-    "samsung": "5",
-    "electron": "1.2"
-  },
-  "es6.array.splice": {
     "chrome": "51",
     "opera": "38",
     "edge": "13",

--- a/packages/babel-compat-data/scripts/data/corejs2-built-in-features.js
+++ b/packages/babel-compat-data/scripts/data/corejs2-built-in-features.js
@@ -27,12 +27,6 @@ const typedArrayMethods = [
 ];
 
 module.exports = {
-  "es6.array.concat": {
-    features: [
-      "well-known symbols / Symbol.isConcatSpreadable",
-      "well-known symbols / Symbol.species, Array.prototype.concat",
-    ],
-  },
   "es6.array.copy-within":
     "Array.prototype methods / Array.prototype.copyWithin",
   "es6.array.every": "Array methods / Array.prototype.every",
@@ -75,8 +69,6 @@ module.exports = {
   "es6.array.some": "Array methods / Array.prototype.some",
   "es6.array.sort": "Array methods / Array.prototype.sort",
   "es6.array.species": "Array static methods / Array[Symbol.species]",
-  "es6.array.splice":
-    "well-known symbols / Symbol.species, Array.prototype.splice",
 
   "es6.date.now": "Date methods / Date.now",
   "es6.date.to-iso-string": "Date methods / Date.prototype.toISOString",

--- a/packages/babel-preset-env/test/fixtures/corejs2/entry-all/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/entry-all/output.mjs
@@ -1,4 +1,3 @@
-import "core-js/modules/es6.array.concat.js";
 import "core-js/modules/es6.array.copy-within.js";
 import "core-js/modules/es6.array.every.js";
 import "core-js/modules/es6.array.fill.js";
@@ -21,7 +20,6 @@ import "core-js/modules/es6.array.slice.js";
 import "core-js/modules/es6.array.some.js";
 import "core-js/modules/es6.array.sort.js";
 import "core-js/modules/es6.array.species.js";
-import "core-js/modules/es6.array.splice.js";
 import "core-js/modules/es6.date.now.js";
 import "core-js/modules/es6.date.to-iso-string.js";
 import "core-js/modules/es6.date.to-json.js";

--- a/packages/babel-preset-env/test/fixtures/corejs2/entry-chrome-48/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/entry-chrome-48/output.mjs
@@ -1,4 +1,3 @@
-import "core-js/modules/es6.array.concat.js";
 import "core-js/modules/es6.array.filter.js";
 import "core-js/modules/es7.array.flat-map.js";
 import "core-js/modules/es6.array.from.js";
@@ -7,7 +6,6 @@ import "core-js/modules/es6.array.map.js";
 import "core-js/modules/es6.array.slice.js";
 import "core-js/modules/es6.array.sort.js";
 import "core-js/modules/es6.array.species.js";
-import "core-js/modules/es6.array.splice.js";
 import "core-js/modules/es6.function.has-instance.js";
 import "core-js/modules/es6.map.js";
 import "core-js/modules/es6.object.assign.js";

--- a/packages/babel-preset-env/test/fixtures/corejs2/entry-chrome-49/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/entry-chrome-49/output.mjs
@@ -1,4 +1,3 @@
-import "core-js/modules/es6.array.concat.js";
 import "core-js/modules/es6.array.filter.js";
 import "core-js/modules/es7.array.flat-map.js";
 import "core-js/modules/es6.array.from.js";
@@ -7,7 +6,6 @@ import "core-js/modules/es6.array.map.js";
 import "core-js/modules/es6.array.slice.js";
 import "core-js/modules/es6.array.sort.js";
 import "core-js/modules/es6.array.species.js";
-import "core-js/modules/es6.array.splice.js";
 import "core-js/modules/es6.function.has-instance.js";
 import "core-js/modules/es6.map.js";
 import "core-js/modules/es7.object.define-getter.js";

--- a/packages/babel-preset-env/test/fixtures/corejs2/entry-ie-11/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/entry-ie-11/output.mjs
@@ -1,4 +1,3 @@
-import "core-js/modules/es6.array.concat.js";
 import "core-js/modules/es6.array.copy-within.js";
 import "core-js/modules/es6.array.fill.js";
 import "core-js/modules/es6.array.filter.js";
@@ -12,7 +11,6 @@ import "core-js/modules/es6.array.map.js";
 import "core-js/modules/es6.array.of.js";
 import "core-js/modules/es6.array.slice.js";
 import "core-js/modules/es6.array.species.js";
-import "core-js/modules/es6.array.splice.js";
 import "core-js/modules/es6.date.to-primitive.js";
 import "core-js/modules/es6.function.has-instance.js";
 import "core-js/modules/es6.function.name.js";

--- a/packages/babel-preset-env/test/fixtures/corejs2/entry-ie-9/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/entry-ie-9/output.mjs
@@ -1,4 +1,3 @@
-import "core-js/modules/es6.array.concat.js";
 import "core-js/modules/es6.array.copy-within.js";
 import "core-js/modules/es6.array.fill.js";
 import "core-js/modules/es6.array.filter.js";
@@ -12,7 +11,6 @@ import "core-js/modules/es6.array.map.js";
 import "core-js/modules/es6.array.of.js";
 import "core-js/modules/es6.array.slice.js";
 import "core-js/modules/es6.array.species.js";
-import "core-js/modules/es6.array.splice.js";
 import "core-js/modules/es6.date.to-primitive.js";
 import "core-js/modules/es6.date.to-string.js";
 import "core-js/modules/es6.function.has-instance.js";

--- a/packages/babel-preset-env/test/fixtures/corejs2/entry-shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/corejs2/entry-shippedProposals/output.js
@@ -1,5 +1,3 @@
-require("core-js/modules/es6.array.concat.js");
-
 require("core-js/modules/es6.array.copy-within.js");
 
 require("core-js/modules/es6.array.every.js");
@@ -43,8 +41,6 @@ require("core-js/modules/es6.array.some.js");
 require("core-js/modules/es6.array.sort.js");
 
 require("core-js/modules/es6.array.species.js");
-
-require("core-js/modules/es6.array.splice.js");
 
 require("core-js/modules/es6.date.now.js");
 

--- a/packages/babel-preset-env/test/fixtures/corejs2/exclude-regenerator/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/exclude-regenerator/output.mjs
@@ -1,4 +1,3 @@
-import "core-js/modules/es6.array.concat.js";
 import "core-js/modules/es6.array.copy-within.js";
 import "core-js/modules/es6.array.every.js";
 import "core-js/modules/es6.array.fill.js";
@@ -21,7 +20,6 @@ import "core-js/modules/es6.array.slice.js";
 import "core-js/modules/es6.array.some.js";
 import "core-js/modules/es6.array.sort.js";
 import "core-js/modules/es6.array.species.js";
-import "core-js/modules/es6.array.splice.js";
 import "core-js/modules/es6.date.now.js";
 import "core-js/modules/es6.date.to-iso-string.js";
 import "core-js/modules/es6.date.to-json.js";

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
@@ -56,7 +56,6 @@ Using polyfills with `entry-global` method:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/input.mjs]
 The corejs2 polyfill entry has been replaced with the following polyfills:
-  es6.array.concat { "android":"4" }
   es6.array.copy-within { "android":"4" }
   es6.array.fill { "android":"4" }
   es6.array.filter { "android":"4" }
@@ -71,7 +70,6 @@ The corejs2 polyfill entry has been replaced with the following polyfills:
   es6.array.slice { "android":"4" }
   es6.array.sort { "android":"4" }
   es6.array.species { "android":"4" }
-  es6.array.splice { "android":"4" }
   es6.date.to-primitive { "android":"4" }
   es6.function.has-instance { "android":"4" }
   es6.map { "android":"4" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -42,7 +42,6 @@ Using polyfills with `entry-global` method:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/input.mjs]
 The corejs2 polyfill entry has been replaced with the following polyfills:
-  es6.array.concat { "electron":"0.36" }
   es6.array.filter { "electron":"0.36" }
   es7.array.flat-map { "electron":"0.36" }
   es6.array.from { "electron":"0.36" }
@@ -51,7 +50,6 @@ The corejs2 polyfill entry has been replaced with the following polyfills:
   es6.array.slice { "electron":"0.36" }
   es6.array.sort { "electron":"0.36" }
   es6.array.species { "electron":"0.36" }
-  es6.array.splice { "electron":"0.36" }
   es6.function.has-instance { "electron":"0.36" }
   es6.map { "electron":"0.36" }
   es6.object.assign { "electron":"0.36" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
@@ -58,7 +58,6 @@ Using polyfills with `entry-global` method:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/input.mjs]
 The corejs2 polyfill entry has been replaced with the following polyfills:
-  es6.array.concat { "ie":"6" }
   es6.array.copy-within { "ie":"6" }
   es6.array.every { "ie":"6" }
   es6.array.fill { "ie":"6" }
@@ -81,7 +80,6 @@ The corejs2 polyfill entry has been replaced with the following polyfills:
   es6.array.some { "ie":"6" }
   es6.array.sort { "ie":"6" }
   es6.array.species { "ie":"6" }
-  es6.array.splice { "ie":"6" }
   es6.date.now { "ie":"6" }
   es6.date.to-iso-string { "ie":"6" }
   es6.date.to-json { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
@@ -60,7 +60,6 @@ Using polyfills with `entry-global` method:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/input.mjs]
 The corejs2 polyfill entry has been replaced with the following polyfills:
-  es6.array.concat { "ie":"6" }
   es6.array.copy-within { "ie":"6" }
   es6.array.every { "ie":"6" }
   es6.array.fill { "ie":"6" }
@@ -83,7 +82,6 @@ The corejs2 polyfill entry has been replaced with the following polyfills:
   es6.array.some { "ie":"6" }
   es6.array.sort { "ie":"6" }
   es6.array.species { "ie":"6" }
-  es6.array.splice { "ie":"6" }
   es6.date.now { "ie":"6" }
   es6.date.to-iso-string { "ie":"6" }
   es6.date.to-json { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -65,7 +65,6 @@ Using polyfills with `entry-global` method:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/input.mjs]
 The corejs2 polyfill entry has been replaced with the following polyfills:
-  es6.array.concat { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   es6.array.copy-within { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   es6.array.fill { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   es6.array.filter { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
@@ -80,7 +79,6 @@ The corejs2 polyfill entry has been replaced with the following polyfills:
   es6.array.slice { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   es6.array.sort { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   es6.array.species { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  es6.array.splice { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   es6.date.to-json { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   es6.date.to-primitive { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   es6.function.has-instance { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -61,7 +61,6 @@ Using polyfills with `entry-global` method:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/input.mjs]
 The corejs2 polyfill entry has been replaced with the following polyfills:
-  es6.array.concat { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.array.copy-within { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.array.fill { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.array.filter { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
@@ -76,7 +75,6 @@ The corejs2 polyfill entry has been replaced with the following polyfills:
   es6.array.slice { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.array.sort { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.array.species { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  es6.array.splice { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.date.to-primitive { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.function.has-instance { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es6.function.name { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
@@ -59,7 +59,6 @@ Using polyfills with `entry-global` method:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/input.mjs]
 The corejs2 polyfill entry has been replaced with the following polyfills:
-  es6.array.concat { "chrome":"54", "ie":"10", "node":"6.10" }
   es6.array.copy-within { "chrome":"54", "ie":"10", "node":"6.10" }
   es6.array.fill { "chrome":"54", "ie":"10", "node":"6.10" }
   es6.array.filter { "chrome":"54", "ie":"10", "node":"6.10" }
@@ -74,7 +73,6 @@ The corejs2 polyfill entry has been replaced with the following polyfills:
   es6.array.slice { "chrome":"54", "ie":"10", "node":"6.10" }
   es6.array.sort { "chrome":"54", "ie":"10", "node":"6.10" }
   es6.array.species { "chrome":"54", "ie":"10", "node":"6.10" }
-  es6.array.splice { "chrome":"54", "ie":"10", "node":"6.10" }
   es6.date.to-primitive { "chrome":"54", "ie":"10", "node":"6.10" }
   es6.function.has-instance { "chrome":"54", "ie":"10", "node":"6.10" }
   es6.function.name { "chrome":"54", "ie":"10", "node":"6.10" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
@@ -59,7 +59,6 @@ Using polyfills with `entry-global` method:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/input.mjs]
 The corejs2 polyfill entry has been replaced with the following polyfills:
-  es6.array.concat { "chrome":"54", "ie":"10", "node":"6" }
   es6.array.copy-within { "chrome":"54", "ie":"10", "node":"6" }
   es6.array.fill { "chrome":"54", "ie":"10", "node":"6" }
   es6.array.filter { "chrome":"54", "ie":"10", "node":"6" }
@@ -74,7 +73,6 @@ The corejs2 polyfill entry has been replaced with the following polyfills:
   es6.array.slice { "chrome":"54", "ie":"10", "node":"6" }
   es6.array.sort { "chrome":"54", "ie":"10", "node":"6" }
   es6.array.species { "chrome":"54", "ie":"10", "node":"6" }
-  es6.array.splice { "chrome":"54", "ie":"10", "node":"6" }
   es6.date.to-primitive { "chrome":"54", "ie":"10", "node":"6" }
   es6.function.has-instance { "chrome":"54", "ie":"10", "node":"6" }
   es6.function.name { "chrome":"54", "ie":"10", "node":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
@@ -60,7 +60,6 @@ Using polyfills with `entry-global` method:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/input.mjs]
 The corejs2 polyfill entry has been replaced with the following polyfills:
-  es6.array.concat { "ie":"6" }
   es6.array.copy-within { "ie":"6" }
   es6.array.every { "ie":"6" }
   es6.array.fill { "ie":"6" }
@@ -83,7 +82,6 @@ The corejs2 polyfill entry has been replaced with the following polyfills:
   es6.array.some { "ie":"6" }
   es6.array.sort { "ie":"6" }
   es6.array.species { "ie":"6" }
-  es6.array.splice { "ie":"6" }
   es6.date.now { "ie":"6" }
   es6.date.to-iso-string { "ie":"6" }
   es6.date.to-json { "ie":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
@@ -59,7 +59,6 @@ Using polyfills with `entry-global` method:
 
 [<CWD>/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/input.mjs]
 The corejs2 polyfill entry has been replaced with the following polyfills:
-  es6.array.concat { "chrome":"54", "ie":"10", "node":"6" }
   es6.array.copy-within { "chrome":"54", "ie":"10", "node":"6" }
   es6.array.fill { "chrome":"54", "ie":"10", "node":"6" }
   es6.array.filter { "chrome":"54", "ie":"10", "node":"6" }
@@ -74,7 +73,6 @@ The corejs2 polyfill entry has been replaced with the following polyfills:
   es6.array.slice { "chrome":"54", "ie":"10", "node":"6" }
   es6.array.sort { "chrome":"54", "ie":"10", "node":"6" }
   es6.array.species { "chrome":"54", "ie":"10", "node":"6" }
-  es6.array.splice { "chrome":"54", "ie":"10", "node":"6" }
   es6.date.to-primitive { "chrome":"54", "ie":"10", "node":"6" }
   es6.function.has-instance { "chrome":"54", "ie":"10", "node":"6" }
   es6.function.name { "chrome":"54", "ie":"10", "node":"6" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,14 +132,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/compat-data@npm:^7.11.0, @babel/compat-data@npm:^7.13.0, @babel/compat-data@npm:^7.13.5":
+"@babel/compat-data@npm:^7.13.0, @babel/compat-data@npm:^7.13.5":
   version: 7.13.6
   resolution: "@babel/compat-data@npm:7.13.6"
   checksum: 0bed7ac3e2c4597140e56db034e2b7a664516c7f094ee521a15efee814a208e3937fd9a5ac12e8d3d6ccfcbbfd35ceced75163fc7b2d9ca71b48d8fcfbc6f990
   languageName: node
   linkType: hard
 
-"@babel/compat-data@workspace:^7.13.0, @babel/compat-data@workspace:^7.13.5, @babel/compat-data@workspace:^7.13.6, @babel/compat-data@workspace:packages/babel-compat-data":
+"@babel/compat-data@workspace:*, @babel/compat-data@workspace:^7.13.0, @babel/compat-data@workspace:^7.13.5, @babel/compat-data@workspace:^7.13.6, @babel/compat-data@workspace:packages/babel-compat-data":
   version: 0.0.0-use.local
   resolution: "@babel/compat-data@workspace:packages/babel-compat-data"
   dependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Bugfix
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No
| License                  | MIT

After upgrade the @babel/compat-data@7.13 encounted the problem below.

![image](https://user-images.githubusercontent.com/7057473/109098552-88c15400-775c-11eb-9d9d-615e610eb986.png)


.babelrc
```
[
      '@babel/preset-env',
      {
        'targets': targets || {
          'android': '4',
          'ios': '9',
        },
        'useBuiltIns': 'entry',
        'corejs': 2,
        'modules': false,
      },
]
```

Usage in code

```js
import '@babel/polyfill'
```

Related this pull request:  https://github.com/babel/babel/pull/12850/files#r582504324
