### PR TITLE
babel-parser: Sort error keys with ESLint

### DIFF
--- a/packages/babel-parser/src/plugins/jsx/index.js
+++ b/packages/babel-parser/src/plugins/jsx/index.js
@@ -19,11 +19,12 @@ import { Errors } from "../../parser/error";
 const HEX_NUMBER = /^[\da-fA-F]+$/;
 const DECIMAL_NUMBER = /^\d+$/;
 
+/* eslint sort-keys: "error" */
 const JsxErrors = Object.freeze({
   AttributeIsEmpty:
     "JSX attributes must only be assigned a non-empty expression",
-  MissingClosingTagFragment: "Expected corresponding JSX closing tag for <>",
   MissingClosingTagElement: "Expected corresponding JSX closing tag for <%0>",
+  MissingClosingTagFragment: "Expected corresponding JSX closing tag for <>",
   UnexpectedSequenceExpression:
     "Sequence expressions cannot be directly nested inside JSX. Did you mean to wrap it in parentheses (...)?",
   UnsupportedJsxValue:
@@ -32,6 +33,7 @@ const JsxErrors = Object.freeze({
   UnwrappedAdjacentJSXElements:
     "Adjacent JSX elements must be wrapped in an enclosing tag. Did you want a JSX fragment <>...</>?",
 });
+/* eslint-disable sort-keys */
 
 // Be aware that this file is always executed and not only when the plugin is enabled.
 // Therefore this contexts and tokens do always exist.

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -59,6 +59,7 @@ type ParsingContext =
   | "TypeMembers"
   | "TypeParametersOrArguments";
 
+/* eslint sort-keys: "error" */
 const TSErrors = Object.freeze({
   AbstractMethodHasImplementation:
     "Method '%0' cannot have an implementation because it is marked abstract.",
@@ -70,8 +71,8 @@ const TSErrors = Object.freeze({
     "Initializers are not allowed in ambient contexts.",
   DeclareFunctionHasImplementation:
     "An implementation cannot be declared in ambient contexts.",
-  DuplicateModifier: "Duplicate modifier: '%0'",
   DuplicateAccessibilityModifier: "Accessibility modifier already seen.",
+  DuplicateModifier: "Duplicate modifier: '%0'",
   EmptyHeritageClauseType: "'%0' list cannot be empty.",
   EmptyTypeArguments: "Type argument list cannot be empty.",
   EmptyTypeParameters: "Type parameter list cannot be empty.",
@@ -82,9 +83,9 @@ const TSErrors = Object.freeze({
     "Index signatures cannot have the 'abstract' modifier",
   IndexSignatureHasAccessibility:
     "Index signatures cannot have an accessibility modifier ('%0')",
-  IndexSignatureHasStatic: "Index signatures cannot have the 'static' modifier",
   IndexSignatureHasDeclare:
     "Index signatures cannot have the 'declare' modifier",
+  IndexSignatureHasStatic: "Index signatures cannot have the 'static' modifier",
   InvalidModifierOnTypeMember: "'%0' modifier cannot appear on a type member.",
   InvalidTupleMemberLabel:
     "Tuple members must be labeled with a simple identifier.",
@@ -119,6 +120,7 @@ const TSErrors = Object.freeze({
   UnsupportedSignatureParameterKind:
     "Name in a signature must be an Identifier, ObjectPattern or ArrayPattern, instead got %0",
 });
+/* eslint-disable sort-keys */
 
 // Doesn't handle "void" or "null" because those are keywords, not identifiers.
 // It also doesn't handle "intrinsic", since usually it's not a keyword.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Y
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Similar to the Flow plugin and the core, sort jsx and typescript plugins error message objects by key.