### PR TITLE
perf(core): check files before interacting with them

### DIFF
--- a/packages/babel-core/src/config/files/configuration.ts
+++ b/packages/babel-core/src/config/files/configuration.ts
@@ -1,4 +1,5 @@
 import buildDebug from "debug";
+import nodeFs from "fs";
 import path from "path";
 import json5 from "json5";
 import gensync from "gensync";
@@ -36,11 +37,11 @@ const RELATIVE_CONFIG_FILENAMES = [
 
 const BABELIGNORE_FILENAME = ".babelignore";
 
-export function* findConfigUpwards(rootDir: string): Handler<string | null> {
+export function findConfigUpwards(rootDir: string): string | null {
   let dirname = rootDir;
-  while (true) {
+  for (;;) {
     for (const filename of ROOT_CONFIG_FILENAMES) {
-      if (yield* fs.exists(path.join(dirname, filename))) {
+      if (nodeFs.existsSync(path.join(dirname, filename))) {
         return dirname;
       }
     }
@@ -165,7 +166,7 @@ const readConfigJS = makeStrongCache(function* readConfigJS(
     caller: CallerMetadata | void;
   }>,
 ): Handler<ConfigFile | null> {
-  if (!fs.exists.sync(filepath)) {
+  if (!nodeFs.existsSync(filepath)) {
     cache.never();
     return null;
   }

--- a/packages/babel-core/src/config/files/index-browser.ts
+++ b/packages/babel-core/src/config/files/index-browser.ts
@@ -11,11 +11,10 @@ import type { CallerMetadata } from "../validation/options";
 
 export type { ConfigFile, IgnoreFile, RelativeConfig, FilePackageData };
 
-// eslint-disable-next-line require-yield
-export function* findConfigUpwards(
+export function findConfigUpwards(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   rootDir: string,
-): Handler<string | null> {
+): string | null {
   return null;
 }
 

--- a/packages/babel-core/src/config/files/utils.ts
+++ b/packages/babel-core/src/config/files/utils.ts
@@ -23,6 +23,8 @@ export function makeStaticFileCache<T>(
 }
 
 function fileMtime(filepath: string): number | null {
+  if (!nodeFs.existsSync(filepath)) return null;
+
   try {
     return +nodeFs.statSync(filepath).mtime;
   } catch (e) {

--- a/packages/babel-core/src/config/partial.ts
+++ b/packages/babel-core/src/config/partial.ts
@@ -23,21 +23,18 @@ import {
 import type { ConfigFile, IgnoreFile } from "./files";
 import { resolveTargets } from "./resolve-targets";
 
-function* resolveRootMode(
-  rootDir: string,
-  rootMode: RootMode,
-): Handler<string> {
+function resolveRootMode(rootDir: string, rootMode: RootMode): string {
   switch (rootMode) {
     case "root":
       return rootDir;
 
     case "upward-optional": {
-      const upwardRootDir = yield* findConfigUpwards(rootDir);
+      const upwardRootDir = findConfigUpwards(rootDir);
       return upwardRootDir === null ? rootDir : upwardRootDir;
     }
 
     case "upward": {
-      const upwardRootDir = yield* findConfigUpwards(rootDir);
+      const upwardRootDir = findConfigUpwards(rootDir);
       if (upwardRootDir !== null) return upwardRootDir;
 
       throw Object.assign(
@@ -89,7 +86,7 @@ export default function* loadPrivatePartialConfig(
     cloneInputAst = true,
   } = args;
   const absoluteCwd = path.resolve(cwd);
-  const absoluteRootDir = yield* resolveRootMode(
+  const absoluteRootDir = resolveRootMode(
     path.resolve(absoluteCwd, rootDir),
     rootMode,
   );

--- a/packages/babel-core/src/gensync-utils/fs.ts
+++ b/packages/babel-core/src/gensync-utils/fs.ts
@@ -10,14 +10,8 @@ export const readFile = gensync<(filepath: string, encoding: "utf8") => string>(
 
 export const exists = gensync<(filepath: string) => boolean>({
   sync(path) {
-    try {
-      fs.accessSync(path);
-      return true;
-    } catch {
-      return false;
-    }
+    return fs.existsSync(path);
   },
-  errback: (path, cb) => fs.access(path, undefined, err => cb(null, !err)),
 });
 
 export const stat = gensync<typeof fs.statSync>({

--- a/packages/babel-core/src/gensync-utils/fs.ts
+++ b/packages/babel-core/src/gensync-utils/fs.ts
@@ -8,12 +8,6 @@ export const readFile = gensync<(filepath: string, encoding: "utf8") => string>(
   },
 );
 
-export const exists = gensync<(filepath: string) => boolean>({
-  sync(path) {
-    return fs.existsSync(path);
-  },
-});
-
 export const stat = gensync<typeof fs.statSync>({
   sync: fs.statSync,
   errback: fs.stat,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT


### What this does

`babel` is relevantly slower than `ts-jest` at transpiling our codebase, after caching. A profiler suggests these file APIs are slow. Use `existsSync` instead, which is quite a bit faster.

This is a problem I've seen before, and potentially raised as a bug here before, but am currently unable to find. :shrug: 


### Benchmarks

`require('./app')` (inside jest, which has other overheads) goes from 6.5s±0.5s to 5.0s±0.1s, which is >20% faster. For reference, `ts-jest`'s cache can do the same operation in 4.3s±0.1s.

Node 14, Ubuntu, linux 5.8, desktop i7-8700, nvme, btrfs. `@babel/preset-env`, `@babel/preset-typescript`.  Around 2,000 source files, around 44,000 files inside node_modules appear to be referenced, according to `strace -ff -yy -estatx,openat node =jest --runInBand require-stuff`.


### Semantic change

This is technically a semantic change, if you previously had files that you couldn't read, you will now see an error when trying to read them (after this function), instead of them being silently ignored. I think this is better behaviour. If we don't agree, maybe we could check `existsSync` then `accessSync`.


### Profiler output

```
  ticks parent  name
   5734   73.6%  /usr/bin/node
   4109   71.7%    /usr/bin/node
    619   15.1%      LazyCompile: *uvException internal/errors.js:402:21
    205   33.1%        LazyCompile: ~handleErrorFromBinding internal/fs/utils.js:303:32
    167   81.5%          LazyCompile: ~accessSync fs.js:214:20
    152   91.0%            LazyCompile: *sync node_modules/@babel/core/lib/gensync-utils/fs.js:18:7
     15    9.0%            LazyCompile: ~sync node_modules/@babel/core/lib/gensync-utils/fs.js:18:7
     38   18.5%          LazyCompile: ~statSync fs.js:1081:18
     30   78.9%            LazyCompile: ~fileMtime node_modules/@babel/core/lib/config/files/utils.js:30:19
      8   21.1%            LazyCompile: ~<anonymous> node_modules/graceful-fs/polyfills.js:306:21
    170   27.5%        LazyCompile: *fileMtime node_modules/@babel/core/lib/config/files/utils.js:30:19
    141   82.9%          LazyCompile: *<anonymous> node_modules/@babel/core/lib/config/files/utils.js:20:37
    136   96.5%            LazyCompile: *sync node_modules/@babel/core/lib/gensync-utils/async.js:26:9
      5    3.5%            LazyCompile: ~using node_modules/@babel/core/lib/config/caching.js:216:8
     29   17.1%          LazyCompile: ~<anonymous> node_modules/@babel/core/lib/config/files/utils.js:20:37
     29  100.0%            LazyCompile: *sync node_modules/@babel/core/lib/gensync-utils/async.js:26:9
```

I believe the `uvException` is explaining that it's expensive to throw and catch and exception, even if you ignore the caught value.