### PR TITLE
Improve error message when not providing a value for JSX key

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.js
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.js
@@ -415,7 +415,7 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
               const keyValue = convertAttributeValue(attr.node.value);
               if (keyValue === null) {
                 throw attr.buildCodeFrameError(
-                  'Provide an explicit value to be used as a key. You are not supposed to use the "key" shorthand for "key={true}".',
+                  'Please provide an explicit key value. Using "key" as a shorthand for "key={true}" is not allowed.',
                 );
               }
 

--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.js
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.js
@@ -411,9 +411,17 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
             case "__self":
               if (extracted[name]) throw sourceSelfError(path, name);
             /* falls through */
-            case "key":
-              extracted[name] = convertAttributeValue(attr.node.value);
+            case "key": {
+              const keyValue = convertAttributeValue(attr.node.value);
+              if (keyValue === null) {
+                throw path.buildCodeFrameError(
+                  'Provide an explicit value to be used as a key. You are not supposed to use the "key" shorthand for "key={true}".',
+                );
+              }
+
+              extracted[name] = keyValue;
               break;
+            }
             default:
               attribs.push(attr.node);
           }

--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.js
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.js
@@ -341,9 +341,9 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
       }
     }
 
-    function accumulateAttribute(array, node) {
-      if (t.isJSXSpreadAttribute(node)) {
-        const arg = node.argument;
+    function accumulateAttribute(array, attribute) {
+      if (t.isJSXSpreadAttribute(attribute.node)) {
+        const arg = attribute.node.argument;
         // Collect properties into props array if spreading object expression
         if (t.isObjectExpression(arg)) {
           array.push(...arg.properties);
@@ -353,26 +353,46 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
         return array;
       }
 
-      const value = convertAttributeValue(node.value || t.booleanLiteral(true));
+      const value = convertAttributeValue(
+        attribute.node.name.name !== "key"
+          ? attribute.node.value || t.booleanLiteral(true)
+          : attribute.node.value,
+      );
 
-      if (t.isStringLiteral(value) && !t.isJSXExpressionContainer(node.value)) {
+      if (attribute.node.name.name === "key" && value === null) {
+        throw attribute.buildCodeFrameError(
+          'Please provide an explicit key value. Using "key" as a shorthand for "key={true}" is not allowed.',
+        );
+      }
+
+      if (
+        t.isStringLiteral(value) &&
+        !t.isJSXExpressionContainer(attribute.node.value)
+      ) {
         value.value = value.value.replace(/\n\s+/g, " ");
 
         // "raw" JSXText should not be used from a StringLiteral because it needs to be escaped.
         delete value.extra?.raw;
       }
 
-      if (t.isJSXNamespacedName(node.name)) {
-        node.name = t.stringLiteral(
-          node.name.namespace.name + ":" + node.name.name.name,
+      if (t.isJSXNamespacedName(attribute.node.name)) {
+        attribute.node.name = t.stringLiteral(
+          attribute.node.name.namespace.name +
+            ":" +
+            attribute.node.name.name.name,
         );
-      } else if (t.isValidIdentifier(node.name.name, false)) {
-        node.name.type = "Identifier";
+      } else if (t.isValidIdentifier(attribute.node.name.name, false)) {
+        attribute.node.name.type = "Identifier";
       } else {
-        node.name = t.stringLiteral(node.name.name);
+        attribute.node.name = t.stringLiteral(attribute.node.name.name);
       }
 
-      array.push(t.inherits(t.objectProperty(node.name, value), node));
+      array.push(
+        t.inherits(
+          t.objectProperty(attribute.node.name, value),
+          attribute.node,
+        ),
+      );
       return array;
     }
 
@@ -423,10 +443,10 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
               break;
             }
             default:
-              attribs.push(attr.node);
+              attribs.push(attr);
           }
         } else {
-          attribs.push(attr.node);
+          attribs.push(attr);
         }
       }
 
@@ -519,7 +539,7 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
         buildCreateElementOpeningElementAttributes(
           file,
           path,
-          openingPath.node.attributes,
+          openingPath.get("attributes"),
         ),
         ...t.react.buildChildren(path.node),
       ]);

--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.js
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.js
@@ -414,7 +414,7 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
             case "key": {
               const keyValue = convertAttributeValue(attr.node.value);
               if (keyValue === null) {
-                throw path.buildCodeFrameError(
+                throw attr.buildCodeFrameError(
                   'Provide an explicit value to be used as a key. You are not supposed to use the "key" shorthand for "key={true}".',
                 );
               }

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-disallow-valueless-key/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-disallow-valueless-key/input.js
@@ -1,0 +1,2 @@
+
+var x = [<div key></div>];

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-disallow-valueless-key/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-disallow-valueless-key/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Provide an explicit value to be used as a key. You are not supposed to use the \"key\" shorthand for \"key={true}\"."
+  "throws": "Please provide an explicit key value. Using \"key\" as a shorthand for \"key={true}\" is not allowed."
 }

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-disallow-valueless-key/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-disallow-valueless-key/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Provide an explicit value to be used as a key. You are not supposed to use the \"key\" shorthand for \"key={true}\"."
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-valueless-key/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-valueless-key/input.js
@@ -1,0 +1,2 @@
+
+var x = [<div key></div>];

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-valueless-key/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-valueless-key/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Please provide an explicit key value. Using \"key\" as a shorthand for \"key={true}\" is not allowed."
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12931 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | - <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | None
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Throwing a more descriptive error when compiling a React element in a list that hasn't been given a value for its key.
eg. `<Component key />`