### PR TITLE
fix: add tokens when tokens: true is passed to parseExpression

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -148,7 +148,7 @@ export default class ExpressionParser extends LValParser {
   }
 
   // Convenience method to parse an Expression only
-  getExpression(): N.Expression {
+  getExpression(): N.Expression & N.ParserOutput {
     let paramFlags = PARAM;
     if (this.hasPlugin("topLevelAwait") && this.inModule) {
       paramFlags |= PARAM_AWAIT;
@@ -162,6 +162,9 @@ export default class ExpressionParser extends LValParser {
     }
     expr.comments = this.state.comments;
     expr.errors = this.state.errors;
+    if (this.options.tokens) {
+      expr.tokens = this.tokens;
+    }
     return expr;
   }
 

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -4,6 +4,7 @@ import type { SourceType } from "./options";
 import type { Token } from "./tokenizer";
 import type { SourceLocation } from "./util/location";
 import type { PlaceholderTypes } from "./plugins/placeholders";
+import type { ParsingError } from "./parser/error";
 
 /*
  * If making any changes to the AST, update:
@@ -129,6 +130,11 @@ export type BigIntLiteral = NodeBase & {
   value: number,
 };
 
+export type ParserOutput = {
+  comments: $ReadOnlyArray<Comment>,
+  errors: Array<ParsingError>,
+  tokens?: $ReadOnlyArray<Token | Comment>,
+};
 // Programs
 
 export type BlockStatementLike = Program | BlockStatement;
@@ -136,9 +142,7 @@ export type BlockStatementLike = Program | BlockStatement;
 export type File = NodeBase & {
   type: "File",
   program: Program,
-  comments: $ReadOnlyArray<Comment>,
-  tokens: $ReadOnlyArray<Token | Comment>,
-};
+} & ParserOutput;
 
 export type Program = NodeBase & {
   type: "Program",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12936 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Assign `tokens` to top level AST node when `tokens: true` is passed to `parser.getExpression()`.