### PR TITLE
support TS 4.3 static index signature in class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FLOW_COMMIT = a1f9a4c709dcebb27a5084acf47755fbae699c25
 TEST262_COMMIT = 31126581e7290f9233c29cefd93f66c6ac78f1c9
-TYPESCRIPT_COMMIT = da8633212023517630de5f3620a23736b63234b1
+TYPESCRIPT_COMMIT = 41dc625b0a609eb294b975dd92675e72b2b3fdec
 
 # Fix color output until TravisCI fixes https://github.com/travis-ci/travis-ci/issues/7967
 export FORCE_COLOR = true

--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -133,7 +133,11 @@ export function TSMethodSignature(this: Printer, node: t.TSMethodSignature) {
 }
 
 export function TSIndexSignature(this: Printer, node: t.TSIndexSignature) {
-  const { readonly } = node;
+  const { readonly, static: isStatic } = node;
+  if (isStatic) {
+    this.word("static");
+    this.space();
+  }
   if (readonly) {
     this.word("readonly");
     this.space();

--- a/packages/babel-generator/test/fixtures/typescript/class-index-signature/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/class-index-signature/input.js
@@ -1,4 +1,5 @@
 class C {
     [x: string]: any;
     readonly [x: string]: any;
+    static [x: string]: any;
 }

--- a/packages/babel-generator/test/fixtures/typescript/class-index-signature/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/class-index-signature/output.js
@@ -1,4 +1,5 @@
 class C {
   [x: string]: any;
   readonly [x: string]: any;
+  static [x: string]: any;
 }

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -95,6 +95,7 @@ const TSErrors = makeErrorTemplates(
       "Index signatures cannot have the 'static' modifier",
     InvalidModifierOnTypeMember:
       "'%0' modifier cannot appear on a type member.",
+    InvalidModifiersOrder: "'%0' modifier must precede '%1' modifier.",
     InvalidTupleMemberLabel:
       "Tuple members must be labeled with a simple identifier.",
     MixedLabeledAndUnlabeledElements:
@@ -251,7 +252,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           } else if (modified.readonly && modifier === "static") {
             this.raise(
               startPos,
-              TSErrors.ModifierPrecede,
+              TSErrors.InvalidModifiersOrder,
               "static",
               "readonly",
             );

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2232,7 +2232,16 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       state: N.ParseClassMemberState,
       isStatic: boolean,
     ): void {
-      this.tsParseModifiers(member, ["abstract", "readonly", "declare"]);
+      this.tsParseModifiers(member, [
+        "abstract",
+        "readonly",
+        "declare",
+        "static",
+      ]);
+
+      if (isStatic) {
+        member.static = true;
+      }
 
       const idx = this.tsTryParseIndexSignature(member);
       if (idx) {
@@ -2240,9 +2249,6 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
         if ((member: any).abstract) {
           this.raise(member.start, TSErrors.IndexSignatureHasAbstract);
-        }
-        if (isStatic) {
-          this.raise(member.start, TSErrors.IndexSignatureHasStatic);
         }
         if ((member: any).accessibility) {
           this.raise(

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -248,6 +248,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         } else {
           if (Object.hasOwnProperty.call(modified, modifier)) {
             this.raise(startPos, TSErrors.DuplicateModifier, modifier);
+          } else if (modified.readonly && modifier === "static") {
+            this.raise(
+              startPos,
+              TSErrors.ModifierPrecede,
+              "static",
+              "readonly",
+            );
           }
           modified[modifier] = true;
         }

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1205,6 +1205,7 @@ export type TsMethodSignature = TsSignatureDeclarationBase &
 // *Not* a ClassMemberBase: Can't have accessibility, can't be abstract, can't be optional.
 export type TsIndexSignature = TsSignatureDeclarationOrIndexSignatureBase & {
   readonly?: true,
+  static?: true,
   type: "TSIndexSignature",
   // Note: parameters.length must be 1.
 };

--- a/packages/babel-parser/test/fixtures/typescript/class/index-signature-errors/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/index-signature-errors/input.ts
@@ -1,0 +1,3 @@
+class C {
+    readonly static [x: string]: any;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/index-signature-errors/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/index-signature-errors/output.json
@@ -1,0 +1,61 @@
+{
+  "type": "File",
+  "start":0,"end":49,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: 'static' modifier must precede 'readonly' modifier. (2:13)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":49,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":49,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"C"},
+          "name": "C"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":8,"end":49,"loc":{"start":{"line":1,"column":8},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "TSIndexSignature",
+              "start":14,"end":47,"loc":{"start":{"line":2,"column":4},"end":{"line":2,"column":37}},
+              "readonly": true,
+              "static": true,
+              "parameters": [
+                {
+                  "type": "Identifier",
+                  "start":31,"end":40,"loc":{"start":{"line":2,"column":21},"end":{"line":2,"column":30},"identifierName":"x"},
+                  "name": "x",
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "start":32,"end":40,"loc":{"start":{"line":2,"column":22},"end":{"line":2,"column":30}},
+                    "typeAnnotation": {
+                      "type": "TSStringKeyword",
+                      "start":34,"end":40,"loc":{"start":{"line":2,"column":24},"end":{"line":2,"column":30}}
+                    }
+                  }
+                }
+              ],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":41,"end":46,"loc":{"start":{"line":2,"column":31},"end":{"line":2,"column":36}},
+                "typeAnnotation": {
+                  "type": "TSAnyKeyword",
+                  "start":43,"end":46,"loc":{"start":{"line":2,"column":33},"end":{"line":2,"column":36}}
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/index-signature/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/index-signature/input.ts
@@ -1,4 +1,5 @@
 class C {
     [x: string]: any;
     readonly [x: string]: any;
+    static [x: string]: any;
 }

--- a/packages/babel-parser/test/fixtures/typescript/class/index-signature/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/index-signature/input.ts
@@ -3,5 +3,4 @@ class C {
     readonly [x: string]: any;
     static [x: string]: any;
     static readonly [x: string]: any;
-    readonly static [x: string]: any;
 }

--- a/packages/babel-parser/test/fixtures/typescript/class/index-signature/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/index-signature/input.ts
@@ -2,4 +2,5 @@ class C {
     [x: string]: any;
     readonly [x: string]: any;
     static [x: string]: any;
+    static readonly [x: string]: any;
 }

--- a/packages/babel-parser/test/fixtures/typescript/class/index-signature/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/index-signature/input.ts
@@ -3,4 +3,5 @@ class C {
     readonly [x: string]: any;
     static [x: string]: any;
     static readonly [x: string]: any;
+    readonly static [x: string]: any;
 }

--- a/packages/babel-parser/test/fixtures/typescript/class/index-signature/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/index-signature/output.json
@@ -1,15 +1,18 @@
 {
   "type": "File",
-  "start":0,"end":131,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
+  "start":0,"end":169,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
+  "errors": [
+    "SyntaxError: 'static' modifier must precede 'readonly' modifier. (6:13)"
+  ],
   "program": {
     "type": "Program",
-    "start":0,"end":131,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
+    "start":0,"end":169,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
-        "start":0,"end":131,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
+        "start":0,"end":169,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
         "id": {
           "type": "Identifier",
           "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"C"},
@@ -18,7 +21,7 @@
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start":8,"end":131,"loc":{"start":{"line":1,"column":8},"end":{"line":6,"column":1}},
+          "start":8,"end":169,"loc":{"start":{"line":1,"column":8},"end":{"line":7,"column":1}},
           "body": [
             {
               "type": "TSIndexSignature",
@@ -129,6 +132,35 @@
                 "typeAnnotation": {
                   "type": "TSAnyKeyword",
                   "start":125,"end":128,"loc":{"start":{"line":5,"column":33},"end":{"line":5,"column":36}}
+                }
+              }
+            },
+            {
+              "type": "TSIndexSignature",
+              "start":134,"end":167,"loc":{"start":{"line":6,"column":4},"end":{"line":6,"column":37}},
+              "readonly": true,
+              "static": true,
+              "parameters": [
+                {
+                  "type": "Identifier",
+                  "start":151,"end":160,"loc":{"start":{"line":6,"column":21},"end":{"line":6,"column":30},"identifierName":"x"},
+                  "name": "x",
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "start":152,"end":160,"loc":{"start":{"line":6,"column":22},"end":{"line":6,"column":30}},
+                    "typeAnnotation": {
+                      "type": "TSStringKeyword",
+                      "start":154,"end":160,"loc":{"start":{"line":6,"column":24},"end":{"line":6,"column":30}}
+                    }
+                  }
+                }
+              ],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":161,"end":166,"loc":{"start":{"line":6,"column":31},"end":{"line":6,"column":36}},
+                "typeAnnotation": {
+                  "type": "TSAnyKeyword",
+                  "start":163,"end":166,"loc":{"start":{"line":6,"column":33},"end":{"line":6,"column":36}}
                 }
               }
             }

--- a/packages/babel-parser/test/fixtures/typescript/class/index-signature/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/index-signature/output.json
@@ -1,15 +1,15 @@
 {
   "type": "File",
-  "start":0,"end":93,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+  "start":0,"end":131,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
   "program": {
     "type": "Program",
-    "start":0,"end":93,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+    "start":0,"end":131,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
-        "start":0,"end":93,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+        "start":0,"end":131,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
         "id": {
           "type": "Identifier",
           "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"C"},
@@ -18,7 +18,7 @@
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start":8,"end":93,"loc":{"start":{"line":1,"column":8},"end":{"line":5,"column":1}},
+          "start":8,"end":131,"loc":{"start":{"line":1,"column":8},"end":{"line":6,"column":1}},
           "body": [
             {
               "type": "TSIndexSignature",
@@ -100,6 +100,35 @@
                 "typeAnnotation": {
                   "type": "TSAnyKeyword",
                   "start":87,"end":90,"loc":{"start":{"line":4,"column":24},"end":{"line":4,"column":27}}
+                }
+              }
+            },
+            {
+              "type": "TSIndexSignature",
+              "start":96,"end":129,"loc":{"start":{"line":5,"column":4},"end":{"line":5,"column":37}},
+              "readonly": true,
+              "static": true,
+              "parameters": [
+                {
+                  "type": "Identifier",
+                  "start":113,"end":122,"loc":{"start":{"line":5,"column":21},"end":{"line":5,"column":30},"identifierName":"x"},
+                  "name": "x",
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "start":114,"end":122,"loc":{"start":{"line":5,"column":22},"end":{"line":5,"column":30}},
+                    "typeAnnotation": {
+                      "type": "TSStringKeyword",
+                      "start":116,"end":122,"loc":{"start":{"line":5,"column":24},"end":{"line":5,"column":30}}
+                    }
+                  }
+                }
+              ],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":123,"end":128,"loc":{"start":{"line":5,"column":31},"end":{"line":5,"column":36}},
+                "typeAnnotation": {
+                  "type": "TSAnyKeyword",
+                  "start":125,"end":128,"loc":{"start":{"line":5,"column":33},"end":{"line":5,"column":36}}
                 }
               }
             }

--- a/packages/babel-parser/test/fixtures/typescript/class/index-signature/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/index-signature/output.json
@@ -1,18 +1,15 @@
 {
   "type": "File",
-  "start":0,"end":169,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
-  "errors": [
-    "SyntaxError: 'static' modifier must precede 'readonly' modifier. (6:13)"
-  ],
+  "start":0,"end":131,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
   "program": {
     "type": "Program",
-    "start":0,"end":169,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
+    "start":0,"end":131,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
-        "start":0,"end":169,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
+        "start":0,"end":131,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
         "id": {
           "type": "Identifier",
           "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"C"},
@@ -21,7 +18,7 @@
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start":8,"end":169,"loc":{"start":{"line":1,"column":8},"end":{"line":7,"column":1}},
+          "start":8,"end":131,"loc":{"start":{"line":1,"column":8},"end":{"line":6,"column":1}},
           "body": [
             {
               "type": "TSIndexSignature",
@@ -132,35 +129,6 @@
                 "typeAnnotation": {
                   "type": "TSAnyKeyword",
                   "start":125,"end":128,"loc":{"start":{"line":5,"column":33},"end":{"line":5,"column":36}}
-                }
-              }
-            },
-            {
-              "type": "TSIndexSignature",
-              "start":134,"end":167,"loc":{"start":{"line":6,"column":4},"end":{"line":6,"column":37}},
-              "readonly": true,
-              "static": true,
-              "parameters": [
-                {
-                  "type": "Identifier",
-                  "start":151,"end":160,"loc":{"start":{"line":6,"column":21},"end":{"line":6,"column":30},"identifierName":"x"},
-                  "name": "x",
-                  "typeAnnotation": {
-                    "type": "TSTypeAnnotation",
-                    "start":152,"end":160,"loc":{"start":{"line":6,"column":22},"end":{"line":6,"column":30}},
-                    "typeAnnotation": {
-                      "type": "TSStringKeyword",
-                      "start":154,"end":160,"loc":{"start":{"line":6,"column":24},"end":{"line":6,"column":30}}
-                    }
-                  }
-                }
-              ],
-              "typeAnnotation": {
-                "type": "TSTypeAnnotation",
-                "start":161,"end":166,"loc":{"start":{"line":6,"column":31},"end":{"line":6,"column":36}},
-                "typeAnnotation": {
-                  "type": "TSAnyKeyword",
-                  "start":163,"end":166,"loc":{"start":{"line":6,"column":33},"end":{"line":6,"column":36}}
                 }
               }
             }

--- a/packages/babel-parser/test/fixtures/typescript/class/index-signature/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/index-signature/output.json
@@ -1,15 +1,15 @@
 {
   "type": "File",
-  "start":0,"end":64,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "start":0,"end":93,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
   "program": {
     "type": "Program",
-    "start":0,"end":64,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "start":0,"end":93,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
-        "start":0,"end":64,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "start":0,"end":93,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
         "id": {
           "type": "Identifier",
           "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"C"},
@@ -18,7 +18,7 @@
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start":8,"end":64,"loc":{"start":{"line":1,"column":8},"end":{"line":4,"column":1}},
+          "start":8,"end":93,"loc":{"start":{"line":1,"column":8},"end":{"line":5,"column":1}},
           "body": [
             {
               "type": "TSIndexSignature",
@@ -72,6 +72,34 @@
                 "typeAnnotation": {
                   "type": "TSAnyKeyword",
                   "start":58,"end":61,"loc":{"start":{"line":3,"column":26},"end":{"line":3,"column":29}}
+                }
+              }
+            },
+            {
+              "type": "TSIndexSignature",
+              "start":67,"end":91,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":28}},
+              "static": true,
+              "parameters": [
+                {
+                  "type": "Identifier",
+                  "start":75,"end":84,"loc":{"start":{"line":4,"column":12},"end":{"line":4,"column":21},"identifierName":"x"},
+                  "name": "x",
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "start":76,"end":84,"loc":{"start":{"line":4,"column":13},"end":{"line":4,"column":21}},
+                    "typeAnnotation": {
+                      "type": "TSStringKeyword",
+                      "start":78,"end":84,"loc":{"start":{"line":4,"column":15},"end":{"line":4,"column":21}}
+                    }
+                  }
+                }
+              ],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":85,"end":90,"loc":{"start":{"line":4,"column":22},"end":{"line":4,"column":27}},
+                "typeAnnotation": {
+                  "type": "TSAnyKeyword",
+                  "start":87,"end":90,"loc":{"start":{"line":4,"column":24},"end":{"line":4,"column":27}}
                 }
               }
             }

--- a/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts
@@ -1,6 +1,5 @@
 class C {
   abstract [key: string]: string;
-  static [key: string]: string;
   declare [key: string]: string;
   private [key: string]: string;
   public [key: string]: string;

--- a/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/output.json
@@ -1,23 +1,22 @@
 {
   "type": "File",
-  "start":0,"end":210,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":1}},
+  "start":0,"end":178,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
   "errors": [
     "SyntaxError: Index signatures cannot have the 'abstract' modifier (2:2)",
-    "SyntaxError: Index signatures cannot have the 'static' modifier (3:2)",
-    "SyntaxError: Index signatures cannot have the 'declare' modifier (4:2)",
-    "SyntaxError: Index signatures cannot have an accessibility modifier ('private') (5:2)",
-    "SyntaxError: Index signatures cannot have an accessibility modifier ('public') (6:2)",
-    "SyntaxError: Index signatures cannot have an accessibility modifier ('protected') (7:2)"
+    "SyntaxError: Index signatures cannot have the 'declare' modifier (3:2)",
+    "SyntaxError: Index signatures cannot have an accessibility modifier ('private') (4:2)",
+    "SyntaxError: Index signatures cannot have an accessibility modifier ('public') (5:2)",
+    "SyntaxError: Index signatures cannot have an accessibility modifier ('protected') (6:2)"
   ],
   "program": {
     "type": "Program",
-    "start":0,"end":210,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":1}},
+    "start":0,"end":178,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
-        "start":0,"end":210,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":1}},
+        "start":0,"end":178,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
         "id": {
           "type": "Identifier",
           "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"C"},
@@ -26,7 +25,7 @@
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start":8,"end":210,"loc":{"start":{"line":1,"column":8},"end":{"line":8,"column":1}},
+          "start":8,"end":178,"loc":{"start":{"line":1,"column":8},"end":{"line":7,"column":1}},
           "body": [
             {
               "type": "TSIndexSignature",
@@ -58,140 +57,113 @@
             },
             {
               "type": "TSIndexSignature",
-              "start":46,"end":75,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":31}},
-              "parameters": [
-                {
-                  "type": "Identifier",
-                  "start":54,"end":65,"loc":{"start":{"line":3,"column":10},"end":{"line":3,"column":21},"identifierName":"key"},
-                  "name": "key",
-                  "typeAnnotation": {
-                    "type": "TSTypeAnnotation",
-                    "start":57,"end":65,"loc":{"start":{"line":3,"column":13},"end":{"line":3,"column":21}},
-                    "typeAnnotation": {
-                      "type": "TSStringKeyword",
-                      "start":59,"end":65,"loc":{"start":{"line":3,"column":15},"end":{"line":3,"column":21}}
-                    }
-                  }
-                }
-              ],
-              "typeAnnotation": {
-                "type": "TSTypeAnnotation",
-                "start":66,"end":74,"loc":{"start":{"line":3,"column":22},"end":{"line":3,"column":30}},
-                "typeAnnotation": {
-                  "type": "TSStringKeyword",
-                  "start":68,"end":74,"loc":{"start":{"line":3,"column":24},"end":{"line":3,"column":30}}
-                }
-              }
-            },
-            {
-              "type": "TSIndexSignature",
-              "start":78,"end":108,"loc":{"start":{"line":4,"column":2},"end":{"line":4,"column":32}},
+              "start":46,"end":76,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":32}},
               "declare": true,
               "parameters": [
                 {
                   "type": "Identifier",
-                  "start":87,"end":98,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":22},"identifierName":"key"},
+                  "start":55,"end":66,"loc":{"start":{"line":3,"column":11},"end":{"line":3,"column":22},"identifierName":"key"},
                   "name": "key",
                   "typeAnnotation": {
                     "type": "TSTypeAnnotation",
-                    "start":90,"end":98,"loc":{"start":{"line":4,"column":14},"end":{"line":4,"column":22}},
+                    "start":58,"end":66,"loc":{"start":{"line":3,"column":14},"end":{"line":3,"column":22}},
                     "typeAnnotation": {
                       "type": "TSStringKeyword",
-                      "start":92,"end":98,"loc":{"start":{"line":4,"column":16},"end":{"line":4,"column":22}}
+                      "start":60,"end":66,"loc":{"start":{"line":3,"column":16},"end":{"line":3,"column":22}}
                     }
                   }
                 }
               ],
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
-                "start":99,"end":107,"loc":{"start":{"line":4,"column":23},"end":{"line":4,"column":31}},
+                "start":67,"end":75,"loc":{"start":{"line":3,"column":23},"end":{"line":3,"column":31}},
                 "typeAnnotation": {
                   "type": "TSStringKeyword",
-                  "start":101,"end":107,"loc":{"start":{"line":4,"column":25},"end":{"line":4,"column":31}}
+                  "start":69,"end":75,"loc":{"start":{"line":3,"column":25},"end":{"line":3,"column":31}}
                 }
               }
             },
             {
               "type": "TSIndexSignature",
-              "start":111,"end":141,"loc":{"start":{"line":5,"column":2},"end":{"line":5,"column":32}},
+              "start":79,"end":109,"loc":{"start":{"line":4,"column":2},"end":{"line":4,"column":32}},
               "accessibility": "private",
               "parameters": [
                 {
                   "type": "Identifier",
-                  "start":120,"end":131,"loc":{"start":{"line":5,"column":11},"end":{"line":5,"column":22},"identifierName":"key"},
+                  "start":88,"end":99,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":22},"identifierName":"key"},
                   "name": "key",
                   "typeAnnotation": {
                     "type": "TSTypeAnnotation",
-                    "start":123,"end":131,"loc":{"start":{"line":5,"column":14},"end":{"line":5,"column":22}},
+                    "start":91,"end":99,"loc":{"start":{"line":4,"column":14},"end":{"line":4,"column":22}},
                     "typeAnnotation": {
                       "type": "TSStringKeyword",
-                      "start":125,"end":131,"loc":{"start":{"line":5,"column":16},"end":{"line":5,"column":22}}
+                      "start":93,"end":99,"loc":{"start":{"line":4,"column":16},"end":{"line":4,"column":22}}
                     }
                   }
                 }
               ],
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
-                "start":132,"end":140,"loc":{"start":{"line":5,"column":23},"end":{"line":5,"column":31}},
+                "start":100,"end":108,"loc":{"start":{"line":4,"column":23},"end":{"line":4,"column":31}},
                 "typeAnnotation": {
                   "type": "TSStringKeyword",
-                  "start":134,"end":140,"loc":{"start":{"line":5,"column":25},"end":{"line":5,"column":31}}
+                  "start":102,"end":108,"loc":{"start":{"line":4,"column":25},"end":{"line":4,"column":31}}
                 }
               }
             },
             {
               "type": "TSIndexSignature",
-              "start":144,"end":173,"loc":{"start":{"line":6,"column":2},"end":{"line":6,"column":31}},
+              "start":112,"end":141,"loc":{"start":{"line":5,"column":2},"end":{"line":5,"column":31}},
               "accessibility": "public",
               "parameters": [
                 {
                   "type": "Identifier",
-                  "start":152,"end":163,"loc":{"start":{"line":6,"column":10},"end":{"line":6,"column":21},"identifierName":"key"},
+                  "start":120,"end":131,"loc":{"start":{"line":5,"column":10},"end":{"line":5,"column":21},"identifierName":"key"},
                   "name": "key",
                   "typeAnnotation": {
                     "type": "TSTypeAnnotation",
-                    "start":155,"end":163,"loc":{"start":{"line":6,"column":13},"end":{"line":6,"column":21}},
+                    "start":123,"end":131,"loc":{"start":{"line":5,"column":13},"end":{"line":5,"column":21}},
                     "typeAnnotation": {
                       "type": "TSStringKeyword",
-                      "start":157,"end":163,"loc":{"start":{"line":6,"column":15},"end":{"line":6,"column":21}}
+                      "start":125,"end":131,"loc":{"start":{"line":5,"column":15},"end":{"line":5,"column":21}}
                     }
                   }
                 }
               ],
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
-                "start":164,"end":172,"loc":{"start":{"line":6,"column":22},"end":{"line":6,"column":30}},
+                "start":132,"end":140,"loc":{"start":{"line":5,"column":22},"end":{"line":5,"column":30}},
                 "typeAnnotation": {
                   "type": "TSStringKeyword",
-                  "start":166,"end":172,"loc":{"start":{"line":6,"column":24},"end":{"line":6,"column":30}}
+                  "start":134,"end":140,"loc":{"start":{"line":5,"column":24},"end":{"line":5,"column":30}}
                 }
               }
             },
             {
               "type": "TSIndexSignature",
-              "start":176,"end":208,"loc":{"start":{"line":7,"column":2},"end":{"line":7,"column":34}},
+              "start":144,"end":176,"loc":{"start":{"line":6,"column":2},"end":{"line":6,"column":34}},
               "accessibility": "protected",
               "parameters": [
                 {
                   "type": "Identifier",
-                  "start":187,"end":198,"loc":{"start":{"line":7,"column":13},"end":{"line":7,"column":24},"identifierName":"key"},
+                  "start":155,"end":166,"loc":{"start":{"line":6,"column":13},"end":{"line":6,"column":24},"identifierName":"key"},
                   "name": "key",
                   "typeAnnotation": {
                     "type": "TSTypeAnnotation",
-                    "start":190,"end":198,"loc":{"start":{"line":7,"column":16},"end":{"line":7,"column":24}},
+                    "start":158,"end":166,"loc":{"start":{"line":6,"column":16},"end":{"line":6,"column":24}},
                     "typeAnnotation": {
                       "type": "TSStringKeyword",
-                      "start":192,"end":198,"loc":{"start":{"line":7,"column":18},"end":{"line":7,"column":24}}
+                      "start":160,"end":166,"loc":{"start":{"line":6,"column":18},"end":{"line":6,"column":24}}
                     }
                   }
                 }
               ],
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
-                "start":199,"end":207,"loc":{"start":{"line":7,"column":25},"end":{"line":7,"column":33}},
+                "start":167,"end":175,"loc":{"start":{"line":6,"column":25},"end":{"line":6,"column":33}},
                 "typeAnnotation": {
                   "type": "TSStringKeyword",
-                  "start":201,"end":207,"loc":{"start":{"line":7,"column":27},"end":{"line":7,"column":33}}
+                  "start":169,"end":175,"loc":{"start":{"line":6,"column":27},"end":{"line":6,"column":33}}
                 }
               }
             }

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -1709,6 +1709,7 @@ export interface TSIndexSignature extends BaseNode {
   parameters: Array<Identifier>;
   typeAnnotation?: TSTypeAnnotation | null;
   readonly?: boolean | null;
+  static?: boolean | null;
 }
 
 export interface TSAnyKeyword extends BaseNode {

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -126,6 +126,7 @@ defineType("TSIndexSignature", {
   visitor: ["parameters", "typeAnnotation"],
   fields: {
     readonly: validateOptional(bool),
+    static: validateOptional(bool),
     parameters: validateArrayOfType("Identifier"), // Length must be 1
     typeAnnotation: validateOptionalType("TSTypeAnnotation"),
   },

--- a/scripts/parser-tests/typescript/allowlist.txt
+++ b/scripts/parser-tests/typescript/allowlist.txt
@@ -26,6 +26,8 @@ amdModuleName2.ts
 anonClassDeclarationEmitIsAnon.ts
 anyDeclare.ts
 argumentsBindsToFunctionScopeArgumentList.ts
+argumentsReferenceInConstructor4_Js.ts
+argumentsReferenceInMethod4_Js.ts
 arrayOfExportedClass.ts
 asiAbstract.ts
 asyncFunctionsAcrossFiles.ts
@@ -80,12 +82,15 @@ conflictingTypeAnnotatedVar.ts
 constDeclarations-invalidContexts.ts
 constDeclarations-scopes.ts
 constDeclarations-validContexts.ts
+constEnumNamespaceReferenceCausesNoImport2.ts
 constEnumNoEmitReexport.ts
 constEnumNoPreserveDeclarationReexport.ts
 constEnumPreserveEmitReexport.ts
+contextualOverloadListFromArrayUnion.ts
 controlFlowPrivateClassField.ts
 convertKeywordsYes.ts
 declarationEmitAmdModuleNameDirective.ts
+declarationEmitCommonSourceDirectoryDoesNotContainAllFiles.ts
 declarationEmitComputedNameCausesImportToBePainted.ts
 declarationEmitComputedNameConstEnumAlias.ts
 declarationEmitCrossFileImportTypeOfAmbientModule.ts
@@ -99,12 +104,16 @@ declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts
 declarationEmitExportAssignment.ts
 declarationEmitExportDeclaration.ts
 declarationEmitExpressionInExtends6.ts
+declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.ts
 declarationEmitForModuleImportingModuleAugmentationRetainsImport.ts
 declarationEmitForTypesWhichNeedImportTypes.ts
 declarationEmitInterfaceWithNonEntityNameExpressionHeritage.ts
+declarationEmitMixinPrivateProtected.ts
 declarationEmitPrefersPathKindBasedOnBundling.ts
 declarationEmitPrefersPathKindBasedOnBundling2.ts
 declarationEmitPrivateSymbolCausesVarDeclarationEmit2.ts
+declarationEmitReadonlyComputedProperty.ts
+declarationEmitStringEnumUsedInNonlocalSpread.ts
 declarationImportTypeAliasInferredAndEmittable.ts
 declarationMapsMultifile.ts
 declarationMapsOutFile.ts
@@ -188,6 +197,7 @@ esModuleInterop.ts
 esModuleInteropImportTSLibHasImport.ts
 esModuleInteropNamedDefaultImports.ts
 esModuleInteropTslibHelpers.ts
+esNextWeakRefs_IterableWeakMap.ts
 expandoFunctionContextualTypesNoValue.ts
 exportAssignClassAndModule.ts
 exportAssignmentImportMergeNoCrash.ts
@@ -227,7 +237,6 @@ gettersAndSettersErrors.ts
 giant.ts
 globalThisDeclarationEmit.ts
 globalThisDeclarationEmit2.ts
-hugeDeclarationOutputGetsTruncatedWithError.ts
 implementClausePrecedingExtends.ts
 implementsClauseAlreadySeen.ts
 importAndVariableDeclarationConflict1.ts
@@ -271,6 +280,8 @@ interfaceWithImplements1.ts
 invalidReferenceSyntax1.ts
 isLiteral1.ts
 isLiteral2.ts
+isolatedModulesImportConstEnum.ts
+isolatedModulesImportConstEnumTypeOnly.ts
 isolatedModulesReExportType.ts
 jsEnumTagOnObjectFrozen.ts
 jsExportMemberMergedWithModuleAugmentation.ts
@@ -336,7 +347,8 @@ moduleAugmentationsImports2.ts
 moduleAugmentationsImports3.ts
 moduleAugmentationsImports4.ts
 moduleDuplicateIdentifiers.ts
-moduleResolutionNoTs.ts
+moduleResolutionNoTsCJS.ts
+moduleResolutionNoTsESM.ts
 moduleResolutionWithSymlinks.ts
 moduleResolutionWithSymlinks_withOutDir.ts
 moduleResolution_automaticTypeDirectiveNames.ts
@@ -353,6 +365,7 @@ noBundledEmitFromNodeModules.ts
 noCrashOnImportShadowing.ts
 noImplicitAnyDestructuringVarDeclaration.ts
 noSymbolForMergeCrash.ts
+nodeModuleReexportFromDottedPath.ts
 nodeResolution4.ts
 nodeResolution6.ts
 nodeResolution8.ts
@@ -398,6 +411,7 @@ shorthandPropertyAssignmentInES6Module.ts
 sourceMap-LineBreaks.ts
 sourceMapValidationDecorators.ts
 sourceMapValidationStatements.ts
+staticAsIdentifier.ts
 staticModifierAlreadySeen.ts
 strictModeReservedWord.ts
 superCallFromClassThatHasNoBaseType1.ts
@@ -422,6 +436,7 @@ typeReferenceDirectives7.ts
 typeReferenceDirectives8.ts
 typeReferenceDirectives9.ts
 uniqueSymbolPropertyDeclarationEmit.ts
+unusedImportWithSpread.ts
 unusedImports1.ts
 unusedImports11.ts
 unusedImports12.ts

--- a/scripts/parser-tests/typescript/allowlist.txt
+++ b/scripts/parser-tests/typescript/allowlist.txt
@@ -398,7 +398,7 @@ shorthandPropertyAssignmentInES6Module.ts
 sourceMap-LineBreaks.ts
 sourceMapValidationDecorators.ts
 sourceMapValidationStatements.ts
-staticIndexer.ts
+staticModifierAlreadySeen.ts
 strictModeReservedWord.ts
 superCallFromClassThatHasNoBaseType1.ts
 symbolLinkDeclarationEmitModuleNames.ts


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-3-beta/#static-index-signatures

Allow:

```ts
class Foo {
    static [propName: string]: string | undefined;
}
```
