### PR TITLE
fix(ts): allow trailing comma after rest parameter in `TSDeclareFunction`

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2779,6 +2779,20 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return super.parseMaybeDecoratorArguments(expr);
     }
 
+    checkCommaAfterRest(close) {
+      if (this.match(tt.comma)) {
+        if (this.lookaheadCharCode() === close) {
+          if (!this.state.isDeclareContext) {
+            this.raiseTrailingCommaAfterRest(this.state.start);
+            return;
+          }
+          this.eat(tt.comma);
+        } else {
+          this.raiseRestNotLast(this.state.start);
+        }
+      }
+    }
+
     // === === === === === === === === === === === === === === === ===
     // Note: All below methods are duplicates of something in flow.js.
     // Not sure what the best way to combine these is.

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2780,16 +2780,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     checkCommaAfterRest(close) {
-      if (this.match(tt.comma)) {
-        if (this.lookaheadCharCode() === close) {
-          if (!this.state.isDeclareContext) {
-            this.raiseTrailingCommaAfterRest(this.state.start);
-            return;
-          }
-          this.eat(tt.comma);
-        } else {
-          this.raiseRestNotLast(this.state.start);
-        }
+      if (
+        this.state.isDeclareContext &&
+        this.match(tt.comma) &&
+        this.lookaheadCharCode() === close
+      ) {
+        this.next();
+      } else {
+        super.checkCommaAfterRest(close);
       }
     }
 

--- a/packages/babel-parser/test/fixtures/typescript/declare/function-rest-trailing-comma/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/declare/function-rest-trailing-comma/input.ts
@@ -1,0 +1,1 @@
+declare function foo(...args: any[], )

--- a/packages/babel-parser/test/fixtures/typescript/declare/function-rest-trailing-comma/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/function-rest-trailing-comma/output.json
@@ -1,0 +1,48 @@
+{
+  "type": "File",
+  "start":0,"end":38,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":38}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":38,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":38}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSDeclareFunction",
+        "start":0,"end":38,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":38}},
+        "declare": true,
+        "id": {
+          "type": "Identifier",
+          "start":17,"end":20,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":20},"identifierName":"foo"},
+          "name": "foo"
+        },
+        "generator": false,
+        "async": false,
+        "params": [
+          {
+            "type": "RestElement",
+            "start":21,"end":35,"loc":{"start":{"line":1,"column":21},"end":{"line":1,"column":35}},
+            "argument": {
+              "type": "Identifier",
+              "start":24,"end":28,"loc":{"start":{"line":1,"column":24},"end":{"line":1,"column":28},"identifierName":"args"},
+              "name": "args"
+            },
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start":28,"end":35,"loc":{"start":{"line":1,"column":28},"end":{"line":1,"column":35}},
+              "typeAnnotation": {
+                "type": "TSArrayType",
+                "start":30,"end":35,"loc":{"start":{"line":1,"column":30},"end":{"line":1,"column":35}},
+                "elementType": {
+                  "type": "TSAnyKeyword",
+                  "start":30,"end":33,"loc":{"start":{"line":1,"column":30},"end":{"line":1,"column":33}}
+                }
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13100  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
If in declare context we can allow a comma after a function rest parameter.