### PR TITLE
WIP: Fallback to the process.cwd to search for modules

### DIFF
--- a/packages/babel-core/src/config/files/plugins.js
+++ b/packages/babel-core/src/config/files/plugins.js
@@ -99,10 +99,11 @@ function resolveStandardizedName(
   dirname: string = process.cwd(),
 ) {
   const standardizedName = standardizeName(type, name);
+  const dirnames = [dirname, process.cwd()];
 
   try {
     return require.resolve(standardizedName, {
-      paths: [dirname],
+      paths: dirnames,
     });
   } catch (e) {
     if (e.code !== "MODULE_NOT_FOUND") throw e;
@@ -111,7 +112,7 @@ function resolveStandardizedName(
       let resolvedOriginal = false;
       try {
         require.resolve(name, {
-          paths: [dirname],
+          paths: dirnames,
         });
         resolvedOriginal = true;
       } catch {}
@@ -124,7 +125,7 @@ function resolveStandardizedName(
     let resolvedBabel = false;
     try {
       require.resolve(standardizeName(type, "@babel/" + name), {
-        paths: [dirname],
+        paths: dirnames,
       });
       resolvedBabel = true;
     } catch {}
@@ -137,7 +138,7 @@ function resolveStandardizedName(
     const oppositeType = type === "preset" ? "plugin" : "preset";
     try {
       require.resolve(standardizeName(oppositeType, name), {
-        paths: [dirname],
+        paths: dirnames,
       });
       resolvedOppositeType = true;
     } catch {}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel-loader/issues/895
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | No (need some help)
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

If you have some uncommen directory structure like: https://github.com/alexander-schranz/build-error-reproducer. Babel can not find the plugins or presets. A fallback to the process.cwd does fix it, not sure if this need is the correct place to fix this, also if other places need to keep in mind.
