### PR TITLE
Update compat data

### DIFF
--- a/packages/babel-compat-data/data/overlapping-plugins.json
+++ b/packages/babel-compat-data/data/overlapping-plugins.json
@@ -16,6 +16,6 @@
     "bugfix/transform-tagged-template-caching"
   ],
   "proposal-optional-chaining": [
-    "bugfix/transform-v8-spread-parameters-after-optional-chaining"
+    "bugfix/transform-v8-spread-parameters-in-optional-chaining"
   ]
 }

--- a/packages/babel-compat-data/data/overlapping-plugins.json
+++ b/packages/babel-compat-data/data/overlapping-plugins.json
@@ -14,5 +14,8 @@
   ],
   "transform-template-literals": [
     "bugfix/transform-tagged-template-caching"
+  ],
+  "proposal-optional-chaining": [
+    "bugfix/transform-v8-spread-parameters-after-optional-chaining"
   ]
 }

--- a/packages/babel-compat-data/data/plugin-bugfixes.json
+++ b/packages/babel-compat-data/data/plugin-bugfixes.json
@@ -133,7 +133,7 @@
     "samsung": "13",
     "electron": "8.0"
   },
-  "bugfix/transform-v8-spread-parameters-after-optional-chaining": {
+  "bugfix/transform-v8-spread-parameters-in-optional-chaining": {
     "firefox": "74",
     "safari": "13.1",
     "ios": "13.4"

--- a/packages/babel-compat-data/data/plugin-bugfixes.json
+++ b/packages/babel-compat-data/data/plugin-bugfixes.json
@@ -121,5 +121,21 @@
     "ios": "13",
     "samsung": "3.4",
     "electron": "0.21"
+  },
+  "proposal-optional-chaining": {
+    "chrome": "80",
+    "opera": "67",
+    "edge": "80",
+    "firefox": "74",
+    "safari": "13.1",
+    "node": "14",
+    "ios": "13.4",
+    "samsung": "13",
+    "electron": "8.0"
+  },
+  "bugfix/transform-v8-spread-parameters-after-optional-chaining": {
+    "firefox": "74",
+    "safari": "13.1",
+    "ios": "13.4"
   }
 }

