### PR TITLE
Fix `esmodule: "intersect"` on iOS versions

### DIFF
--- a/packages/babel-compat-data/data/native-modules.json
+++ b/packages/babel-compat-data/data/native-modules.json
@@ -9,9 +9,10 @@
     "opera": "48",
     "op_mob": "48",
     "safari": "10.1",
-    "ios_saf": "10.3",
+    "ios": "10.3",
     "samsung": "8.2",
     "android": "61",
-    "electron": "2.0"
+    "electron": "2.0",
+    "ios_saf": "10.3"
   }
 }

--- a/packages/babel-compat-data/scripts/build-modules-support.js
+++ b/packages/babel-compat-data/scripts/build-modules-support.js
@@ -8,7 +8,7 @@ const { addElectronSupportFromChromium } = require("./chromium-to-electron");
 const browserNameMap = {
   chrome_android: "and_chr",
   firefox_android: "and_ff",
-  safari_ios: "ios_saf",
+  safari_ios: "ios",
   nodejs: "node",
   webview_android: "android",
   opera_android: "op_mob",
@@ -58,8 +58,13 @@ function process(source) {
 }
 
 const dataPath = path.join(__dirname, "../data/native-modules.json");
+const processed = process(compatData.statements.export);
+// Todo(Babel 8): remove `ios_saf` as it is identical to ios
+if (processed.ios) {
+  processed.ios_saf = processed.ios;
+}
 const data = {
-  "es6.module": process(compatData.statements.export),
+  "es6.module": processed,
 };
 fs.writeFileSync(dataPath, `${JSON.stringify(data, null, 2)}\n`);
 exports.process = process;

--- a/packages/babel-helper-compilation-targets/test/__snapshots__/targets-parser.spec.js.snap
+++ b/packages/babel-helper-compilation-targets/test/__snapshots__/targets-parser.spec.js.snap
@@ -7,6 +7,12 @@ Object {
 }
 `;
 
+exports[`getTargets esmodules can be intersected with ios browsers option 1`] = `
+Object {
+  "ios": "12.0.0",
+}
+`;
+
 exports[`getTargets esmodules can be intersected with the browsers option 1`] = `
 Object {
   "chrome": "70.0.0",

--- a/packages/babel-helper-compilation-targets/test/targets-parser.spec.js
+++ b/packages/babel-helper-compilation-targets/test/targets-parser.spec.js
@@ -245,6 +245,15 @@ describe("getTargets", () => {
       ).toMatchSnapshot();
     });
 
+    it("can be intersected with ios browsers option", () => {
+      expect(
+        getTargets({
+          esmodules: "intersect",
+          browsers: ["ios >= 12"],
+        }),
+      ).toMatchSnapshot();
+    });
+
     it("can be intersected with a .browserslistrc file", () => {
       expect(
         getTargets(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `getTargets({ esmodule: "intersect", browsers: ["ios >= 12"] })` returns empty object
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Extracted from #12989 per https://github.com/babel/babel/pull/12989#issuecomment-797076781.