### PR TITLE
Allow nullish extends in interfaceish

### DIFF
--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -360,7 +360,7 @@ export function _interfaceish(
 ) {
   this.print(node.id, node);
   this.print(node.typeParameters, node);
-  if (node.extends.length) {
+  if (node.extends && node.extends.length) {
     this.space();
     this.word("extends");
     this.space();

--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -360,7 +360,7 @@ export function _interfaceish(
 ) {
   this.print(node.id, node);
   this.print(node.typeParameters, node);
-  if (node.extends && node.extends.length) {
+  if (node.extends?.length) {
     this.space();
     this.word("extends");
     this.space();

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -462,6 +462,17 @@ describe("programmatic generation", function () {
 }`);
   });
 
+  it("flow interface with nullish extends", () => {
+    const interfaceDeclaration = t.interfaceDeclaration(
+      t.identifier("A"),
+      undefined,
+      undefined,
+      t.objectTypeAnnotation([]),
+    );
+    const output = generate(interfaceDeclaration).code;
+    expect(output).toBe("interface A {}");
+  });
+
   describe("directives", function () {
     it("preserves escapes", function () {
       const directive = t.directive(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I've allowed nullish `extends` in interfaceish, cause otherwise code such as

```ts
t.interfaceDeclaration(
  t.identifier('id'),
  undefined,
  undefined,
  t.objectTypeAnnotation([])
)
```

Will fail when priting with ` TypeError: unknown: Cannot read property 'length' of null`
Despite nullish values being allowed in `t.interfaceDeclaration` definitions