--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -47,15 +47,9 @@
     "electron": "8.0"
   },
   "proposal-optional-chaining": {
-    "chrome": "80",
-    "opera": "67",
-    "edge": "80",
     "firefox": "74",
     "safari": "13.1",
-    "node": "14",
-    "ios": "13.4",
-    "samsung": "13",
-    "electron": "8.0"
+    "ios": "13.4"
   },
   "proposal-json-strings": {
     "chrome": "66",

--- a/packages/babel-compat-data/scripts/build-bugfixes-targets.js
+++ b/packages/babel-compat-data/scripts/build-bugfixes-targets.js
@@ -44,7 +44,10 @@ for (const [plugin, { replaces, features }] of Object.entries(data)) {
 
 for (const [replaced, features] of Object.entries(allReplacedFeatures)) {
   let replacedFeatures = pluginFeatures[replaced];
-  if (!Array.isArray(replacedFeatures)) {
+  if (
+    typeof replacedFeatures === "object" &&
+    !Array.isArray(replacedFeatures)
+  ) {
     replacedFeatures = replacedFeatures.features;
   }
 

--- a/packages/babel-compat-data/scripts/data/plugin-bugfixes.js
+++ b/packages/babel-compat-data/scripts/data/plugin-bugfixes.js
@@ -35,4 +35,10 @@ module.exports = {
     features: ["template literals / TemplateStrings permanent caching"],
     replaces: "transform-template-literals",
   },
+  "bugfix/transform-v8-spread-parameters-after-optional-chaining": {
+    features: [
+      "optional chaining operator (?.) / spread parameters after optional chaining",
+    ],
+    replaces: "proposal-optional-chaining",
+  },
 };

--- a/packages/babel-compat-data/scripts/data/plugin-bugfixes.js
+++ b/packages/babel-compat-data/scripts/data/plugin-bugfixes.js
@@ -35,7 +35,7 @@ module.exports = {
     features: ["template literals / TemplateStrings permanent caching"],
     replaces: "transform-template-literals",
   },
-  "bugfix/transform-v8-spread-parameters-after-optional-chaining": {
+  "bugfix/transform-v8-spread-parameters-in-optional-chaining": {
     features: [
       "optional chaining operator (?.) / spread parameters after optional chaining",
     ],

--- a/packages/babel-compat-data/scripts/download-compat-table.sh
+++ b/packages/babel-compat-data/scripts/download-compat-table.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-COMPAT_TABLE_COMMIT=ec317e988ed0011cc5d24364e0f4f3a2e86d1f7f
+COMPAT_TABLE_COMMIT=ab73608bddb6895f6f3296c03dba057b47ba8aea
 GIT_HEAD=build/compat-table/.git/HEAD
 
 if [ -d "build/compat-table" ]; then

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -18,7 +18,7 @@ Using plugins:
   proposal-numeric-separator { "ios":"12.2" }
   proposal-logical-assignment-operators { "chrome":"84", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
   proposal-nullish-coalescing-operator { "ios":"12.2", "samsung":"11.1" }
-  proposal-optional-chaining { "ios":"12.2", "samsung":"11.1" }
+  proposal-optional-chaining { "android":"85", "chrome":"84", "edge":"85", "ios":"12.2", "opera":"71", "samsung":"11.1" }
   syntax-json-strings { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
   syntax-optional-catch-binding { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
   syntax-async-generators { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -19,7 +19,7 @@ Using plugins:
   proposal-numeric-separator { "ie":"11", "ios":"12.2" }
   proposal-logical-assignment-operators { "chrome":"84", "firefox":"78", "ie":"11", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
   proposal-nullish-coalescing-operator { "ie":"11", "ios":"12.2", "samsung":"11.1" }
-  proposal-optional-chaining { "ie":"11", "ios":"12.2", "samsung":"11.1" }
+  proposal-optional-chaining { "android":"85", "chrome":"84", "edge":"85", "ie":"11", "ios":"12.2", "opera":"71", "samsung":"11.1" }
   proposal-json-strings { "ie":"11" }
   proposal-optional-catch-binding { "ie":"11" }
   transform-parameters { "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -18,7 +18,7 @@ Using plugins:
   syntax-numeric-separator { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
   proposal-logical-assignment-operators { "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
   proposal-nullish-coalescing-operator { "samsung":"11.1" }
-  proposal-optional-chaining { "samsung":"11.1" }
+  proposal-optional-chaining { "android":"85", "chrome":"85", "edge":"85", "opera":"71", "samsung":"11.1" }
   syntax-json-strings { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
   syntax-optional-catch-binding { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
   syntax-async-generators { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
@@ -13,7 +13,7 @@ Using plugins:
   syntax-numeric-separator { "chrome":"80" }
   proposal-logical-assignment-operators { "chrome":"80" }
   syntax-nullish-coalescing-operator { "chrome":"80" }
-  syntax-optional-chaining { "chrome":"80" }
+  proposal-optional-chaining { "chrome":"80" }
   syntax-json-strings { "chrome":"80" }
   syntax-optional-catch-binding { "chrome":"80" }
   syntax-async-generators { "chrome":"80" }

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
@@ -12,7 +12,7 @@ Using plugins:
   syntax-numeric-separator { "chrome":"84" }
   proposal-logical-assignment-operators { "chrome":"84" }
   syntax-nullish-coalescing-operator { "chrome":"84" }
-  syntax-optional-chaining { "chrome":"84" }
+  proposal-optional-chaining { "chrome":"84" }
   syntax-json-strings { "chrome":"84" }
   syntax-optional-catch-binding { "chrome":"84" }
   syntax-async-generators { "chrome":"84" }

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
@@ -11,7 +11,7 @@ Using plugins:
   syntax-numeric-separator { "chrome":"80" }
   proposal-logical-assignment-operators { "chrome":"80" }
   syntax-nullish-coalescing-operator { "chrome":"80" }
-  syntax-optional-chaining { "chrome":"80" }
+  proposal-optional-chaining { "chrome":"80" }
   syntax-json-strings { "chrome":"80" }
   syntax-optional-catch-binding { "chrome":"80" }
   syntax-async-generators { "chrome":"80" }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The second step on fixing #13001
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR bumps `compat-table` and adds support data on the upcoming `bugfix/transform-v8-spread-parameters-after-optional-chaining`.