### PR TITLE
Don't show warning from spied `console.warn`

### DIFF
--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -274,10 +274,20 @@ fs.readdirSync(fixtureLoc).forEach(function (binName) {
 describe("util.js", () => {
   describe("chmod", () => {
     it("should warn the user if chmod fails", () => {
-      const spyConsoleWarn = jest.spyOn(console, "warn");
-      // should expect a string as first argument
+      const spyConsoleWarn = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      // The first argument should be a string.
+      // The real reason chmod will fail is due to wrong permissions,
+      // but this is enough to cause a failure.
       chmod(100, "file.js");
+
       expect(spyConsoleWarn).toHaveBeenCalledTimes(1);
+      expect(spyConsoleWarn).toHaveBeenCalledWith(
+        "Cannot change permissions of file.js",
+      );
+
       spyConsoleWarn.mockRestore();
     });
   });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The warning is expected, so we can avoid showing it when running tests.

On `main` it's currently like this:
![Schermata da 2021-03-02 12-48-21](https://user-images.githubusercontent.com/7000710/109644327-a2e0a500-7b55-11eb-9e46-7f6cce35dd44.png)
