### PR TITLE
check descriptor before private field access

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1336,6 +1336,9 @@ helpers.classPrivateFieldSet = helper("7.0.0-beta.0")`
 
 helpers.classPrivateFieldDestructureSet = helper("7.4.4")`
   export default function _classPrivateFieldDestructureSet(receiver, privateMap) {
+    if (privateMap === undefined) {
+      throw new TypeError("attempted to set private static field before its declaration");
+    }
     if (!privateMap.has(receiver)) {
       throw new TypeError("attempted to set private field on non-instance");
     }
@@ -1367,6 +1370,9 @@ helpers.classStaticPrivateFieldSpecGet = helper("7.0.2")`
     if (receiver !== classConstructor) {
       throw new TypeError("Private static access of wrong provenance");
     }
+    if (descriptor === undefined) {
+      throw new TypeError("attempted to get private static field before its declaration");
+    }
     if (descriptor.get) {
       return descriptor.get.call(receiver);
     }
@@ -1378,6 +1384,9 @@ helpers.classStaticPrivateFieldSpecSet = helper("7.0.2")`
   export default function _classStaticPrivateFieldSpecSet(receiver, classConstructor, descriptor, value) {
     if (receiver !== classConstructor) {
       throw new TypeError("Private static access of wrong provenance");
+    }
+    if (descriptor === undefined) {
+      throw new TypeError("attempted to set private static field before its declaration");
     }
     if (descriptor.set) {
       descriptor.set.call(receiver, value);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/access-before-declaration/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/access-before-declaration/exec.js
@@ -1,0 +1,29 @@
+expect(() => {
+  class C {
+    static #_ = new C;
+    static #p;
+    constructor() {
+      C.#p;
+    }
+  }
+}).toThrow(/attempted to use private field on non-instance/);
+
+expect(() => {
+  class C {
+    static #_ = new C;
+    static #p;
+    constructor() {
+      C.#p = 0;
+    }
+  }
+}).toThrow(/attempted to use private field on non-instance/);
+
+expect(() => {
+  class C {
+    static #_ = new C;
+    static #p;
+    constructor() {
+      for (C.#p of [0]);
+    }
+  }
+}).toThrow(/attempted to use private field on non-instance/);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/access-before-declaration/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/access-before-declaration/exec.js
@@ -1,0 +1,29 @@
+expect(() => {
+  class C {
+    static #_ = new C;
+    static #p;
+    constructor() {
+      C.#p;
+    }
+  }
+}).toThrow(/attempted to get private static field before its declaration/);
+
+expect(() => {
+  class C {
+    static #_ = new C;
+    static #p;
+    constructor() {
+      C.#p = 0;
+    }
+  }
+}).toThrow(/attempted to set private static field before its declaration/);
+
+expect(() => {
+  class C {
+    static #_ = new C;
+    static #p;
+    constructor() {
+      for (C.#p of [0]);
+    }
+  }
+}).toThrow(/attempted to set private static field before its declaration/);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/access-before-declaration/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/access-before-declaration/exec.js
@@ -1,0 +1,29 @@
+expect(() => {
+  class C {
+    static #_ = new C;
+    static get #p() { return C };
+    constructor() {
+      C.#p;
+    }
+  }
+}).toThrow(/attempted to use private field on non-instance/);
+
+expect(() => {
+  class C {
+    static #_ = new C;
+    static set #p(v) {};
+    constructor() {
+      C.#p = 0;
+    }
+  }
+}).toThrow(/attempted to use private field on non-instance/);
+
+expect(() => {
+  class C {
+    static #_ = new C;
+    static set #p(v) {};
+    constructor() {
+      for (C.#p of [0]);
+    }
+  }
+}).toThrow(/attempted to use private field on non-instance/);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/access-before-declaration/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/access-before-declaration/exec.js
@@ -1,0 +1,29 @@
+expect(() => {
+  class C {
+    static #_ = new C;
+    static get #p() { return C };
+    constructor() {
+      C.#p;
+    }
+  }
+}).toThrow(/attempted to use private field on non-instance/);
+
+expect(() => {
+  class C {
+    static #_ = new C;
+    static set #p(v) {};
+    constructor() {
+      C.#p = 0;
+    }
+  }
+}).toThrow(/attempted to use private field on non-instance/);
+
+expect(() => {
+  class C {
+    static #_ = new C;
+    static set #p(v) {};
+    constructor() {
+      for (C.#p of [0]);
+    }
+  }
+}).toThrow(/attempted to use private field on non-instance/);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/access-before-declaration/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/access-before-declaration/exec.js
@@ -1,0 +1,29 @@
+expect(() => {
+  class C {
+    static #_ = new C;
+    static get #p() { return C };
+    constructor() {
+      C.#p;
+    }
+  }
+}).toThrow(/attempted to get private static field before its declaration/);
+
+expect(() => {
+  class C {
+    static #_ = new C;
+    static set #p(v) {};
+    constructor() {
+      C.#p = 0;
+    }
+  }
+}).toThrow(/attempted to set private static field before its declaration/);
+
+expect(() => {
+  class C {
+    static #_ = new C;
+    static set #p(v) {};
+    constructor() {
+      for (C.#p of [0]);
+    }
+  }
+}).toThrow(/attempted to set private static field before its declaration/);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12904
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As suggested in #12904, check if `descriptor` is `undefined` before pass it as a descriptor. Note that the `privateFieldAsProperty` a.k.a. loose handler is not affected because the loosePrivateKey is always hoisted before class declaration. So in this case they will throw the same error as if we are accessing a private properties that is not defined in current class.

I mark this PR as polish because we still throw on the new cases, but the error message is confusing. <s>This PR is now based on #12911, please review that PR first.</s>