### PR TITLE
babel-parser(ts): Add new plugin option `dts: boolean`

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2791,7 +2791,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     checkCommaAfterRest(close) {
       if (
-        this.state.isDeclareContext &&
+        this.state.isAmbientContext &&
         this.match(tt.comma) &&
         this.lookaheadCharCode() === close
       ) {

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -3011,4 +3011,15 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       }
       return method;
     }
+
+    shouldParseAsDts(): boolean {
+      return !!this.getPluginOption("typescript", "dts");
+    }
+
+    parse() {
+      if (this.shouldParseAsDts()) {
+        this.state.isAmbientContext = true;
+      }
+      return super.parse();
+    }
   };

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1563,7 +1563,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         kind = "let";
       }
 
-      return this.tsInDeclareContext(() => {
+      return this.tsInAmbientContext(() => {
         switch (starttype) {
           case tt._function:
             nany.declare = true;
@@ -1853,7 +1853,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         this.finishNode(node, bodilessType);
         return;
       }
-      if (bodilessType === "TSDeclareFunction" && this.state.isDeclareContext) {
+      if (bodilessType === "TSDeclareFunction" && this.state.isAmbientContext) {
         this.raise(node.start, TSErrors.DeclareFunctionHasImplementation);
         if (
           // $FlowIgnore
@@ -2207,7 +2207,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         super.parseClassMember(classBody, member, state);
       };
       if (member.declare) {
-        this.tsInDeclareContext(callParseClassMember);
+        this.tsInAmbientContext(callParseClassMember);
       } else {
         callParseClassMember();
       }
@@ -2430,7 +2430,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     parseClassProperty(node: N.ClassProperty): N.ClassProperty {
       this.parseClassPropertyAnnotation(node);
 
-      if (this.state.isDeclareContext && this.match(tt.eq)) {
+      if (this.state.isAmbientContext && this.match(tt.eq)) {
         this.raise(this.state.start, TSErrors.DeclareClassFieldHasInitializer);
       }
 
@@ -2680,7 +2680,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (this.eat(tt.question)) {
         if (
           param.type !== "Identifier" &&
-          !this.state.isDeclareContext &&
+          !this.state.isAmbientContext &&
           !this.state.inType
         ) {
           this.raise(param.start, TSErrors.PatternIsOptional);
@@ -2940,13 +2940,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return param;
     }
 
-    tsInDeclareContext<T>(cb: () => T): T {
-      const oldIsDeclareContext = this.state.isDeclareContext;
-      this.state.isDeclareContext = true;
+    tsInAmbientContext<T>(cb: () => T): T {
+      const oldIsAmbientContext = this.state.isAmbientContext;
+      this.state.isAmbientContext = true;
       try {
         return cb();
       } finally {
-        this.state.isDeclareContext = oldIsDeclareContext;
+        this.state.isAmbientContext = oldIsAmbientContext;
       }
     }
 

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -3012,10 +3012,21 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return method;
     }
 
+    shouldParseAsAmbientContext(): boolean {
+      return !!this.getPluginOption("typescript", "dts");
+    }
+
     parse() {
-      if (this.getPluginOption("typescript", "dts")) {
+      if (this.shouldParseAsAmbientContext()) {
         this.state.isAmbientContext = true;
       }
       return super.parse();
+    }
+
+    getExpression() {
+      if (this.shouldParseAsAmbientContext()) {
+        this.state.isAmbientContext = true;
+      }
+      return super.getExpression();
     }
   };

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -3012,12 +3012,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return method;
     }
 
-    shouldParseAsDts(): boolean {
-      return !!this.getPluginOption("typescript", "dts");
-    }
-
     parse() {
-      if (this.shouldParseAsDts()) {
+      if (this.getPluginOption("typescript", "dts")) {
         this.state.isAmbientContext = true;
       }
       return super.parse();

--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -65,7 +65,7 @@ export default class State {
   inPropertyName: boolean = false;
   hasFlowComment: boolean = false;
   isIterator: boolean = false;
-  isDeclareContext: boolean = false;
+  isAmbientContext: boolean = false;
   inAbstractClass: boolean = false;
 
   // For the smartPipelines plugin:

--- a/packages/babel-parser/test/fixtures/typescript/dts/invalid-class-implementation/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/dts/invalid-class-implementation/input.ts
@@ -1,0 +1,1 @@
+function foo(): any {}

--- a/packages/babel-parser/test/fixtures/typescript/dts/invalid-class-implementation/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/dts/invalid-class-implementation/output.json
@@ -1,0 +1,42 @@
+{
+  "type": "File",
+  "start":0,"end":22,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":22}},
+  "errors": [
+    "SyntaxError: An implementation cannot be declared in ambient contexts. (1:0)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":22,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":22}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start":0,"end":22,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":22}},
+        "id": {
+          "type": "Identifier",
+          "start":9,"end":12,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":12},"identifierName":"foo"},
+          "name": "foo"
+        },
+        "generator": false,
+        "async": false,
+        "params": [],
+        "returnType": {
+          "type": "TSTypeAnnotation",
+          "start":14,"end":19,"loc":{"start":{"line":1,"column":14},"end":{"line":1,"column":19}},
+          "typeAnnotation": {
+            "type": "TSAnyKeyword",
+            "start":16,"end":19,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":19}}
+          }
+        },
+        "body": {
+          "type": "BlockStatement",
+          "start":20,"end":22,"loc":{"start":{"line":1,"column":20},"end":{"line":1,"column":22}},
+          "body": [],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/dts/invalid-class-initializer/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/dts/invalid-class-initializer/input.ts
@@ -1,0 +1,3 @@
+class Foo {
+  foo = 3;
+}

--- a/packages/babel-parser/test/fixtures/typescript/dts/invalid-class-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/dts/invalid-class-initializer/output.json
@@ -1,0 +1,52 @@
+{
+  "type": "File",
+  "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: Initializers are not allowed in ambient contexts. (2:6)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":24,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":14,"end":22,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":10}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":14,"end":17,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":5},"identifierName":"foo"},
+                "name": "foo"
+              },
+              "computed": false,
+              "value": {
+                "type": "NumericLiteral",
+                "start":20,"end":21,"loc":{"start":{"line":2,"column":8},"end":{"line":2,"column":9}},
+                "extra": {
+                  "rawValue": 3,
+                  "raw": "3"
+                },
+                "value": 3
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/dts/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/dts/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["typescript", { "dts": true }], "classProperties"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/dts/valid-optional-pattern/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/dts/valid-optional-pattern/input.ts
@@ -1,0 +1,1 @@
+function f([]?): any;

--- a/packages/babel-parser/test/fixtures/typescript/dts/valid-optional-pattern/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/dts/valid-optional-pattern/output.json
@@ -1,0 +1,40 @@
+{
+  "type": "File",
+  "start":0,"end":21,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":21}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":21,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":21}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSDeclareFunction",
+        "start":0,"end":21,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":21}},
+        "id": {
+          "type": "Identifier",
+          "start":9,"end":10,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":10},"identifierName":"f"},
+          "name": "f"
+        },
+        "generator": false,
+        "async": false,
+        "params": [
+          {
+            "type": "ArrayPattern",
+            "start":11,"end":14,"loc":{"start":{"line":1,"column":11},"end":{"line":1,"column":14}},
+            "elements": [],
+            "optional": true
+          }
+        ],
+        "returnType": {
+          "type": "TSTypeAnnotation",
+          "start":15,"end":20,"loc":{"start":{"line":1,"column":15},"end":{"line":1,"column":20}},
+          "typeAnnotation": {
+            "type": "TSAnyKeyword",
+            "start":17,"end":20,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":20}}
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/dts/valid-trailing-comma-for-rest/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/dts/valid-trailing-comma-for-rest/input.ts
@@ -1,0 +1,1 @@
+function foo(...args: any[], );

--- a/packages/babel-parser/test/fixtures/typescript/dts/valid-trailing-comma-for-rest/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/dts/valid-trailing-comma-for-rest/output.json
@@ -1,0 +1,47 @@
+{
+  "type": "File",
+  "start":0,"end":31,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":31}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":31,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":31}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSDeclareFunction",
+        "start":0,"end":31,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":31}},
+        "id": {
+          "type": "Identifier",
+          "start":9,"end":12,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":12},"identifierName":"foo"},
+          "name": "foo"
+        },
+        "generator": false,
+        "async": false,
+        "params": [
+          {
+            "type": "RestElement",
+            "start":13,"end":27,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":27}},
+            "argument": {
+              "type": "Identifier",
+              "start":16,"end":20,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":20},"identifierName":"args"},
+              "name": "args"
+            },
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start":20,"end":27,"loc":{"start":{"line":1,"column":20},"end":{"line":1,"column":27}},
+              "typeAnnotation": {
+                "type": "TSArrayType",
+                "start":22,"end":27,"loc":{"start":{"line":1,"column":22},"end":{"line":1,"column":27}},
+                "elementType": {
+                  "type": "TSAnyKeyword",
+                  "start":22,"end":25,"loc":{"start":{"line":1,"column":22},"end":{"line":1,"column":25}}
+                }
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13108
| Minor: New Feature?      | Y
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2487
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I want to use `checkCommaAfterRest` method that is implemented in #13101 so this branch is based on `main`, not [`feat-7.14.0/parser-updates`](https://github.com/babel/babel/pull/13098).

- Rename `this.state.isDeclareContext` => `this.state.isAmbientContext`.
- Add new parser plugin option `dts: boolean`.
- Add tests for syntax errors related ambient context.