### PR TITLE
Compile classes when spread is unsupported

### DIFF
--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -320,7 +320,7 @@
     "chrome": "46",
     "opera": "33",
     "edge": "13",
-    "firefox": "36",
+    "firefox": "45",
     "safari": "10",
     "node": "5",
     "ios": "10",

--- a/packages/babel-compat-data/scripts/data/plugin-features.js
+++ b/packages/babel-compat-data/scripts/data/plugin-features.js
@@ -72,7 +72,14 @@ const es2015 = {
     ],
   },
   "transform-spread": {
-    features: ["spread syntax for iterable objects"],
+    features: [
+      "spread syntax for iterable objects",
+      // We need to compile classes when spread is not supported, because
+      // we cannot compile super(...args) without also rewriting the
+      // "super" handling. There is a bugfix that makes it better.
+      "class",
+      "super",
+    ],
   },
   "transform-destructuring": {
     features: ["destructuring, assignment", "destructuring, declarations"],

--- a/packages/babel-compat-data/scripts/utils-build-data.js
+++ b/packages/babel-compat-data/scripts/utils-build-data.js
@@ -88,7 +88,10 @@ exports.getLowestImplementedVersion = (
 };
 
 exports.generateData = (environments, features) => {
-  return Object.values(features).map(options => {
+  const data = {};
+
+  // eslint-disable-next-line prefer-const
+  for (let [key, options] of Object.entries(features)) {
     if (!options.features) {
       options = {
         features: [options],
@@ -103,8 +106,10 @@ exports.generateData = (environments, features) => {
     });
     addElectronSupportFromChromium(plugin);
 
-    return plugin;
-  });
+    data[key] = plugin;
+  }
+
+  return data;
 };
 
 exports.writeFile = function (data, dataPath, name) {

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/spread-super-firefox-40/input.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/spread-super-firefox-40/input.js
@@ -1,0 +1,5 @@
+class A extends B {
+  constructor(args) {
+    super(...args)
+  }
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/spread-super-firefox-40/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/spread-super-firefox-40/options.json
@@ -1,0 +1,4 @@
+{
+  "targets": "firefox 40",
+  "presets": ["env"]
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/spread-super-firefox-40/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/spread-super-firefox-40/output.js
@@ -1,0 +1,14 @@
+var A = /*#__PURE__*/function (_B) {
+  "use strict";
+
+  babelHelpers.inherits(A, _B);
+
+  var _super = babelHelpers.createSuper(A);
+
+  function A(args) {
+    babelHelpers.classCallCheck(this, A);
+    return _super.call.apply(_super, [this].concat(babelHelpers.toConsumableArray(args)));
+  }
+
+  return A;
+}(B);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Ref https://github.com/babel/babel/pull/12722
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

There are some firefox versions where one thing between "classes" and "spread" is supported and the other is not. This causes a compilation error.

I bumped the spread data to align them with the classes data. I also wrote [a bugfix plugin](https://github.com/babel/babel/commit/90730e495010c6b67ce14596a24e60aa3e5a61ed), but given that the compat data are almost the same probably it's not worth the complexity.

I'm really confused about comparing supported versions (i.e. what supports what), so it's possible that this PR isn't needed and I just interpreted the data in a wrong way.