### PR TITLE
Parse type imports in TSImportEqualsDeclaration

### DIFF
--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1461,6 +1461,7 @@ export type TsImportEqualsDeclaration = NodeBase & {
   type: "TSImportEqualsDeclaration",
   isExport: boolean,
   id: Identifier,
+  importKind: "type" | "value",
   moduleReference: TsModuleReference,
 };
 

--- a/packages/babel-parser/test/fixtures/estree/typescript/import-require/output.json
+++ b/packages/babel-parser/test/fixtures/estree/typescript/import-require/output.json
@@ -10,6 +10,7 @@
       {
         "type": "TSImportEqualsDeclaration",
         "start":0,"end":32,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":32}},
+        "importKind": "value",
         "isExport": false,
         "id": {
           "type": "Identifier",

--- a/packages/babel-parser/test/fixtures/typescript/import/equals-require/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/equals-require/output.json
@@ -10,6 +10,7 @@
       {
         "type": "TSImportEqualsDeclaration",
         "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":24}},
+        "importKind": "value",
         "isExport": false,
         "id": {
           "type": "Identifier",

--- a/packages/babel-parser/test/fixtures/typescript/import/equals/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/equals/output.json
@@ -10,6 +10,7 @@
       {
         "type": "TSImportEqualsDeclaration",
         "start":0,"end":15,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":15}},
+        "importKind": "value",
         "isExport": false,
         "id": {
           "type": "Identifier",

--- a/packages/babel-parser/test/fixtures/typescript/import/export-import-require/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/export-import-require/output.json
@@ -10,6 +10,7 @@
       {
         "type": "TSImportEqualsDeclaration",
         "start":0,"end":31,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":31}},
+        "importKind": "value",
         "isExport": true,
         "id": {
           "type": "Identifier",

--- a/packages/babel-parser/test/fixtures/typescript/import/export-import-type-as-identifier/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/import/export-import-type-as-identifier/input.ts
@@ -1,0 +1,1 @@
+export import type = require("A");

--- a/packages/babel-parser/test/fixtures/typescript/import/export-import-type-as-identifier/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/export-import-type-as-identifier/output.json
@@ -1,0 +1,37 @@
+{
+  "type": "File",
+  "start":0,"end":34,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":34}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":34,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":34}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":0,"end":34,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":34}},
+        "importKind": "value",
+        "isExport": true,
+        "id": {
+          "type": "Identifier",
+          "start":14,"end":18,"loc":{"start":{"line":1,"column":14},"end":{"line":1,"column":18},"identifierName":"type"},
+          "name": "type"
+        },
+        "moduleReference": {
+          "type": "TSExternalModuleReference",
+          "start":21,"end":33,"loc":{"start":{"line":1,"column":21},"end":{"line":1,"column":33}},
+          "expression": {
+            "type": "StringLiteral",
+            "start":29,"end":32,"loc":{"start":{"line":1,"column":29},"end":{"line":1,"column":32}},
+            "extra": {
+              "rawValue": "A",
+              "raw": "\"A\""
+            },
+            "value": "A"
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/import/export-import-type-require/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/import/export-import-type-require/input.ts
@@ -1,0 +1,1 @@
+export import type a = require("a");

--- a/packages/babel-parser/test/fixtures/typescript/import/export-import-type-require/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/export-import-type-require/output.json
@@ -1,0 +1,37 @@
+{
+  "type": "File",
+  "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":36}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":36}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":36}},
+        "importKind": "type",
+        "isExport": true,
+        "id": {
+          "type": "Identifier",
+          "start":19,"end":20,"loc":{"start":{"line":1,"column":19},"end":{"line":1,"column":20},"identifierName":"a"},
+          "name": "a"
+        },
+        "moduleReference": {
+          "type": "TSExternalModuleReference",
+          "start":23,"end":35,"loc":{"start":{"line":1,"column":23},"end":{"line":1,"column":35}},
+          "expression": {
+            "type": "StringLiteral",
+            "start":31,"end":34,"loc":{"start":{"line":1,"column":31},"end":{"line":1,"column":34}},
+            "extra": {
+              "rawValue": "a",
+              "raw": "\"a\""
+            },
+            "value": "a"
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/import/export-import-type/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/import/export-import-type/input.ts
@@ -1,0 +1,1 @@
+export import type A = B.C;

--- a/packages/babel-parser/test/fixtures/typescript/import/export-import-type/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/export-import-type/output.json
@@ -1,0 +1,41 @@
+{
+  "type": "File",
+  "start":0,"end":27,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":27}},
+  "errors": [
+    "SyntaxError: An import alias can not use 'import type' (1:23)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":27,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":27}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":0,"end":27,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":27}},
+        "importKind": "type",
+        "isExport": true,
+        "id": {
+          "type": "Identifier",
+          "start":19,"end":20,"loc":{"start":{"line":1,"column":19},"end":{"line":1,"column":20},"identifierName":"A"},
+          "name": "A"
+        },
+        "moduleReference": {
+          "type": "TSQualifiedName",
+          "start":23,"end":26,"loc":{"start":{"line":1,"column":23},"end":{"line":1,"column":26}},
+          "left": {
+            "type": "Identifier",
+            "start":23,"end":24,"loc":{"start":{"line":1,"column":23},"end":{"line":1,"column":24},"identifierName":"B"},
+            "name": "B"
+          },
+          "right": {
+            "type": "Identifier",
+            "start":25,"end":26,"loc":{"start":{"line":1,"column":25},"end":{"line":1,"column":26},"identifierName":"C"},
+            "name": "C"
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/import/export-import/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/export-import/output.json
@@ -10,6 +10,7 @@
       {
         "type": "TSImportEqualsDeclaration",
         "start":0,"end":22,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":22}},
+        "importKind": "value",
         "isExport": true,
         "id": {
           "type": "Identifier",

--- a/packages/babel-parser/test/fixtures/typescript/import/export-named-import-require/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/export-named-import-require/output.json
@@ -10,6 +10,7 @@
       {
         "type": "TSImportEqualsDeclaration",
         "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":24}},
+        "importKind": "value",
         "isExport": false,
         "id": {
           "type": "Identifier",

--- a/packages/babel-parser/test/fixtures/typescript/import/import-type-as-identifier/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/import/import-type-as-identifier/input.ts
@@ -1,0 +1,1 @@
+import type = require("A");

--- a/packages/babel-parser/test/fixtures/typescript/import/import-type-as-identifier/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/import-type-as-identifier/output.json
@@ -1,0 +1,37 @@
+{
+  "type": "File",
+  "start":0,"end":27,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":27}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":27,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":27}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":0,"end":27,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":27}},
+        "importKind": "value",
+        "isExport": false,
+        "id": {
+          "type": "Identifier",
+          "start":7,"end":11,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":11},"identifierName":"type"},
+          "name": "type"
+        },
+        "moduleReference": {
+          "type": "TSExternalModuleReference",
+          "start":14,"end":26,"loc":{"start":{"line":1,"column":14},"end":{"line":1,"column":26}},
+          "expression": {
+            "type": "StringLiteral",
+            "start":22,"end":25,"loc":{"start":{"line":1,"column":22},"end":{"line":1,"column":25}},
+            "extra": {
+              "rawValue": "A",
+              "raw": "\"A\""
+            },
+            "value": "A"
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/import/type-asi/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/import/type-asi/input.ts
@@ -1,0 +1,15 @@
+import type
+A = require("A");
+
+import
+type
+a = require("a");
+
+export import
+type
+B = require("B");
+
+export
+import
+type
+b = require("b");

--- a/packages/babel-parser/test/fixtures/typescript/import/type-asi/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/type-asi/output.json
@@ -1,0 +1,109 @@
+{
+  "type": "File",
+  "start":0,"end":136,"loc":{"start":{"line":1,"column":0},"end":{"line":15,"column":17}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":136,"loc":{"start":{"line":1,"column":0},"end":{"line":15,"column":17}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":0,"end":29,"loc":{"start":{"line":1,"column":0},"end":{"line":2,"column":17}},
+        "importKind": "type",
+        "isExport": false,
+        "id": {
+          "type": "Identifier",
+          "start":12,"end":13,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":1},"identifierName":"A"},
+          "name": "A"
+        },
+        "moduleReference": {
+          "type": "TSExternalModuleReference",
+          "start":16,"end":28,"loc":{"start":{"line":2,"column":4},"end":{"line":2,"column":16}},
+          "expression": {
+            "type": "StringLiteral",
+            "start":24,"end":27,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":15}},
+            "extra": {
+              "rawValue": "A",
+              "raw": "\"A\""
+            },
+            "value": "A"
+          }
+        }
+      },
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":31,"end":60,"loc":{"start":{"line":4,"column":0},"end":{"line":6,"column":17}},
+        "importKind": "type",
+        "isExport": false,
+        "id": {
+          "type": "Identifier",
+          "start":43,"end":44,"loc":{"start":{"line":6,"column":0},"end":{"line":6,"column":1},"identifierName":"a"},
+          "name": "a"
+        },
+        "moduleReference": {
+          "type": "TSExternalModuleReference",
+          "start":47,"end":59,"loc":{"start":{"line":6,"column":4},"end":{"line":6,"column":16}},
+          "expression": {
+            "type": "StringLiteral",
+            "start":55,"end":58,"loc":{"start":{"line":6,"column":12},"end":{"line":6,"column":15}},
+            "extra": {
+              "rawValue": "a",
+              "raw": "\"a\""
+            },
+            "value": "a"
+          }
+        }
+      },
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":62,"end":98,"loc":{"start":{"line":8,"column":0},"end":{"line":10,"column":17}},
+        "importKind": "type",
+        "isExport": true,
+        "id": {
+          "type": "Identifier",
+          "start":81,"end":82,"loc":{"start":{"line":10,"column":0},"end":{"line":10,"column":1},"identifierName":"B"},
+          "name": "B"
+        },
+        "moduleReference": {
+          "type": "TSExternalModuleReference",
+          "start":85,"end":97,"loc":{"start":{"line":10,"column":4},"end":{"line":10,"column":16}},
+          "expression": {
+            "type": "StringLiteral",
+            "start":93,"end":96,"loc":{"start":{"line":10,"column":12},"end":{"line":10,"column":15}},
+            "extra": {
+              "rawValue": "B",
+              "raw": "\"B\""
+            },
+            "value": "B"
+          }
+        }
+      },
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":100,"end":136,"loc":{"start":{"line":12,"column":0},"end":{"line":15,"column":17}},
+        "importKind": "type",
+        "isExport": true,
+        "id": {
+          "type": "Identifier",
+          "start":119,"end":120,"loc":{"start":{"line":15,"column":0},"end":{"line":15,"column":1},"identifierName":"b"},
+          "name": "b"
+        },
+        "moduleReference": {
+          "type": "TSExternalModuleReference",
+          "start":123,"end":135,"loc":{"start":{"line":15,"column":4},"end":{"line":15,"column":16}},
+          "expression": {
+            "type": "StringLiteral",
+            "start":131,"end":134,"loc":{"start":{"line":15,"column":12},"end":{"line":15,"column":15}},
+            "extra": {
+              "rawValue": "b",
+              "raw": "\"b\""
+            },
+            "value": "b"
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/import/type-equals-require/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/import/type-equals-require/input.ts
@@ -1,0 +1,1 @@
+import type a = require("a");

--- a/packages/babel-parser/test/fixtures/typescript/import/type-equals-require/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/type-equals-require/output.json
@@ -1,0 +1,37 @@
+{
+  "type": "File",
+  "start":0,"end":29,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":29}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":29,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":29}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":0,"end":29,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":29}},
+        "importKind": "type",
+        "isExport": false,
+        "id": {
+          "type": "Identifier",
+          "start":12,"end":13,"loc":{"start":{"line":1,"column":12},"end":{"line":1,"column":13},"identifierName":"a"},
+          "name": "a"
+        },
+        "moduleReference": {
+          "type": "TSExternalModuleReference",
+          "start":16,"end":28,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":28}},
+          "expression": {
+            "type": "StringLiteral",
+            "start":24,"end":27,"loc":{"start":{"line":1,"column":24},"end":{"line":1,"column":27}},
+            "extra": {
+              "rawValue": "a",
+              "raw": "\"a\""
+            },
+            "value": "a"
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/import/type-equals/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/import/type-equals/input.ts
@@ -1,0 +1,2 @@
+import type A = B.C;
+import type B = C;

--- a/packages/babel-parser/test/fixtures/typescript/import/type-equals/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/type-equals/output.json
@@ -1,0 +1,58 @@
+{
+  "type": "File",
+  "start":0,"end":39,"loc":{"start":{"line":1,"column":0},"end":{"line":2,"column":18}},
+  "errors": [
+    "SyntaxError: An import alias can not use 'import type' (1:16)",
+    "SyntaxError: An import alias can not use 'import type' (2:16)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":39,"loc":{"start":{"line":1,"column":0},"end":{"line":2,"column":18}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":0,"end":20,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":20}},
+        "importKind": "type",
+        "isExport": false,
+        "id": {
+          "type": "Identifier",
+          "start":12,"end":13,"loc":{"start":{"line":1,"column":12},"end":{"line":1,"column":13},"identifierName":"A"},
+          "name": "A"
+        },
+        "moduleReference": {
+          "type": "TSQualifiedName",
+          "start":16,"end":19,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":19}},
+          "left": {
+            "type": "Identifier",
+            "start":16,"end":17,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":17},"identifierName":"B"},
+            "name": "B"
+          },
+          "right": {
+            "type": "Identifier",
+            "start":18,"end":19,"loc":{"start":{"line":1,"column":18},"end":{"line":1,"column":19},"identifierName":"C"},
+            "name": "C"
+          }
+        }
+      },
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":21,"end":39,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":18}},
+        "importKind": "type",
+        "isExport": false,
+        "id": {
+          "type": "Identifier",
+          "start":33,"end":34,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":13},"identifierName":"B"},
+          "name": "B"
+        },
+        "moduleReference": {
+          "type": "Identifier",
+          "start":37,"end":38,"loc":{"start":{"line":2,"column":16},"end":{"line":2,"column":17},"identifierName":"C"},
+          "name": "C"
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12957
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR implements parsing support on type imports in TSImportEqualsDeclaration
```ts
import type A = require("A");
export import type B = require("B");
```

Similar to what we did for `ImportDeclaration`, an enum property `importKind: "value" | "type"` will be added to `TsImportEqualsDeclaration`.

Note that when `importKind` is `"type"`, the TSModuleReference on the RHS can not be an Identifier or a TSQualfiedName, which becomes an import alias for TypeScript, e.g. both
```ts
import type A = B.C;
```
and
```ts
export import type B = C;
```
will throw "An import alias can not use 'import type'".