### PR TITLE
chore: do not provide polyfills on bundling @babel/standalone

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -76,7 +76,15 @@ module.exports = function (api) {
     case "standalone":
       includeRegeneratorRuntime = true;
       unambiguousSources.push("packages/babel-runtime/regenerator");
-    // fall through
+      convertESM = false;
+      ignoreLib = false;
+      // rollup-commonjs will converts node_modules to ESM
+      unambiguousSources.push(
+        "/**/node_modules",
+        "packages/babel-preset-env/data",
+        "packages/babel-compat-data"
+      );
+      break;
     case "rollup":
       convertESM = false;
       ignoreLib = false;
@@ -86,7 +94,7 @@ module.exports = function (api) {
         "packages/babel-preset-env/data",
         "packages/babel-compat-data"
       );
-      if (env === "rollup") targets = { node: nodeVersion };
+      targets = { node: nodeVersion };
       needsPolyfillsForOldNode = true;
       break;
     case "test-legacy": // In test-legacy environment, we build babel on latest node but test on minimum supported legacy versions

--- a/babel.config.js
+++ b/babel.config.js
@@ -75,14 +75,14 @@ module.exports = function (api) {
     // Configs used during bundling builds.
     case "standalone":
       includeRegeneratorRuntime = true;
-      unambiguousSources.push("packages/babel-runtime/regenerator");
       convertESM = false;
       ignoreLib = false;
       // rollup-commonjs will converts node_modules to ESM
       unambiguousSources.push(
         "/**/node_modules",
         "packages/babel-preset-env/data",
-        "packages/babel-compat-data"
+        "packages/babel-compat-data",
+        "packages/babel-runtime/regenerator"
       );
       break;
     case "rollup":

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,7 +375,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/helper-compilation-targets@npm:^7.10.4, @babel/helper-compilation-targets@npm:^7.13.0":
+"@babel/helper-compilation-targets@npm:^7.13.0":
   version: 7.13.0
   resolution: "@babel/helper-compilation-targets@npm:7.13.0"
   dependencies:
@@ -470,20 +470,20 @@ __metadata:
   linkType: soft
 
 "@babel/helper-define-polyfill-provider@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "@babel/helper-define-polyfill-provider@npm:0.1.1"
+  version: 0.1.4
+  resolution: "@babel/helper-define-polyfill-provider@npm:0.1.4"
   dependencies:
-    "@babel/helper-compilation-targets": ^7.10.4
-    "@babel/helper-module-imports": ^7.10.4
-    "@babel/helper-plugin-utils": ^7.10.4
-    "@babel/traverse": ^7.11.5
+    "@babel/helper-compilation-targets": ^7.13.0
+    "@babel/helper-module-imports": ^7.12.13
+    "@babel/helper-plugin-utils": ^7.13.0
+    "@babel/traverse": ^7.13.0
     debug: ^4.1.1
     lodash.debounce: ^4.0.8
     resolve: ^1.14.2
     semver: ^6.1.2
   peerDependencies:
     "@babel/core": ^7.4.0-0
-  checksum: c2298d3b9b0e73d3646baae77f9c794ea5b4d76959a65cecde8622156ffaceca693e84dc0a66faaddbb6f4c96a2785ec07b623bc6b9580d8ebb3335f12efeab5
+  checksum: 268ad963d95dd22c2fab0822a42b9a5bf7d0d2909bbaacf7377326c70c0071e0423c0092085a7e6531bbaf4ae917f8fa86f15de4da395add99cca900b95a7498
   languageName: node
   linkType: hard
 
@@ -3395,7 +3395,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/traverse@npm:^7.0.0, @babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.11.5, @babel/traverse@npm:^7.13.0":
+"@babel/traverse@npm:^7.0.0, @babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.13.0":
   version: 7.13.0
   resolution: "@babel/traverse@npm:7.13.0"
   dependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12907 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The issue #12907 was introduced in #12458, where we injected `require("module")` in the polyfill for `require.resolve(_, { paths })`. However, we should not inject it when bundling `@babel/standalone`, because `require("module")` is not available in browsers.