### PR TITLE
Class static private field destructure set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,9 @@ jobs:
           git config user.email "babel-bot@users.noreply.github.com"
 
       - name: Create new version
-        run: yarn release-tool version -f @babel/standalone --yes patch
+        run: |
+          make new-version-checklist
+          yarn release-tool version -f @babel/standalone --yes patch
 
       - name: Push to GitHub
         id: push
@@ -167,5 +169,4 @@ jobs:
 
       - name: Delete temporary branch from GitHub
         if: needs.git-version.result == 'success'
-        run:
-          git push "https://babel-bot:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" :${{ needs.git-version.outputs.branch }}
+        run: git push "https://babel-bot:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" :${{ needs.git-version.outputs.branch }}

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ new-version:
 	@echo "!!!!!!   Update classStaticPrivateFieldDestructureSet    !!!!!!"
 	@echo "!!!!!!   helper version in                               !!!!!!"
 	@echo "!!!!!!   packages/babel-helpers/src/helpers.js           !!!!!!"
+	@echo "!!!!!!   packages/babel-helper-create-class-features-plugin/src/fields.js"
 	@echo "!!!!!!                                                   !!!!!!"
 	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ prepublish:
 	$(MAKE) prepublish-build
 	IS_PUBLISH=true $(MAKE) test
 
-new-version:
+new-version-checklist:
 	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 	@echo "!!!!!!                                                   !!!!!!"
@@ -207,6 +207,9 @@ new-version:
 	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 	@exit 1
+
+new-version:
+	$(MAKE) new-version-checklist
 	git pull --rebase
 	$(YARN) release-tool version -f @babel/standalone
 

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,16 @@ prepublish:
 	IS_PUBLISH=true $(MAKE) test
 
 new-version:
+	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+	@echo "!!!!!!                                                   !!!!!!"
+	@echo "!!!!!!   Update classStaticPrivateFieldDestructureSet    !!!!!!"
+	@echo "!!!!!!   helper version in                               !!!!!!"
+	@echo "!!!!!!   packages/babel-helpers/src/helpers.js           !!!!!!"
+	@echo "!!!!!!                                                   !!!!!!"
+	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+	@exit 1
 	git pull --rebase
 	$(YARN) release-tool version -f @babel/standalone
 

