### PR TITLE
Fix importing polyfill plugins in the Rollup bundle

### DIFF
--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -166,6 +166,20 @@ const require = createRequire(import.meta.url);
           "function Foo() {\n  this instanceof Foo ? this.constructor : void 0;\n}",
         );
       });
+
+      it("useBuiltIns works", () => {
+        const output = Babel.transform("[].includes(2)", {
+          sourceType: "module",
+          presets: [
+            ["env", { useBuiltIns: "usage", corejs: 3, modules: false }],
+          ],
+        }).code;
+
+        expect(output).toMatchInlineSnapshot(`
+          "import \\"core-js/modules/es.array.includes.js\\";
+          [].includes(2);"
+        `);
+      });
     });
 
     describe("custom plugins and presets", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/13016
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The polyfill plugins are ESM files compiled down to CJS, and thus they have an `__esModule: true` property.

When bundling CJS files that have the `__esModule: true` option, Rollup matches the default Babel interop and transforms `import foo from "foo"` to `const foo = require("foo").default` (rather than `const foo = require("foo")`, as Node.js does).

This PR introduces a small Babel plugins that rewrites those specific `import foo` to `import * as foo` when bundling.

I opened https://github.com/rollup/plugins/pull/838 to see if the Rollup community is interested in aligning with Node.js.