### PR TITLE
fix: constant variables only enable constant react elements

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.js
@@ -64,11 +64,15 @@ export default declare((api, options) => {
       // Ignore identifiers & JSX expressions.
       if (
         path.isJSXIdentifier() ||
-        path.isIdentifier() ||
         path.isJSXMemberExpression() ||
         path.isJSXNamespacedName()
       ) {
         return;
+      }
+
+      if (path.isIdentifier()) {
+        const binding = path.scope.getBinding(path.node.name);
+        if (binding && binding.constant) return;
       }
 
       if (!path.isImmutable()) {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/deopt-mutable-complex/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/deopt-mutable-complex/output.mjs
@@ -1,5 +1,3 @@
-var _span;
-
 let foo = 'hello';
 
 const mutate = () => {
@@ -8,5 +6,5 @@ const mutate = () => {
 
 export const Component = () => {
   if (Math.random() > 0.5) mutate();
-  return _span || (_span = <span>{foo}</span>);
+  return <span>{foo}</span>;
 };

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/deopt-mutable/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/deopt-mutable/output.mjs
@@ -1,7 +1,5 @@
-var _span;
-
 let foo = 'hello';
 export const Component = () => {
   foo = 'goodbye';
-  return _span || (_span = <span>{foo}</span>);
+  return <span>{foo}</span>;
 };

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/for-loop/input.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/for-loop/input.js
@@ -1,0 +1,10 @@
+function render() {
+    const nodes = [];
+
+    for(let i = 0; i < 5; i++) {
+        nodes.push(<div>{i}</div>)
+    }
+
+    return nodes;
+}
+  

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/for-loop/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/for-loop/output.js
@@ -1,0 +1,10 @@
+function render() {
+  const nodes = [];
+
+  for (let i = 0; i < 5; i++) {
+    nodes.push(<div>{i}</div>);
+  }
+
+  return nodes;
+}
+  

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/global-reference/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/global-reference/output.js
@@ -1,7 +1,5 @@
-var _div;
-
 var Foo = React.createClass({
   render: function render() {
-    return _div || (_div = <div foo={notDeclared}></div>);
+    return <div foo={notDeclared}></div>;
   }
 });


### PR DESCRIPTION
fix: constant variables only enable constant react elements

fix #13051

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | fix #13051
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

After submitting the issue 13051, @jridgewell suggested this fix.  Thank you for your help @jridgewell.
