### PR TITLE
fix: do not filter report from functions within class elements

### DIFF
--- a/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/src/rules/no-invalid-this.js
@@ -17,7 +17,13 @@ export default ruleComposer.filterReports(noInvalidThisRule, problem => {
         node.key.type === "PrivateIdentifier")
     ) {
       inClassMember = true;
-      return;
+      break;
+    } else if (
+      node.type === "FunctionDeclaration" ||
+      node.type === "FunctionExpression"
+    ) {
+      inClassMember = false;
+      break;
     }
 
     node = node.parent;

--- a/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
@@ -93,6 +93,30 @@ const patterns = [
     invalid: [],
   },
 
+  {
+    code: "class A {a = () => { function b() { return this.b;} };};",
+    parserOptions: { ecmaVersion: 6 },
+    valid: [],
+    invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+    errors: [
+      {
+        message: "Unexpected 'this'.",
+      },
+    ],
+  },
+
+  {
+    code: "class A {a = () => { (function b() { return this.b;}); };};",
+    parserOptions: { ecmaVersion: 6 },
+    valid: [],
+    invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+    errors: [
+      {
+        message: "Unexpected 'this'.",
+      },
+    ],
+  },
+
   // Class Private methods
   {
     code: "class A {#a = this.b;};",
@@ -106,6 +130,30 @@ const patterns = [
     parserOptions: { ecmaVersion: 6 },
     valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
     invalid: [],
+  },
+
+  {
+    code: "class A {#a = () => { function b() { return this.b;} };};",
+    parserOptions: { ecmaVersion: 6 },
+    valid: [],
+    invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+    errors: [
+      {
+        message: "Unexpected 'this'.",
+      },
+    ],
+  },
+
+  {
+    code: "class A {#a = () => { (function b() { return this.b;}); };};",
+    parserOptions: { ecmaVersion: 6 },
+    valid: [],
+    invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+    errors: [
+      {
+        message: "Unexpected 'this'.",
+      },
+    ],
   },
 
   {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13085 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`@babel/no-invalid-this` incorrectly mark a `no-invalid-this` report as valid, when it is thrown from a function nested within a class element. This PR breaks `inClassMember` check when we see a function.