### PR TITLE
Use `function` rather than `var` to compile private methods

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-private-methods/loose-false/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-private-methods/loose-false/output.js
@@ -7,6 +7,6 @@ class X {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {
+function _privateMethod2() {
   return 42;
-};
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-private-methods/loose-true/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-private-methods/loose-true/output.js
@@ -9,6 +9,6 @@ class X {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {
+function _privateMethod2() {
   return 42;
-};
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/replace-supers/method/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/replace-supers/method/output.js
@@ -9,8 +9,8 @@ class A extends B {
 
 }
 
-var _foo2 = function _foo2() {
+function _foo2() {
   let _A;
 
   babelHelpers.get(babelHelpers.getPrototypeOf(A.prototype), "x", this);
-};
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-private-method/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-private-method/output.js
@@ -7,7 +7,7 @@ class C {
 
 }
 
-var _g2 = function _g2() {
+function _g2() {
   var _this = this;
 
   return babelHelpers.wrapAsyncGenerator(function* () {
@@ -16,4 +16,4 @@ var _g2 = function _g2() {
     yield 2;
     return 3;
   })();
-};
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/decorators-legacy-interop/local-define-property/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/decorators-legacy-interop/local-define-property/output.js
@@ -1,18 +1,18 @@
-var _class, _descriptor, _descriptor2, _temp;
+var _class, _descriptor, _descriptor2;
 
 function dec() {} // Create a local function binding so babel has to change the name of the helper
 
 
 function _defineProperty() {}
 
-let A = (_class = (_temp = function A() {
+let A = (_class = function A() {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
   babelHelpers.initializerDefineProperty(this, "a", _descriptor, this);
   babelHelpers.initializerDefineProperty(this, "b", _descriptor2, this);
   babelHelpers.defineProperty(this, "c", 456);
-}, _temp), (_descriptor = babelHelpers.applyDecoratedDescriptor(_class.prototype, "a", [dec], {
+}, (_descriptor = babelHelpers.applyDecoratedDescriptor(_class.prototype, "a", [dec], {
   configurable: true,
   enumerable: true,
   writable: true,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/decorators-legacy-interop/loose/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/decorators-legacy-interop/loose/output.js
@@ -1,15 +1,15 @@
-var _class, _descriptor, _descriptor2, _temp;
+var _class, _descriptor, _descriptor2;
 
 function dec() {}
 
-let A = (_class = (_temp = function A() {
+let A = (_class = function A() {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
   babelHelpers.initializerDefineProperty(this, "a", _descriptor, this);
   babelHelpers.initializerDefineProperty(this, "b", _descriptor2, this);
   this.c = 456;
-}, _temp), (_descriptor = babelHelpers.applyDecoratedDescriptor(_class.prototype, "a", [dec], {
+}, (_descriptor = babelHelpers.applyDecoratedDescriptor(_class.prototype, "a", [dec], {
   configurable: true,
   enumerable: true,
   writable: true,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/decorators-legacy-interop/strict/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/decorators-legacy-interop/strict/output.js
@@ -1,15 +1,15 @@
-var _class, _descriptor, _descriptor2, _temp;
+var _class, _descriptor, _descriptor2;
 
 function dec() {}
 
-let A = (_class = (_temp = function A() {
+let A = (_class = function A() {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
   babelHelpers.initializerDefineProperty(this, "a", _descriptor, this);
   babelHelpers.initializerDefineProperty(this, "b", _descriptor2, this);
   babelHelpers.defineProperty(this, "c", 456);
-}, _temp), (_descriptor = babelHelpers.applyDecoratedDescriptor(_class.prototype, "a", [dec], {
+}, (_descriptor = babelHelpers.applyDecoratedDescriptor(_class.prototype, "a", [dec], {
   configurable: true,
   enumerable: true,
   writable: true,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
@@ -14,7 +14,7 @@ var Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _foo3, _temp;
+      var _foo3;
 
       var _babelHelpers$classPr;
 
@@ -38,7 +38,7 @@ var Foo = /*#__PURE__*/function () {
         }
 
         return Nested;
-      }((_temp = (_foo3 = babelHelpers.classPrivateFieldLooseKey("foo"), _babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo3)[_foo3], /*#__PURE__*/function () {
+      }((_foo3 = babelHelpers.classPrivateFieldLooseKey("foo"), _babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo3)[_foo3], /*#__PURE__*/function () {
         function _class2() {
           babelHelpers.classCallCheck(this, _class2);
           Object.defineProperty(this, _foo3, {
@@ -49,7 +49,7 @@ var Foo = /*#__PURE__*/function () {
         }
 
         return _class2;
-      }()), _temp));
+      }()));
     }
   }]);
   return Foo;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
@@ -14,8 +14,6 @@ var Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _temp;
-
       var _babelHelpers$classPr;
 
       var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
@@ -38,14 +36,14 @@ var Foo = /*#__PURE__*/function () {
         }
 
         return Nested;
-      }((_temp = (_babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo], /*#__PURE__*/function () {
+      }((_babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo], /*#__PURE__*/function () {
         function _class2() {
           babelHelpers.classCallCheck(this, _class2);
           this[_babelHelpers$classPr] = 2;
         }
 
         return _class2;
-      }()), _temp));
+      }()));
     }
   }]);
   return Foo;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
@@ -15,7 +15,7 @@ var Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _foo3, _temp;
+      var _foo3;
 
       var _babelHelpers$classPr;
 
@@ -41,7 +41,7 @@ var Foo = /*#__PURE__*/function () {
         }
 
         return Nested;
-      }((_temp = (_foo3 = new WeakMap(), _babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo3), /*#__PURE__*/function () {
+      }((_foo3 = new WeakMap(), _babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo3), /*#__PURE__*/function () {
         function _class2() {
           babelHelpers.classCallCheck(this, _class2);
 
@@ -54,7 +54,7 @@ var Foo = /*#__PURE__*/function () {
         }
 
         return _class2;
-      }()), _temp));
+      }()));
     }
   }]);
   return Foo;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
@@ -15,8 +15,6 @@ var Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _temp;
-
       var _babelHelpers$classPr;
 
       var _foo2 = new WeakMap();
@@ -41,14 +39,14 @@ var Foo = /*#__PURE__*/function () {
         }
 
         return Nested;
-      }((_temp = (_babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo), /*#__PURE__*/function () {
+      }((_babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo), /*#__PURE__*/function () {
         function _class2() {
           babelHelpers.classCallCheck(this, _class2);
           babelHelpers.defineProperty(this, _babelHelpers$classPr, 2);
         }
 
         return _class2;
-      }()), _temp));
+      }()));
     }
   }]);
   return Foo;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed-without-block/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed-without-block/output.js
@@ -1,9 +1,7 @@
 var createClass = k => {
-  var _temp;
-
   var _k;
 
-  return _temp = (_k = k(), /*#__PURE__*/function () {
+  return _k = k(), /*#__PURE__*/function () {
     "use strict";
 
     function _class2() {
@@ -12,5 +10,5 @@ var createClass = k => {
     }
 
     return _class2;
-  }()), _temp;
+  }();
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/decorator-interop/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/decorator-interop/output.js
@@ -1,10 +1,10 @@
 let _Symbol$search;
 
-var _class, _descriptor, _temp;
+var _class, _descriptor;
 
 function dec() {}
 
-let A = (_class = (_temp = (_Symbol$search = Symbol.search, /*#__PURE__*/function () {
+let A = (_class = (_Symbol$search = Symbol.search, /*#__PURE__*/function () {
   "use strict";
 
   function A() {
@@ -17,7 +17,7 @@ let A = (_class = (_temp = (_Symbol$search = Symbol.search, /*#__PURE__*/functio
     value: function () {}
   }]);
   return A;
-}()), _temp), (_descriptor = babelHelpers.applyDecoratedDescriptor(_class.prototype, "a", [dec], {
+}()), (_descriptor = babelHelpers.applyDecoratedDescriptor(_class.prototype, "a", [dec], {
   configurable: true,
   enumerable: true,
   writable: true,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/basic/output.js
@@ -25,10 +25,10 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
-};
+}
 
-var _set_privateFieldValue = function (newValue) {
+function _set_privateFieldValue(newValue) {
   babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = newValue;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/get-only-setter/output.js
@@ -17,6 +17,6 @@ class Cl {
 
 }
 
-var _set_privateFieldValue = function (newValue) {
+function _set_privateFieldValue(newValue) {
   babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = newValue;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/reassignment/output.js
@@ -13,6 +13,6 @@ class Foo {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return 42;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/output.js
@@ -18,6 +18,6 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/updates/output.js
@@ -46,10 +46,10 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
-};
+}
 
-var _set_privateFieldValue = function (newValue) {
+function _set_privateFieldValue(newValue) {
   babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = newValue;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/basic/output.js
@@ -25,10 +25,10 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
-};
+}
 
-var _set_privateFieldValue = function (newValue) {
+function _set_privateFieldValue(newValue) {
   babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = newValue;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/get-only-setter/output.js
@@ -17,6 +17,6 @@ class Cl {
 
 }
 
-var _set_privateFieldValue = function (newValue) {
+function _set_privateFieldValue(newValue) {
   babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = newValue;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/output.js
@@ -18,6 +18,6 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/updates/output.js
@@ -46,10 +46,10 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
-};
+}
 
-var _set_privateFieldValue = function (newValue) {
+function _set_privateFieldValue(newValue) {
   babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = newValue;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/basic/output.js
@@ -27,10 +27,10 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldGet(this, _privateField);
-};
+}
 
-var _set_privateFieldValue = function (newValue) {
+function _set_privateFieldValue(newValue) {
   babelHelpers.classPrivateFieldSet(this, _privateField, newValue);
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/get-only-setter/output.js
@@ -19,6 +19,6 @@ class Cl {
 
 }
 
-var _set_privateFieldValue = function (newValue) {
+function _set_privateFieldValue(newValue) {
   babelHelpers.classPrivateFieldSet(this, _privateField, newValue);
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/output.js
@@ -19,6 +19,6 @@ class Foo {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return 42;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
@@ -25,8 +25,8 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldGet(this, _privateField);
-};
+}
 
 var cl = new Cl();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/updates/output.js
@@ -50,10 +50,10 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldGet(this, _privateField);
-};
+}
 
-var _set_privateFieldValue = function (newValue) {
+function _set_privateFieldValue(newValue) {
   babelHelpers.classPrivateFieldSet(this, _privateField, newValue);
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/assumption-constantSuper/private-method-super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/assumption-constantSuper/private-method-super/output.js
@@ -24,6 +24,6 @@ class Sub extends Base {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {
+function _privateMethod2() {
   return Base.prototype.superMethod.call(this);
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/get-set/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/get-set/output.js
@@ -17,10 +17,10 @@ class Cl {
 
 }
 
-var _get_getSet = function () {
+function _get_getSet() {
   return babelHelpers.classPrivateFieldGet(this, _privateField);
-};
+}
 
-var _set_getSet = function (newValue) {
+function _set_getSet(newValue) {
   babelHelpers.classPrivateFieldSet(this, _privateField, newValue);
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/set-get/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/set-get/output.js
@@ -17,10 +17,10 @@ class Cl {
 
 }
 
-var _set_getSet = function (newValue) {
+function _set_getSet(newValue) {
   babelHelpers.classPrivateFieldSet(this, _privateField, newValue);
-};
+}
 
-var _get_getSet = function () {
+function _get_getSet() {
   return babelHelpers.classPrivateFieldGet(this, _privateField);
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/assignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/assignment/output.js
@@ -10,6 +10,6 @@ class Foo {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {
+function _privateMethod2() {
   return 42;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/async/output.js
@@ -13,6 +13,6 @@ class Cl {
 
 }
 
-var _foo2 = async function _foo2() {
+async function _foo2() {
   return 2;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/before-fields/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/before-fields/output.js
@@ -20,6 +20,6 @@ class Cl {
 
 }
 
-var _method2 = function _method2(x) {
+function _method2(x) {
   return x;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/class-expression/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/class-expression/input.js
@@ -1,0 +1,7 @@
+console.log(class A {
+  #foo() {}
+
+  method() {
+    this.#foo();
+  }
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/class-expression/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/class-expression/output.js
@@ -1,0 +1,16 @@
+var _foo;
+
+console.log((_foo = babelHelpers.classPrivateFieldLooseKey("foo"), class A {
+  constructor() {
+    Object.defineProperty(this, _foo, {
+      value: _foo2
+    });
+  }
+
+  method() {
+    babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
+  }
+
+}));
+
+function _foo2() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/context/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/context/output.js
@@ -35,6 +35,6 @@ class Foo {
 
 }
 
-var _getStatus2 = function _getStatus2() {
+function _getStatus2() {
   return this.status;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/exfiltrated/output.js
@@ -15,4 +15,4 @@ class Foo {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {};
+function _privateMethod2() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/generator/output.js
@@ -13,7 +13,7 @@ class Cl {
 
 }
 
-var _foo2 = function* _foo2() {
+function* _foo2() {
   yield 2;
   return 3;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/output.js
@@ -12,6 +12,6 @@ class Foo {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {
+function _privateMethod2() {
   return 42;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/output.js
@@ -25,6 +25,6 @@ class Sub extends Base {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {
+function _privateMethod2() {
   return Base.prototype.superMethod.call(this);
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/assignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/assignment/output.js
@@ -10,6 +10,6 @@ class Foo {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {
+function _privateMethod2() {
   return 42;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/output.js
@@ -13,6 +13,6 @@ class Cl {
 
 }
 
-var _foo2 = async function _foo2() {
+async function _foo2() {
   return 2;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/before-fields/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/before-fields/output.js
@@ -20,6 +20,6 @@ class Cl {
 
 }
 
-var _method2 = function _method2(x) {
+function _method2(x) {
   return x;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/class-expression/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/class-expression/input.js
@@ -1,0 +1,7 @@
+console.log(class A {
+  #foo() {}
+
+  method() {
+    this.#foo();
+  }
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/class-expression/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/class-expression/output.js
@@ -1,0 +1,16 @@
+var _foo;
+
+console.log((_foo = babelHelpers.classPrivateFieldLooseKey("foo"), class A {
+  constructor() {
+    Object.defineProperty(this, _foo, {
+      value: _foo2
+    });
+  }
+
+  method() {
+    babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
+  }
+
+}));
+
+function _foo2() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/context/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/context/output.js
@@ -35,6 +35,6 @@ class Foo {
 
 }
 
-var _getStatus2 = function _getStatus2() {
+function _getStatus2() {
   return this.status;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/exfiltrated/output.js
@@ -15,4 +15,4 @@ class Foo {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {};
+function _privateMethod2() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/generator/output.js
@@ -13,7 +13,7 @@ class Cl {
 
 }
 
-var _foo2 = function* _foo2() {
+function* _foo2() {
   yield 2;
   return 3;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/output.js
@@ -25,6 +25,6 @@ class Sub extends Base {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {
+function _privateMethod2() {
   return babelHelpers.get(babelHelpers.getPrototypeOf(Sub.prototype), "superMethod", this).call(this);
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/assignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/assignment/output.js
@@ -9,6 +9,6 @@ class Foo {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {
+function _privateMethod2() {
   return 42;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/async/output.js
@@ -11,6 +11,6 @@ class Cl {
 
 }
 
-var _foo2 = async function _foo2() {
+async function _foo2() {
   return 2;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/before-fields/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/before-fields/output.js
@@ -20,6 +20,6 @@ class Cl {
 
 }
 
-var _method2 = function _method2(x) {
+function _method2(x) {
   return x;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/class-expression/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/class-expression/input.js
@@ -1,0 +1,7 @@
+console.log(class A {
+  #foo() {}
+
+  method() {
+    this.#foo();
+  }
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/class-expression/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/class-expression/output.js
@@ -1,0 +1,14 @@
+var _foo;
+
+console.log((_foo = new WeakSet(), class A {
+  constructor() {
+    _foo.add(this);
+  }
+
+  method() {
+    babelHelpers.classPrivateMethodGet(this, _foo, _foo2).call(this);
+  }
+
+}));
+
+function _foo2() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/context/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/context/output.js
@@ -33,6 +33,6 @@ class Foo {
 
 }
 
-var _getStatus2 = function _getStatus2() {
+function _getStatus2() {
   return this.status;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/exfiltrated/output.js
@@ -13,4 +13,4 @@ class Foo {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {};
+function _privateMethod2() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/generator/output.js
@@ -11,7 +11,7 @@ class Cl {
 
 }
 
-var _foo2 = function* _foo2() {
+function* _foo2() {
   yield 2;
   return 3;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
@@ -16,4 +16,4 @@ class A {
 
 }
 
-var _method2 = function _method2() {};
+function _method2() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/output.js
@@ -16,6 +16,6 @@ class Foo {
 
 }
 
-var _privateFieldValue2 = function _privateFieldValue2() {
+function _privateFieldValue2() {
   return 42;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/output.js
@@ -24,6 +24,6 @@ class Sub extends Base {
 
 }
 
-var _privateMethod2 = function _privateMethod2() {
+function _privateMethod2() {
   return babelHelpers.get(babelHelpers.getPrototypeOf(Sub.prototype), "superMethod", this).call(this);
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/async/output.js
@@ -5,9 +5,9 @@ class Cl {
 
 }
 
-var _privateStaticMethod = async function _privateStaticMethod() {
+async function _privateStaticMethod() {
   return 2;
-};
+}
 
 return new Cl().test().then(val => {
   expect(val).toBe(2);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/basic/output.js
@@ -23,9 +23,9 @@ class Cl {
 
 }
 
-var _privateStaticMethod2 = function _privateStaticMethod2() {
+function _privateStaticMethod2() {
   return 1017;
-};
+}
 
 Object.defineProperty(Cl, _privateStaticMethod, {
   value: _privateStaticMethod2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/class-check/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/class-check/output.js
@@ -7,7 +7,7 @@ class Cl {
 
 }
 
-var _privateStaticMethod2 = function _privateStaticMethod2() {};
+function _privateStaticMethod2() {}
 
 Object.defineProperty(Cl, _privateStaticMethod, {
   value: _privateStaticMethod2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/class-expression/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/class-expression/input.js
@@ -1,0 +1,7 @@
+console.log(class A {
+  static #foo() {}
+
+  method() {
+    this.#foo();
+  }
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/class-expression/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/class-expression/output.js
@@ -1,0 +1,12 @@
+var _class, _foo, _temp;
+
+console.log((_temp = (_foo = babelHelpers.classPrivateFieldLooseKey("foo"), _class = class A {
+  method() {
+    babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
+  }
+
+}), Object.defineProperty(_class, _foo, {
+  value: _foo2
+}), _temp));
+
+function _foo2() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/exfiltrated/output.js
@@ -11,9 +11,9 @@ class Cl {
 
 }
 
-var _privateStaticMethod2 = function _privateStaticMethod2() {
+function _privateStaticMethod2() {
   return 1017;
-};
+}
 
 Object.defineProperty(Cl, _privateStaticMethod, {
   value: _privateStaticMethod2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/generator/output.js
@@ -7,10 +7,10 @@ class Cl {
 
 }
 
-var _foo2 = function* _foo2() {
+function* _foo2() {
   yield 2;
   return 3;
-};
+}
 
 Object.defineProperty(Cl, _foo, {
   value: _foo2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/reassignment/output.js
@@ -7,7 +7,7 @@ class Cl {
 
 }
 
-var _privateStaticMethod2 = function _privateStaticMethod2() {};
+function _privateStaticMethod2() {}
 
 Object.defineProperty(Cl, _privateStaticMethod, {
   value: _privateStaticMethod2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/output.js
@@ -18,9 +18,9 @@ class Sub extends Base {
 
 }
 
-var _subStaticPrivateMethod2 = function _subStaticPrivateMethod2() {
+function _subStaticPrivateMethod2() {
   return Base.basePublicStaticMethod.call(this);
-};
+}
 
 Object.defineProperty(Sub, _subStaticPrivateMethod, {
   value: _subStaticPrivateMethod2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/this/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/this/output.js
@@ -20,18 +20,17 @@ class B extends A {
 
 }
 
-var _getB2 = function _getB2() {
+function _getA2() {
+  return A.a;
+}
+
+function _getB2() {
   return this.b;
-};
+}
 
 Object.defineProperty(B, _getB, {
   value: _getB2
 });
-
-var _getA2 = function _getA2() {
-  return A.a;
-};
-
 Object.defineProperty(B, _getA, {
   value: _getA2
 });

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/async/output.js
@@ -7,9 +7,9 @@ class Cl {
 
 }
 
-var _privateStaticMethod2 = async function _privateStaticMethod2() {
+async function _privateStaticMethod2() {
   return 2;
-};
+}
 
 Object.defineProperty(Cl, _privateStaticMethod, {
   value: _privateStaticMethod2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/basic/output.js
@@ -23,9 +23,9 @@ class Cl {
 
 }
 
-var _privateStaticMethod2 = function _privateStaticMethod2() {
+function _privateStaticMethod2() {
   return 1017;
-};
+}
 
 Object.defineProperty(Cl, _privateStaticMethod, {
   value: _privateStaticMethod2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-check/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-check/output.js
@@ -7,7 +7,7 @@ class Cl {
 
 }
 
-var _privateStaticMethod2 = function _privateStaticMethod2() {};
+function _privateStaticMethod2() {}
 
 Object.defineProperty(Cl, _privateStaticMethod, {
   value: _privateStaticMethod2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-expression/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-expression/input.js
@@ -1,0 +1,7 @@
+console.log(class A {
+  static #foo() {}
+
+  method() {
+    this.#foo();
+  }
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-expression/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-expression/output.js
@@ -1,0 +1,12 @@
+var _class, _foo, _temp;
+
+console.log((_temp = (_foo = babelHelpers.classPrivateFieldLooseKey("foo"), _class = class A {
+  method() {
+    babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
+  }
+
+}), Object.defineProperty(_class, _foo, {
+  value: _foo2
+}), _temp));
+
+function _foo2() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/exfiltrated/output.js
@@ -11,9 +11,9 @@ class Cl {
 
 }
 
-var _privateStaticMethod2 = function _privateStaticMethod2() {
+function _privateStaticMethod2() {
   return 1017;
-};
+}
 
 Object.defineProperty(Cl, _privateStaticMethod, {
   value: _privateStaticMethod2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/generator/output.js
@@ -7,10 +7,10 @@ class Cl {
 
 }
 
-var _foo2 = function* _foo2() {
+function* _foo2() {
   yield 2;
   return 3;
-};
+}
 
 Object.defineProperty(Cl, _foo, {
   value: _foo2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/reassignment/output.js
@@ -7,7 +7,7 @@ class Cl {
 
 }
 
-var _privateStaticMethod2 = function _privateStaticMethod2() {};
+function _privateStaticMethod2() {}
 
 Object.defineProperty(Cl, _privateStaticMethod, {
   value: _privateStaticMethod2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/output.js
@@ -18,9 +18,9 @@ class Sub extends Base {
 
 }
 
-var _subStaticPrivateMethod2 = function _subStaticPrivateMethod2() {
+function _subStaticPrivateMethod2() {
   return babelHelpers.get(babelHelpers.getPrototypeOf(Sub), "basePublicStaticMethod", this).call(this);
-};
+}
 
 Object.defineProperty(Sub, _subStaticPrivateMethod, {
   value: _subStaticPrivateMethod2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/output.js
@@ -20,18 +20,17 @@ class B extends A {
 
 }
 
-var _getB2 = function _getB2() {
+function _getA2() {
+  return babelHelpers.get(babelHelpers.getPrototypeOf(B), "a", this);
+}
+
+function _getB2() {
   return this.b;
-};
+}
 
 Object.defineProperty(B, _getB, {
   value: _getB2
 });
-
-var _getA2 = function _getA2() {
-  return babelHelpers.get(babelHelpers.getPrototypeOf(B), "a", this);
-};
-
 Object.defineProperty(B, _getA, {
   value: _getA2
 });

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/async/output.js
@@ -5,9 +5,9 @@ class Cl {
 
 }
 
-var _privateStaticMethod = async function _privateStaticMethod() {
+async function _privateStaticMethod() {
   return 2;
-};
+}
 
 return new Cl().test().then(val => {
   expect(val).toBe(2);

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/basic/output.js
@@ -21,6 +21,6 @@ class Cl {
 
 }
 
-var _privateStaticMethod = function _privateStaticMethod() {
+function _privateStaticMethod() {
   return 1017;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/class-check/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/class-check/output.js
@@ -5,4 +5,4 @@ class Cl {
 
 }
 
-var _privateStaticMethod = function _privateStaticMethod() {};
+function _privateStaticMethod() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/class-expression/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/class-expression/input.js
@@ -1,0 +1,7 @@
+console.log(class A {
+  static #foo() {}
+
+  method() {
+    this.#foo();
+  }
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/class-expression/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/class-expression/output.js
@@ -1,0 +1,10 @@
+var _class;
+
+console.log(_class = class A {
+  method() {
+    babelHelpers.classStaticPrivateMethodGet(this, _class, _foo).call(this);
+  }
+
+});
+
+function _foo() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/exfiltrated/output.js
@@ -9,6 +9,6 @@ class Cl {
 
 }
 
-var _privateStaticMethod = function _privateStaticMethod() {
+function _privateStaticMethod() {
   return 1017;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/generator/output.js
@@ -5,7 +5,7 @@ class Cl {
 
 }
 
-var _foo = function* _foo() {
+function* _foo() {
   yield 2;
   return 3;
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/read-only/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/read-only/output.js
@@ -6,4 +6,4 @@ class A {
 
 }
 
-var _method = function _method() {};
+function _method() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/output.js
@@ -16,6 +16,6 @@ class Sub extends Base {
 
 }
 
-var _subStaticPrivateMethod = function _subStaticPrivateMethod() {
+function _subStaticPrivateMethod() {
   return babelHelpers.get(babelHelpers.getPrototypeOf(Sub), "basePublicStaticMethod", this).call(this);
-};
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/this/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/this/output.js
@@ -16,12 +16,12 @@ class B extends A {
 
 }
 
-var _getB = function _getB() {
-  return this.b;
-};
-
-var _getA = function _getA() {
+function _getA() {
   return babelHelpers.get(babelHelpers.getPrototypeOf(B), "a", this);
-};
+}
+
+function _getB() {
+  return this.b;
+}
 
 var [getA, getB] = B.extract();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/basic/output.js
@@ -13,13 +13,13 @@ class Cl {
 
 }
 
-var _set_privateStaticFieldValue = function (newValue) {
-  babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = `Updated: ${newValue}`;
-};
-
-var _get_privateStaticFieldValue = function () {
+function _get_privateStaticFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
-};
+}
+
+function _set_privateStaticFieldValue(newValue) {
+  babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = `Updated: ${newValue}`;
+}
 
 Object.defineProperty(Cl, _privateStaticFieldValue, {
   get: _get_privateStaticFieldValue,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/destructure-set/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/destructure-set/output.js
@@ -9,9 +9,9 @@ class C {
 
 }
 
-var _set_p = function (v) {
+function _set_p(v) {
   babelHelpers.classPrivateFieldLooseBase(C, _q)[_q] = v;
-};
+}
 
 Object.defineProperty(C, _p, {
   get: void 0,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/get-only-setter/output.js
@@ -9,9 +9,9 @@ class Cl {
 
 }
 
-var _set_privateStaticFieldValue = function (newValue) {
+function _set_privateStaticFieldValue(newValue) {
   babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = newValue;
-};
+}
 
 Object.defineProperty(Cl, _privateStaticFieldValue, {
   get: void 0,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/set-only-getter/output.js
@@ -10,9 +10,9 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
-};
+}
 
 Object.defineProperty(Cl, _privateFieldValue, {
   get: _get_privateFieldValue,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/updates/output.js
@@ -34,13 +34,13 @@ class Cl {
 
 }
 
-var _set_privateFieldValue = function (newValue) {
-  babelHelpers.classPrivateFieldLooseBase(Cl, _privateField)[_privateField] = newValue;
-};
-
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(Cl, _privateField)[_privateField];
-};
+}
+
+function _set_privateFieldValue(newValue) {
+  babelHelpers.classPrivateFieldLooseBase(Cl, _privateField)[_privateField] = newValue;
+}
 
 Object.defineProperty(Cl, _privateFieldValue, {
   get: _get_privateFieldValue,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/output.js
@@ -13,13 +13,13 @@ class Cl {
 
 }
 
-var _set_privateStaticFieldValue = function (newValue) {
-  babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = `Updated: ${newValue}`;
-};
-
-var _get_privateStaticFieldValue = function () {
+function _get_privateStaticFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
-};
+}
+
+function _set_privateStaticFieldValue(newValue) {
+  babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = `Updated: ${newValue}`;
+}
 
 Object.defineProperty(Cl, _privateStaticFieldValue, {
   get: _get_privateStaticFieldValue,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/output.js
@@ -9,9 +9,9 @@ class C {
 
 }
 
-var _set_p = function (v) {
+function _set_p(v) {
   babelHelpers.classPrivateFieldLooseBase(C, _q)[_q] = v;
-};
+}
 
 Object.defineProperty(C, _p, {
   get: void 0,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/output.js
@@ -9,9 +9,9 @@ class Cl {
 
 }
 
-var _set_privateStaticFieldValue = function (newValue) {
+function _set_privateStaticFieldValue(newValue) {
   babelHelpers.classPrivateFieldLooseBase(Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = newValue;
-};
+}
 
 Object.defineProperty(Cl, _privateStaticFieldValue, {
   get: void 0,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/output.js
@@ -10,9 +10,9 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField];
-};
+}
 
 Object.defineProperty(Cl, _privateFieldValue, {
   get: _get_privateFieldValue,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/output.js
@@ -34,13 +34,13 @@ class Cl {
 
 }
 
-var _set_privateFieldValue = function (newValue) {
-  babelHelpers.classPrivateFieldLooseBase(Cl, _privateField)[_privateField] = newValue;
-};
-
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classPrivateFieldLooseBase(Cl, _privateField)[_privateField];
-};
+}
+
+function _set_privateFieldValue(newValue) {
+  babelHelpers.classPrivateFieldLooseBase(Cl, _privateField)[_privateField] = newValue;
+}
 
 Object.defineProperty(Cl, _privateFieldValue, {
   get: _get_privateFieldValue,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/basic/output.js
@@ -9,13 +9,13 @@ class Cl {
 
 }
 
-var _set_privateStaticFieldValue = function (newValue) {
-  babelHelpers.classStaticPrivateFieldSpecSet(Cl, Cl, _PRIVATE_STATIC_FIELD, `Updated: ${newValue}`);
-};
-
-var _get_privateStaticFieldValue = function () {
+function _get_privateStaticFieldValue() {
   return babelHelpers.classStaticPrivateFieldSpecGet(Cl, Cl, _PRIVATE_STATIC_FIELD);
-};
+}
+
+function _set_privateStaticFieldValue(newValue) {
+  babelHelpers.classStaticPrivateFieldSpecSet(Cl, Cl, _PRIVATE_STATIC_FIELD, `Updated: ${newValue}`);
+}
 
 var _privateStaticFieldValue = {
   get: _get_privateStaticFieldValue,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/destructure-set/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/destructure-set/output.js
@@ -5,9 +5,9 @@ class C {
 
 }
 
-var _set_p = function (v) {
+function _set_p(v) {
   babelHelpers.classStaticPrivateFieldSpecSet(C, C, _q, v);
-};
+}
 
 var _p = {
   get: void 0,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/get-only-setter/output.js
@@ -5,9 +5,9 @@ class Cl {
 
 }
 
-var _set_privateStaticFieldValue = function (newValue) {
+function _set_privateStaticFieldValue(newValue) {
   babelHelpers.classStaticPrivateFieldSpecSet(Cl, Cl, _PRIVATE_STATIC_FIELD, newValue);
-};
+}
 
 var _privateStaticFieldValue = {
   get: void 0,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/set-only-getter/output.js
@@ -6,9 +6,9 @@ class Cl {
 
 }
 
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classStaticPrivateFieldSpecGet(this, Cl, _privateField);
-};
+}
 
 var _privateFieldValue = {
   get: _get_privateFieldValue,

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/updates/output.js
@@ -32,13 +32,13 @@ class Cl {
 
 }
 
-var _set_privateFieldValue = function (newValue) {
-  babelHelpers.classStaticPrivateFieldSpecSet(Cl, Cl, _privateField, newValue);
-};
-
-var _get_privateFieldValue = function () {
+function _get_privateFieldValue() {
   return babelHelpers.classStaticPrivateFieldSpecGet(Cl, Cl, _privateField);
-};
+}
+
+function _set_privateFieldValue(newValue) {
+  babelHelpers.classStaticPrivateFieldSpecSet(Cl, Cl, _privateField, newValue);
+}
 
 var _privateFieldValue = {
   get: _get_privateFieldValue,

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/accessor/output.js
@@ -14,4 +14,4 @@ class Foo {
 
 }
 
-var _get_foo = function () {};
+function _get_foo() {}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/output.js
@@ -13,4 +13,4 @@ class Foo {
 
 }
 
-var _foo2 = function _foo2() {};
+function _foo2() {}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-accessor/output.js
@@ -7,7 +7,7 @@ class Foo {
 
 }
 
-var _get_foo = function () {};
+function _get_foo() {}
 
 Object.defineProperty(Foo, _foo, {
   get: _get_foo,

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-method/output.js
@@ -7,7 +7,7 @@ class Foo {
 
 }
 
-var _foo2 = function _foo2() {};
+function _foo2() {}
 
 Object.defineProperty(Foo, _foo, {
   value: _foo2

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/accessor/output.js
@@ -20,4 +20,4 @@ let Foo = /*#__PURE__*/function () {
   return Foo;
 }();
 
-var _get_foo = function () {};
+function _get_foo() {}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/method/output.js
@@ -19,4 +19,4 @@ let Foo = /*#__PURE__*/function () {
   return Foo;
 }();
 
-var _foo2 = function _foo2() {};
+function _foo2() {}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/static-accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/static-accessor/output.js
@@ -16,7 +16,7 @@ let Foo = /*#__PURE__*/function () {
   return Foo;
 }();
 
-var _get_foo = function () {};
+function _get_foo() {}
 
 Object.defineProperty(Foo, _foo, {
   get: _get_foo,

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/static-method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/static-method/output.js
@@ -16,7 +16,7 @@ let Foo = /*#__PURE__*/function () {
   return Foo;
 }();
 
-var _foo2 = function _foo2() {};
+function _foo2() {}
 
 Object.defineProperty(Foo, _foo, {
   value: _foo2

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/accessor/output.js
@@ -21,4 +21,4 @@ let Foo = /*#__PURE__*/function () {
   return Foo;
 }();
 
-var _get_foo = function () {};
+function _get_foo() {}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/method/output.js
@@ -18,4 +18,4 @@ let Foo = /*#__PURE__*/function () {
   return Foo;
 }();
 
-var _foo2 = function _foo2() {};
+function _foo2() {}

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/static-accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/static-accessor/output.js
@@ -14,7 +14,7 @@ let Foo = /*#__PURE__*/function () {
   return Foo;
 }();
 
-var _get_foo = function () {};
+function _get_foo() {}
 
 var _foo = {
   get: _get_foo,

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/static-method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/static-method/output.js
@@ -14,4 +14,4 @@ let Foo = /*#__PURE__*/function () {
   return Foo;
 }();
 
-var _foo = function _foo() {};
+function _foo() {}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/decorated-declare-properties/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/decorated-declare-properties/output.js
@@ -1,11 +1,11 @@
-var _class, _descriptor, _temp;
+var _class, _descriptor;
 
-let Foo = (_class = (_temp = class Foo {
+let Foo = (_class = class Foo {
   constructor() {
     babelHelpers.initializerDefineProperty(this, "bar", _descriptor, this);
   }
 
-}, _temp), (_descriptor = babelHelpers.applyDecoratedDescriptor(_class.prototype, "bar", [decorator], {
+}, (_descriptor = babelHelpers.applyDecoratedDescriptor(_class.prototype, "bar", [decorator], {
   configurable: true,
   enumerable: true,
   writable: true,

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/methods-loose-preset-not-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/methods-loose-preset-not-loose/output.js
@@ -10,4 +10,4 @@ class A {
 
 }
 
-var _foo2 = function _foo2() {};
+function _foo2() {}

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/preset-loose-no-plugins/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/preset-loose-no-plugins/output.js
@@ -10,4 +10,4 @@ class A {
 
 }
 
-var _foo2 = function _foo2() {};
+function _foo2() {}

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/preset-not-loose-no-plugins/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/preset-not-loose-no-plugins/output.js
@@ -9,4 +9,4 @@ class A {
 
 }
 
-var _foo2 = function _foo2() {};
+function _foo2() {}

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-loose-preset-not-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-loose-preset-not-loose/output.js
@@ -10,4 +10,4 @@ class A {
 
 }
 
-var _foo2 = function _foo2() {};
+function _foo2() {}

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-not-loose-preset-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-not-loose-preset-loose/output.js
@@ -9,4 +9,4 @@ class A {
 
 }
 
-var _foo2 = function _foo2() {};
+function _foo2() {}

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-loose-preset-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-loose-preset-loose/output.js
@@ -10,4 +10,4 @@ class A {
 
 }
 
-var _foo2 = function _foo2() {};
+function _foo2() {}

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-loose-preset-not-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-loose-preset-not-loose/output.js
@@ -10,4 +10,4 @@ class A {
 
 }
 
-var _foo2 = function _foo2() {};
+function _foo2() {}

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-not-loose-preset-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-not-loose-preset-loose/output.js
@@ -9,4 +9,4 @@ class A {
 
 }
 
-var _foo2 = function _foo2() {};
+function _foo2() {}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | /
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I was working on a prototype for https://github.com/babel/babel/pull/12849#issuecomment-786237020, and I noticed this small output optimization that lets us save a few bytes for each private method.