### PR TITLE
Evaluate member expressions

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -391,6 +391,27 @@ function _evaluate(path: NodePath, state) {
     }
   }
 
+  if (path.isMemberExpression()) {
+    const property = path.get("property");
+    const object = path.get("object");
+    let key: any;
+
+    if (path.node.computed) {
+      key = evaluateCached(property, state);
+      if (!state.confident) return deopt(property, state);
+    } else if (property.isIdentifier()) {
+      key = property.node.name;
+    } else {
+      return deopt(property, state);
+    }
+
+    const value = evaluateCached(object, state);
+    if (state.confident && Object.prototype.hasOwnProperty.call(value, key)) {
+      return value[key];
+    }
+    return deopt(object, state);
+  }
+
   deopt(path, state);
 }
 


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | No
| License                  | MIT

Adds support for evaluating member expressions, e.g.:

```javascript
const obj = { foo: 'bar' };
obj.foo // evaluates to 'bar'
```

Gets the object value using evaluate, and uses the property name if it's not computed or using evaluate if it is. Works for nested member expressions, e.g. `obj.foo.bar`.
