### PR TITLE
Fix a bug with invalid print output when empty array is passed to t.tsInterfaceDeclaration

### DIFF
--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -435,7 +435,7 @@ export function TSInterfaceDeclaration(
   this.space();
   this.print(id, node);
   this.print(typeParameters, node);
-  if (extendz) {
+  if (extendz?.length) {
     this.space();
     this.word("extends");
     this.space();

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -724,6 +724,19 @@ describe("programmatic generation", function () {
       }
     });
   });
+
+  describe("typescript interface declaration", () => {
+    it("empty extends array", () => {
+      const tsInterfaceDeclaration = t.tsInterfaceDeclaration(
+        t.identifier("A"),
+        undefined,
+        [],
+        t.tsInterfaceBody([]),
+      );
+      const output = generate(tsInterfaceDeclaration).code;
+      expect(output).toBe("interface A {}");
+    });
+  });
 });
 
 describe("CodeGenerator", function () {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Fix a bug with invalid print output when empty array is passed to t.tsInterfaceDeclaration
If you pass an empty array as `extends` in `t.tsInterfaceDeclaration` you'll get an invalid code printed

```ts
t.tsInterfaceDeclaration(
  t.identifier('A'),
  undefined,
  [],
  t.tsInterfaceBody([])
)
```

You will get
```ts
interface A extends {}
```

Which is an invalid TS, this PR fixes that
