### PR TITLE
Point to CJS files in `@babel/compat-data`'s `exports`

### DIFF
--- a/packages/babel-compat-data/corejs2-built-ins.js
+++ b/packages/babel-compat-data/corejs2-built-ins.js
@@ -1,4 +1,1 @@
-// Node < 13.3 doesn't support export maps in package.json.
-// Use this proxy file as a fallback.
-
 module.exports = require("./data/corejs2-built-ins.json");

--- a/packages/babel-compat-data/corejs3-shipped-proposals.js
+++ b/packages/babel-compat-data/corejs3-shipped-proposals.js
@@ -1,4 +1,1 @@
-// Node < 13.3 doesn't support export maps in package.json.
-// Use this proxy file as a fallback.
-
 module.exports = require("./data/corejs3-shipped-proposals.json");

--- a/packages/babel-compat-data/native-modules.js
+++ b/packages/babel-compat-data/native-modules.js
@@ -1,4 +1,1 @@
-// Node < 13.3 doesn't support export maps in package.json.
-// Use this proxy file as a fallback.
-
 module.exports = require("./data/native-modules.json");

--- a/packages/babel-compat-data/overlapping-plugins.js
+++ b/packages/babel-compat-data/overlapping-plugins.js
@@ -1,4 +1,1 @@
-// Node < 13.3 doesn't support export maps in package.json.
-// Use this proxy file as a fallback.
-
 module.exports = require("./data/overlapping-plugins.json");

--- a/packages/babel-compat-data/package.json
+++ b/packages/babel-compat-data/package.json
@@ -13,12 +13,12 @@
     "access": "public"
   },
   "exports": {
-    "./plugins": "./data/plugins.json",
-    "./native-modules": "./data/native-modules.json",
-    "./corejs2-built-ins": "./data/corejs2-built-ins.json",
-    "./corejs3-shipped-proposals": "./data/corejs3-shipped-proposals.json",
-    "./overlapping-plugins": "./data/overlapping-plugins.json",
-    "./plugin-bugfixes": "./data/plugin-bugfixes.json"
+    "./plugins": "./plugins.js",
+    "./native-modules": "./native-modules.js",
+    "./corejs2-built-ins": "./corejs2-built-ins.js",
+    "./corejs3-shipped-proposals": "./corejs3-shipped-proposals.js",
+    "./overlapping-plugins": "./overlapping-plugins.js",
+    "./plugin-bugfixes": "./plugin-bugfixes.js"
   },
   "scripts": {
     "build-data": "./scripts/download-compat-table.sh && node ./scripts/build-data.js && node ./scripts/build-modules-support.js && node ./scripts/build-bugfixes-targets.js"

--- a/packages/babel-compat-data/plugin-bugfixes.js
+++ b/packages/babel-compat-data/plugin-bugfixes.js
@@ -1,4 +1,1 @@
-// Node < 13.3 doesn't support export maps in package.json.
-// Use this proxy file as a fallback.
-
 module.exports = require("./data/plugin-bugfixes.json");

--- a/packages/babel-compat-data/plugins.js
+++ b/packages/babel-compat-data/plugins.js
@@ -1,4 +1,1 @@
-// Node < 13.3 doesn't support export maps in package.json.
-// Use this proxy file as a fallback.
-
 module.exports = require("./data/plugins.json");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`.json` files cannot be imported in native ESM files ([docs](https://nodejs.org/api/esm.html#esm_json_modules)). Always pointing to the CJS proxies makes `@babel/compat-data` work both with `require()` and `import`.