### PR TITLE
Optionally enable external-helpers in tests

### DIFF
--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -135,7 +135,8 @@ function pushTask(taskName, taskDir, suite, suiteName) {
         ? taskOpts.BABEL_8_BREAKING === false
         : taskOpts.BABEL_8_BREAKING === true),
     options: taskOpts,
-    externalHelpers: taskOpts.externalHelpers ?? true,
+    externalHelpers:
+      taskOpts.externalHelpers ?? tryResolve("babel-plugin-external-helpers"),
     validateLogs: taskOpts.validateLogs,
     ignoreOutput: taskOpts.ignoreOutput,
     stdout: { loc: stdoutLoc, code: readFile(stdoutLoc) },

--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -136,7 +136,7 @@ function pushTask(taskName, taskDir, suite, suiteName) {
         : taskOpts.BABEL_8_BREAKING === true),
     options: taskOpts,
     externalHelpers:
-      taskOpts.externalHelpers ?? tryResolve("babel-plugin-external-helpers"),
+      taskOpts.externalHelpers ?? !!tryResolve("babel-plugin-external-helpers"),
     validateLogs: taskOpts.validateLogs,
     ignoreOutput: taskOpts.ignoreOutput,
     stdout: { loc: stdoutLoc, code: readFile(stdoutLoc) },

--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -136,7 +136,8 @@ function pushTask(taskName, taskDir, suite, suiteName) {
         : taskOpts.BABEL_8_BREAKING === true),
     options: taskOpts,
     externalHelpers:
-      taskOpts.externalHelpers ?? !!tryResolve("babel-plugin-external-helpers"),
+      taskOpts.externalHelpers ??
+      !!tryResolve("@babel/plugin-external-helpers"),
     validateLogs: taskOpts.validateLogs,
     ignoreOutput: taskOpts.ignoreOutput,
     stdout: { loc: stdoutLoc, code: readFile(stdoutLoc) },


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

https://github.com/babel/babel/pull/12911 was a breaking change that now requires you to keep `babel-plugin-external-helpers` in your `package.json`. It'll will probably be unnoticeable for most, because another dependency could transitively depend on it, but AMP recently hit it when cleaning up our deps.