### PR TITLE
Clone Position objects in NodeUtils to prevent modification in different places

### DIFF
--- a/packages/babel-parser/src/parser/node.js
+++ b/packages/babel-parser/src/parser/node.js
@@ -2,7 +2,7 @@
 
 import type Parser from "./index";
 import UtilParser from "./util";
-import { SourceLocation, type Position } from "../util/location";
+import { SourceLocation, Position } from "../util/location";
 import type { Comment, Node as NodeType, NodeBase } from "../types";
 
 // Start an AST node, attaching a start offset.
@@ -50,13 +50,17 @@ class Node implements NodeBase {
 
 export class NodeUtils extends UtilParser {
   startNode<T: NodeType>(): T {
+    const startLoc = new Position(
+      this.state.startLoc.line,
+      this.state.startLoc.column,
+    );
     // $FlowIgnore
-    return new Node(this, this.state.start, this.state.startLoc);
+    return new Node(this, this.state.start, startLoc);
   }
 
   startNodeAt<T: NodeType>(pos: number, loc: Position): T {
     // $FlowIgnore
-    return new Node(this, pos, loc);
+    return new Node(this, pos, new Position(loc.line, loc.column));
   }
 
   /** Start a new node with a previous node's location. */
@@ -91,7 +95,7 @@ export class NodeUtils extends UtilParser {
     }
     node.type = type;
     node.end = pos;
-    node.loc.end = loc;
+    node.loc.end = new Position(loc.line, loc.column);
     if (this.options.ranges) node.range[1] = pos;
     this.processComment(node);
     return node;
@@ -99,7 +103,7 @@ export class NodeUtils extends UtilParser {
 
   resetStartLocation(node: NodeBase, start: number, startLoc: Position): void {
     node.start = start;
-    node.loc.start = startLoc;
+    node.loc.start = new Position(startLoc.line, startLoc.column);
     if (this.options.ranges) node.range[0] = start;
   }
 
@@ -109,7 +113,11 @@ export class NodeUtils extends UtilParser {
     endLoc?: Position = this.state.lastTokEndLoc,
   ): void {
     node.end = end;
-    node.loc.end = endLoc;
+    if (endLoc) {
+      node.loc.end = new Position(endLoc.line, endLoc.column);
+    } else {
+      node.loc.end = endLoc;
+    }
     if (this.options.ranges) node.range[1] = end;
   }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12980 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This commit prevent node loc info in ast from being implicitly modified because of sharing same object between many nodes