### PR TITLE
Correctly handle relative `browserslistConfigFile` paths

### DIFF
--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -126,7 +126,7 @@ export default function* loadPrivatePartialConfig(
 
   const options: NormalizedOptions = {
     ...merged,
-    targets: resolveTargets(merged, absoluteRootDir, absoluteRootDir),
+    targets: resolveTargets(merged, absoluteRootDir),
 
     // Tack the passes onto the object itself so that, if this object is
     // passed back to Babel a second time, it will be in the right structure

--- a/packages/babel-core/src/config/resolve-targets-browser.js
+++ b/packages/babel-core/src/config/resolve-targets-browser.js
@@ -3,12 +3,19 @@
 import type { ValidatedOptions } from "./validation/options";
 import getTargets, { type Targets } from "@babel/helper-compilation-targets";
 
+export function resolveBrowserslistConfigFile(
+  // eslint-disable-next-line no-unused-vars
+  browserslistConfigFile: string,
+  // eslint-disable-next-line no-unused-vars
+  configFilePath: string,
+): string | void {
+  return undefined;
+}
+
 export function resolveTargets(
   options: ValidatedOptions,
   // eslint-disable-next-line no-unused-vars
   root: string,
-  // eslint-disable-next-line no-unused-vars
-  configFilePath: string | void,
 ): Targets {
   let { targets } = options;
   if (typeof targets === "string" || Array.isArray(targets)) {

--- a/packages/babel-core/src/config/resolve-targets.js
+++ b/packages/babel-core/src/config/resolve-targets.js
@@ -11,10 +11,16 @@ import type { ValidatedOptions } from "./validation/options";
 import path from "path";
 import getTargets, { type Targets } from "@babel/helper-compilation-targets";
 
+export function resolveBrowserslistConfigFile(
+  browserslistConfigFile: string,
+  configFileDir: string,
+): string | void {
+  return path.resolve(configFileDir, browserslistConfigFile);
+}
+
 export function resolveTargets(
   options: ValidatedOptions,
   root: string,
-  configFilePath: string = root,
 ): Targets {
   let { targets } = options;
   if (typeof targets === "string" || Array.isArray(targets)) {
@@ -25,14 +31,11 @@ export function resolveTargets(
     targets = { ...targets, esmodules: "intersect" };
   }
 
-  let configFile;
-  if (typeof options.browserslistConfigFile === "string") {
-    configFile = path.resolve(configFilePath, options.browserslistConfigFile);
-  }
+  const { browserslistConfigFile } = options;
 
   return getTargets((targets: any), {
-    ignoreBrowserslistConfig: options.browserslistConfigFile === false,
-    configFile,
+    ignoreBrowserslistConfig: browserslistConfigFile === false,
+    configFile: browserslistConfigFile,
     configPath: root,
     browserslistEnv: options.browserslistEnv,
   });

--- a/packages/babel-core/src/config/resolve-targets.js
+++ b/packages/babel-core/src/config/resolve-targets.js
@@ -32,10 +32,17 @@ export function resolveTargets(
   }
 
   const { browserslistConfigFile } = options;
+  let configFile;
+  let ignoreBrowserslistConfig = false;
+  if (typeof browserslistConfigFile === "string") {
+    configFile = browserslistConfigFile;
+  } else {
+    ignoreBrowserslistConfig = browserslistConfigFile === false;
+  }
 
   return getTargets((targets: any), {
-    ignoreBrowserslistConfig: browserslistConfigFile === false,
-    configFile: browserslistConfigFile,
+    ignoreBrowserslistConfig,
+    configFile,
     configPath: root,
     browserslistEnv: options.browserslistEnv,
   });

--- a/packages/babel-core/test/targets.js
+++ b/packages/babel-core/test/targets.js
@@ -100,19 +100,6 @@ describe("browserslist", () => {
     ).toEqual({ chrome: "80.0.0" });
   });
 
-  // TODO: browserslistConfig is currently resolved starting from the root
-  // rather than from the config file.
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("loads nested .browserslistrc files if explicitly specified", () => {
-    expect(
-      loadOptions({
-        cwd: join(cwd, "fixtures", "targets"),
-        filename: "./node_modules/dep/test.js",
-        babelrcRoots: ["./node_modules/dep/"],
-      }).targets,
-    ).toEqual({ edge: "14.0.0" });
-  });
-
   describe("browserslistConfigFile", () => {
     it("can disable config loading", () => {
       expect(
@@ -132,15 +119,25 @@ describe("browserslist", () => {
       ).toEqual({ firefox: "74.0.0" });
     });
 
-    it("is relative to the project root", () => {
+    it("is relative to the cwd even if specifying 'root'", () => {
       expect(
         loadOptions({
           cwd: join(cwd, "fixtures", "targets"),
           root: "..",
           filename: "./nested/test.js",
-          browserslistConfigFile: "./targets/.browserslistrc-firefox",
+          browserslistConfigFile: "./.browserslistrc-firefox",
         }).targets,
       ).toEqual({ firefox: "74.0.0" });
+    });
+
+    it("is relative to the config files that defines it", () => {
+      expect(
+        loadOptions({
+          cwd: join(cwd, "fixtures", "targets"),
+          filename: "./node_modules/dep/test.js",
+          babelrcRoots: ["./node_modules/dep/"],
+        }).targets,
+      ).toEqual({ edge: "14.0.0" });
     });
   });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/pull/13028#discussion_r597631093
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2469 <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The first commit is from https://github.com/babel/babel/pull/13028, please review that PR first.

The current behavior of `browserslistConfigFile` is to be always resolved relative to the project root, regardless of where it's set. This PR changes it to be resolved:
1. Relative to the config file where it's specified
2. Relative to `cwd`, if it's specified in programmatic options

This aligns it behavior with every other Babel option whose value can be a relative path (`extends`, `plugins`, `presets`), and (when used as a progrmmatic option) with how Node.js generally handles relative paths (they are always resolved relative to the cwd).

This change is technically observable, but probably no one ever reported it as a bug because in 99% of the cases `root` === `cwd` === `config file location`.