### PR TITLE
Do not load root `babel.config.js` in tests

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -27,11 +27,22 @@ const cachedScripts = new QuickLRU({ maxSize: 10 });
 const contextModuleCache = new WeakMap();
 const sharedTestContext = createContext();
 
+// We never want our tests to accidentally load the root
+// babel.config.js file, so we disable config loading by
+// default. Tests can still set `configFile: true | string`
+// to re-enable config loading.
+function transformWithoutConfigFile(code, opts) {
+  return babel.transform(code, {
+    configFile: false,
+    ...opts,
+  });
+}
+
 function createContext() {
   const context = vm.createContext({
     ...helpers,
     process: process,
-    transform: babel.transform,
+    transform: transformWithoutConfigFile,
     setTimeout: setTimeout,
     setImmediate: setImmediate,
     expect,
@@ -207,6 +218,7 @@ function run(task) {
       sourceFileName: self.filename,
       sourceType: "script",
       babelrc: false,
+      configFile: false,
       inputSourceMap: task.inputSourceMap || undefined,
       ...opts,
     };

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -34,6 +34,7 @@ const sharedTestContext = createContext();
 function transformWithoutConfigFile(code, opts) {
   return babel.transform(code, {
     configFile: false,
+    babelrc: false,
     ...opts,
   });
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

While working on the native ESM Babel build (wip implementation: https://github.com/nicolo-ribaudo/babel/tree/native-esm), I had to add some `configFile: false` to our tests (you can see them for `babel-core` at https://github.com/nicolo-ribaudo/babel/commit/5d15dc703d3d741375a7a8a25a23d32cfdf52adf) because they were accidentally loading the top-level `babel.config.js` file.

This didn't cause problems so far because our `babel.config.js` has an `ignore` entry for `packages/*/test/fixtures`, but it caused problems for the ESM tests because even if a file is ignored all the plugins/presets are still resolved and `require`'d.

Also, tests should be isolated so it's better to make sure that they don't accidentally load an unrelated config anyway.

cc @jridgewell If I recall correctly, AMP uses our test runner plugins. I would consider this PR a bugfix, but would it cause problems to AMP?