### PR TITLE
Workaround for self-referencing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,21 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('yarn.lock') }}
+      # See https://github.com/babel/babel/pull/12906
+      - name: Workaround yarn bug
+        run: |
+          echo '{
+            "private": true,
+            "devDependencies": {
+              "@babel/runtime": "workspace:*",
+              "@babel/runtime-corejs3": "workspace:*"
+            }
+          }' > packages/package.json
+          node -e "
+            const pkg = require('./package.json');
+            pkg.workspaces.push('packages');
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2))
+          "
       - name: Install
         run: yarn install
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The lockfile changes in 039eb2710d54d03f02240106808cd9f0ef1732d8 break the tests of bb558aaf28ee84a85eba25c4b6765a5bac50d15d. Note that it _only_ breaks our test, any package outside of this monorepo would work without problems.

We can revert this PR after the next release, by bumping `@babel/runtime` in our lockfile.

~I _think_ this is a Yarn bug~ (it's just a non-supported feature), I posted a description in https://github.com/babel/babel/pull/12893#issuecomment-785863266:
> Are self-references (documented in the first tip [here](https://yarnpkg.com/features/protocols/#why-is-the-link-protocol-recommended-over-aliases-for-path-mapping)) supposed to work with the `node_modules` linker?
>
> After merging this PR to `main` (bb558aaf28ee84a85eba25c4b6765a5bac50d15d) the tests that here was passing started failing. I can consistently reproduce it with Node.js 13.6 (which doesn't natively implement self-references), running `make bootstrap` and `node test/runtime-integration/src/main-cjs.cjs`.
>
> The problem is that `packages/babel-runtime` has `require()` calls like
> ```js
> var objectWithoutPropertiesLoose = require("@babel/runtime/helpers/objectWithoutPropertiesLoose");
> ```
> and this ends up requiring `node_modules/@babel/runtime` (which is the version downloaded from the registry) rather than `packages/babel-runtime`.