### PR TITLE
fix: the LHS in for-of loop should not start with let

### DIFF
--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -57,6 +57,7 @@ export const ErrorMessages = Object.freeze({
     "'from' is not allowed as an identifier after 'export default'",
   ForInOfLoopInitializer:
     "%0 loop variable declaration may not have an initializer",
+  ForOfLet: "The left-hand side of a for-of loop may not start with 'let'.",
   GeneratorInSingleStatementContext:
     "Generators can only be declared at the top level or inside a block",
   IllegalBreakContinue: "Unsyntactic %0",

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -548,7 +548,7 @@ export default class StatementParser extends ExpressionParser {
     const refExpressionErrors = new ExpressionErrors();
     const init = this.parseExpression(true, refExpressionErrors);
     const isForOf = this.isContextual("of");
-    if (this.match(tt._in) || isForOf) {
+    if (isForOf || this.match(tt._in)) {
       if (isForOf && startsWithLet) {
         this.raise(init.start, Errors.ForOfLet);
       }

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -125,6 +125,19 @@ export default class StatementParser extends ExpressionParser {
     if (!this.isContextual("let")) {
       return false;
     }
+    return this.isLetKeyword(context);
+  }
+
+  /**
+   * Assuming we have seen a contextual `let`, check if it starts a variable declaration
+   so that `left` should be interpreted as a `let` keyword.
+   *
+   * @param {?string} context When `context` is non nullish, it will return early and _skip_ checking
+                              if the next token after `let` is `{` or a keyword relational operator
+   * @returns {boolean}
+   * @memberof StatementParser
+   */
+  isLetKeyword(context: ?string): boolean {
     const next = this.nextTokenStart();
     const nextCh = this.input.charCodeAt(next);
     // For ambiguous cases, determine if a LexicalDeclaration (or only a
@@ -511,7 +524,8 @@ export default class StatementParser extends ExpressionParser {
       return this.parseFor(node, null);
     }
 
-    const isLet = this.isLet();
+    const startsWithLet = this.isContextual("let");
+    const isLet = startsWithLet && this.isLetKeyword();
     if (this.match(tt._var) || this.match(tt._const) || isLet) {
       const init = this.startNode();
       const kind = isLet ? "let" : this.state.value;
@@ -533,11 +547,13 @@ export default class StatementParser extends ExpressionParser {
 
     const refExpressionErrors = new ExpressionErrors();
     const init = this.parseExpression(true, refExpressionErrors);
-    if (this.match(tt._in) || this.isContextual("of")) {
+    const isForOf = this.isContextual("of");
+    if (this.match(tt._in) || isForOf) {
+      if (isForOf && startsWithLet) {
+        this.raise(init.start, Errors.ForOfLet);
+      }
       this.toAssignable(init, /* isLHS */ true);
-      const description = this.isContextual("of")
-        ? "for-of statement"
-        : "for-in statement";
+      const description = isForOf ? "for-of statement" : "for-in statement";
       this.checkLVal(init, description);
       return this.parseForIn(node, init, awaitAt);
     } else {

--- a/packages/babel-parser/test/fixtures/es2015/for-of/invalid-let-as-identifier/input.js
+++ b/packages/babel-parser/test/fixtures/es2015/for-of/invalid-let-as-identifier/input.js
@@ -1,0 +1,3 @@
+for (let.foo of []);
+for (let().bar of []);
+for (let``.bar of []);

--- a/packages/babel-parser/test/fixtures/es2015/for-of/invalid-let-as-identifier/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/for-of/invalid-let-as-identifier/output.json
@@ -1,0 +1,130 @@
+{
+  "type": "File",
+  "start":0,"end":66,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":22}},
+  "errors": [
+    "SyntaxError: The left-hand side of a for-of loop may not start with 'let'. (1:5)",
+    "SyntaxError: The left-hand side of a for-of loop may not start with 'let'. (2:5)",
+    "SyntaxError: The left-hand side of a for-of loop may not start with 'let'. (3:5)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":66,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":22}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ForOfStatement",
+        "start":0,"end":20,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":20}},
+        "await": false,
+        "left": {
+          "type": "MemberExpression",
+          "start":5,"end":12,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":12}},
+          "object": {
+            "type": "Identifier",
+            "start":5,"end":8,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":8},"identifierName":"let"},
+            "name": "let"
+          },
+          "computed": false,
+          "property": {
+            "type": "Identifier",
+            "start":9,"end":12,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":12},"identifierName":"foo"},
+            "name": "foo"
+          }
+        },
+        "right": {
+          "type": "ArrayExpression",
+          "start":16,"end":18,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":18}},
+          "elements": []
+        },
+        "body": {
+          "type": "EmptyStatement",
+          "start":19,"end":20,"loc":{"start":{"line":1,"column":19},"end":{"line":1,"column":20}}
+        }
+      },
+      {
+        "type": "ForOfStatement",
+        "start":21,"end":43,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":22}},
+        "await": false,
+        "left": {
+          "type": "MemberExpression",
+          "start":26,"end":35,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":14}},
+          "object": {
+            "type": "CallExpression",
+            "start":26,"end":31,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":10}},
+            "callee": {
+              "type": "Identifier",
+              "start":26,"end":29,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":8},"identifierName":"let"},
+              "name": "let"
+            },
+            "arguments": []
+          },
+          "computed": false,
+          "property": {
+            "type": "Identifier",
+            "start":32,"end":35,"loc":{"start":{"line":2,"column":11},"end":{"line":2,"column":14},"identifierName":"bar"},
+            "name": "bar"
+          }
+        },
+        "right": {
+          "type": "ArrayExpression",
+          "start":39,"end":41,"loc":{"start":{"line":2,"column":18},"end":{"line":2,"column":20}},
+          "elements": []
+        },
+        "body": {
+          "type": "EmptyStatement",
+          "start":42,"end":43,"loc":{"start":{"line":2,"column":21},"end":{"line":2,"column":22}}
+        }
+      },
+      {
+        "type": "ForOfStatement",
+        "start":44,"end":66,"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":22}},
+        "await": false,
+        "left": {
+          "type": "MemberExpression",
+          "start":49,"end":58,"loc":{"start":{"line":3,"column":5},"end":{"line":3,"column":14}},
+          "object": {
+            "type": "TaggedTemplateExpression",
+            "start":49,"end":54,"loc":{"start":{"line":3,"column":5},"end":{"line":3,"column":10}},
+            "tag": {
+              "type": "Identifier",
+              "start":49,"end":52,"loc":{"start":{"line":3,"column":5},"end":{"line":3,"column":8},"identifierName":"let"},
+              "name": "let"
+            },
+            "quasi": {
+              "type": "TemplateLiteral",
+              "start":52,"end":54,"loc":{"start":{"line":3,"column":8},"end":{"line":3,"column":10}},
+              "expressions": [],
+              "quasis": [
+                {
+                  "type": "TemplateElement",
+                  "start":53,"end":53,"loc":{"start":{"line":3,"column":9},"end":{"line":3,"column":9}},
+                  "value": {
+                    "raw": "",
+                    "cooked": ""
+                  },
+                  "tail": true
+                }
+              ]
+            }
+          },
+          "computed": false,
+          "property": {
+            "type": "Identifier",
+            "start":55,"end":58,"loc":{"start":{"line":3,"column":11},"end":{"line":3,"column":14},"identifierName":"bar"},
+            "name": "bar"
+          }
+        },
+        "right": {
+          "type": "ArrayExpression",
+          "start":62,"end":64,"loc":{"start":{"line":3,"column":18},"end":{"line":3,"column":20}},
+          "elements": []
+        },
+        "body": {
+          "type": "EmptyStatement",
+          "start":65,"end":66,"loc":{"start":{"line":3,"column":21},"end":{"line":3,"column":22}}
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes same issue as https://github.com/acornjs/acorn/issues/1009
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The error message is copied from https://cs.chromium.org/chromium/src/v8/src/common/message-template.h. 

A new routine `isLetKeyword` is extracted from `isLet` so we don't introduce extra contextual check of `let`.