--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -318,9 +318,19 @@ const privateNameHandlerSpec = {
   },
 
   destructureSet(member) {
-    const { privateNamesMap, file } = this;
+    const { classRef, privateNamesMap, file } = this;
     const { name } = member.node.property.id;
-    const { id } = privateNamesMap.get(name);
+    const { id, static: isStatic } = privateNamesMap.get(name);
+    if (isStatic) {
+      return t.memberExpression(
+        t.callExpression(
+          file.addHelper("classStaticPrivateFieldDestructureSet"),
+          [this.receiver(member), t.cloneNode(classRef), t.cloneNode(id)],
+        ),
+        t.identifier("value"),
+      );
+    }
+
     return t.memberExpression(
       t.callExpression(file.addHelper("classPrivateFieldDestructureSet"), [
         this.receiver(member),

--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -328,8 +328,8 @@ const privateNameHandlerSpec = {
         var helper = file.addHelper("classStaticPrivateFieldDestructureSet");
       } catch {
         throw new Error(
-          "Babel can not transpile `[C.#p] = [0]` with @babel/helper < 7.99.0, \n" +
-            "please update @babel/helper to the latest version",
+          "Babel can not transpile `[C.#p] = [0]` with @babel/helpers < 7.99.0, \n" +
+            "please update @babel/helpers to the latest version.",
         );
       }
       return t.memberExpression(

--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -322,11 +322,22 @@ const privateNameHandlerSpec = {
     const { name } = member.node.property.id;
     const { id, static: isStatic } = privateNamesMap.get(name);
     if (isStatic) {
+      try {
+        // classStaticPrivateFieldDestructureSet was introduced in 7.99.0
+        // eslint-disable-next-line no-var
+        var helper = file.addHelper("classStaticPrivateFieldDestructureSet");
+      } catch {
+        throw new Error(
+          "Babel can not transpile `[C.#p] = [0]` with @babel/helper < 7.99.0, \n" +
+            "please update @babel/helper to the latest version",
+        );
+      }
       return t.memberExpression(
-        t.callExpression(
-          file.addHelper("classStaticPrivateFieldDestructureSet"),
-          [this.receiver(member), t.cloneNode(classRef), t.cloneNode(id)],
-        ),
+        t.callExpression(helper, [
+          this.receiver(member),
+          t.cloneNode(classRef),
+          t.cloneNode(id),
+        ]),
         t.identifier("value"),
       );
     }

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1299,113 +1299,69 @@ helpers.classPrivateFieldLooseBase = helper("7.0.0-beta.0")`
 `;
 
 helpers.classPrivateFieldGet = helper("7.0.0-beta.0")`
+  import classApplyDescriptorGet from "classApplyDescriptorGet";
+  import classExtractFieldDescriptor from "classExtractFieldDescriptor";
   export default function _classPrivateFieldGet(receiver, privateMap) {
-    var descriptor = privateMap.get(receiver);
-    if (!descriptor) {
-      throw new TypeError("attempted to get private field on non-instance");
-    }
-    if (descriptor.get) {
-      return descriptor.get.call(receiver);
-    }
-    return descriptor.value;
+    var descriptor = classExtractFieldDescriptor(receiver, privateMap, "get");
+    return classApplyDescriptorGet(receiver, descriptor);
   }
 `;
 
 helpers.classPrivateFieldSet = helper("7.0.0-beta.0")`
+  import classApplyDescriptorSet from "classApplyDescriptorSet";
+  import classExtractFieldDescriptor from "classExtractFieldDescriptor";
   export default function _classPrivateFieldSet(receiver, privateMap, value) {
-    var descriptor = privateMap.get(receiver);
-    if (!descriptor) {
-      throw new TypeError("attempted to set private field on non-instance");
-    }
-    if (descriptor.set) {
-      descriptor.set.call(receiver, value);
-    } else {
-      if (!descriptor.writable) {
-        // This should only throw in strict mode, but class bodies are
-        // always strict and private fields can only be used inside
-        // class bodies.
-        throw new TypeError("attempted to set read only private field");
-      }
-
-      descriptor.value = value;
-    }
-
+    var descriptor = classExtractFieldDescriptor(receiver, privateMap, "set");
+    classApplyDescriptorSet(receiver, descriptor, value);
     return value;
   }
 `;
 
 helpers.classPrivateFieldDestructureSet = helper("7.4.4")`
+  import classApplyDescriptorDestructureSet from "classApplyDescriptorDestructureSet";
+  import classExtractFieldDescriptor from "classExtractFieldDescriptor";
   export default function _classPrivateFieldDestructureSet(receiver, privateMap) {
-    if (!privateMap.has(receiver)) {
-      throw new TypeError("attempted to set private field on non-instance");
-    }
-    var descriptor = privateMap.get(receiver);
-    if (descriptor.set) {
-      if (!("__destrObj" in descriptor)) {
-        descriptor.__destrObj = {
-          set value(v) {
-            descriptor.set.call(receiver, v)
-          },
-        };
-      }
-      return descriptor.__destrObj;
-    } else {
-      if (!descriptor.writable) {
-        // This should only throw in strict mode, but class bodies are
-        // always strict and private fields can only be used inside
-        // class bodies.
-        throw new TypeError("attempted to set read only private field");
-      }
+    var descriptor = classExtractFieldDescriptor(receiver, privateMap, "set");
+    return classApplyDescriptorDestructureSet(receiver, descriptor);
+  }
+`;
 
-      return descriptor;
+helpers.classExtractFieldDescriptor = helper("7.99.0")`
+  export default function _classExtractFieldDescriptor(receiver, privateMap, action) {
+    if (!privateMap.has(receiver)) {
+      throw new TypeError("attempted to " + action + " private field on non-instance");
     }
+    return privateMap.get(receiver);
   }
 `;
 
 helpers.classStaticPrivateFieldSpecGet = helper("7.0.2")`
+  import classApplyDescriptorGet from "classApplyDescriptorGet";
+  import classCheckPrivateStaticAccess from "classCheckPrivateStaticAccess";
+  import classCheckPrivateStaticFieldDescriptor from "classCheckPrivateStaticFieldDescriptor";
   export default function _classStaticPrivateFieldSpecGet(receiver, classConstructor, descriptor) {
-    if (receiver !== classConstructor) {
-      throw new TypeError("Private static access of wrong provenance");
-    }
-    if (descriptor === undefined) {
-      throw new TypeError("attempted to get private static field before its declaration");
-    }
-    if (descriptor.get) {
-      return descriptor.get.call(receiver);
-    }
-    return descriptor.value;
+    classCheckPrivateStaticAccess(receiver, classConstructor);
+    classCheckPrivateStaticFieldDescriptor(descriptor, "get");
+    return classApplyDescriptorGet(receiver, descriptor);
   }
 `;
 
 helpers.classStaticPrivateFieldSpecSet = helper("7.0.2")`
+  import classApplyDescriptorSet from "classApplyDescriptorSet";
+  import classCheckPrivateStaticAccess from "classCheckPrivateStaticAccess";
+  import classCheckPrivateStaticFieldDescriptor from "classCheckPrivateStaticFieldDescriptor";
   export default function _classStaticPrivateFieldSpecSet(receiver, classConstructor, descriptor, value) {
-    if (receiver !== classConstructor) {
-      throw new TypeError("Private static access of wrong provenance");
-    }
-    if (descriptor === undefined) {
-      throw new TypeError("attempted to set private static field before its declaration");
-    }
-    if (descriptor.set) {
-      descriptor.set.call(receiver, value);
-    } else {
-      if (!descriptor.writable) {
-        // This should only throw in strict mode, but class bodies are
-        // always strict and private fields can only be used inside
-        // class bodies.
-        throw new TypeError("attempted to set read only private field");
-      }
-      descriptor.value = value;
-    }
-
+    classCheckPrivateStaticAccess(receiver, classConstructor);
+    classCheckPrivateStaticFieldDescriptor(descriptor, "set");
+    classApplyDescriptorSet(receiver, descriptor, value);
     return value;
   }
 `;
 
 helpers.classStaticPrivateMethodGet = helper("7.3.2")`
+  import classCheckPrivateStaticAccess from "classCheckPrivateStaticAccess";
   export default function _classStaticPrivateMethodGet(receiver, classConstructor, method) {
-    if (receiver !== classConstructor) {
-      throw new TypeError("Private static access of wrong provenance");
-    }
+    classCheckPrivateStaticAccess(receiver, classConstructor);
     return method;
   }
 `;
@@ -1416,14 +1372,33 @@ helpers.classStaticPrivateMethodSet = helper("7.3.2")`
   }
 `;
 
-helpers.classStaticPrivateFieldDestructureSet = helper("7.99.0")`
-  export default function _classStaticPrivateFieldDestructureSet(receiver, classConstructor, descriptor) {
-    if (receiver !== classConstructor) {
-      throw new TypeError("Private static access of wrong provenance");
+helpers.classApplyDescriptorGet = helper("7.99.0")`
+  export default function _classApplyDescriptorGet(receiver, descriptor) {
+    if (descriptor.get) {
+      return descriptor.get.call(receiver);
     }
-    if (descriptor === undefined) {
-      throw new TypeError("attempted to set private static field before its declaration");
+    return descriptor.value;
+  }
+`;
+
+helpers.classApplyDescriptorSet = helper("7.99.0")`
+  export default function _classApplyDescriptorSet(receiver, descriptor, value) {
+    if (descriptor.set) {
+      descriptor.set.call(receiver, value);
+    } else {
+      if (!descriptor.writable) {
+        // This should only throw in strict mode, but class bodies are
+        // always strict and private fields can only be used inside
+        // class bodies.
+        throw new TypeError("attempted to set read only private field");
+      }
+      descriptor.value = value;
     }
+  }
+`;
+
+helpers.classApplyDescriptorDestructureSet = helper("7.99.0")`
+  export default function _classApplyDescriptorDestructureSet(receiver, descriptor) {
     if (descriptor.set) {
       if (!("__destrObj" in descriptor)) {
         descriptor.__destrObj = {
@@ -1442,6 +1417,33 @@ helpers.classStaticPrivateFieldDestructureSet = helper("7.99.0")`
       }
 
       return descriptor;
+    }
+  }
+`;
+
+helpers.classStaticPrivateFieldDestructureSet = helper("7.99.0")`
+  import classApplyDescriptorDestructureSet from "classApplyDescriptorDestructureSet";
+  import classCheckPrivateStaticAccess from "classCheckPrivateStaticAccess";
+  import classCheckPrivateStaticFieldDescriptor from "classCheckPrivateStaticFieldDescriptor";
+  export default function _classStaticPrivateFieldDestructureSet(receiver, classConstructor, descriptor) {
+    classCheckPrivateStaticAccess(receiver, classConstructor);
+    classCheckPrivateStaticFieldDescriptor(descriptor, "set");
+    return classApplyDescriptorDestructureSet(receiver, descriptor);
+  }
+`;
+
+helpers.classCheckPrivateStaticAccess = helper("7.99.0")`
+  export default function _classCheckPrivateStaticAccess(receiver, classConstructor) {
+    if (receiver !== classConstructor) {
+      throw new TypeError("Private static access of wrong provenance");
+    }
+  }
+`;
+
+helpers.classCheckPrivateStaticFieldDescriptor = helper("7.99.0")`
+  export default function _classCheckPrivateStaticFieldDescriptor(descriptor, action) {
+    if (descriptor === undefined) {
+      throw new TypeError("attempted to " + action + " private static field before its declaration");
     }
   }
 `;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-static/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-static/exec.js
@@ -1,0 +1,14 @@
+class Foo {
+  static #client
+
+  constructor(props) {
+    ;([Foo.#client] = props);
+  }
+
+  getClient() {
+    return Foo.#client;
+  }
+}
+
+const foo = new Foo(['bar']);
+expect(foo.getClient()).toBe('bar');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-static/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-static/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  static #client
+
+  constructor(props) {
+    ([Foo.#client] = props);
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-static/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-static/output.js
@@ -1,0 +1,13 @@
+var _client = babelHelpers.classPrivateFieldLooseKey("client");
+
+var Foo = function Foo(props) {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, Foo);
+  [babelHelpers.classPrivateFieldLooseBase(Foo, _client)[_client]] = props;
+};
+
+Object.defineProperty(Foo, _client, {
+  writable: true,
+  value: void 0
+});

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-static/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-static/exec.js
@@ -1,0 +1,14 @@
+class Foo {
+  static #client
+
+  constructor(props) {
+    ;({ client: Foo.#client } = props)
+  }
+
+  getClient() {
+    return Foo.#client;
+  }
+}
+
+const foo = new Foo({ client: 'bar' });
+expect(foo.getClient()).toBe('bar');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-static/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-static/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  static #client
+
+  constructor(props) {
+    ({ client: Foo.#client } = props)
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-static/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-static/output.js
@@ -1,0 +1,15 @@
+var _client = babelHelpers.classPrivateFieldLooseKey("client");
+
+var Foo = function Foo(props) {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, Foo);
+  ({
+    client: babelHelpers.classPrivateFieldLooseBase(Foo, _client)[_client]
+  } = props);
+};
+
+Object.defineProperty(Foo, _client, {
+  writable: true,
+  value: void 0
+});

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-static/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-static/exec.js
@@ -1,0 +1,14 @@
+class Foo {
+  static #client
+
+  constructor(props) {
+    ;([Foo.#client] = props);
+  }
+
+  getClient() {
+    return Foo.#client;
+  }
+}
+
+const foo = new Foo(['bar']);
+expect(foo.getClient()).toBe('bar');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-static/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-static/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  static #client
+
+  constructor(props) {
+    ([Foo.#client] = props);
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-static/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-static/output.js
@@ -1,0 +1,11 @@
+var Foo = function Foo(props) {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, Foo);
+  [babelHelpers.classStaticPrivateFieldDestructureSet(Foo, Foo, _client).value] = props;
+};
+
+var _client = {
+  writable: true,
+  value: void 0
+};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-static/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-static/exec.js
@@ -1,0 +1,14 @@
+class Foo {
+  static #client
+
+  constructor(props) {
+    ;({ client: Foo.#client } = props)
+  }
+
+  getClient() {
+    return Foo.#client;
+  }
+}
+
+const foo = new Foo({ client: 'bar' });
+expect(foo.getClient()).toBe('bar');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-static/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-static/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  static #client
+
+  constructor(props) {
+    ({ client: Foo.#client } = props)
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-static/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-static/output.js
@@ -1,0 +1,13 @@
+var Foo = function Foo(props) {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, Foo);
+  ({
+    client: babelHelpers.classStaticPrivateFieldDestructureSet(Foo, Foo, _client).value
+  } = props);
+};
+
+var _client = {
+  writable: true,
+  value: void 0
+};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/exec.js
@@ -7,6 +7,7 @@ class Cl {
 
   constructor() {
     expect(() => this.#privateFieldValue = 1).toThrow(TypeError);
+    expect(() => ([this.#privateFieldValue] = [1])).toThrow(TypeError);
   }
 }
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/input.js
@@ -7,5 +7,6 @@ class Cl {
 
   constructor() {
     this.#privateFieldValue = 1;
+    ([this.#privateFieldValue] = [1]);
   }
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/output.js
@@ -13,6 +13,7 @@ class Cl {
       value: 0
     });
     babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = 1;
+    [babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue]] = [1];
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/exec.js
@@ -7,6 +7,7 @@ class Cl {
 
   constructor() {
     expect(() => this.#privateFieldValue = 1).toThrow(TypeError);
+    expect(() => ([this.#privateFieldValue] = [1])).toThrow(TypeError);
   }
 }
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/input.js
@@ -7,5 +7,6 @@ class Cl {
 
   constructor() {
     this.#privateFieldValue = 1;
+    ([this.#privateFieldValue] = [1]);
   }
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/output.js
@@ -13,6 +13,7 @@ class Cl {
       value: 0
     });
     babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = 1;
+    [babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue]] = [1];
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/exec.js
@@ -14,6 +14,8 @@ class Cl {
   constructor() {
     expect(() => this.self.#privateFieldValue = 1).toThrow(TypeError);
     expect(this.counter).toBe(1);
+    expect(() => ([this.self.#privateFieldValue] = [1])).toThrow(TypeError);
+    expect(this.counter).toBe(2);
   }
 }
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/input.js
@@ -13,6 +13,7 @@ class Cl {
 
   constructor() {
     this.self.#privateFieldValue = 1
+    ([this.self.#privateFieldValue] = [1]);
   }
 }
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
@@ -20,7 +20,7 @@ class Cl {
     });
 
     babelHelpers.defineProperty(this, "counter", 0);
-    this.self, 1, babelHelpers.readOnlyError("#privateFieldValue");
+    this.self, 1([babelHelpers.classPrivateFieldDestructureSet(this.self, _privateFieldValue).value] = [1]), babelHelpers.readOnlyError("#privateFieldValue");
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/exec.js
@@ -9,6 +9,7 @@ class A {
   constructor() {
     expect(() => this.self().#method = 2).toThrow(TypeError);
     expect(this.counter).toBe(1);
+    expect(() => ([this.#method] = [2])).toThrow(TypeError);
   }
 }
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/input.js
@@ -8,5 +8,6 @@ class A {
 
   constructor() {
     this.self().#method = 2;
+    ([this.#method] = [2]);
   }
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
@@ -11,6 +11,7 @@ class A {
 
     babelHelpers.defineProperty(this, "counter", 0);
     this.self(), 2, babelHelpers.readOnlyError("#method");
+    [babelHelpers.classPrivateFieldDestructureSet(this, _method).value] = [2];
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/read-only/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/read-only/exec.js
@@ -1,0 +1,10 @@
+class A {
+  static #method() {}
+
+  run() {
+    expect(() => A.#method = 2).toThrow(TypeError);
+    expect(() => ([A.#method] = [2])).toThrow(TypeError);
+  }
+}
+
+

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/read-only/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/read-only/input.js
@@ -1,0 +1,8 @@
+class A {
+  static #method() {}
+
+  run() {
+    A.#method = 2;
+    ([A.#method] = [2]);
+  }
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/read-only/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/read-only/output.js
@@ -1,0 +1,9 @@
+class A {
+  run() {
+    babelHelpers.classStaticPrivateMethodSet(A, A, _method, 2);
+    [babelHelpers.classStaticPrivateFieldDestructureSet(A, A, _method).value] = [2];
+  }
+
+}
+
+var _method = function _method() {};

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/destructure-set/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/destructure-set/exec.js
@@ -1,0 +1,10 @@
+class C {
+  static set #p(v) { C.#q = v }
+  static #q;
+  constructor() {
+    ([C.#p] = [0]);
+    expect(C.#q).toBe(0);
+  }
+}
+
+new C;

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/destructure-set/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/destructure-set/input.js
@@ -1,0 +1,9 @@
+class C {
+  static set #p(v) { C.#q = v }
+  static #q;
+  constructor() {
+    ([C.#p] = [0]);
+  }
+}
+
+new C;

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/destructure-set/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/destructure-set/output.js
@@ -1,0 +1,24 @@
+var _p = babelHelpers.classPrivateFieldLooseKey("p");
+
+var _q = babelHelpers.classPrivateFieldLooseKey("q");
+
+class C {
+  constructor() {
+    [babelHelpers.classPrivateFieldLooseBase(C, _p)[_p]] = [0];
+  }
+
+}
+
+var _set_p = function (v) {
+  babelHelpers.classPrivateFieldLooseBase(C, _q)[_q] = v;
+};
+
+Object.defineProperty(C, _p, {
+  get: void 0,
+  set: _set_p
+});
+Object.defineProperty(C, _q, {
+  writable: true,
+  value: void 0
+});
+new C();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/set-only-getter/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/set-only-getter/exec.js
@@ -1,13 +1,14 @@
 class Cl {
-  static #PRIVATE_STATIC_FIELD = 0;
+  static #privateField = 0;
 
-  static get #privateStaticFieldValue() {
-    return Cl.#PRIVATE_STATIC_FIELD;
+  static get #privateFieldValue() {
+    return this.#privateField;
   }
 
-  static setPrivateStaticFieldValue() {
-    Cl.#privateStaticFieldValue = 1;
+  constructor() {
+    expect(() => Cl.#privateFieldValue = 1).toThrow(TypeError);
+    expect(() => ([Cl.#privateFieldValue] = [1])).toThrow(TypeError);
   }
 }
 
-expect(() => Cl.setPrivateStaticFieldValue()).toThrow(TypeError);
+const cl = new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/set-only-getter/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/set-only-getter/input.js
@@ -1,11 +1,15 @@
 class Cl {
-  static #PRIVATE_STATIC_FIELD = 0;
+  static #privateField = 0;
 
-  static get #privateStaticFieldValue() {
-    return Cl.#PRIVATE_STATIC_FIELD;
+  static get #privateFieldValue() {
+    return this.#privateField;
   }
 
-  static setPrivateStaticFieldValue() {
-    Cl.#privateStaticFieldValue = 1;
+  constructor() {
+    Cl.#privateFieldValue = 1;
+    ([Cl.#privateFieldValue] = [1]);
   }
 }
+
+const cl = new Cl();
+

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/set-only-getter/output.js
@@ -1,23 +1,25 @@
-var _PRIVATE_STATIC_FIELD = babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
+var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateStaticFieldValue = babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
+var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
-  static setPrivateStaticFieldValue() {
-    babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue] = 1;
+  constructor() {
+    babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue] = 1;
+    [babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue]] = [1];
   }
 
 }
 
-var _get_privateStaticFieldValue = function () {
-  return babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
+var _get_privateFieldValue = function () {
+  return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
 };
 
-Object.defineProperty(Cl, _PRIVATE_STATIC_FIELD, {
+Object.defineProperty(Cl, _privateField, {
   writable: true,
   value: 0
 });
-Object.defineProperty(Cl, _privateStaticFieldValue, {
-  get: _get_privateStaticFieldValue,
+Object.defineProperty(Cl, _privateFieldValue, {
+  get: _get_privateFieldValue,
   set: void 0
 });
+var cl = new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/exec.js
@@ -1,0 +1,10 @@
+class C {
+  static set #p(v) { C.#q = v }
+  static #q;
+  constructor() {
+    ([C.#p] = [0]);
+    expect(C.#q).toBe(0);
+  }
+}
+
+new C;

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/input.js
@@ -1,0 +1,9 @@
+class C {
+  static set #p(v) { C.#q = v }
+  static #q;
+  constructor() {
+    ([C.#p] = [0]);
+  }
+}
+
+new C;

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/output.js
@@ -1,0 +1,24 @@
+var _p = babelHelpers.classPrivateFieldLooseKey("p");
+
+var _q = babelHelpers.classPrivateFieldLooseKey("q");
+
+class C {
+  constructor() {
+    [babelHelpers.classPrivateFieldLooseBase(C, _p)[_p]] = [0];
+  }
+
+}
+
+var _set_p = function (v) {
+  babelHelpers.classPrivateFieldLooseBase(C, _q)[_q] = v;
+};
+
+Object.defineProperty(C, _p, {
+  get: void 0,
+  set: _set_p
+});
+Object.defineProperty(C, _q, {
+  writable: true,
+  value: void 0
+});
+new C();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/exec.js
@@ -1,13 +1,14 @@
 class Cl {
-  static #PRIVATE_STATIC_FIELD = 0;
+  static #privateField = 0;
 
-  static get #privateStaticFieldValue() {
-    return Cl.#PRIVATE_STATIC_FIELD;
+  static get #privateFieldValue() {
+    return this.#privateField;
   }
 
-  static setPrivateStaticFieldValue() {
-    Cl.#privateStaticFieldValue = 1;
+  constructor() {
+    expect(() => Cl.#privateFieldValue = 1).toThrow(TypeError);
+    expect(() => ([Cl.#privateFieldValue] = [1])).toThrow(TypeError);
   }
 }
 
-expect(() => Cl.setPrivateStaticFieldValue()).toThrow(TypeError);
+const cl = new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/input.js
@@ -1,11 +1,15 @@
 class Cl {
-  static #PRIVATE_STATIC_FIELD = 0;
+  static #privateField = 0;
 
-  static get #privateStaticFieldValue() {
-    return Cl.#PRIVATE_STATIC_FIELD;
+  static get #privateFieldValue() {
+    return this.#privateField;
   }
 
-  static setPrivateStaticFieldValue() {
-    Cl.#privateStaticFieldValue = 1;
+  constructor() {
+    Cl.#privateFieldValue = 1;
+    ([Cl.#privateFieldValue] = [1]);
   }
 }
+
+const cl = new Cl();
+

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/output.js
@@ -1,23 +1,25 @@
-var _PRIVATE_STATIC_FIELD = babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
+var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateStaticFieldValue = babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
+var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
-  static setPrivateStaticFieldValue() {
-    babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue] = 1;
+  constructor() {
+    babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue] = 1;
+    [babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue]] = [1];
   }
 
 }
 
-var _get_privateStaticFieldValue = function () {
-  return babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
+var _get_privateFieldValue = function () {
+  return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
 };
 
-Object.defineProperty(Cl, _PRIVATE_STATIC_FIELD, {
+Object.defineProperty(Cl, _privateField, {
   writable: true,
   value: 0
 });
-Object.defineProperty(Cl, _privateStaticFieldValue, {
-  get: _get_privateStaticFieldValue,
+Object.defineProperty(Cl, _privateFieldValue, {
+  get: _get_privateFieldValue,
   set: void 0
 });
+const cl = new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/destructure-set/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/destructure-set/exec.js
@@ -1,0 +1,10 @@
+class C {
+  static set #p(v) { C.#q = v }
+  static #q;
+  constructor() {
+    ([C.#p] = [0]);
+    expect(C.#q).toBe(0);
+  }
+}
+
+new C;

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/destructure-set/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/destructure-set/input.js
@@ -1,0 +1,9 @@
+class C {
+  static set #p(v) { C.#q = v }
+  static #q;
+  constructor() {
+    ([C.#p] = [0]);
+  }
+}
+
+new C;

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/destructure-set/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/destructure-set/output.js
@@ -1,0 +1,20 @@
+class C {
+  constructor() {
+    [babelHelpers.classStaticPrivateFieldDestructureSet(C, C, _p).value] = [0];
+  }
+
+}
+
+var _set_p = function (v) {
+  babelHelpers.classStaticPrivateFieldSpecSet(C, C, _q, v);
+};
+
+var _p = {
+  get: void 0,
+  set: _set_p
+};
+var _q = {
+  writable: true,
+  value: void 0
+};
+new C();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/set-only-getter/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/set-only-getter/exec.js
@@ -1,13 +1,14 @@
 class Cl {
-  static #PRIVATE_STATIC_FIELD = 0;
+  static #privateField = 0;
 
-  static get #privateStaticFieldValue() {
-    return Cl.#PRIVATE_STATIC_FIELD;
+  static get #privateFieldValue() {
+    return this.#privateField;
   }
 
-  static setPrivateStaticFieldValue() {
-    Cl.#privateStaticFieldValue = 1;
+  constructor() {
+    expect(() => Cl.#privateFieldValue = 1).toThrow(TypeError);
+    expect(() => ([Cl.#privateFieldValue] = [1])).toThrow(TypeError);
   }
 }
 
-expect(() => Cl.setPrivateStaticFieldValue()).toThrow(TypeError);
+const cl = new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/set-only-getter/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/set-only-getter/input.js
@@ -1,11 +1,15 @@
 class Cl {
-  static #PRIVATE_STATIC_FIELD = 0;
+  static #privateField = 0;
 
-  static get #privateStaticFieldValue() {
-    return Cl.#PRIVATE_STATIC_FIELD;
+  static get #privateFieldValue() {
+    return this.#privateField;
   }
 
-  static setPrivateStaticFieldValue() {
-    Cl.#privateStaticFieldValue = 1;
+  constructor() {
+    Cl.#privateFieldValue = 1;
+    ([Cl.#privateFieldValue] = [1]);
   }
 }
+
+const cl = new Cl();
+

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/set-only-getter/output.js
@@ -1,19 +1,21 @@
 class Cl {
-  static setPrivateStaticFieldValue() {
-    babelHelpers.classStaticPrivateFieldSpecSet(Cl, Cl, _privateStaticFieldValue, 1);
+  constructor() {
+    babelHelpers.classStaticPrivateFieldSpecSet(Cl, Cl, _privateFieldValue, 1);
+    [babelHelpers.classStaticPrivateFieldDestructureSet(Cl, Cl, _privateFieldValue).value] = [1];
   }
 
 }
 
-var _get_privateStaticFieldValue = function () {
-  return babelHelpers.classStaticPrivateFieldSpecGet(Cl, Cl, _PRIVATE_STATIC_FIELD);
+var _get_privateFieldValue = function () {
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, Cl, _privateField);
 };
 
-var _PRIVATE_STATIC_FIELD = {
+var _privateField = {
   writable: true,
   value: 0
 };
-var _privateStaticFieldValue = {
-  get: _get_privateStaticFieldValue,
+var _privateFieldValue = {
+  get: _get_privateFieldValue,
   set: void 0
 };
+var cl = new Cl();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Runtime error is thrown when running transpiled `[C.#p] = [0]` ([REPL](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&spec=true&loose=false&code_lz=MYGwhgzhAEDC0G8BQ1oQC5nQS2NAxAA4DcK0wA9gHYYBOArsOhbQBQCUiZqA2rAHREAutAC80HgAYhpVAF8kCpFQCmAdzjEgA&debug=false&forceAllTransforms=false&shippedProposals=true&circleciRepo=&evaluate=true&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact&prettier=false&targets=&version=7.13.7&externalPlugins=))
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This PR depends on #12910, please review that one first.

In this PR we introduce a new helper `classStaticPrivateFieldDestructureSet` similar to `classPrivateFieldDestructureSet` except that it accepts a classRef and descriptor. From this perspective this PR can be considered the `static` flavor of #10017.