### PR TITLE
Change babel/eslint-parser's inclusion of eslint-scope to be compatible with ESlint

### DIFF
--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -30,7 +30,7 @@
     "eslint": ">=7.5.0"
   },
   "dependencies": {
-    "eslint-scope": "5.1.0",
+    "eslint-scope": "^5.1.0",
     "eslint-visitor-keys": "^1.3.0",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,7 +238,7 @@ __metadata:
     "@babel/core": "workspace:*"
     dedent: ^0.7.0
     eslint: ^7.5.0
-    eslint-scope: 5.1.0
+    eslint-scope: ^5.1.0
     eslint-visitor-keys: ^1.3.0
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   peerDependencies:
@@ -7570,16 +7570,6 @@ __metadata:
   version: 0.3.0
   resolution: "eslint-rule-composer@npm:0.3.0"
   checksum: eb96fffa4eb2cc40061bf082bb4cc48df746e9c556e4b20c653e1b84b34cabd66462bafad124d44ea2b89a750a2aec26c21507bd7b8b23f355136a8901e09d00
-  languageName: node
-  linkType: hard
-
-"eslint-scope@npm:5.1.0":
-  version: 5.1.0
-  resolution: "eslint-scope@npm:5.1.0"
-  dependencies:
-    esrecurse: ^4.1.0
-    estraverse: ^4.1.1
-  checksum: 4a0e97979a855d09c4bb3a3f4f945cefaf8f6638a6a8f49472cefb0cf64982ab7ed1683a1e63d20ce1bcb01f94c133dc7a5bdf03b28eb945999f50f08878a2b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

[eslint-scope](https://github.com/eslint/eslint-scope) is included as a dependency within `@babel/eslint-parser` using exact matching, i.e. only `5.1.0`.

However since before ESLint version 7.5.0, ESLint has specified `eslint-scope` as `^5.1.0`, and in more recent versions it is `^5.1.1`. This means multiple versions can end up in the node dependency tree for those using ESLint with Babel, potentially causing conflicts or other issues.

This PR updates the dependency to match that of ESLint, so that the dependency tree for projects will only have one version of `eslint-scope`.