### PR TITLE
Fix completion record for labeled statement

### DIFF
--- a/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expression-switch-case/nested-break-block/exec.js
+++ b/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expression-switch-case/nested-break-block/exec.js
@@ -21,6 +21,9 @@ const x = (n) => do {
       }
       { break; "l" }
     case 7:
+      { a: "m" }
+      break;
+    case 8:
   }
 }
 
@@ -31,4 +34,5 @@ expect(x(3)).toBeUndefined()
 expect(x(4)).toBe("g")
 expect(x(5)).toBe("j")
 expect(x(6)).toBe("k")
-expect(x(7)).toBeUndefined()
+expect(x(7)).toBe("m")
+expect(x(8)).toBeUndefined()

--- a/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expression-switch-case/nested-break-block/input.js
+++ b/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expression-switch-case/nested-break-block/input.js
@@ -21,5 +21,8 @@ const x = (n) => do {
       }
       { break; "l" }
     case 7:
+      { a: "m" }
+      break;
+    case 8:
   }
 }

--- a/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expression-switch-case/nested-break-block/output.js
+++ b/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expression-switch-case/nested-break-block/output.js
@@ -62,5 +62,10 @@ const x = n => function () {
       }
 
     case 7:
+      {
+        a: return "m";
+      }
+
+    case 8:
   }
 }();

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -210,7 +210,12 @@ function _getCompletionRecords(
   if (path.isIfStatement()) {
     records = addCompletionRecords(path.get("consequent"), records, context);
     records = addCompletionRecords(path.get("alternate"), records, context);
-  } else if (path.isDoExpression() || path.isFor() || path.isWhile()) {
+  } else if (
+    path.isDoExpression() ||
+    path.isFor() ||
+    path.isWhile() ||
+    path.isLabeledStatement()
+  ) {
     // @ts-expect-error(flow->ts): todo
     records = addCompletionRecords(path.get("body"), records, context);
   } else if (path.isProgram() || path.isBlockStatement()) {


### PR DESCRIPTION
`{labelAlthoughIMeantItToBeAKey: value}` strikes again :)

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | (where are the tests for getCompletionRecords?)
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
