### PR TITLE
Align `regenerator-transform` import with native ESM

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -475,15 +475,14 @@ function pluginNodeImportInteropBabel({ template }) {
 }
 
 function pluginNodeImportInteropRollup({ types: t }) {
-  const depsUsing__esModuleAndDefaultExport = [
-    src => src.startsWith("babel-plugin-polyfill-"),
-  ];
+  const depsUsing__esModuleAndDefaultExport = src =>
+    src.startsWith("babel-plugin-polyfill-") || src === "regenerator-transform";
 
   return {
     visitor: {
       ImportDeclaration(path) {
         const { value: source } = path.node.source;
-        if (depsUsing__esModuleAndDefaultExport.every(test => !test(source))) {
+        if (!depsUsing__esModuleAndDefaultExport(source)) {
           return;
         }
 

--- a/packages/babel-plugin-transform-regenerator/src/index.js
+++ b/packages/babel-plugin-transform-regenerator/src/index.js
@@ -1,1 +1,2 @@
-export { default } from "regenerator-transform";
+import regeneratorTransform from "regenerator-transform";
+export default regeneratorTransform.default;

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -181,6 +181,16 @@ const require = createRequire(import.meta.url);
           [].includes(2);"
         `);
       });
+
+      it("regenerator works", () => {
+        const output = Babel.transform("function* fn() {}", {
+          sourceType: "module",
+          targets: { ie: 11 },
+          presets: ["env"],
+        }).code;
+
+        expect(output).toMatch("regeneratorRuntime.mark(fn)");
+      });
     });
 
     describe("custom plugins and presets", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I missed this in https://github.com/babel/babel/pull/12795 because it was using `export ... from` rather than import.

`regenerator-transform` is a compiled CJS module, so the `default` export in Node.js is `module.exports` and we'll need to get `.default` from `module.exports` (thus `.default` from the `default` export).