### PR TITLE
[preset-env - debug] Print targets that need each plugin

### DIFF
--- a/packages/babel-preset-env/src/debug.js
+++ b/packages/babel-preset-env/src/debug.js
@@ -27,6 +27,7 @@ export const logPlugin = (
     if (!first) formattedTargets += `,`;
     first = false;
     formattedTargets += ` ${target}`;
+    // $FlowIgnore
     if (support[target]) formattedTargets += ` < ${support[target]}`;
   }
   formattedTargets += ` }`;

--- a/packages/babel-preset-env/src/debug.js
+++ b/packages/babel-preset-env/src/debug.js
@@ -14,10 +14,21 @@ export const logPlugin = (
 ) => {
   const filteredList = getInclusionReasons(item, targetVersions, list);
 
-  const formattedTargets = JSON.stringify(filteredList)
-    .replace(/,/g, ", ")
-    .replace(/^\{"/, '{ "')
-    .replace(/"\}$/, '" }');
+  const support = list[item];
+  let formattedTargets;
+  if (support) {
+    formattedTargets = `{`;
+    let first = true;
+    for (const target of Object.keys(filteredList)) {
+      if (!first) formattedTargets += `,`;
+      first = false;
+      formattedTargets += ` ${target}`;
+      if (support[target]) formattedTargets += ` < ${support[target]}`;
+    }
+    formattedTargets += ` }`;
+  } else {
+    formattedTargets = "{}";
+  }
 
   console.log(`  ${item} ${formattedTargets}`);
 };

--- a/packages/babel-preset-env/src/debug.js
+++ b/packages/babel-preset-env/src/debug.js
@@ -15,20 +15,21 @@ export const logPlugin = (
   const filteredList = getInclusionReasons(item, targetVersions, list);
 
   const support = list[item];
-  let formattedTargets;
-  if (support) {
-    formattedTargets = `{`;
-    let first = true;
-    for (const target of Object.keys(filteredList)) {
-      if (!first) formattedTargets += `,`;
-      first = false;
-      formattedTargets += ` ${target}`;
-      if (support[target]) formattedTargets += ` < ${support[target]}`;
-    }
-    formattedTargets += ` }`;
-  } else {
-    formattedTargets = "{}";
+
+  if (!support) {
+    console.log(`  ${item}`);
+    return;
   }
+
+  let formattedTargets = `{`;
+  let first = true;
+  for (const target of Object.keys(filteredList)) {
+    if (!first) formattedTargets += `,`;
+    first = false;
+    formattedTargets += ` ${target}`;
+    if (support[target]) formattedTargets += ` < ${support[target]}`;
+  }
+  formattedTargets += ` }`;
 
   console.log(`  ${item} ${formattedTargets}`);
 };

--- a/packages/babel-preset-env/src/debug.js
+++ b/packages/babel-preset-env/src/debug.js
@@ -5,13 +5,9 @@ import {
   type Targets,
 } from "@babel/helper-compilation-targets";
 
-const wordEnds = (size: number) => {
-  return size > 1 ? "s" : "";
-};
-
 // Outputs a message that shows which target(s) caused an item to be included:
 // transform-foo { "edge":"13", "firefox":"49", "ie":"10" }
-export const logPluginOrPolyfill = (
+export const logPlugin = (
   item: string,
   targetVersions: Targets,
   list: { [key: string]: Targets },
@@ -24,59 +20,4 @@ export const logPluginOrPolyfill = (
     .replace(/"\}$/, '" }');
 
   console.log(`  ${item} ${formattedTargets}`);
-};
-
-export const logEntryPolyfills = (
-  polyfillName: string,
-  importPolyfillIncluded: boolean,
-  polyfills: Set<string>,
-  filename: string,
-  polyfillTargets: Targets,
-  allBuiltInsList: { [key: string]: Targets },
-) => {
-  if (!importPolyfillIncluded) {
-    console.log(`\n[${filename}] Import of ${polyfillName} was not found.`);
-    return;
-  }
-  if (!polyfills.size) {
-    console.log(
-      `\n[${filename}] Based on your targets, polyfills were not added.`,
-    );
-    return;
-  }
-
-  console.log(
-    `\n[${filename}] Replaced ${polyfillName} entries with the following polyfill${wordEnds(
-      polyfills.size,
-    )}:`,
-  );
-  for (const polyfill of polyfills) {
-    logPluginOrPolyfill(polyfill, polyfillTargets, allBuiltInsList);
-  }
-};
-
-export const logUsagePolyfills = (
-  polyfills: Set<string>,
-  filename: string,
-  polyfillTargets: Targets,
-  allBuiltInsList: { [key: string]: Targets },
-) => {
-  // normalize filename to generate consistent preset-env test fixtures
-  if (process.env.BABEL_ENV === "test") {
-    filename = filename.replace(/\\/g, "/");
-  }
-  if (!polyfills.size) {
-    console.log(
-      `\n[${filename}] Based on your code and targets, core-js polyfills were not added.`,
-    );
-    return;
-  }
-  console.log(
-    `\n[${filename}] Added following core-js polyfill${wordEnds(
-      polyfills.size,
-    )}:`,
-  );
-  for (const polyfill of polyfills) {
-    logPluginOrPolyfill(polyfill, polyfillTargets, allBuiltInsList);
-  }
 };

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -1,7 +1,7 @@
 //@flow
 
 import { SemVer, lt } from "semver";
-import { logPluginOrPolyfill } from "./debug";
+import { logPlugin } from "./debug";
 import getOptionSpecificExcludesFor from "./get-option-specific-excludes";
 import { removeUnnecessaryItems } from "./filter-items";
 import moduleTransformations from "./module-transformations";
@@ -420,7 +420,7 @@ option \`forceAllTransforms: true\` instead.
     console.log(`\nUsing modules transform: ${modules.toString()}`);
     console.log("\nUsing plugins:");
     pluginNames.forEach(pluginName => {
-      logPluginOrPolyfill(pluginName, targets, pluginsList);
+      logPlugin(pluginName, targets, pluginsList);
     });
 
     if (!useBuiltIns) {

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -420,7 +420,7 @@ option \`forceAllTransforms: true\` instead.
     console.log(`\nUsing modules transform: ${modules.toString()}`);
     console.log("\nUsing plugins:");
     pluginNames.forEach(pluginName => {
-      logPlugin(pluginName, targets, pluginsList);
+      logPlugin(pluginName, targets, compatData);
     });
 
     if (!useBuiltIns) {

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
@@ -16,25 +16,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-logical-assignment-operators { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-catch-binding { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-parameters { "edge":"16" }
-  proposal-async-generator-functions { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-object-rest-spread { "edge":"16", "ios":"10.3", "safari":"10.1" }
-  transform-dotall-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-unicode-property-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-named-capturing-groups-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
-  transform-template-literals { "ios":"10.3", "safari":"10.1" }
-  transform-function-name { "edge":"16" }
-  transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
-  transform-block-scoping { "ios":"10.3", "safari":"10.1" }
-  proposal-export-namespace-from { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-modules-commonjs { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, firefox < 74, ios < 13.4, node, opera, safari < 13.1, samsung }
+  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  transform-parameters { edge < 18 }
+  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
+  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-async-to-generator { ios < 11, safari < 11 }
+  transform-template-literals { ios < 13, safari < 13 }
+  transform-function-name { edge < 79 }
+  transform-unicode-regex { ios < 12, safari < 12 }
+  transform-block-scoping { ios < 11, safari < 11 }
+  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
@@ -34,7 +34,7 @@ Using plugins:
   transform-unicode-regex { ios < 12, safari < 12 }
   transform-block-scoping { ios < 11, safari < 11 }
   proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
@@ -16,26 +16,26 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-logical-assignment-operators { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-catch-binding { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-async-generator-functions { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-object-rest-spread { "edge":"16", "ios":"10.3", "safari":"10.1" }
-  transform-dotall-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-unicode-property-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-named-capturing-groups-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
-  proposal-export-namespace-from { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  bugfix/transform-async-arrows-in-class { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  bugfix/transform-edge-default-parameters { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  bugfix/transform-edge-function-name { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  bugfix/transform-safari-block-shadowing { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  bugfix/transform-safari-for-shadowing { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  bugfix/transform-tagged-template-caching { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-modules-commonjs { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, firefox < 74, ios < 13.4, node, opera, safari < 13.1, samsung }
+  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
+  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-unicode-regex { ios < 12, safari < 12 }
+  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  bugfix/transform-async-arrows-in-class {}
+  bugfix/transform-edge-default-parameters {}
+  bugfix/transform-edge-function-name {}
+  bugfix/transform-safari-block-shadowing {}
+  bugfix/transform-safari-for-shadowing {}
+  bugfix/transform-tagged-template-caching {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
@@ -19,7 +19,7 @@ Using plugins:
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
   proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera, safari < 14, samsung }
   proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
-  proposal-optional-chaining { android, chrome, edge, firefox < 74, ios < 13.4, node, opera, safari < 13.1, samsung }
+  proposal-optional-chaining { android, chrome < 80, edge < 80, firefox < 74, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
   proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
   proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
   proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
@@ -29,12 +29,12 @@ Using plugins:
   transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-unicode-regex { ios < 12, safari < 12 }
   proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
-  bugfix/transform-async-arrows-in-class
-  bugfix/transform-edge-default-parameters
-  bugfix/transform-edge-function-name
-  bugfix/transform-safari-block-shadowing
-  bugfix/transform-safari-for-shadowing
-  bugfix/transform-tagged-template-caching
+  bugfix/transform-async-arrows-in-class { ios < 11, safari < 11 }
+  bugfix/transform-edge-default-parameters { edge < 18 }
+  bugfix/transform-edge-function-name { edge < 79 }
+  bugfix/transform-safari-block-shadowing { ios < 11, safari < 11 }
+  bugfix/transform-safari-for-shadowing { ios < 11, safari < 11 }
+  bugfix/transform-tagged-template-caching { ios < 13, safari < 13 }
   transform-modules-commonjs
   proposal-dynamic-import
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
@@ -29,13 +29,13 @@ Using plugins:
   transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-unicode-regex { ios < 12, safari < 12 }
   proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
-  bugfix/transform-async-arrows-in-class {}
-  bugfix/transform-edge-default-parameters {}
-  bugfix/transform-edge-function-name {}
-  bugfix/transform-safari-block-shadowing {}
-  bugfix/transform-safari-for-shadowing {}
-  bugfix/transform-tagged-template-caching {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  bugfix/transform-async-arrows-in-class
+  bugfix/transform-edge-default-parameters
+  bugfix/transform-edge-function-name
+  bugfix/transform-safari-block-shadowing
+  bugfix/transform-safari-for-shadowing
+  bugfix/transform-tagged-template-caching
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
@@ -8,39 +8,39 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"40" }
-  proposal-logical-assignment-operators { "chrome":"40" }
-  proposal-nullish-coalescing-operator { "chrome":"40" }
-  proposal-optional-chaining { "chrome":"40" }
-  proposal-json-strings { "chrome":"40" }
-  proposal-optional-catch-binding { "chrome":"40" }
-  transform-parameters { "chrome":"40" }
-  proposal-async-generator-functions { "chrome":"40" }
-  proposal-object-rest-spread { "chrome":"40" }
-  transform-dotall-regex { "chrome":"40" }
-  proposal-unicode-property-regex { "chrome":"40" }
-  transform-named-capturing-groups-regex { "chrome":"40" }
-  transform-async-to-generator { "chrome":"40" }
-  transform-exponentiation-operator { "chrome":"40" }
-  transform-template-literals { "chrome":"40" }
-  transform-literals { "chrome":"40" }
-  transform-function-name { "chrome":"40" }
-  transform-block-scoped-functions { "chrome":"40" }
-  transform-classes { "chrome":"40" }
-  transform-object-super { "chrome":"40" }
-  transform-shorthand-properties { "chrome":"40" }
-  transform-duplicate-keys { "chrome":"40" }
-  transform-computed-properties { "chrome":"40" }
-  transform-for-of { "chrome":"40" }
-  transform-sticky-regex { "chrome":"40" }
-  transform-unicode-escapes { "chrome":"40" }
-  transform-unicode-regex { "chrome":"40" }
-  transform-spread { "chrome":"40" }
-  transform-block-scoping { "chrome":"40" }
-  transform-new-target { "chrome":"40" }
-  transform-regenerator { "chrome":"40" }
-  proposal-export-namespace-from { "chrome":"40" }
-  transform-modules-commonjs { "chrome":"40" }
-  proposal-dynamic-import { "chrome":"40" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  transform-parameters { chrome < 49 }
+  proposal-async-generator-functions { chrome < 63 }
+  proposal-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  transform-async-to-generator { chrome < 55 }
+  transform-exponentiation-operator { chrome < 52 }
+  transform-template-literals { chrome < 41 }
+  transform-literals { chrome < 44 }
+  transform-function-name { chrome < 51 }
+  transform-block-scoped-functions { chrome < 41 }
+  transform-classes { chrome < 46 }
+  transform-object-super { chrome < 46 }
+  transform-shorthand-properties { chrome < 43 }
+  transform-duplicate-keys { chrome < 42 }
+  transform-computed-properties { chrome < 44 }
+  transform-for-of { chrome < 51 }
+  transform-sticky-regex { chrome < 49 }
+  transform-unicode-escapes { chrome < 44 }
+  transform-unicode-regex { chrome < 50 }
+  transform-spread { chrome < 46 }
+  transform-block-scoping { chrome < 49 }
+  transform-new-target { chrome < 46 }
+  transform-regenerator { chrome < 50 }
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
@@ -40,7 +40,7 @@ Using plugins:
   transform-new-target { chrome < 46 }
   transform-regenerator { chrome < 50 }
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
@@ -11,7 +11,7 @@ Using plugins:
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome }
+  proposal-optional-chaining { chrome < 80 }
   proposal-json-strings { chrome < 66 }
   proposal-optional-catch-binding { chrome < 66 }
   transform-parameters { chrome < 49 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
@@ -12,12 +12,12 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
@@ -8,16 +8,16 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"70" }
-  proposal-logical-assignment-operators { "chrome":"70" }
-  proposal-nullish-coalescing-operator { "chrome":"70" }
-  proposal-optional-chaining { "chrome":"70" }
-  syntax-json-strings { "chrome":"70" }
-  syntax-optional-catch-binding { "chrome":"70" }
-  syntax-async-generators { "chrome":"70" }
-  syntax-object-rest-spread { "chrome":"70" }
-  proposal-export-namespace-from { "chrome":"70" }
-  transform-modules-commonjs { "chrome":"70" }
-  proposal-dynamic-import { "chrome":"70" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
@@ -11,7 +11,7 @@ Using plugins:
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome }
+  proposal-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "edge":"14" }
-  proposal-logical-assignment-operators { "edge":"14" }
-  proposal-nullish-coalescing-operator { "edge":"14" }
-  proposal-optional-chaining { "edge":"14" }
-  proposal-json-strings { "edge":"14" }
-  proposal-optional-catch-binding { "edge":"14" }
-  transform-parameters { "edge":"14" }
-  proposal-async-generator-functions { "edge":"14" }
-  proposal-object-rest-spread { "edge":"14" }
-  transform-dotall-regex { "edge":"14" }
-  proposal-unicode-property-regex { "edge":"14" }
-  transform-named-capturing-groups-regex { "edge":"14" }
-  transform-async-to-generator { "edge":"14" }
-  transform-for-of { "edge":"14" }
-  transform-destructuring { "edge":"14" }
-  proposal-export-namespace-from { "edge":"14" }
-  bugfix/transform-edge-function-name { "edge":"14" }
-  transform-modules-commonjs { "edge":"14" }
-  proposal-dynamic-import { "edge":"14" }
+  proposal-numeric-separator { edge < 79 }
+  proposal-logical-assignment-operators { edge < 85 }
+  proposal-nullish-coalescing-operator { edge < 80 }
+  proposal-optional-chaining { edge }
+  proposal-json-strings { edge < 79 }
+  proposal-optional-catch-binding { edge < 79 }
+  transform-parameters { edge < 18 }
+  proposal-async-generator-functions { edge < 79 }
+  proposal-object-rest-spread { edge < 79 }
+  transform-dotall-regex { edge < 79 }
+  proposal-unicode-property-regex { edge < 79 }
+  transform-named-capturing-groups-regex { edge < 79 }
+  transform-async-to-generator { edge < 15 }
+  transform-for-of { edge < 15 }
+  transform-destructuring { edge < 15 }
+  proposal-export-namespace-from { edge < 79 }
+  bugfix/transform-edge-function-name {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
@@ -11,10 +11,10 @@ Using plugins:
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }
   proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge }
+  proposal-optional-chaining { edge < 80 }
   proposal-json-strings { edge < 79 }
   proposal-optional-catch-binding { edge < 79 }
-  transform-parameters { edge < 18 }
+  transform-parameters { edge < 15 }
   proposal-async-generator-functions { edge < 79 }
   proposal-object-rest-spread { edge < 79 }
   transform-dotall-regex { edge < 79 }
@@ -24,7 +24,7 @@ Using plugins:
   transform-for-of { edge < 15 }
   transform-destructuring { edge < 15 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-function-name
+  bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   proposal-dynamic-import
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
@@ -24,8 +24,8 @@ Using plugins:
   transform-for-of { edge < 15 }
   transform-destructuring { edge < 15 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-function-name {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  bugfix/transform-edge-function-name
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
@@ -20,9 +20,9 @@ Using plugins:
   proposal-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-default-parameters {}
-  bugfix/transform-edge-function-name {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  bugfix/transform-edge-default-parameters
+  bugfix/transform-edge-function-name
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
@@ -11,7 +11,7 @@ Using plugins:
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }
   proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge }
+  proposal-optional-chaining { edge < 80 }
   proposal-json-strings { edge < 79 }
   proposal-optional-catch-binding { edge < 79 }
   proposal-async-generator-functions { edge < 79 }
@@ -20,8 +20,8 @@ Using plugins:
   proposal-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-default-parameters
-  bugfix/transform-edge-function-name
+  bugfix/transform-edge-default-parameters { edge < 18 }
+  bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   proposal-dynamic-import
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "edge":"15" }
-  proposal-logical-assignment-operators { "edge":"15" }
-  proposal-nullish-coalescing-operator { "edge":"15" }
-  proposal-optional-chaining { "edge":"15" }
-  proposal-json-strings { "edge":"15" }
-  proposal-optional-catch-binding { "edge":"15" }
-  proposal-async-generator-functions { "edge":"15" }
-  proposal-object-rest-spread { "edge":"15" }
-  transform-dotall-regex { "edge":"15" }
-  proposal-unicode-property-regex { "edge":"15" }
-  transform-named-capturing-groups-regex { "edge":"15" }
-  proposal-export-namespace-from { "edge":"15" }
-  bugfix/transform-edge-default-parameters { "edge":"15" }
-  bugfix/transform-edge-function-name { "edge":"15" }
-  transform-modules-commonjs { "edge":"15" }
-  proposal-dynamic-import { "edge":"15" }
+  proposal-numeric-separator { edge < 79 }
+  proposal-logical-assignment-operators { edge < 85 }
+  proposal-nullish-coalescing-operator { edge < 80 }
+  proposal-optional-chaining { edge }
+  proposal-json-strings { edge < 79 }
+  proposal-optional-catch-binding { edge < 79 }
+  proposal-async-generator-functions { edge < 79 }
+  proposal-object-rest-spread { edge < 79 }
+  transform-dotall-regex { edge < 79 }
+  proposal-unicode-property-regex { edge < 79 }
+  transform-named-capturing-groups-regex { edge < 79 }
+  proposal-export-namespace-from { edge < 79 }
+  bugfix/transform-edge-default-parameters {}
+  bugfix/transform-edge-function-name {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "edge":"17" }
-  proposal-logical-assignment-operators { "edge":"17" }
-  proposal-nullish-coalescing-operator { "edge":"17" }
-  proposal-optional-chaining { "edge":"17" }
-  proposal-json-strings { "edge":"17" }
-  proposal-optional-catch-binding { "edge":"17" }
-  transform-parameters { "edge":"17" }
-  proposal-async-generator-functions { "edge":"17" }
-  proposal-object-rest-spread { "edge":"17" }
-  transform-dotall-regex { "edge":"17" }
-  proposal-unicode-property-regex { "edge":"17" }
-  transform-named-capturing-groups-regex { "edge":"17" }
-  transform-function-name { "edge":"17" }
-  proposal-export-namespace-from { "edge":"17" }
-  transform-modules-commonjs { "edge":"17" }
-  proposal-dynamic-import { "edge":"17" }
+  proposal-numeric-separator { edge < 79 }
+  proposal-logical-assignment-operators { edge < 85 }
+  proposal-nullish-coalescing-operator { edge < 80 }
+  proposal-optional-chaining { edge }
+  proposal-json-strings { edge < 79 }
+  proposal-optional-catch-binding { edge < 79 }
+  transform-parameters { edge < 18 }
+  proposal-async-generator-functions { edge < 79 }
+  proposal-object-rest-spread { edge < 79 }
+  transform-dotall-regex { edge < 79 }
+  proposal-unicode-property-regex { edge < 79 }
+  transform-named-capturing-groups-regex { edge < 79 }
+  transform-function-name { edge < 79 }
+  proposal-export-namespace-from { edge < 79 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
@@ -22,7 +22,7 @@ Using plugins:
   transform-named-capturing-groups-regex { edge < 79 }
   transform-function-name { edge < 79 }
   proposal-export-namespace-from { edge < 79 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
@@ -20,9 +20,9 @@ Using plugins:
   proposal-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-default-parameters {}
-  bugfix/transform-edge-function-name {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  bugfix/transform-edge-default-parameters
+  bugfix/transform-edge-function-name
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
@@ -11,7 +11,7 @@ Using plugins:
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }
   proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge }
+  proposal-optional-chaining { edge < 80 }
   proposal-json-strings { edge < 79 }
   proposal-optional-catch-binding { edge < 79 }
   proposal-async-generator-functions { edge < 79 }
@@ -20,8 +20,8 @@ Using plugins:
   proposal-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-default-parameters
-  bugfix/transform-edge-function-name
+  bugfix/transform-edge-default-parameters { edge < 18 }
+  bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   proposal-dynamic-import
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "edge":"17" }
-  proposal-logical-assignment-operators { "edge":"17" }
-  proposal-nullish-coalescing-operator { "edge":"17" }
-  proposal-optional-chaining { "edge":"17" }
-  proposal-json-strings { "edge":"17" }
-  proposal-optional-catch-binding { "edge":"17" }
-  proposal-async-generator-functions { "edge":"17" }
-  proposal-object-rest-spread { "edge":"17" }
-  transform-dotall-regex { "edge":"17" }
-  proposal-unicode-property-regex { "edge":"17" }
-  transform-named-capturing-groups-regex { "edge":"17" }
-  proposal-export-namespace-from { "edge":"17" }
-  bugfix/transform-edge-default-parameters { "edge":"17" }
-  bugfix/transform-edge-function-name { "edge":"17" }
-  transform-modules-commonjs { "edge":"17" }
-  proposal-dynamic-import { "edge":"17" }
+  proposal-numeric-separator { edge < 79 }
+  proposal-logical-assignment-operators { edge < 85 }
+  proposal-nullish-coalescing-operator { edge < 80 }
+  proposal-optional-chaining { edge }
+  proposal-json-strings { edge < 79 }
+  proposal-optional-catch-binding { edge < 79 }
+  proposal-async-generator-functions { edge < 79 }
+  proposal-object-rest-spread { edge < 79 }
+  transform-dotall-regex { edge < 79 }
+  proposal-unicode-property-regex { edge < 79 }
+  transform-named-capturing-groups-regex { edge < 79 }
+  proposal-export-namespace-from { edge < 79 }
+  bugfix/transform-edge-default-parameters {}
+  bugfix/transform-edge-function-name {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "edge":"18" }
-  proposal-logical-assignment-operators { "edge":"18" }
-  proposal-nullish-coalescing-operator { "edge":"18" }
-  proposal-optional-chaining { "edge":"18" }
-  proposal-json-strings { "edge":"18" }
-  proposal-optional-catch-binding { "edge":"18" }
-  proposal-async-generator-functions { "edge":"18" }
-  proposal-object-rest-spread { "edge":"18" }
-  transform-dotall-regex { "edge":"18" }
-  proposal-unicode-property-regex { "edge":"18" }
-  transform-named-capturing-groups-regex { "edge":"18" }
-  proposal-export-namespace-from { "edge":"18" }
-  bugfix/transform-edge-function-name { "edge":"18" }
-  transform-modules-commonjs { "edge":"18" }
-  proposal-dynamic-import { "edge":"18" }
+  proposal-numeric-separator { edge < 79 }
+  proposal-logical-assignment-operators { edge < 85 }
+  proposal-nullish-coalescing-operator { edge < 80 }
+  proposal-optional-chaining { edge }
+  proposal-json-strings { edge < 79 }
+  proposal-optional-catch-binding { edge < 79 }
+  proposal-async-generator-functions { edge < 79 }
+  proposal-object-rest-spread { edge < 79 }
+  transform-dotall-regex { edge < 79 }
+  proposal-unicode-property-regex { edge < 79 }
+  transform-named-capturing-groups-regex { edge < 79 }
+  proposal-export-namespace-from { edge < 79 }
+  bugfix/transform-edge-function-name {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
@@ -11,7 +11,7 @@ Using plugins:
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }
   proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge }
+  proposal-optional-chaining { edge < 80 }
   proposal-json-strings { edge < 79 }
   proposal-optional-catch-binding { edge < 79 }
   proposal-async-generator-functions { edge < 79 }
@@ -20,7 +20,7 @@ Using plugins:
   proposal-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-function-name
+  bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   proposal-dynamic-import
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
@@ -20,8 +20,8 @@ Using plugins:
   proposal-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-function-name {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  bugfix/transform-edge-function-name
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
@@ -25,7 +25,7 @@ Using plugins:
   transform-for-of { edge < 15 }
   transform-destructuring { edge < 15 }
   proposal-export-namespace-from { edge < 79 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "edge":"14" }
-  proposal-logical-assignment-operators { "edge":"14" }
-  proposal-nullish-coalescing-operator { "edge":"14" }
-  proposal-optional-chaining { "edge":"14" }
-  proposal-json-strings { "edge":"14" }
-  proposal-optional-catch-binding { "edge":"14" }
-  transform-parameters { "edge":"14" }
-  proposal-async-generator-functions { "edge":"14" }
-  proposal-object-rest-spread { "edge":"14" }
-  transform-dotall-regex { "edge":"14" }
-  proposal-unicode-property-regex { "edge":"14" }
-  transform-named-capturing-groups-regex { "edge":"14" }
-  transform-async-to-generator { "edge":"14" }
-  transform-function-name { "edge":"14" }
-  transform-for-of { "edge":"14" }
-  transform-destructuring { "edge":"14" }
-  proposal-export-namespace-from { "edge":"14" }
-  transform-modules-commonjs { "edge":"14" }
-  proposal-dynamic-import { "edge":"14" }
+  proposal-numeric-separator { edge < 79 }
+  proposal-logical-assignment-operators { edge < 85 }
+  proposal-nullish-coalescing-operator { edge < 80 }
+  proposal-optional-chaining { edge }
+  proposal-json-strings { edge < 79 }
+  proposal-optional-catch-binding { edge < 79 }
+  transform-parameters { edge < 18 }
+  proposal-async-generator-functions { edge < 79 }
+  proposal-object-rest-spread { edge < 79 }
+  transform-dotall-regex { edge < 79 }
+  proposal-unicode-property-regex { edge < 79 }
+  transform-named-capturing-groups-regex { edge < 79 }
+  transform-async-to-generator { edge < 15 }
+  transform-function-name { edge < 79 }
+  transform-for-of { edge < 15 }
+  transform-destructuring { edge < 15 }
+  proposal-export-namespace-from { edge < 79 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "edge":"14" }
-  proposal-logical-assignment-operators { "edge":"14" }
-  proposal-nullish-coalescing-operator { "edge":"14" }
-  proposal-optional-chaining { "edge":"14" }
-  proposal-json-strings { "edge":"14" }
-  proposal-optional-catch-binding { "edge":"14" }
-  transform-parameters { "edge":"14" }
-  proposal-async-generator-functions { "edge":"14" }
-  proposal-object-rest-spread { "edge":"14" }
-  transform-dotall-regex { "edge":"14" }
-  proposal-unicode-property-regex { "edge":"14" }
-  transform-named-capturing-groups-regex { "edge":"14" }
-  transform-async-to-generator { "edge":"14" }
-  transform-for-of { "edge":"14" }
-  transform-destructuring { "edge":"14" }
-  proposal-export-namespace-from { "edge":"14" }
-  bugfix/transform-edge-function-name { "edge":"14" }
-  transform-modules-commonjs { "edge":"14" }
-  proposal-dynamic-import { "edge":"14" }
+  proposal-numeric-separator { edge < 79 }
+  proposal-logical-assignment-operators { edge < 85 }
+  proposal-nullish-coalescing-operator { edge < 80 }
+  proposal-optional-chaining { edge }
+  proposal-json-strings { edge < 79 }
+  proposal-optional-catch-binding { edge < 79 }
+  transform-parameters { edge < 18 }
+  proposal-async-generator-functions { edge < 79 }
+  proposal-object-rest-spread { edge < 79 }
+  transform-dotall-regex { edge < 79 }
+  proposal-unicode-property-regex { edge < 79 }
+  transform-named-capturing-groups-regex { edge < 79 }
+  transform-async-to-generator { edge < 15 }
+  transform-for-of { edge < 15 }
+  transform-destructuring { edge < 15 }
+  proposal-export-namespace-from { edge < 79 }
+  bugfix/transform-edge-function-name {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
@@ -11,10 +11,10 @@ Using plugins:
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }
   proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge }
+  proposal-optional-chaining { edge < 80 }
   proposal-json-strings { edge < 79 }
   proposal-optional-catch-binding { edge < 79 }
-  transform-parameters { edge < 18 }
+  transform-parameters { edge < 15 }
   proposal-async-generator-functions { edge < 79 }
   proposal-object-rest-spread { edge < 79 }
   transform-dotall-regex { edge < 79 }
@@ -24,7 +24,7 @@ Using plugins:
   transform-for-of { edge < 15 }
   transform-destructuring { edge < 15 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-function-name
+  bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   proposal-dynamic-import
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
@@ -24,8 +24,8 @@ Using plugins:
   transform-for-of { edge < 15 }
   transform-destructuring { edge < 15 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-function-name {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  bugfix/transform-edge-function-name
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
@@ -20,9 +20,9 @@ Using plugins:
   proposal-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-default-parameters {}
-  bugfix/transform-edge-function-name {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  bugfix/transform-edge-default-parameters
+  bugfix/transform-edge-function-name
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
@@ -11,7 +11,7 @@ Using plugins:
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }
   proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge }
+  proposal-optional-chaining { edge < 80 }
   proposal-json-strings { edge < 79 }
   proposal-optional-catch-binding { edge < 79 }
   proposal-async-generator-functions { edge < 79 }
@@ -20,8 +20,8 @@ Using plugins:
   proposal-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   proposal-export-namespace-from { edge < 79 }
-  bugfix/transform-edge-default-parameters
-  bugfix/transform-edge-function-name
+  bugfix/transform-edge-default-parameters { edge < 18 }
+  bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   proposal-dynamic-import
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "edge":"15" }
-  proposal-logical-assignment-operators { "edge":"15" }
-  proposal-nullish-coalescing-operator { "edge":"15" }
-  proposal-optional-chaining { "edge":"15" }
-  proposal-json-strings { "edge":"15" }
-  proposal-optional-catch-binding { "edge":"15" }
-  proposal-async-generator-functions { "edge":"15" }
-  proposal-object-rest-spread { "edge":"15" }
-  transform-dotall-regex { "edge":"15" }
-  proposal-unicode-property-regex { "edge":"15" }
-  transform-named-capturing-groups-regex { "edge":"15" }
-  proposal-export-namespace-from { "edge":"15" }
-  bugfix/transform-edge-default-parameters { "edge":"15" }
-  bugfix/transform-edge-function-name { "edge":"15" }
-  transform-modules-commonjs { "edge":"15" }
-  proposal-dynamic-import { "edge":"15" }
+  proposal-numeric-separator { edge < 79 }
+  proposal-logical-assignment-operators { edge < 85 }
+  proposal-nullish-coalescing-operator { edge < 80 }
+  proposal-optional-chaining { edge }
+  proposal-json-strings { edge < 79 }
+  proposal-optional-catch-binding { edge < 79 }
+  proposal-async-generator-functions { edge < 79 }
+  proposal-object-rest-spread { edge < 79 }
+  transform-dotall-regex { edge < 79 }
+  proposal-unicode-property-regex { edge < 79 }
+  transform-named-capturing-groups-regex { edge < 79 }
+  proposal-export-namespace-from { edge < 79 }
+  bugfix/transform-edge-default-parameters {}
+  bugfix/transform-edge-function-name {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
@@ -25,7 +25,7 @@ Using plugins:
   transform-unicode-regex { safari < 12 }
   transform-block-scoping { safari < 11 }
   proposal-export-namespace-from { safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "safari":"10" }
-  proposal-logical-assignment-operators { "safari":"10" }
-  proposal-nullish-coalescing-operator { "safari":"10" }
-  proposal-optional-chaining { "safari":"10" }
-  proposal-json-strings { "safari":"10" }
-  proposal-optional-catch-binding { "safari":"10" }
-  proposal-async-generator-functions { "safari":"10" }
-  proposal-object-rest-spread { "safari":"10" }
-  transform-dotall-regex { "safari":"10" }
-  proposal-unicode-property-regex { "safari":"10" }
-  transform-named-capturing-groups-regex { "safari":"10" }
-  transform-async-to-generator { "safari":"10" }
-  transform-exponentiation-operator { "safari":"10" }
-  transform-template-literals { "safari":"10" }
-  transform-unicode-regex { "safari":"10" }
-  transform-block-scoping { "safari":"10" }
-  proposal-export-namespace-from { "safari":"10" }
-  transform-modules-commonjs { "safari":"10" }
-  proposal-dynamic-import { "safari":"10" }
+  proposal-numeric-separator { safari < 13 }
+  proposal-logical-assignment-operators { safari < 14 }
+  proposal-nullish-coalescing-operator { safari < 13.1 }
+  proposal-optional-chaining { safari < 13.1 }
+  proposal-json-strings { safari < 12 }
+  proposal-optional-catch-binding { safari < 11.1 }
+  proposal-async-generator-functions { safari < 12 }
+  proposal-object-rest-spread { safari < 11.1 }
+  transform-dotall-regex { safari < 11.1 }
+  proposal-unicode-property-regex { safari < 11.1 }
+  transform-named-capturing-groups-regex { safari < 11.1 }
+  transform-async-to-generator { safari < 11 }
+  transform-exponentiation-operator { safari < 10.1 }
+  transform-template-literals { safari < 13 }
+  transform-unicode-regex { safari < 12 }
+  transform-block-scoping { safari < 11 }
+  proposal-export-namespace-from { safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
@@ -23,10 +23,10 @@ Using plugins:
   transform-exponentiation-operator { safari < 10.1 }
   transform-unicode-regex { safari < 12 }
   proposal-export-namespace-from { safari }
-  bugfix/transform-safari-block-shadowing {}
-  bugfix/transform-safari-for-shadowing {}
-  bugfix/transform-tagged-template-caching {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  bugfix/transform-safari-block-shadowing
+  bugfix/transform-safari-for-shadowing
+  bugfix/transform-tagged-template-caching
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
@@ -19,13 +19,13 @@ Using plugins:
   transform-dotall-regex { safari < 11.1 }
   proposal-unicode-property-regex { safari < 11.1 }
   transform-named-capturing-groups-regex { safari < 11.1 }
-  transform-async-to-generator { safari < 11 }
+  transform-async-to-generator { safari < 10.1 }
   transform-exponentiation-operator { safari < 10.1 }
   transform-unicode-regex { safari < 12 }
   proposal-export-namespace-from { safari }
-  bugfix/transform-safari-block-shadowing
-  bugfix/transform-safari-for-shadowing
-  bugfix/transform-tagged-template-caching
+  bugfix/transform-safari-block-shadowing { safari < 11 }
+  bugfix/transform-safari-for-shadowing { safari < 11 }
+  bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
   proposal-dynamic-import
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
@@ -8,25 +8,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "safari":"10" }
-  proposal-logical-assignment-operators { "safari":"10" }
-  proposal-nullish-coalescing-operator { "safari":"10" }
-  proposal-optional-chaining { "safari":"10" }
-  proposal-json-strings { "safari":"10" }
-  proposal-optional-catch-binding { "safari":"10" }
-  proposal-async-generator-functions { "safari":"10" }
-  proposal-object-rest-spread { "safari":"10" }
-  transform-dotall-regex { "safari":"10" }
-  proposal-unicode-property-regex { "safari":"10" }
-  transform-named-capturing-groups-regex { "safari":"10" }
-  transform-async-to-generator { "safari":"10" }
-  transform-exponentiation-operator { "safari":"10" }
-  transform-unicode-regex { "safari":"10" }
-  proposal-export-namespace-from { "safari":"10" }
-  bugfix/transform-safari-block-shadowing { "safari":"10" }
-  bugfix/transform-safari-for-shadowing { "safari":"10" }
-  bugfix/transform-tagged-template-caching { "safari":"10" }
-  transform-modules-commonjs { "safari":"10" }
-  proposal-dynamic-import { "safari":"10" }
+  proposal-numeric-separator { safari < 13 }
+  proposal-logical-assignment-operators { safari < 14 }
+  proposal-nullish-coalescing-operator { safari < 13.1 }
+  proposal-optional-chaining { safari < 13.1 }
+  proposal-json-strings { safari < 12 }
+  proposal-optional-catch-binding { safari < 11.1 }
+  proposal-async-generator-functions { safari < 12 }
+  proposal-object-rest-spread { safari < 11.1 }
+  transform-dotall-regex { safari < 11.1 }
+  proposal-unicode-property-regex { safari < 11.1 }
+  transform-named-capturing-groups-regex { safari < 11.1 }
+  transform-async-to-generator { safari < 11 }
+  transform-exponentiation-operator { safari < 10.1 }
+  transform-unicode-regex { safari < 12 }
+  proposal-export-namespace-from { safari }
+  bugfix/transform-safari-block-shadowing {}
+  bugfix/transform-safari-for-shadowing {}
+  bugfix/transform-tagged-template-caching {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
@@ -21,7 +21,7 @@ Using plugins:
   transform-named-capturing-groups-regex { safari < 11.1 }
   transform-unicode-regex { safari < 12 }
   proposal-export-namespace-from { safari }
-  bugfix/transform-tagged-template-caching
+  bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
   proposal-dynamic-import
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "safari":"11" }
-  proposal-logical-assignment-operators { "safari":"11" }
-  proposal-nullish-coalescing-operator { "safari":"11" }
-  proposal-optional-chaining { "safari":"11" }
-  proposal-json-strings { "safari":"11" }
-  proposal-optional-catch-binding { "safari":"11" }
-  proposal-async-generator-functions { "safari":"11" }
-  proposal-object-rest-spread { "safari":"11" }
-  transform-dotall-regex { "safari":"11" }
-  proposal-unicode-property-regex { "safari":"11" }
-  transform-named-capturing-groups-regex { "safari":"11" }
-  transform-unicode-regex { "safari":"11" }
-  proposal-export-namespace-from { "safari":"11" }
-  bugfix/transform-tagged-template-caching { "safari":"11" }
-  transform-modules-commonjs { "safari":"11" }
-  proposal-dynamic-import { "safari":"11" }
+  proposal-numeric-separator { safari < 13 }
+  proposal-logical-assignment-operators { safari < 14 }
+  proposal-nullish-coalescing-operator { safari < 13.1 }
+  proposal-optional-chaining { safari < 13.1 }
+  proposal-json-strings { safari < 12 }
+  proposal-optional-catch-binding { safari < 11.1 }
+  proposal-async-generator-functions { safari < 12 }
+  proposal-object-rest-spread { safari < 11.1 }
+  transform-dotall-regex { safari < 11.1 }
+  proposal-unicode-property-regex { safari < 11.1 }
+  transform-named-capturing-groups-regex { safari < 11.1 }
+  transform-unicode-regex { safari < 12 }
+  proposal-export-namespace-from { safari }
+  bugfix/transform-tagged-template-caching {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
@@ -21,8 +21,8 @@ Using plugins:
   transform-named-capturing-groups-regex { safari < 11.1 }
   transform-unicode-regex { safari < 12 }
   proposal-export-namespace-from { safari }
-  bugfix/transform-tagged-template-caching {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  bugfix/transform-tagged-template-caching
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
@@ -8,34 +8,34 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "safari":"9" }
-  proposal-logical-assignment-operators { "safari":"9" }
-  proposal-nullish-coalescing-operator { "safari":"9" }
-  proposal-optional-chaining { "safari":"9" }
-  proposal-json-strings { "safari":"9" }
-  proposal-optional-catch-binding { "safari":"9" }
-  transform-parameters { "safari":"9" }
-  proposal-async-generator-functions { "safari":"9" }
-  proposal-object-rest-spread { "safari":"9" }
-  transform-dotall-regex { "safari":"9" }
-  proposal-unicode-property-regex { "safari":"9" }
-  transform-named-capturing-groups-regex { "safari":"9" }
-  transform-async-to-generator { "safari":"9" }
-  transform-exponentiation-operator { "safari":"9" }
-  transform-function-name { "safari":"9" }
-  transform-block-scoped-functions { "safari":"9" }
-  transform-classes { "safari":"9" }
-  transform-object-super { "safari":"9" }
-  transform-sticky-regex { "safari":"9" }
-  transform-unicode-regex { "safari":"9" }
-  transform-spread { "safari":"9" }
-  transform-destructuring { "safari":"9" }
-  transform-block-scoping { "safari":"9" }
-  transform-new-target { "safari":"9" }
-  transform-regenerator { "safari":"9" }
-  proposal-export-namespace-from { "safari":"9" }
-  bugfix/transform-tagged-template-caching { "safari":"9" }
-  transform-modules-commonjs { "safari":"9" }
-  proposal-dynamic-import { "safari":"9" }
+  proposal-numeric-separator { safari < 13 }
+  proposal-logical-assignment-operators { safari < 14 }
+  proposal-nullish-coalescing-operator { safari < 13.1 }
+  proposal-optional-chaining { safari < 13.1 }
+  proposal-json-strings { safari < 12 }
+  proposal-optional-catch-binding { safari < 11.1 }
+  transform-parameters { safari < 10 }
+  proposal-async-generator-functions { safari < 12 }
+  proposal-object-rest-spread { safari < 11.1 }
+  transform-dotall-regex { safari < 11.1 }
+  proposal-unicode-property-regex { safari < 11.1 }
+  transform-named-capturing-groups-regex { safari < 11.1 }
+  transform-async-to-generator { safari < 11 }
+  transform-exponentiation-operator { safari < 10.1 }
+  transform-function-name { safari < 10 }
+  transform-block-scoped-functions { safari < 10 }
+  transform-classes { safari < 10 }
+  transform-object-super { safari < 10 }
+  transform-sticky-regex { safari < 10 }
+  transform-unicode-regex { safari < 12 }
+  transform-spread { safari < 10 }
+  transform-destructuring { safari < 10 }
+  transform-block-scoping { safari < 11 }
+  transform-new-target { safari < 10 }
+  transform-regenerator { safari < 10 }
+  proposal-export-namespace-from { safari }
+  bugfix/transform-tagged-template-caching {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
@@ -20,7 +20,7 @@ Using plugins:
   transform-dotall-regex { safari < 11.1 }
   proposal-unicode-property-regex { safari < 11.1 }
   transform-named-capturing-groups-regex { safari < 11.1 }
-  transform-async-to-generator { safari < 11 }
+  transform-async-to-generator { safari < 10.1 }
   transform-exponentiation-operator { safari < 10.1 }
   transform-function-name { safari < 10 }
   transform-block-scoped-functions { safari < 10 }
@@ -30,11 +30,11 @@ Using plugins:
   transform-unicode-regex { safari < 12 }
   transform-spread { safari < 10 }
   transform-destructuring { safari < 10 }
-  transform-block-scoping { safari < 11 }
+  transform-block-scoping { safari < 10 }
   transform-new-target { safari < 10 }
   transform-regenerator { safari < 10 }
   proposal-export-namespace-from { safari }
-  bugfix/transform-tagged-template-caching
+  bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
   proposal-dynamic-import
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
@@ -34,8 +34,8 @@ Using plugins:
   transform-new-target { safari < 10 }
   transform-regenerator { safari < 10 }
   proposal-export-namespace-from { safari }
-  bugfix/transform-tagged-template-caching {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  bugfix/transform-tagged-template-caching
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
@@ -8,15 +8,15 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator {}
-  syntax-nullish-coalescing-operator {}
+  syntax-numeric-separator
+  syntax-nullish-coalescing-operator
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
+  transform-modules-commonjs
+  proposal-dynamic-import
   proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
@@ -8,15 +8,15 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator { "chrome":"89" }
-  syntax-nullish-coalescing-operator { "chrome":"89" }
-  proposal-optional-chaining { "chrome":"89" }
-  syntax-json-strings { "chrome":"89" }
-  syntax-optional-catch-binding { "chrome":"89" }
-  syntax-async-generators { "chrome":"89" }
-  syntax-object-rest-spread { "chrome":"89" }
-  transform-modules-commonjs { "chrome":"89" }
-  proposal-dynamic-import { "chrome":"89" }
-  proposal-export-namespace-from {}
+  syntax-numeric-separator {}
+  syntax-nullish-coalescing-operator {}
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
+  proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
@@ -15,7 +15,7 @@ Using plugins:
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  bugfix/transform-v8-spread-parameters-in-optional-chaining
+  bugfix/transform-v8-spread-parameters-in-optional-chaining { chrome }
   transform-modules-commonjs
   proposal-dynamic-import
   proposal-export-namespace-from { }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
@@ -8,16 +8,16 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator { "chrome":"89" }
-  syntax-nullish-coalescing-operator { "chrome":"89" }
-  syntax-optional-chaining { "chrome":"89" }
-  syntax-json-strings { "chrome":"89" }
-  syntax-optional-catch-binding { "chrome":"89" }
-  syntax-async-generators { "chrome":"89" }
-  syntax-object-rest-spread { "chrome":"89" }
-  bugfix/transform-v8-spread-parameters-in-optional-chaining { "chrome":"89" }
-  transform-modules-commonjs { "chrome":"89" }
-  proposal-dynamic-import { "chrome":"89" }
-  proposal-export-namespace-from {}
+  syntax-numeric-separator {}
+  syntax-nullish-coalescing-operator {}
+  syntax-optional-chaining {}
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  bugfix/transform-v8-spread-parameters-in-optional-chaining {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
+  proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
@@ -8,16 +8,16 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator {}
-  syntax-nullish-coalescing-operator {}
-  syntax-optional-chaining {}
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
-  bugfix/transform-v8-spread-parameters-in-optional-chaining {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  syntax-numeric-separator
+  syntax-nullish-coalescing-operator
+  syntax-optional-chaining
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
+  bugfix/transform-v8-spread-parameters-in-optional-chaining
+  transform-modules-commonjs
+  proposal-dynamic-import
   proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -16,25 +16,25 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-numeric-separator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-logical-assignment-operators { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-catch-binding { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-parameters { "edge":"16" }
-  proposal-async-generator-functions { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-object-rest-spread { "edge":"16", "ios":"10.3", "safari":"10.1" }
-  transform-dotall-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-unicode-property-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-named-capturing-groups-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
-  transform-template-literals { "ios":"10.3", "safari":"10.1" }
-  transform-function-name { "edge":"16" }
-  transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
-  transform-block-scoping { "ios":"10.3", "safari":"10.1" }
-  proposal-export-namespace-from { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  syntax-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, firefox < 74, ios < 13.4, node, opera, safari < 13.1, samsung }
+  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  transform-parameters { edge < 18 }
+  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
+  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-async-to-generator { ios < 11, safari < 11 }
+  transform-template-literals { ios < 13, safari < 13 }
+  transform-function-name { edge < 79 }
+  transform-unicode-regex { ios < 12, safari < 12 }
+  transform-block-scoping { ios < 11, safari < 11 }
+  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  syntax-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -34,7 +34,7 @@ Using plugins:
   transform-unicode-regex { ios < 12, safari < 12 }
   transform-block-scoping { ios < 11, safari < 11 }
   proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
-  syntax-dynamic-import {}
+  syntax-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -16,25 +16,25 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-numeric-separator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-logical-assignment-operators { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-catch-binding { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-parameters { "edge":"16" }
-  proposal-async-generator-functions { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-object-rest-spread { "edge":"16", "ios":"10.3", "safari":"10.1" }
-  transform-dotall-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-unicode-property-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-named-capturing-groups-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
-  transform-template-literals { "ios":"10.3", "safari":"10.1" }
-  transform-function-name { "edge":"16" }
-  transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
-  transform-block-scoping { "ios":"10.3", "safari":"10.1" }
-  proposal-export-namespace-from { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  syntax-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, firefox < 74, ios < 13.4, node, opera, safari < 13.1, samsung }
+  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  transform-parameters { edge < 18 }
+  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
+  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-async-to-generator { ios < 11, safari < 11 }
+  transform-template-literals { ios < 13, safari < 13 }
+  transform-function-name { edge < 79 }
+  transform-unicode-regex { ios < 12, safari < 12 }
+  transform-block-scoping { ios < 11, safari < 11 }
+  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  syntax-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -34,7 +34,7 @@ Using plugins:
   transform-unicode-regex { ios < 12, safari < 12 }
   transform-block-scoping { ios < 11, safari < 11 }
   proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
-  syntax-dynamic-import {}
+  syntax-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -16,25 +16,25 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-numeric-separator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-logical-assignment-operators { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-catch-binding { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-parameters { "edge":"16" }
-  proposal-async-generator-functions { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-object-rest-spread { "edge":"16", "ios":"10.3", "safari":"10.1" }
-  transform-dotall-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-unicode-property-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-named-capturing-groups-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
-  transform-template-literals { "ios":"10.3", "safari":"10.1" }
-  transform-function-name { "edge":"16" }
-  transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
-  transform-block-scoping { "ios":"10.3", "safari":"10.1" }
-  proposal-export-namespace-from { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  syntax-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, firefox < 74, ios < 13.4, node, opera, safari < 13.1, samsung }
+  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  transform-parameters { edge < 18 }
+  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
+  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-async-to-generator { ios < 11, safari < 11 }
+  transform-template-literals { ios < 13, safari < 13 }
+  transform-function-name { edge < 79 }
+  transform-unicode-regex { ios < 12, safari < 12 }
+  transform-block-scoping { ios < 11, safari < 11 }
+  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  syntax-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -34,7 +34,7 @@ Using plugins:
   transform-unicode-regex { ios < 12, safari < 12 }
   transform-block-scoping { ios < 11, safari < 11 }
   proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
-  syntax-dynamic-import {}
+  syntax-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -16,25 +16,25 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-numeric-separator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-logical-assignment-operators { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-nullish-coalescing-operator { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-chaining { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-json-strings { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  proposal-optional-catch-binding { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-parameters { "edge":"16" }
-  proposal-async-generator-functions { "android":"61", "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-object-rest-spread { "edge":"16", "ios":"10.3", "safari":"10.1" }
-  transform-dotall-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-unicode-property-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-named-capturing-groups-regex { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
-  transform-template-literals { "ios":"10.3", "safari":"10.1" }
-  transform-function-name { "edge":"16" }
-  transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
-  transform-block-scoping { "ios":"10.3", "safari":"10.1" }
-  proposal-export-namespace-from { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1", "samsung":"8.2" }
-  syntax-dynamic-import { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, firefox < 74, ios < 13.4, node, opera, safari < 13.1, samsung }
+  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  transform-parameters { edge < 18 }
+  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
+  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-async-to-generator { ios < 11, safari < 11 }
+  transform-template-literals { ios < 13, safari < 13 }
+  transform-function-name { edge < 79 }
+  transform-unicode-regex { ios < 12, safari < 12 }
+  transform-block-scoping { ios < 11, safari < 11 }
+  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  syntax-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -34,7 +34,7 @@ Using plugins:
   transform-unicode-regex { ios < 12, safari < 12 }
   transform-block-scoping { ios < 11, safari < 11 }
   proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
-  syntax-dynamic-import {}
+  syntax-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslist-env/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslist-env/stdout.txt
@@ -8,41 +8,41 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ie":"11" }
-  proposal-logical-assignment-operators { "ie":"11" }
-  proposal-nullish-coalescing-operator { "ie":"11" }
-  proposal-optional-chaining { "ie":"11" }
-  proposal-json-strings { "ie":"11" }
-  proposal-optional-catch-binding { "ie":"11" }
-  transform-parameters { "ie":"11" }
-  proposal-async-generator-functions { "ie":"11" }
-  proposal-object-rest-spread { "ie":"11" }
-  transform-dotall-regex { "ie":"11" }
-  proposal-unicode-property-regex { "ie":"11" }
-  transform-named-capturing-groups-regex { "ie":"11" }
-  transform-async-to-generator { "ie":"11" }
-  transform-exponentiation-operator { "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "ie":"11" }
-  transform-function-name { "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "ie":"11" }
-  transform-block-scoping { "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "ie":"11" }
-  proposal-export-namespace-from { "ie":"11" }
-  transform-modules-commonjs { "ie":"11" }
-  proposal-dynamic-import { "ie":"11" }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslist-env/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslist-env/stdout.txt
@@ -42,7 +42,7 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-android-3/stdout.txt
@@ -46,7 +46,7 @@ Using plugins:
   transform-property-literals { android < 4 }
   transform-reserved-words { android < 4.4 }
   proposal-export-namespace-from { android < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-android-3/stdout.txt
@@ -8,45 +8,45 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "android":"3" }
-  proposal-logical-assignment-operators { "android":"3" }
-  proposal-nullish-coalescing-operator { "android":"3" }
-  proposal-optional-chaining { "android":"3" }
-  proposal-json-strings { "android":"3" }
-  proposal-optional-catch-binding { "android":"3" }
-  transform-parameters { "android":"3" }
-  proposal-async-generator-functions { "android":"3" }
-  proposal-object-rest-spread { "android":"3" }
-  transform-dotall-regex { "android":"3" }
-  proposal-unicode-property-regex { "android":"3" }
-  transform-named-capturing-groups-regex { "android":"3" }
-  transform-async-to-generator { "android":"3" }
-  transform-exponentiation-operator { "android":"3" }
-  transform-template-literals { "android":"3" }
-  transform-literals { "android":"3" }
-  transform-function-name { "android":"3" }
-  transform-arrow-functions { "android":"3" }
-  transform-block-scoped-functions { "android":"3" }
-  transform-classes { "android":"3" }
-  transform-object-super { "android":"3" }
-  transform-shorthand-properties { "android":"3" }
-  transform-duplicate-keys { "android":"3" }
-  transform-computed-properties { "android":"3" }
-  transform-for-of { "android":"3" }
-  transform-sticky-regex { "android":"3" }
-  transform-unicode-escapes { "android":"3" }
-  transform-unicode-regex { "android":"3" }
-  transform-spread { "android":"3" }
-  transform-destructuring { "android":"3" }
-  transform-block-scoping { "android":"3" }
-  transform-typeof-symbol { "android":"3" }
-  transform-new-target { "android":"3" }
-  transform-regenerator { "android":"3" }
-  transform-member-expression-literals { "android":"3" }
-  transform-property-literals { "android":"3" }
-  transform-reserved-words { "android":"3" }
-  proposal-export-namespace-from { "android":"3" }
-  transform-modules-commonjs { "android":"3" }
-  proposal-dynamic-import { "android":"3" }
+  proposal-numeric-separator { android }
+  proposal-logical-assignment-operators { android }
+  proposal-nullish-coalescing-operator { android }
+  proposal-optional-chaining { android }
+  proposal-json-strings { android }
+  proposal-optional-catch-binding { android }
+  transform-parameters { android }
+  proposal-async-generator-functions { android }
+  proposal-object-rest-spread { android }
+  transform-dotall-regex { android }
+  proposal-unicode-property-regex { android }
+  transform-named-capturing-groups-regex { android }
+  transform-async-to-generator { android }
+  transform-exponentiation-operator { android }
+  transform-template-literals { android }
+  transform-literals { android }
+  transform-function-name { android }
+  transform-arrow-functions { android }
+  transform-block-scoped-functions { android }
+  transform-classes { android }
+  transform-object-super { android }
+  transform-shorthand-properties { android }
+  transform-duplicate-keys { android }
+  transform-computed-properties { android }
+  transform-for-of { android }
+  transform-sticky-regex { android }
+  transform-unicode-escapes { android }
+  transform-unicode-regex { android }
+  transform-spread { android }
+  transform-destructuring { android }
+  transform-block-scoping { android }
+  transform-typeof-symbol { android }
+  transform-new-target { android }
+  transform-regenerator { android }
+  transform-member-expression-literals { android < 4 }
+  transform-property-literals { android < 4 }
+  transform-reserved-words { android < 4.4 }
+  proposal-export-namespace-from { android < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
@@ -15,17 +15,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ios":"12.2" }
-  proposal-logical-assignment-operators { "chrome":"84", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-nullish-coalescing-operator { "ios":"12.2", "samsung":"11.1" }
-  proposal-optional-chaining { "android":"85", "chrome":"84", "edge":"85", "ios":"12.2", "opera":"71", "samsung":"11.1" }
-  syntax-json-strings { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-optional-catch-binding { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-async-generators { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-object-rest-spread { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  transform-template-literals { "ios":"12.2" }
-  proposal-export-namespace-from { "firefox":"78", "ios":"12.2", "safari":"13.1" }
-  transform-modules-commonjs { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-dynamic-import { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
+  proposal-numeric-separator { ios < 13 }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ios < 14, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { ios < 13.4, samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, ios < 13.4, opera, samsung }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  transform-template-literals { ios < 13 }
+  proposal-export-namespace-from { firefox < 80, ios, safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
@@ -19,13 +19,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ios < 14, opera, safari < 14, samsung }
   proposal-nullish-coalescing-operator { ios < 13.4, samsung < 13 }
   proposal-optional-chaining { android, chrome, edge, ios < 13.4, opera, samsung }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   transform-template-literals { ios < 13 }
   proposal-export-namespace-from { firefox < 80, ios, safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
@@ -50,7 +50,7 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { firefox < 80, ie, ios, safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
@@ -16,41 +16,41 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ie":"11", "ios":"12.2" }
-  proposal-logical-assignment-operators { "chrome":"84", "firefox":"78", "ie":"11", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-nullish-coalescing-operator { "ie":"11", "ios":"12.2", "samsung":"11.1" }
-  proposal-optional-chaining { "android":"85", "chrome":"84", "edge":"85", "ie":"11", "ios":"12.2", "opera":"71", "samsung":"11.1" }
-  proposal-json-strings { "ie":"11" }
-  proposal-optional-catch-binding { "ie":"11" }
-  transform-parameters { "ie":"11" }
-  proposal-async-generator-functions { "ie":"11" }
-  proposal-object-rest-spread { "ie":"11" }
-  transform-dotall-regex { "ie":"11" }
-  proposal-unicode-property-regex { "ie":"11" }
-  transform-named-capturing-groups-regex { "ie":"11" }
-  transform-async-to-generator { "ie":"11" }
-  transform-exponentiation-operator { "ie":"11" }
-  transform-template-literals { "ie":"11", "ios":"12.2" }
-  transform-literals { "ie":"11" }
-  transform-function-name { "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "ie":"11" }
-  transform-block-scoping { "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "ie":"11" }
-  proposal-export-namespace-from { "firefox":"78", "ie":"11", "ios":"12.2", "safari":"13.1" }
-  transform-modules-commonjs { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ie":"11", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-dynamic-import { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ie":"11", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
+  proposal-numeric-separator { ie, ios < 13 }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie, ios < 14, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { ie, ios < 13.4, samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, ie, ios < 13.4, opera, samsung }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie, ios < 13 }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { firefox < 80, ie, ios, safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
@@ -15,16 +15,16 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-logical-assignment-operators { "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-nullish-coalescing-operator { "samsung":"11.1" }
-  proposal-optional-chaining { "android":"85", "chrome":"85", "edge":"85", "opera":"71", "samsung":"11.1" }
-  syntax-json-strings { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-optional-catch-binding { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-async-generators { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-object-rest-spread { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-export-namespace-from { "ios":"13.4", "safari":"13.1" }
-  transform-modules-commonjs { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-dynamic-import { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
+  syntax-numeric-separator {}
+  proposal-logical-assignment-operators { ios < 14, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, opera, samsung }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { ios, safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
@@ -15,16 +15,16 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator {}
+  syntax-numeric-separator
   proposal-logical-assignment-operators { ios < 14, opera, safari < 14, samsung }
   proposal-nullish-coalescing-operator { samsung < 13 }
   proposal-optional-chaining { android, chrome, edge, opera, samsung }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { ios, safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/corejs-without-usebuiltins/stdout.txt
@@ -8,45 +8,45 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/corejs-without-usebuiltins/stdout.txt
@@ -46,7 +46,7 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-android/stdout.txt
@@ -8,44 +8,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "android":"4" }
-  proposal-logical-assignment-operators { "android":"4" }
-  proposal-nullish-coalescing-operator { "android":"4" }
-  proposal-optional-chaining { "android":"4" }
-  proposal-json-strings { "android":"4" }
-  proposal-optional-catch-binding { "android":"4" }
-  transform-parameters { "android":"4" }
-  proposal-async-generator-functions { "android":"4" }
-  proposal-object-rest-spread { "android":"4" }
-  transform-dotall-regex { "android":"4" }
-  proposal-unicode-property-regex { "android":"4" }
-  transform-named-capturing-groups-regex { "android":"4" }
-  transform-async-to-generator { "android":"4" }
-  transform-exponentiation-operator { "android":"4" }
-  transform-template-literals { "android":"4" }
-  transform-literals { "android":"4" }
-  transform-function-name { "android":"4" }
-  transform-arrow-functions { "android":"4" }
-  transform-block-scoped-functions { "android":"4" }
-  transform-classes { "android":"4" }
-  transform-object-super { "android":"4" }
-  transform-shorthand-properties { "android":"4" }
-  transform-duplicate-keys { "android":"4" }
-  transform-computed-properties { "android":"4" }
-  transform-for-of { "android":"4" }
-  transform-sticky-regex { "android":"4" }
-  transform-unicode-escapes { "android":"4" }
-  transform-unicode-regex { "android":"4" }
-  transform-spread { "android":"4" }
-  transform-destructuring { "android":"4" }
-  transform-block-scoping { "android":"4" }
-  transform-typeof-symbol { "android":"4" }
-  transform-new-target { "android":"4" }
-  transform-regenerator { "android":"4" }
-  transform-reserved-words { "android":"4" }
-  proposal-export-namespace-from { "android":"4" }
-  transform-modules-commonjs { "android":"4" }
-  proposal-dynamic-import { "android":"4" }
+  proposal-numeric-separator { android }
+  proposal-logical-assignment-operators { android }
+  proposal-nullish-coalescing-operator { android }
+  proposal-optional-chaining { android }
+  proposal-json-strings { android }
+  proposal-optional-catch-binding { android }
+  transform-parameters { android }
+  proposal-async-generator-functions { android }
+  proposal-object-rest-spread { android }
+  transform-dotall-regex { android }
+  proposal-unicode-property-regex { android }
+  transform-named-capturing-groups-regex { android }
+  transform-async-to-generator { android }
+  transform-exponentiation-operator { android }
+  transform-template-literals { android }
+  transform-literals { android }
+  transform-function-name { android }
+  transform-arrow-functions { android }
+  transform-block-scoped-functions { android }
+  transform-classes { android }
+  transform-object-super { android }
+  transform-shorthand-properties { android }
+  transform-duplicate-keys { android }
+  transform-computed-properties { android }
+  transform-for-of { android }
+  transform-sticky-regex { android }
+  transform-unicode-escapes { android }
+  transform-unicode-regex { android }
+  transform-spread { android }
+  transform-destructuring { android }
+  transform-block-scoping { android }
+  transform-typeof-symbol { android }
+  transform-new-target { android }
+  transform-regenerator { android }
+  transform-reserved-words { android < 4.4 }
+  proposal-export-namespace-from { android < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-android/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-regenerator { android }
   transform-reserved-words { android < 4.4 }
   proposal-export-namespace-from { android < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
@@ -8,30 +8,30 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "electron":"0.36" }
-  proposal-logical-assignment-operators { "electron":"0.36" }
-  proposal-nullish-coalescing-operator { "electron":"0.36" }
-  proposal-optional-chaining { "electron":"0.36" }
-  proposal-json-strings { "electron":"0.36" }
-  proposal-optional-catch-binding { "electron":"0.36" }
-  transform-parameters { "electron":"0.36" }
-  proposal-async-generator-functions { "electron":"0.36" }
-  proposal-object-rest-spread { "electron":"0.36" }
-  transform-dotall-regex { "electron":"0.36" }
-  proposal-unicode-property-regex { "electron":"0.36" }
-  transform-named-capturing-groups-regex { "electron":"0.36" }
-  transform-async-to-generator { "electron":"0.36" }
-  transform-exponentiation-operator { "electron":"0.36" }
-  transform-function-name { "electron":"0.36" }
-  transform-for-of { "electron":"0.36" }
-  transform-sticky-regex { "electron":"0.36" }
-  transform-unicode-regex { "electron":"0.36" }
-  transform-destructuring { "electron":"0.36" }
-  transform-block-scoping { "electron":"0.36" }
-  transform-regenerator { "electron":"0.36" }
-  proposal-export-namespace-from { "electron":"0.36" }
-  transform-modules-commonjs { "electron":"0.36" }
-  proposal-dynamic-import { "electron":"0.36" }
+  proposal-numeric-separator { electron < 6.0 }
+  proposal-logical-assignment-operators { electron < 10.0 }
+  proposal-nullish-coalescing-operator { electron < 8.0 }
+  proposal-optional-chaining { electron }
+  proposal-json-strings { electron < 3.0 }
+  proposal-optional-catch-binding { electron < 3.0 }
+  transform-parameters { electron < 0.37 }
+  proposal-async-generator-functions { electron < 3.0 }
+  proposal-object-rest-spread { electron < 2.0 }
+  transform-dotall-regex { electron < 3.0 }
+  proposal-unicode-property-regex { electron < 3.0 }
+  transform-named-capturing-groups-regex { electron < 3.0 }
+  transform-async-to-generator { electron < 1.6 }
+  transform-exponentiation-operator { electron < 1.3 }
+  transform-function-name { electron < 1.2 }
+  transform-for-of { electron < 1.2 }
+  transform-sticky-regex { electron < 0.37 }
+  transform-unicode-regex { electron < 1.1 }
+  transform-destructuring { electron < 1.2 }
+  transform-block-scoping { electron < 0.37 }
+  transform-regenerator { electron < 1.1 }
+  proposal-export-namespace-from { electron < 5.0 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
@@ -30,8 +30,8 @@ Using plugins:
   transform-block-scoping { electron < 0.37 }
   transform-regenerator { electron < 1.1 }
   proposal-export-namespace-from { electron < 5.0 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
@@ -46,7 +46,7 @@ Using plugins:
   transform-property-literals { }
   transform-reserved-words { }
   proposal-export-namespace-from { chrome < 72 }
-  syntax-dynamic-import {}
+  syntax-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
@@ -8,45 +8,45 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"55" }
-  proposal-logical-assignment-operators { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  transform-parameters {}
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  transform-dotall-regex { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from { "chrome":"55" }
-  syntax-dynamic-import { "chrome":"55" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  transform-parameters { }
+  proposal-async-generator-functions { chrome < 63 }
+  proposal-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  transform-async-to-generator { }
+  transform-exponentiation-operator { }
+  transform-template-literals { }
+  transform-literals { }
+  transform-function-name { }
+  transform-arrow-functions { }
+  transform-block-scoped-functions { }
+  transform-classes { }
+  transform-object-super { }
+  transform-shorthand-properties { }
+  transform-duplicate-keys { }
+  transform-computed-properties { }
+  transform-for-of { }
+  transform-sticky-regex { }
+  transform-unicode-escapes { }
+  transform-unicode-regex { }
+  transform-spread { }
+  transform-destructuring { }
+  transform-block-scoping { }
+  transform-typeof-symbol { }
+  transform-new-target { }
+  transform-regenerator { }
+  transform-member-expression-literals { }
+  transform-property-literals { }
+  transform-reserved-words { }
+  proposal-export-namespace-from { chrome < 72 }
+  syntax-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
@@ -8,25 +8,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "node":"6" }
-  proposal-logical-assignment-operators { "node":"6" }
-  proposal-nullish-coalescing-operator { "node":"6" }
-  proposal-optional-chaining { "node":"6" }
-  proposal-json-strings { "node":"6" }
-  proposal-optional-catch-binding { "node":"6" }
-  proposal-async-generator-functions { "node":"6" }
-  proposal-object-rest-spread { "node":"6" }
-  transform-dotall-regex { "node":"6" }
-  proposal-unicode-property-regex { "node":"6" }
-  transform-named-capturing-groups-regex { "node":"6" }
-  transform-async-to-generator { "node":"6" }
-  transform-exponentiation-operator { "node":"6" }
-  transform-function-name { "node":"6" }
-  transform-for-of { "node":"6" }
-  transform-destructuring { "node":"6" }
-  proposal-export-namespace-from { "node":"6" }
-  transform-modules-commonjs { "node":"6" }
-  proposal-dynamic-import { "node":"6" }
+  proposal-numeric-separator { node < 12.5 }
+  proposal-logical-assignment-operators { node < 15 }
+  proposal-nullish-coalescing-operator { node < 14 }
+  proposal-optional-chaining { node }
+  proposal-json-strings { node < 10 }
+  proposal-optional-catch-binding { node < 10 }
+  proposal-async-generator-functions { node < 10 }
+  proposal-object-rest-spread { node < 8.3 }
+  transform-dotall-regex { node < 8.10 }
+  proposal-unicode-property-regex { node < 10 }
+  transform-named-capturing-groups-regex { node < 10 }
+  transform-async-to-generator { node < 7.6 }
+  transform-exponentiation-operator { node < 7 }
+  transform-function-name { node < 6.5 }
+  transform-for-of { node < 6.5 }
+  transform-destructuring { node < 6.5 }
+  proposal-export-namespace-from { node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
@@ -25,8 +25,8 @@ Using plugins:
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
   proposal-export-namespace-from { node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals/stdout.txt
@@ -8,46 +8,46 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
   proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
@@ -13,43 +13,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-logical-assignment-operators { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-chaining { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-catch-binding { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-parameters { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-async-generator-functions { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-object-rest-spread { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-dotall-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-unicode-property-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-named-capturing-groups-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-async-to-generator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-template-literals { "ie":"10", "ios":"9", "safari":"7" }
-  transform-literals { "firefox":"49", "ie":"10", "safari":"7" }
-  transform-function-name { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-arrow-functions { "ie":"10", "ios":"9", "safari":"7" }
-  transform-block-scoped-functions { "ie":"10", "ios":"9", "safari":"7" }
-  transform-classes { "ie":"10", "ios":"9", "safari":"7" }
-  transform-object-super { "ie":"10", "ios":"9", "safari":"7" }
-  transform-shorthand-properties { "ie":"10", "safari":"7" }
-  transform-duplicate-keys { "ie":"10", "safari":"7" }
-  transform-computed-properties { "ie":"10", "safari":"7" }
-  transform-for-of { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-sticky-regex { "ie":"10", "ios":"9", "safari":"7" }
-  transform-unicode-escapes { "firefox":"49", "ie":"10", "safari":"7" }
-  transform-unicode-regex { "ie":"10", "ios":"9", "safari":"7" }
-  transform-spread { "ie":"10", "ios":"9", "safari":"7" }
-  transform-destructuring { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-block-scoping { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-typeof-symbol { "ie":"10", "safari":"7" }
-  transform-new-target { "edge":"13", "ie":"10", "ios":"9", "safari":"7" }
-  transform-regenerator { "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-export-namespace-from { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-modules-commonjs { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-dynamic-import { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
+  proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
+  proposal-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
+  proposal-optional-chaining { chrome, edge, firefox < 74, ie, ios < 13.4, safari < 13.1 }
+  proposal-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
+  proposal-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
+  transform-parameters { edge < 18, firefox < 53, ie, ios < 10, safari < 10 }
+  proposal-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
+  proposal-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
+  transform-dotall-regex { chrome < 62, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  proposal-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-named-capturing-groups-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-async-to-generator { chrome < 55, edge < 15, firefox < 52, ie, ios < 11, safari < 11 }
+  transform-exponentiation-operator { edge < 14, firefox < 52, ie, ios < 10.3, safari < 10.1 }
+  transform-template-literals { ie, ios < 13, safari < 13 }
+  transform-literals { firefox < 53, ie, safari < 9 }
+  transform-function-name { edge < 79, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-arrow-functions { ie, ios < 10, safari < 10 }
+  transform-block-scoped-functions { ie < 11, ios < 10, safari < 10 }
+  transform-classes { ie, ios < 10, safari < 10 }
+  transform-object-super { ie, ios < 10, safari < 10 }
+  transform-shorthand-properties { ie, safari < 9 }
+  transform-duplicate-keys { ie, safari < 9 }
+  transform-computed-properties { ie, safari < 7.1 }
+  transform-for-of { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-sticky-regex { ie, ios < 10, safari < 10 }
+  transform-unicode-escapes { firefox < 53, ie, safari < 9 }
+  transform-unicode-regex { ie, ios < 12, safari < 12 }
+  transform-spread { ie, ios < 10, safari < 10 }
+  transform-destructuring { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-block-scoping { edge < 14, firefox < 51, ie, ios < 11, safari < 11 }
+  transform-typeof-symbol { ie, safari < 9 }
+  transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
+  transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
+  proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
@@ -11,43 +11,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-logical-assignment-operators { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-chaining { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-json-strings { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-catch-binding { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-parameters { "electron":"0.36", "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-object-rest-spread { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-dotall-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-unicode-property-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-named-capturing-groups-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-async-to-generator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-sticky-regex { "electron":"0.36", "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "electron":"0.36", "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-block-scoping { "electron":"0.36", "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "electron":"0.36", "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-modules-commonjs { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-dynamic-import { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
+  proposal-optional-chaining { chrome, electron, ie, node }
+  proposal-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-parameters { electron < 0.37, ie }
+  proposal-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, electron < 3.0, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, electron < 1.6, ie, node < 7.6 }
+  transform-exponentiation-operator { electron < 1.3, ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { electron < 1.2, ie, node < 6.5 }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { electron < 1.2, ie, node < 6.5 }
+  transform-sticky-regex { electron < 0.37, ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { electron < 1.1, ie }
+  transform-spread { ie }
+  transform-destructuring { electron < 1.2, ie, node < 6.5 }
+  transform-block-scoping { electron < 0.37, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { electron < 1.1, ie }
+  proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }
   proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
-  transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10", "node":"6" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10", "node":"6" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10", "node":"6" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie, node < 6.5 }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie, node < 6.5 }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie, node < 6.5 }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-android/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-regenerator { android }
   transform-reserved-words { android < 4.4 }
   proposal-export-namespace-from { android < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-android/stdout.txt
@@ -8,44 +8,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "android":"4" }
-  proposal-logical-assignment-operators { "android":"4" }
-  proposal-nullish-coalescing-operator { "android":"4" }
-  proposal-optional-chaining { "android":"4" }
-  proposal-json-strings { "android":"4" }
-  proposal-optional-catch-binding { "android":"4" }
-  transform-parameters { "android":"4" }
-  proposal-async-generator-functions { "android":"4" }
-  proposal-object-rest-spread { "android":"4" }
-  transform-dotall-regex { "android":"4" }
-  proposal-unicode-property-regex { "android":"4" }
-  transform-named-capturing-groups-regex { "android":"4" }
-  transform-async-to-generator { "android":"4" }
-  transform-exponentiation-operator { "android":"4" }
-  transform-template-literals { "android":"4" }
-  transform-literals { "android":"4" }
-  transform-function-name { "android":"4" }
-  transform-arrow-functions { "android":"4" }
-  transform-block-scoped-functions { "android":"4" }
-  transform-classes { "android":"4" }
-  transform-object-super { "android":"4" }
-  transform-shorthand-properties { "android":"4" }
-  transform-duplicate-keys { "android":"4" }
-  transform-computed-properties { "android":"4" }
-  transform-for-of { "android":"4" }
-  transform-sticky-regex { "android":"4" }
-  transform-unicode-escapes { "android":"4" }
-  transform-unicode-regex { "android":"4" }
-  transform-spread { "android":"4" }
-  transform-destructuring { "android":"4" }
-  transform-block-scoping { "android":"4" }
-  transform-typeof-symbol { "android":"4" }
-  transform-new-target { "android":"4" }
-  transform-regenerator { "android":"4" }
-  transform-reserved-words { "android":"4" }
-  proposal-export-namespace-from { "android":"4" }
-  transform-modules-commonjs { "android":"4" }
-  proposal-dynamic-import { "android":"4" }
+  proposal-numeric-separator { android }
+  proposal-logical-assignment-operators { android }
+  proposal-nullish-coalescing-operator { android }
+  proposal-optional-chaining { android }
+  proposal-json-strings { android }
+  proposal-optional-catch-binding { android }
+  transform-parameters { android }
+  proposal-async-generator-functions { android }
+  proposal-object-rest-spread { android }
+  transform-dotall-regex { android }
+  proposal-unicode-property-regex { android }
+  transform-named-capturing-groups-regex { android }
+  transform-async-to-generator { android }
+  transform-exponentiation-operator { android }
+  transform-template-literals { android }
+  transform-literals { android }
+  transform-function-name { android }
+  transform-arrow-functions { android }
+  transform-block-scoped-functions { android }
+  transform-classes { android }
+  transform-object-super { android }
+  transform-shorthand-properties { android }
+  transform-duplicate-keys { android }
+  transform-computed-properties { android }
+  transform-for-of { android }
+  transform-sticky-regex { android }
+  transform-unicode-escapes { android }
+  transform-unicode-regex { android }
+  transform-spread { android }
+  transform-destructuring { android }
+  transform-block-scoping { android }
+  transform-typeof-symbol { android }
+  transform-new-target { android }
+  transform-regenerator { android }
+  transform-reserved-words { android < 4.4 }
+  proposal-export-namespace-from { android < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-babel-polyfill/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-babel-polyfill/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
@@ -30,8 +30,8 @@ Using plugins:
   transform-block-scoping { electron < 0.37 }
   transform-regenerator { electron < 1.1 }
   proposal-export-namespace-from { electron < 5.0 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
@@ -8,30 +8,30 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "electron":"0.36" }
-  proposal-logical-assignment-operators { "electron":"0.36" }
-  proposal-nullish-coalescing-operator { "electron":"0.36" }
-  proposal-optional-chaining { "electron":"0.36" }
-  proposal-json-strings { "electron":"0.36" }
-  proposal-optional-catch-binding { "electron":"0.36" }
-  transform-parameters { "electron":"0.36" }
-  proposal-async-generator-functions { "electron":"0.36" }
-  proposal-object-rest-spread { "electron":"0.36" }
-  transform-dotall-regex { "electron":"0.36" }
-  proposal-unicode-property-regex { "electron":"0.36" }
-  transform-named-capturing-groups-regex { "electron":"0.36" }
-  transform-async-to-generator { "electron":"0.36" }
-  transform-exponentiation-operator { "electron":"0.36" }
-  transform-function-name { "electron":"0.36" }
-  transform-for-of { "electron":"0.36" }
-  transform-sticky-regex { "electron":"0.36" }
-  transform-unicode-regex { "electron":"0.36" }
-  transform-destructuring { "electron":"0.36" }
-  transform-block-scoping { "electron":"0.36" }
-  transform-regenerator { "electron":"0.36" }
-  proposal-export-namespace-from { "electron":"0.36" }
-  transform-modules-commonjs { "electron":"0.36" }
-  proposal-dynamic-import { "electron":"0.36" }
+  proposal-numeric-separator { electron < 6.0 }
+  proposal-logical-assignment-operators { electron < 10.0 }
+  proposal-nullish-coalescing-operator { electron < 8.0 }
+  proposal-optional-chaining { electron }
+  proposal-json-strings { electron < 3.0 }
+  proposal-optional-catch-binding { electron < 3.0 }
+  transform-parameters { electron < 0.37 }
+  proposal-async-generator-functions { electron < 3.0 }
+  proposal-object-rest-spread { electron < 2.0 }
+  transform-dotall-regex { electron < 3.0 }
+  proposal-unicode-property-regex { electron < 3.0 }
+  transform-named-capturing-groups-regex { electron < 3.0 }
+  transform-async-to-generator { electron < 1.6 }
+  transform-exponentiation-operator { electron < 1.3 }
+  transform-function-name { electron < 1.2 }
+  transform-for-of { electron < 1.2 }
+  transform-sticky-regex { electron < 0.37 }
+  transform-unicode-regex { electron < 1.1 }
+  transform-destructuring { electron < 1.2 }
+  transform-block-scoping { electron < 0.37 }
+  transform-regenerator { electron < 1.1 }
+  proposal-export-namespace-from { electron < 5.0 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
@@ -46,7 +46,7 @@ Using plugins:
   transform-property-literals { }
   transform-reserved-words { }
   proposal-export-namespace-from { chrome < 72 }
-  syntax-dynamic-import {}
+  syntax-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
@@ -8,45 +8,45 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"55" }
-  proposal-logical-assignment-operators { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  transform-parameters {}
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  transform-dotall-regex { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from { "chrome":"55" }
-  syntax-dynamic-import { "chrome":"55" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  transform-parameters { }
+  proposal-async-generator-functions { chrome < 63 }
+  proposal-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  transform-async-to-generator { }
+  transform-exponentiation-operator { }
+  transform-template-literals { }
+  transform-literals { }
+  transform-function-name { }
+  transform-arrow-functions { }
+  transform-block-scoped-functions { }
+  transform-classes { }
+  transform-object-super { }
+  transform-shorthand-properties { }
+  transform-duplicate-keys { }
+  transform-computed-properties { }
+  transform-for-of { }
+  transform-sticky-regex { }
+  transform-unicode-escapes { }
+  transform-unicode-regex { }
+  transform-spread { }
+  transform-destructuring { }
+  transform-block-scoping { }
+  transform-typeof-symbol { }
+  transform-new-target { }
+  transform-regenerator { }
+  transform-member-expression-literals { }
+  transform-property-literals { }
+  transform-reserved-words { }
+  proposal-export-namespace-from { chrome < 72 }
+  syntax-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
@@ -25,8 +25,8 @@ Using plugins:
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
   proposal-export-namespace-from { node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
@@ -8,25 +8,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "node":"6" }
-  proposal-logical-assignment-operators { "node":"6" }
-  proposal-nullish-coalescing-operator { "node":"6" }
-  proposal-optional-chaining { "node":"6" }
-  proposal-json-strings { "node":"6" }
-  proposal-optional-catch-binding { "node":"6" }
-  proposal-async-generator-functions { "node":"6" }
-  proposal-object-rest-spread { "node":"6" }
-  transform-dotall-regex { "node":"6" }
-  proposal-unicode-property-regex { "node":"6" }
-  transform-named-capturing-groups-regex { "node":"6" }
-  transform-async-to-generator { "node":"6" }
-  transform-exponentiation-operator { "node":"6" }
-  transform-function-name { "node":"6" }
-  transform-for-of { "node":"6" }
-  transform-destructuring { "node":"6" }
-  proposal-export-namespace-from { "node":"6" }
-  transform-modules-commonjs { "node":"6" }
-  proposal-dynamic-import { "node":"6" }
+  proposal-numeric-separator { node < 12.5 }
+  proposal-logical-assignment-operators { node < 15 }
+  proposal-nullish-coalescing-operator { node < 14 }
+  proposal-optional-chaining { node }
+  proposal-json-strings { node < 10 }
+  proposal-optional-catch-binding { node < 10 }
+  proposal-async-generator-functions { node < 10 }
+  proposal-object-rest-spread { node < 8.3 }
+  transform-dotall-regex { node < 8.10 }
+  proposal-unicode-property-regex { node < 10 }
+  transform-named-capturing-groups-regex { node < 10 }
+  transform-async-to-generator { node < 7.6 }
+  transform-exponentiation-operator { node < 7 }
+  transform-function-name { node < 6.5 }
+  transform-for-of { node < 6.5 }
+  transform-destructuring { node < 6.5 }
+  proposal-export-namespace-from { node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals/stdout.txt
@@ -8,46 +8,46 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
   proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
@@ -13,43 +13,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-logical-assignment-operators { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-chaining { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-catch-binding { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-parameters { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-async-generator-functions { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-object-rest-spread { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-dotall-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-unicode-property-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-named-capturing-groups-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-async-to-generator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-template-literals { "ie":"10", "ios":"9", "safari":"7" }
-  transform-literals { "firefox":"49", "ie":"10", "safari":"7" }
-  transform-function-name { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-arrow-functions { "ie":"10", "ios":"9", "safari":"7" }
-  transform-block-scoped-functions { "ie":"10", "ios":"9", "safari":"7" }
-  transform-classes { "ie":"10", "ios":"9", "safari":"7" }
-  transform-object-super { "ie":"10", "ios":"9", "safari":"7" }
-  transform-shorthand-properties { "ie":"10", "safari":"7" }
-  transform-duplicate-keys { "ie":"10", "safari":"7" }
-  transform-computed-properties { "ie":"10", "safari":"7" }
-  transform-for-of { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-sticky-regex { "ie":"10", "ios":"9", "safari":"7" }
-  transform-unicode-escapes { "firefox":"49", "ie":"10", "safari":"7" }
-  transform-unicode-regex { "ie":"10", "ios":"9", "safari":"7" }
-  transform-spread { "ie":"10", "ios":"9", "safari":"7" }
-  transform-destructuring { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-block-scoping { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-typeof-symbol { "ie":"10", "safari":"7" }
-  transform-new-target { "edge":"13", "ie":"10", "ios":"9", "safari":"7" }
-  transform-regenerator { "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-export-namespace-from { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-modules-commonjs { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-dynamic-import { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
+  proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
+  proposal-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
+  proposal-optional-chaining { chrome, edge, firefox < 74, ie, ios < 13.4, safari < 13.1 }
+  proposal-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
+  proposal-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
+  transform-parameters { edge < 18, firefox < 53, ie, ios < 10, safari < 10 }
+  proposal-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
+  proposal-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
+  transform-dotall-regex { chrome < 62, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  proposal-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-named-capturing-groups-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-async-to-generator { chrome < 55, edge < 15, firefox < 52, ie, ios < 11, safari < 11 }
+  transform-exponentiation-operator { edge < 14, firefox < 52, ie, ios < 10.3, safari < 10.1 }
+  transform-template-literals { ie, ios < 13, safari < 13 }
+  transform-literals { firefox < 53, ie, safari < 9 }
+  transform-function-name { edge < 79, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-arrow-functions { ie, ios < 10, safari < 10 }
+  transform-block-scoped-functions { ie < 11, ios < 10, safari < 10 }
+  transform-classes { ie, ios < 10, safari < 10 }
+  transform-object-super { ie, ios < 10, safari < 10 }
+  transform-shorthand-properties { ie, safari < 9 }
+  transform-duplicate-keys { ie, safari < 9 }
+  transform-computed-properties { ie, safari < 7.1 }
+  transform-for-of { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-sticky-regex { ie, ios < 10, safari < 10 }
+  transform-unicode-escapes { firefox < 53, ie, safari < 9 }
+  transform-unicode-regex { ie, ios < 12, safari < 12 }
+  transform-spread { ie, ios < 10, safari < 10 }
+  transform-destructuring { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-block-scoping { edge < 14, firefox < 51, ie, ios < 11, safari < 11 }
+  transform-typeof-symbol { ie, safari < 9 }
+  transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
+  transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
+  proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "samsung":"8.2" }
-  proposal-private-methods { "samsung":"8.2" }
-  proposal-numeric-separator { "samsung":"8.2" }
-  proposal-logical-assignment-operators { "samsung":"8.2" }
-  proposal-nullish-coalescing-operator { "samsung":"8.2" }
-  proposal-optional-chaining { "samsung":"8.2" }
-  proposal-json-strings { "samsung":"8.2" }
-  proposal-optional-catch-binding { "samsung":"8.2" }
-  syntax-async-generators { "samsung":"8.2" }
-  syntax-object-rest-spread { "samsung":"8.2" }
-  proposal-unicode-property-regex { "samsung":"8.2" }
-  transform-named-capturing-groups-regex { "samsung":"8.2" }
-  proposal-export-namespace-from { "samsung":"8.2" }
-  transform-modules-commonjs { "samsung":"8.2" }
-  proposal-dynamic-import { "samsung":"8.2" }
+  proposal-class-properties { samsung }
+  proposal-private-methods { samsung }
+  proposal-numeric-separator { samsung < 11 }
+  proposal-logical-assignment-operators { samsung }
+  proposal-nullish-coalescing-operator { samsung < 13 }
+  proposal-optional-chaining { samsung }
+  proposal-json-strings { samsung < 9 }
+  proposal-optional-catch-binding { samsung < 9 }
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-unicode-property-regex { samsung < 9 }
+  transform-named-capturing-groups-regex { samsung < 9 }
+  proposal-export-namespace-from { samsung < 11.0 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -16,13 +16,13 @@ Using plugins:
   proposal-optional-chaining { samsung }
   proposal-json-strings { samsung < 9 }
   proposal-optional-catch-binding { samsung < 9 }
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-unicode-property-regex { samsung < 9 }
   transform-named-capturing-groups-regex { samsung < 9 }
   proposal-export-namespace-from { samsung < 11.0 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }
   proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
@@ -11,43 +11,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-logical-assignment-operators { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-chaining { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-json-strings { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-catch-binding { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-parameters { "electron":"0.36", "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-object-rest-spread { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-dotall-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-unicode-property-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-named-capturing-groups-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-async-to-generator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-sticky-regex { "electron":"0.36", "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "electron":"0.36", "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-block-scoping { "electron":"0.36", "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "electron":"0.36", "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-modules-commonjs { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-dynamic-import { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
+  proposal-optional-chaining { chrome, electron, ie, node }
+  proposal-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-parameters { electron < 0.37, ie }
+  proposal-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, electron < 3.0, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, electron < 1.6, ie, node < 7.6 }
+  transform-exponentiation-operator { electron < 1.3, ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { electron < 1.2, ie, node < 6.5 }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { electron < 1.2, ie, node < 6.5 }
+  transform-sticky-regex { electron < 0.37, ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { electron < 1.1, ie }
+  transform-spread { ie }
+  transform-destructuring { electron < 1.2, ie, node < 6.5 }
+  transform-block-scoping { electron < 0.37, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { electron < 1.1, ie }
+  proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
-  transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10", "node":"6" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10", "node":"6" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10", "node":"6" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie, node < 6.5 }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie, node < 6.5 }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie, node < 6.5 }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
@@ -8,25 +8,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "node":"6" }
-  proposal-logical-assignment-operators { "node":"6" }
-  proposal-nullish-coalescing-operator { "node":"6" }
-  proposal-optional-chaining { "node":"6" }
-  proposal-json-strings { "node":"6" }
-  proposal-optional-catch-binding { "node":"6" }
-  proposal-async-generator-functions { "node":"6" }
-  proposal-object-rest-spread { "node":"6" }
-  transform-dotall-regex { "node":"6" }
-  proposal-unicode-property-regex { "node":"6" }
-  transform-named-capturing-groups-regex { "node":"6" }
-  transform-async-to-generator { "node":"6" }
-  transform-exponentiation-operator { "node":"6" }
-  transform-function-name { "node":"6" }
-  transform-for-of { "node":"6" }
-  transform-destructuring { "node":"6" }
-  proposal-export-namespace-from { "node":"6" }
-  transform-modules-commonjs { "node":"6" }
-  proposal-dynamic-import { "node":"6" }
+  proposal-numeric-separator { node < 12.5 }
+  proposal-logical-assignment-operators { node < 15 }
+  proposal-nullish-coalescing-operator { node < 14 }
+  proposal-optional-chaining { node }
+  proposal-json-strings { node < 10 }
+  proposal-optional-catch-binding { node < 10 }
+  proposal-async-generator-functions { node < 10 }
+  proposal-object-rest-spread { node < 8.3 }
+  transform-dotall-regex { node < 8.10 }
+  proposal-unicode-property-regex { node < 10 }
+  transform-named-capturing-groups-regex { node < 10 }
+  transform-async-to-generator { node < 7.6 }
+  transform-exponentiation-operator { node < 7 }
+  transform-function-name { node < 6.5 }
+  transform-for-of { node < 6.5 }
+  transform-destructuring { node < 6.5 }
+  proposal-export-namespace-from { node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
@@ -25,8 +25,8 @@ Using plugins:
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
   proposal-export-namespace-from { node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-shippedProposals/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-shippedProposals/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
@@ -46,7 +46,7 @@ Using plugins:
   transform-property-literals { }
   transform-reserved-words { }
   proposal-export-namespace-from { chrome < 72 }
-  syntax-dynamic-import {}
+  syntax-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
@@ -8,45 +8,45 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"55" }
-  proposal-logical-assignment-operators { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  transform-parameters {}
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  transform-dotall-regex { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from { "chrome":"55" }
-  syntax-dynamic-import { "chrome":"55" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  transform-parameters { }
+  proposal-async-generator-functions { chrome < 63 }
+  proposal-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  transform-async-to-generator { }
+  transform-exponentiation-operator { }
+  transform-template-literals { }
+  transform-literals { }
+  transform-function-name { }
+  transform-arrow-functions { }
+  transform-block-scoped-functions { }
+  transform-classes { }
+  transform-object-super { }
+  transform-shorthand-properties { }
+  transform-duplicate-keys { }
+  transform-computed-properties { }
+  transform-for-of { }
+  transform-sticky-regex { }
+  transform-unicode-escapes { }
+  transform-unicode-regex { }
+  transform-spread { }
+  transform-destructuring { }
+  transform-block-scoping { }
+  transform-typeof-symbol { }
+  transform-new-target { }
+  transform-regenerator { }
+  transform-member-expression-literals { }
+  transform-property-literals { }
+  transform-reserved-words { }
+  proposal-export-namespace-from { chrome < 72 }
+  syntax-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
-  transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10", "node":"6" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10", "node":"6" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10", "node":"6" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie, node < 6.5 }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie, node < 6.5 }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie, node < 6.5 }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
@@ -9,24 +9,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "firefox":"52", "node":"7.4" }
-  proposal-logical-assignment-operators { "firefox":"52", "node":"7.4" }
-  proposal-nullish-coalescing-operator { "firefox":"52", "node":"7.4" }
-  proposal-optional-chaining { "firefox":"52", "node":"7.4" }
-  proposal-json-strings { "firefox":"52", "node":"7.4" }
-  proposal-optional-catch-binding { "firefox":"52", "node":"7.4" }
-  proposal-async-generator-functions { "firefox":"52", "node":"7.4" }
-  proposal-object-rest-spread { "firefox":"52", "node":"7.4" }
-  transform-dotall-regex { "firefox":"52", "node":"7.4" }
-  proposal-unicode-property-regex { "firefox":"52", "node":"7.4" }
-  transform-named-capturing-groups-regex { "firefox":"52", "node":"7.4" }
-  transform-literals { "firefox":"52" }
-  transform-function-name { "firefox":"52" }
-  transform-for-of { "firefox":"52" }
-  transform-unicode-escapes { "firefox":"52" }
-  transform-destructuring { "firefox":"52" }
-  proposal-export-namespace-from { "firefox":"52", "node":"7.4" }
-  transform-modules-commonjs { "firefox":"52", "node":"7.4" }
-  proposal-dynamic-import { "firefox":"52", "node":"7.4" }
+  proposal-numeric-separator { firefox < 70, node < 12.5 }
+  proposal-logical-assignment-operators { firefox < 79, node < 15 }
+  proposal-nullish-coalescing-operator { firefox < 72, node < 14 }
+  proposal-optional-chaining { firefox < 74, node }
+  proposal-json-strings { firefox < 62, node < 10 }
+  proposal-optional-catch-binding { firefox < 58, node < 10 }
+  proposal-async-generator-functions { firefox < 57, node < 10 }
+  proposal-object-rest-spread { firefox < 55, node < 8.3 }
+  transform-dotall-regex { firefox < 78, node < 8.10 }
+  proposal-unicode-property-regex { firefox < 78, node < 10 }
+  transform-named-capturing-groups-regex { firefox < 78, node < 10 }
+  transform-literals { firefox < 53 }
+  transform-function-name { firefox < 53 }
+  transform-for-of { firefox < 53 }
+  transform-unicode-escapes { firefox < 53 }
+  transform-destructuring { firefox < 53 }
+  proposal-export-namespace-from { firefox < 80, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
@@ -26,7 +26,7 @@ Using plugins:
   transform-unicode-escapes { firefox < 53 }
   transform-destructuring { firefox < 53 }
   proposal-export-namespace-from { firefox < 80, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
@@ -10,16 +10,16 @@ Using modules transform: auto
 Using plugins:
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
-  syntax-numeric-separator {}
+  syntax-numeric-separator
   proposal-logical-assignment-operators { chrome < 85 }
-  syntax-nullish-coalescing-operator {}
+  syntax-nullish-coalescing-operator
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
+  transform-modules-commonjs
+  proposal-dynamic-import
   proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
@@ -8,18 +8,18 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"80" }
-  proposal-private-methods { "chrome":"80" }
-  syntax-numeric-separator { "chrome":"80" }
-  proposal-logical-assignment-operators { "chrome":"80" }
-  syntax-nullish-coalescing-operator { "chrome":"80" }
-  proposal-optional-chaining { "chrome":"80" }
-  syntax-json-strings { "chrome":"80" }
-  syntax-optional-catch-binding { "chrome":"80" }
-  syntax-async-generators { "chrome":"80" }
-  syntax-object-rest-spread { "chrome":"80" }
-  transform-modules-commonjs { "chrome":"80" }
-  proposal-dynamic-import { "chrome":"80" }
-  proposal-export-namespace-from {}
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  syntax-numeric-separator {}
+  proposal-logical-assignment-operators { chrome < 85 }
+  syntax-nullish-coalescing-operator {}
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
+  proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-class-properties { "chrome":"84" }
-  syntax-numeric-separator { "chrome":"84" }
-  proposal-logical-assignment-operators { "chrome":"84" }
-  syntax-nullish-coalescing-operator { "chrome":"84" }
-  proposal-optional-chaining { "chrome":"84" }
-  syntax-json-strings { "chrome":"84" }
-  syntax-optional-catch-binding { "chrome":"84" }
-  syntax-async-generators { "chrome":"84" }
-  syntax-object-rest-spread { "chrome":"84" }
-  transform-modules-commonjs { "chrome":"84" }
-  proposal-dynamic-import { "chrome":"84" }
-  proposal-export-namespace-from {}
+  syntax-class-properties {}
+  syntax-numeric-separator {}
+  proposal-logical-assignment-operators { chrome < 85 }
+  syntax-nullish-coalescing-operator {}
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
+  proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-class-properties {}
-  syntax-numeric-separator {}
+  syntax-class-properties
+  syntax-numeric-separator
   proposal-logical-assignment-operators { chrome < 85 }
-  syntax-nullish-coalescing-operator {}
+  syntax-nullish-coalescing-operator
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
+  transform-modules-commonjs
+  proposal-dynamic-import
   proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
@@ -15,12 +15,12 @@ Using plugins:
   proposal-json-strings { chrome < 66 }
   proposal-optional-catch-binding { chrome < 66 }
   proposal-async-generator-functions { chrome < 63 }
-  syntax-object-rest-spread {}
+  syntax-object-rest-spread
   transform-dotall-regex { chrome < 62 }
   proposal-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"60" }
-  proposal-logical-assignment-operators { "chrome":"60" }
-  proposal-nullish-coalescing-operator { "chrome":"60" }
-  proposal-optional-chaining { "chrome":"60" }
-  proposal-json-strings { "chrome":"60" }
-  proposal-optional-catch-binding { "chrome":"60" }
-  proposal-async-generator-functions { "chrome":"60" }
-  syntax-object-rest-spread { "chrome":"60" }
-  transform-dotall-regex { "chrome":"60" }
-  proposal-unicode-property-regex { "chrome":"60" }
-  transform-named-capturing-groups-regex { "chrome":"60" }
-  proposal-export-namespace-from { "chrome":"60" }
-  transform-modules-commonjs { "chrome":"60" }
-  proposal-dynamic-import { "chrome":"60" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  proposal-async-generator-functions { chrome < 63 }
+  syntax-object-rest-spread {}
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
@@ -8,16 +8,16 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator {}
+  syntax-numeric-separator
   proposal-logical-assignment-operators { chrome < 85 }
-  syntax-nullish-coalescing-operator {}
+  syntax-nullish-coalescing-operator
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
+  transform-modules-commonjs
+  proposal-dynamic-import
   proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
@@ -8,16 +8,16 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator { "chrome":"80" }
-  proposal-logical-assignment-operators { "chrome":"80" }
-  syntax-nullish-coalescing-operator { "chrome":"80" }
-  proposal-optional-chaining { "chrome":"80" }
-  syntax-json-strings { "chrome":"80" }
-  syntax-optional-catch-binding { "chrome":"80" }
-  syntax-async-generators { "chrome":"80" }
-  syntax-object-rest-spread { "chrome":"80" }
-  transform-modules-commonjs { "chrome":"80" }
-  proposal-dynamic-import { "chrome":"80" }
-  proposal-export-namespace-from {}
+  syntax-numeric-separator {}
+  proposal-logical-assignment-operators { chrome < 85 }
+  syntax-nullish-coalescing-operator {}
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
+  proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
@@ -10,44 +10,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-class-properties { chrome < 84, firefox, ie }
+  proposal-private-methods { chrome < 84, firefox, ie }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
@@ -10,44 +10,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-class-properties { chrome < 84, firefox, ie }
+  proposal-private-methods { chrome < 84, firefox, ie }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
@@ -20,8 +20,8 @@ Using plugins:
   proposal-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"55" }
-  proposal-logical-assignment-operators { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  transform-dotall-regex { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
-  proposal-export-namespace-from { "chrome":"55" }
-  transform-modules-commonjs { "chrome":"55" }
-  proposal-dynamic-import { "chrome":"55" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  proposal-async-generator-functions { chrome < 63 }
+  proposal-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
@@ -10,44 +10,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-class-properties { chrome < 84, firefox, ie }
+  proposal-private-methods { chrome < 84, firefox, ie }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
@@ -10,44 +10,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-class-properties { chrome < 84, firefox, ie }
+  proposal-private-methods { chrome < 84, firefox, ie }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
@@ -20,8 +20,8 @@ Using plugins:
   proposal-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"55" }
-  proposal-logical-assignment-operators { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  transform-dotall-regex { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
-  proposal-export-namespace-from { "chrome":"55" }
-  transform-modules-commonjs { "chrome":"55" }
-  proposal-dynamic-import { "chrome":"55" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  proposal-async-generator-functions { chrome < 63 }
+  proposal-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
@@ -8,41 +8,41 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ie":"11" }
-  proposal-logical-assignment-operators { "ie":"11" }
-  proposal-nullish-coalescing-operator { "ie":"11" }
-  proposal-optional-chaining { "ie":"11" }
-  proposal-json-strings { "ie":"11" }
-  proposal-optional-catch-binding { "ie":"11" }
-  transform-parameters { "ie":"11" }
-  proposal-async-generator-functions { "ie":"11" }
-  proposal-object-rest-spread { "ie":"11" }
-  transform-dotall-regex { "ie":"11" }
-  proposal-unicode-property-regex { "ie":"11" }
-  transform-named-capturing-groups-regex { "ie":"11" }
-  transform-async-to-generator { "ie":"11" }
-  transform-exponentiation-operator { "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "ie":"11" }
-  transform-function-name { "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "ie":"11" }
-  transform-block-scoping { "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "ie":"11" }
-  proposal-export-namespace-from { "ie":"11" }
-  transform-modules-commonjs { "ie":"11" }
-  proposal-dynamic-import { "ie":"11" }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
@@ -42,7 +42,7 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
@@ -46,7 +46,7 @@ Using plugins:
   transform-property-literals { android < 4 }
   transform-reserved-words { android < 4.4 }
   proposal-export-namespace-from { android < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
@@ -8,45 +8,45 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "android":"3" }
-  proposal-logical-assignment-operators { "android":"3" }
-  proposal-nullish-coalescing-operator { "android":"3" }
-  proposal-optional-chaining { "android":"3" }
-  proposal-json-strings { "android":"3" }
-  proposal-optional-catch-binding { "android":"3" }
-  transform-parameters { "android":"3" }
-  proposal-async-generator-functions { "android":"3" }
-  proposal-object-rest-spread { "android":"3" }
-  transform-dotall-regex { "android":"3" }
-  proposal-unicode-property-regex { "android":"3" }
-  transform-named-capturing-groups-regex { "android":"3" }
-  transform-async-to-generator { "android":"3" }
-  transform-exponentiation-operator { "android":"3" }
-  transform-template-literals { "android":"3" }
-  transform-literals { "android":"3" }
-  transform-function-name { "android":"3" }
-  transform-arrow-functions { "android":"3" }
-  transform-block-scoped-functions { "android":"3" }
-  transform-classes { "android":"3" }
-  transform-object-super { "android":"3" }
-  transform-shorthand-properties { "android":"3" }
-  transform-duplicate-keys { "android":"3" }
-  transform-computed-properties { "android":"3" }
-  transform-for-of { "android":"3" }
-  transform-sticky-regex { "android":"3" }
-  transform-unicode-escapes { "android":"3" }
-  transform-unicode-regex { "android":"3" }
-  transform-spread { "android":"3" }
-  transform-destructuring { "android":"3" }
-  transform-block-scoping { "android":"3" }
-  transform-typeof-symbol { "android":"3" }
-  transform-new-target { "android":"3" }
-  transform-regenerator { "android":"3" }
-  transform-member-expression-literals { "android":"3" }
-  transform-property-literals { "android":"3" }
-  transform-reserved-words { "android":"3" }
-  proposal-export-namespace-from { "android":"3" }
-  transform-modules-commonjs { "android":"3" }
-  proposal-dynamic-import { "android":"3" }
+  proposal-numeric-separator { android }
+  proposal-logical-assignment-operators { android }
+  proposal-nullish-coalescing-operator { android }
+  proposal-optional-chaining { android }
+  proposal-json-strings { android }
+  proposal-optional-catch-binding { android }
+  transform-parameters { android }
+  proposal-async-generator-functions { android }
+  proposal-object-rest-spread { android }
+  transform-dotall-regex { android }
+  proposal-unicode-property-regex { android }
+  transform-named-capturing-groups-regex { android }
+  transform-async-to-generator { android }
+  transform-exponentiation-operator { android }
+  transform-template-literals { android }
+  transform-literals { android }
+  transform-function-name { android }
+  transform-arrow-functions { android }
+  transform-block-scoped-functions { android }
+  transform-classes { android }
+  transform-object-super { android }
+  transform-shorthand-properties { android }
+  transform-duplicate-keys { android }
+  transform-computed-properties { android }
+  transform-for-of { android }
+  transform-sticky-regex { android }
+  transform-unicode-escapes { android }
+  transform-unicode-regex { android }
+  transform-spread { android }
+  transform-destructuring { android }
+  transform-block-scoping { android }
+  transform-typeof-symbol { android }
+  transform-new-target { android }
+  transform-regenerator { android }
+  transform-member-expression-literals { android < 4 }
+  transform-property-literals { android < 4 }
+  transform-reserved-words { android < 4.4 }
+  proposal-export-namespace-from { android < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -15,17 +15,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ios":"12.2" }
-  proposal-logical-assignment-operators { "chrome":"84", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-nullish-coalescing-operator { "ios":"12.2", "samsung":"11.1" }
-  proposal-optional-chaining { "android":"85", "chrome":"84", "edge":"85", "ios":"12.2", "opera":"71", "samsung":"11.1" }
-  syntax-json-strings { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-optional-catch-binding { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-async-generators { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-object-rest-spread { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  transform-template-literals { "ios":"12.2" }
-  proposal-export-namespace-from { "firefox":"78", "ios":"12.2", "safari":"13.1" }
-  transform-modules-commonjs { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-dynamic-import { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
+  proposal-numeric-separator { ios < 13 }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ios < 14, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { ios < 13.4, samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, ios < 13.4, opera, samsung }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  transform-template-literals { ios < 13 }
+  proposal-export-namespace-from { firefox < 80, ios, safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -19,13 +19,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ios < 14, opera, safari < 14, samsung }
   proposal-nullish-coalescing-operator { ios < 13.4, samsung < 13 }
   proposal-optional-chaining { android, chrome, edge, ios < 13.4, opera, samsung }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   transform-template-literals { ios < 13 }
   proposal-export-namespace-from { firefox < 80, ios, safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -50,7 +50,7 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { firefox < 80, ie, ios, safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -16,41 +16,41 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ie":"11", "ios":"12.2" }
-  proposal-logical-assignment-operators { "chrome":"84", "firefox":"78", "ie":"11", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-nullish-coalescing-operator { "ie":"11", "ios":"12.2", "samsung":"11.1" }
-  proposal-optional-chaining { "android":"85", "chrome":"84", "edge":"85", "ie":"11", "ios":"12.2", "opera":"71", "samsung":"11.1" }
-  proposal-json-strings { "ie":"11" }
-  proposal-optional-catch-binding { "ie":"11" }
-  transform-parameters { "ie":"11" }
-  proposal-async-generator-functions { "ie":"11" }
-  proposal-object-rest-spread { "ie":"11" }
-  transform-dotall-regex { "ie":"11" }
-  proposal-unicode-property-regex { "ie":"11" }
-  transform-named-capturing-groups-regex { "ie":"11" }
-  transform-async-to-generator { "ie":"11" }
-  transform-exponentiation-operator { "ie":"11" }
-  transform-template-literals { "ie":"11", "ios":"12.2" }
-  transform-literals { "ie":"11" }
-  transform-function-name { "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "ie":"11" }
-  transform-block-scoping { "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "ie":"11" }
-  proposal-export-namespace-from { "firefox":"78", "ie":"11", "ios":"12.2", "safari":"13.1" }
-  transform-modules-commonjs { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ie":"11", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-dynamic-import { "android":"85", "chrome":"84", "edge":"85", "firefox":"78", "ie":"11", "ios":"12.2", "opera":"71", "safari":"13.1", "samsung":"11.1" }
+  proposal-numeric-separator { ie, ios < 13 }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie, ios < 14, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { ie, ios < 13.4, samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, ie, ios < 13.4, opera, samsung }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie, ios < 13 }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { firefox < 80, ie, ios, safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -15,16 +15,16 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-logical-assignment-operators { "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-nullish-coalescing-operator { "samsung":"11.1" }
-  proposal-optional-chaining { "android":"85", "chrome":"85", "edge":"85", "opera":"71", "samsung":"11.1" }
-  syntax-json-strings { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-optional-catch-binding { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-async-generators { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  syntax-object-rest-spread { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-export-namespace-from { "ios":"13.4", "safari":"13.1" }
-  transform-modules-commonjs { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
-  proposal-dynamic-import { "android":"85", "chrome":"85", "edge":"85", "firefox":"81", "ios":"13.4", "opera":"71", "safari":"13.1", "samsung":"11.1" }
+  syntax-numeric-separator {}
+  proposal-logical-assignment-operators { ios < 14, opera, safari < 14, samsung }
+  proposal-nullish-coalescing-operator { samsung < 13 }
+  proposal-optional-chaining { android, chrome, edge, opera, samsung }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { ios, safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -15,16 +15,16 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator {}
+  syntax-numeric-separator
   proposal-logical-assignment-operators { ios < 14, opera, safari < 14, samsung }
   proposal-nullish-coalescing-operator { samsung < 13 }
   proposal-optional-chaining { android, chrome, edge, opera, samsung }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { ios, safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
@@ -8,45 +8,45 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
@@ -46,7 +46,7 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
@@ -8,44 +8,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "android":"4" }
-  proposal-logical-assignment-operators { "android":"4" }
-  proposal-nullish-coalescing-operator { "android":"4" }
-  proposal-optional-chaining { "android":"4" }
-  proposal-json-strings { "android":"4" }
-  proposal-optional-catch-binding { "android":"4" }
-  transform-parameters { "android":"4" }
-  proposal-async-generator-functions { "android":"4" }
-  proposal-object-rest-spread { "android":"4" }
-  transform-dotall-regex { "android":"4" }
-  proposal-unicode-property-regex { "android":"4" }
-  transform-named-capturing-groups-regex { "android":"4" }
-  transform-async-to-generator { "android":"4" }
-  transform-exponentiation-operator { "android":"4" }
-  transform-template-literals { "android":"4" }
-  transform-literals { "android":"4" }
-  transform-function-name { "android":"4" }
-  transform-arrow-functions { "android":"4" }
-  transform-block-scoped-functions { "android":"4" }
-  transform-classes { "android":"4" }
-  transform-object-super { "android":"4" }
-  transform-shorthand-properties { "android":"4" }
-  transform-duplicate-keys { "android":"4" }
-  transform-computed-properties { "android":"4" }
-  transform-for-of { "android":"4" }
-  transform-sticky-regex { "android":"4" }
-  transform-unicode-escapes { "android":"4" }
-  transform-unicode-regex { "android":"4" }
-  transform-spread { "android":"4" }
-  transform-destructuring { "android":"4" }
-  transform-block-scoping { "android":"4" }
-  transform-typeof-symbol { "android":"4" }
-  transform-new-target { "android":"4" }
-  transform-regenerator { "android":"4" }
-  transform-reserved-words { "android":"4" }
-  proposal-export-namespace-from { "android":"4" }
-  transform-modules-commonjs { "android":"4" }
-  proposal-dynamic-import { "android":"4" }
+  proposal-numeric-separator { android }
+  proposal-logical-assignment-operators { android }
+  proposal-nullish-coalescing-operator { android }
+  proposal-optional-chaining { android }
+  proposal-json-strings { android }
+  proposal-optional-catch-binding { android }
+  transform-parameters { android }
+  proposal-async-generator-functions { android }
+  proposal-object-rest-spread { android }
+  transform-dotall-regex { android }
+  proposal-unicode-property-regex { android }
+  transform-named-capturing-groups-regex { android }
+  transform-async-to-generator { android }
+  transform-exponentiation-operator { android }
+  transform-template-literals { android }
+  transform-literals { android }
+  transform-function-name { android }
+  transform-arrow-functions { android }
+  transform-block-scoped-functions { android }
+  transform-classes { android }
+  transform-object-super { android }
+  transform-shorthand-properties { android }
+  transform-duplicate-keys { android }
+  transform-computed-properties { android }
+  transform-for-of { android }
+  transform-sticky-regex { android }
+  transform-unicode-escapes { android }
+  transform-unicode-regex { android }
+  transform-spread { android }
+  transform-destructuring { android }
+  transform-block-scoping { android }
+  transform-typeof-symbol { android }
+  transform-new-target { android }
+  transform-regenerator { android }
+  transform-reserved-words { android < 4.4 }
+  proposal-export-namespace-from { android < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-regenerator { android }
   transform-reserved-words { android < 4.4 }
   proposal-export-namespace-from { android < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -8,30 +8,30 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "electron":"0.36" }
-  proposal-logical-assignment-operators { "electron":"0.36" }
-  proposal-nullish-coalescing-operator { "electron":"0.36" }
-  proposal-optional-chaining { "electron":"0.36" }
-  proposal-json-strings { "electron":"0.36" }
-  proposal-optional-catch-binding { "electron":"0.36" }
-  transform-parameters { "electron":"0.36" }
-  proposal-async-generator-functions { "electron":"0.36" }
-  proposal-object-rest-spread { "electron":"0.36" }
-  transform-dotall-regex { "electron":"0.36" }
-  proposal-unicode-property-regex { "electron":"0.36" }
-  transform-named-capturing-groups-regex { "electron":"0.36" }
-  transform-async-to-generator { "electron":"0.36" }
-  transform-exponentiation-operator { "electron":"0.36" }
-  transform-function-name { "electron":"0.36" }
-  transform-for-of { "electron":"0.36" }
-  transform-sticky-regex { "electron":"0.36" }
-  transform-unicode-regex { "electron":"0.36" }
-  transform-destructuring { "electron":"0.36" }
-  transform-block-scoping { "electron":"0.36" }
-  transform-regenerator { "electron":"0.36" }
-  proposal-export-namespace-from { "electron":"0.36" }
-  transform-modules-commonjs { "electron":"0.36" }
-  proposal-dynamic-import { "electron":"0.36" }
+  proposal-numeric-separator { electron < 6.0 }
+  proposal-logical-assignment-operators { electron < 10.0 }
+  proposal-nullish-coalescing-operator { electron < 8.0 }
+  proposal-optional-chaining { electron }
+  proposal-json-strings { electron < 3.0 }
+  proposal-optional-catch-binding { electron < 3.0 }
+  transform-parameters { electron < 0.37 }
+  proposal-async-generator-functions { electron < 3.0 }
+  proposal-object-rest-spread { electron < 2.0 }
+  transform-dotall-regex { electron < 3.0 }
+  proposal-unicode-property-regex { electron < 3.0 }
+  transform-named-capturing-groups-regex { electron < 3.0 }
+  transform-async-to-generator { electron < 1.6 }
+  transform-exponentiation-operator { electron < 1.3 }
+  transform-function-name { electron < 1.2 }
+  transform-for-of { electron < 1.2 }
+  transform-sticky-regex { electron < 0.37 }
+  transform-unicode-regex { electron < 1.1 }
+  transform-destructuring { electron < 1.2 }
+  transform-block-scoping { electron < 0.37 }
+  transform-regenerator { electron < 1.1 }
+  proposal-export-namespace-from { electron < 5.0 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -30,8 +30,8 @@ Using plugins:
   transform-block-scoping { electron < 0.37 }
   transform-regenerator { electron < 1.1 }
   proposal-export-namespace-from { electron < 5.0 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
@@ -46,7 +46,7 @@ Using plugins:
   transform-property-literals { }
   transform-reserved-words { }
   proposal-export-namespace-from { chrome < 72 }
-  syntax-dynamic-import {}
+  syntax-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
@@ -8,45 +8,45 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"55" }
-  proposal-logical-assignment-operators { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  transform-parameters {}
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  transform-dotall-regex { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from { "chrome":"55" }
-  syntax-dynamic-import { "chrome":"55" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  transform-parameters { }
+  proposal-async-generator-functions { chrome < 63 }
+  proposal-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  transform-async-to-generator { }
+  transform-exponentiation-operator { }
+  transform-template-literals { }
+  transform-literals { }
+  transform-function-name { }
+  transform-arrow-functions { }
+  transform-block-scoped-functions { }
+  transform-classes { }
+  transform-object-super { }
+  transform-shorthand-properties { }
+  transform-duplicate-keys { }
+  transform-computed-properties { }
+  transform-for-of { }
+  transform-sticky-regex { }
+  transform-unicode-escapes { }
+  transform-unicode-regex { }
+  transform-spread { }
+  transform-destructuring { }
+  transform-block-scoping { }
+  transform-typeof-symbol { }
+  transform-new-target { }
+  transform-regenerator { }
+  transform-member-expression-literals { }
+  transform-property-literals { }
+  transform-reserved-words { }
+  proposal-export-namespace-from { chrome < 72 }
+  syntax-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
@@ -8,25 +8,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "node":"6" }
-  proposal-logical-assignment-operators { "node":"6" }
-  proposal-nullish-coalescing-operator { "node":"6" }
-  proposal-optional-chaining { "node":"6" }
-  proposal-json-strings { "node":"6" }
-  proposal-optional-catch-binding { "node":"6" }
-  proposal-async-generator-functions { "node":"6" }
-  proposal-object-rest-spread { "node":"6" }
-  transform-dotall-regex { "node":"6" }
-  proposal-unicode-property-regex { "node":"6" }
-  transform-named-capturing-groups-regex { "node":"6" }
-  transform-async-to-generator { "node":"6" }
-  transform-exponentiation-operator { "node":"6" }
-  transform-function-name { "node":"6" }
-  transform-for-of { "node":"6" }
-  transform-destructuring { "node":"6" }
-  proposal-export-namespace-from { "node":"6" }
-  transform-modules-commonjs { "node":"6" }
-  proposal-dynamic-import { "node":"6" }
+  proposal-numeric-separator { node < 12.5 }
+  proposal-logical-assignment-operators { node < 15 }
+  proposal-nullish-coalescing-operator { node < 14 }
+  proposal-optional-chaining { node }
+  proposal-json-strings { node < 10 }
+  proposal-optional-catch-binding { node < 10 }
+  proposal-async-generator-functions { node < 10 }
+  proposal-object-rest-spread { node < 8.3 }
+  transform-dotall-regex { node < 8.10 }
+  proposal-unicode-property-regex { node < 10 }
+  transform-named-capturing-groups-regex { node < 10 }
+  transform-async-to-generator { node < 7.6 }
+  transform-exponentiation-operator { node < 7 }
+  transform-function-name { node < 6.5 }
+  transform-for-of { node < 6.5 }
+  transform-destructuring { node < 6.5 }
+  proposal-export-namespace-from { node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
@@ -25,8 +25,8 @@ Using plugins:
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
   proposal-export-namespace-from { node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
@@ -8,46 +8,46 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
   proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -13,43 +13,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-logical-assignment-operators { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-chaining { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-catch-binding { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-parameters { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-async-generator-functions { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-object-rest-spread { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-dotall-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-unicode-property-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-named-capturing-groups-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-async-to-generator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-template-literals { "ie":"10", "ios":"9", "safari":"7" }
-  transform-literals { "firefox":"49", "ie":"10", "safari":"7" }
-  transform-function-name { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-arrow-functions { "ie":"10", "ios":"9", "safari":"7" }
-  transform-block-scoped-functions { "ie":"10", "ios":"9", "safari":"7" }
-  transform-classes { "ie":"10", "ios":"9", "safari":"7" }
-  transform-object-super { "ie":"10", "ios":"9", "safari":"7" }
-  transform-shorthand-properties { "ie":"10", "safari":"7" }
-  transform-duplicate-keys { "ie":"10", "safari":"7" }
-  transform-computed-properties { "ie":"10", "safari":"7" }
-  transform-for-of { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-sticky-regex { "ie":"10", "ios":"9", "safari":"7" }
-  transform-unicode-escapes { "firefox":"49", "ie":"10", "safari":"7" }
-  transform-unicode-regex { "ie":"10", "ios":"9", "safari":"7" }
-  transform-spread { "ie":"10", "ios":"9", "safari":"7" }
-  transform-destructuring { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-block-scoping { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-typeof-symbol { "ie":"10", "safari":"7" }
-  transform-new-target { "edge":"13", "ie":"10", "ios":"9", "safari":"7" }
-  transform-regenerator { "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-export-namespace-from { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-modules-commonjs { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-dynamic-import { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
+  proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
+  proposal-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
+  proposal-optional-chaining { chrome, edge, firefox < 74, ie, ios < 13.4, safari < 13.1 }
+  proposal-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
+  proposal-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
+  transform-parameters { edge < 18, firefox < 53, ie, ios < 10, safari < 10 }
+  proposal-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
+  proposal-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
+  transform-dotall-regex { chrome < 62, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  proposal-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-named-capturing-groups-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-async-to-generator { chrome < 55, edge < 15, firefox < 52, ie, ios < 11, safari < 11 }
+  transform-exponentiation-operator { edge < 14, firefox < 52, ie, ios < 10.3, safari < 10.1 }
+  transform-template-literals { ie, ios < 13, safari < 13 }
+  transform-literals { firefox < 53, ie, safari < 9 }
+  transform-function-name { edge < 79, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-arrow-functions { ie, ios < 10, safari < 10 }
+  transform-block-scoped-functions { ie < 11, ios < 10, safari < 10 }
+  transform-classes { ie, ios < 10, safari < 10 }
+  transform-object-super { ie, ios < 10, safari < 10 }
+  transform-shorthand-properties { ie, safari < 9 }
+  transform-duplicate-keys { ie, safari < 9 }
+  transform-computed-properties { ie, safari < 7.1 }
+  transform-for-of { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-sticky-regex { ie, ios < 10, safari < 10 }
+  transform-unicode-escapes { firefox < 53, ie, safari < 9 }
+  transform-unicode-regex { ie, ios < 12, safari < 12 }
+  transform-spread { ie, ios < 10, safari < 10 }
+  transform-destructuring { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-block-scoping { edge < 14, firefox < 51, ie, ios < 11, safari < 11 }
+  transform-typeof-symbol { ie, safari < 9 }
+  transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
+  transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
+  proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -11,43 +11,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-logical-assignment-operators { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-chaining { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-json-strings { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-catch-binding { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-parameters { "electron":"0.36", "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-object-rest-spread { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-dotall-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-unicode-property-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-named-capturing-groups-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-async-to-generator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-sticky-regex { "electron":"0.36", "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "electron":"0.36", "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-block-scoping { "electron":"0.36", "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "electron":"0.36", "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-modules-commonjs { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-dynamic-import { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
+  proposal-optional-chaining { chrome, electron, ie, node }
+  proposal-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-parameters { electron < 0.37, ie }
+  proposal-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, electron < 3.0, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, electron < 1.6, ie, node < 7.6 }
+  transform-exponentiation-operator { electron < 1.3, ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { electron < 1.2, ie, node < 6.5 }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { electron < 1.2, ie, node < 6.5 }
+  transform-sticky-regex { electron < 0.37, ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { electron < 1.1, ie }
+  transform-spread { ie }
+  transform-destructuring { electron < 1.2, ie, node < 6.5 }
+  transform-block-scoping { electron < 0.37, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { electron < 1.1, ie }
+  proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }
   proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
-  transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10", "node":"6" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10", "node":"6" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10", "node":"6" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie, node < 6.5 }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie, node < 6.5 }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie, node < 6.5 }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-regenerator { android }
   transform-reserved-words { android < 4.4 }
   proposal-export-namespace-from { android < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
@@ -8,44 +8,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "android":"4" }
-  proposal-logical-assignment-operators { "android":"4" }
-  proposal-nullish-coalescing-operator { "android":"4" }
-  proposal-optional-chaining { "android":"4" }
-  proposal-json-strings { "android":"4" }
-  proposal-optional-catch-binding { "android":"4" }
-  transform-parameters { "android":"4" }
-  proposal-async-generator-functions { "android":"4" }
-  proposal-object-rest-spread { "android":"4" }
-  transform-dotall-regex { "android":"4" }
-  proposal-unicode-property-regex { "android":"4" }
-  transform-named-capturing-groups-regex { "android":"4" }
-  transform-async-to-generator { "android":"4" }
-  transform-exponentiation-operator { "android":"4" }
-  transform-template-literals { "android":"4" }
-  transform-literals { "android":"4" }
-  transform-function-name { "android":"4" }
-  transform-arrow-functions { "android":"4" }
-  transform-block-scoped-functions { "android":"4" }
-  transform-classes { "android":"4" }
-  transform-object-super { "android":"4" }
-  transform-shorthand-properties { "android":"4" }
-  transform-duplicate-keys { "android":"4" }
-  transform-computed-properties { "android":"4" }
-  transform-for-of { "android":"4" }
-  transform-sticky-regex { "android":"4" }
-  transform-unicode-escapes { "android":"4" }
-  transform-unicode-regex { "android":"4" }
-  transform-spread { "android":"4" }
-  transform-destructuring { "android":"4" }
-  transform-block-scoping { "android":"4" }
-  transform-typeof-symbol { "android":"4" }
-  transform-new-target { "android":"4" }
-  transform-regenerator { "android":"4" }
-  transform-reserved-words { "android":"4" }
-  proposal-export-namespace-from { "android":"4" }
-  transform-modules-commonjs { "android":"4" }
-  proposal-dynamic-import { "android":"4" }
+  proposal-numeric-separator { android }
+  proposal-logical-assignment-operators { android }
+  proposal-nullish-coalescing-operator { android }
+  proposal-optional-chaining { android }
+  proposal-json-strings { android }
+  proposal-optional-catch-binding { android }
+  transform-parameters { android }
+  proposal-async-generator-functions { android }
+  proposal-object-rest-spread { android }
+  transform-dotall-regex { android }
+  proposal-unicode-property-regex { android }
+  transform-named-capturing-groups-regex { android }
+  transform-async-to-generator { android }
+  transform-exponentiation-operator { android }
+  transform-template-literals { android }
+  transform-literals { android }
+  transform-function-name { android }
+  transform-arrow-functions { android }
+  transform-block-scoped-functions { android }
+  transform-classes { android }
+  transform-object-super { android }
+  transform-shorthand-properties { android }
+  transform-duplicate-keys { android }
+  transform-computed-properties { android }
+  transform-for-of { android }
+  transform-sticky-regex { android }
+  transform-unicode-escapes { android }
+  transform-unicode-regex { android }
+  transform-spread { android }
+  transform-destructuring { android }
+  transform-block-scoping { android }
+  transform-typeof-symbol { android }
+  transform-new-target { android }
+  transform-regenerator { android }
+  transform-reserved-words { android < 4.4 }
+  proposal-export-namespace-from { android < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -30,8 +30,8 @@ Using plugins:
   transform-block-scoping { electron < 0.37 }
   transform-regenerator { electron < 1.1 }
   proposal-export-namespace-from { electron < 5.0 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -8,30 +8,30 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "electron":"0.36" }
-  proposal-logical-assignment-operators { "electron":"0.36" }
-  proposal-nullish-coalescing-operator { "electron":"0.36" }
-  proposal-optional-chaining { "electron":"0.36" }
-  proposal-json-strings { "electron":"0.36" }
-  proposal-optional-catch-binding { "electron":"0.36" }
-  transform-parameters { "electron":"0.36" }
-  proposal-async-generator-functions { "electron":"0.36" }
-  proposal-object-rest-spread { "electron":"0.36" }
-  transform-dotall-regex { "electron":"0.36" }
-  proposal-unicode-property-regex { "electron":"0.36" }
-  transform-named-capturing-groups-regex { "electron":"0.36" }
-  transform-async-to-generator { "electron":"0.36" }
-  transform-exponentiation-operator { "electron":"0.36" }
-  transform-function-name { "electron":"0.36" }
-  transform-for-of { "electron":"0.36" }
-  transform-sticky-regex { "electron":"0.36" }
-  transform-unicode-regex { "electron":"0.36" }
-  transform-destructuring { "electron":"0.36" }
-  transform-block-scoping { "electron":"0.36" }
-  transform-regenerator { "electron":"0.36" }
-  proposal-export-namespace-from { "electron":"0.36" }
-  transform-modules-commonjs { "electron":"0.36" }
-  proposal-dynamic-import { "electron":"0.36" }
+  proposal-numeric-separator { electron < 6.0 }
+  proposal-logical-assignment-operators { electron < 10.0 }
+  proposal-nullish-coalescing-operator { electron < 8.0 }
+  proposal-optional-chaining { electron }
+  proposal-json-strings { electron < 3.0 }
+  proposal-optional-catch-binding { electron < 3.0 }
+  transform-parameters { electron < 0.37 }
+  proposal-async-generator-functions { electron < 3.0 }
+  proposal-object-rest-spread { electron < 2.0 }
+  transform-dotall-regex { electron < 3.0 }
+  proposal-unicode-property-regex { electron < 3.0 }
+  transform-named-capturing-groups-regex { electron < 3.0 }
+  transform-async-to-generator { electron < 1.6 }
+  transform-exponentiation-operator { electron < 1.3 }
+  transform-function-name { electron < 1.2 }
+  transform-for-of { electron < 1.2 }
+  transform-sticky-regex { electron < 0.37 }
+  transform-unicode-regex { electron < 1.1 }
+  transform-destructuring { electron < 1.2 }
+  transform-block-scoping { electron < 0.37 }
+  transform-regenerator { electron < 1.1 }
+  proposal-export-namespace-from { electron < 5.0 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
@@ -46,7 +46,7 @@ Using plugins:
   transform-property-literals { }
   transform-reserved-words { }
   proposal-export-namespace-from { chrome < 72 }
-  syntax-dynamic-import {}
+  syntax-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
@@ -8,45 +8,45 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"55" }
-  proposal-logical-assignment-operators { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  transform-parameters {}
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  transform-dotall-regex { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from { "chrome":"55" }
-  syntax-dynamic-import { "chrome":"55" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  transform-parameters { }
+  proposal-async-generator-functions { chrome < 63 }
+  proposal-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  transform-async-to-generator { }
+  transform-exponentiation-operator { }
+  transform-template-literals { }
+  transform-literals { }
+  transform-function-name { }
+  transform-arrow-functions { }
+  transform-block-scoped-functions { }
+  transform-classes { }
+  transform-object-super { }
+  transform-shorthand-properties { }
+  transform-duplicate-keys { }
+  transform-computed-properties { }
+  transform-for-of { }
+  transform-sticky-regex { }
+  transform-unicode-escapes { }
+  transform-unicode-regex { }
+  transform-spread { }
+  transform-destructuring { }
+  transform-block-scoping { }
+  transform-typeof-symbol { }
+  transform-new-target { }
+  transform-regenerator { }
+  transform-member-expression-literals { }
+  transform-property-literals { }
+  transform-reserved-words { }
+  proposal-export-namespace-from { chrome < 72 }
+  syntax-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
@@ -25,8 +25,8 @@ Using plugins:
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
   proposal-export-namespace-from { node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
@@ -8,25 +8,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "node":"6" }
-  proposal-logical-assignment-operators { "node":"6" }
-  proposal-nullish-coalescing-operator { "node":"6" }
-  proposal-optional-chaining { "node":"6" }
-  proposal-json-strings { "node":"6" }
-  proposal-optional-catch-binding { "node":"6" }
-  proposal-async-generator-functions { "node":"6" }
-  proposal-object-rest-spread { "node":"6" }
-  transform-dotall-regex { "node":"6" }
-  proposal-unicode-property-regex { "node":"6" }
-  transform-named-capturing-groups-regex { "node":"6" }
-  transform-async-to-generator { "node":"6" }
-  transform-exponentiation-operator { "node":"6" }
-  transform-function-name { "node":"6" }
-  transform-for-of { "node":"6" }
-  transform-destructuring { "node":"6" }
-  proposal-export-namespace-from { "node":"6" }
-  transform-modules-commonjs { "node":"6" }
-  proposal-dynamic-import { "node":"6" }
+  proposal-numeric-separator { node < 12.5 }
+  proposal-logical-assignment-operators { node < 15 }
+  proposal-nullish-coalescing-operator { node < 14 }
+  proposal-optional-chaining { node }
+  proposal-json-strings { node < 10 }
+  proposal-optional-catch-binding { node < 10 }
+  proposal-async-generator-functions { node < 10 }
+  proposal-object-rest-spread { node < 8.3 }
+  transform-dotall-regex { node < 8.10 }
+  proposal-unicode-property-regex { node < 10 }
+  transform-named-capturing-groups-regex { node < 10 }
+  transform-async-to-generator { node < 7.6 }
+  transform-exponentiation-operator { node < 7 }
+  transform-function-name { node < 6.5 }
+  transform-for-of { node < 6.5 }
+  transform-destructuring { node < 6.5 }
+  proposal-export-namespace-from { node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
@@ -8,46 +8,46 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
   proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
@@ -13,43 +13,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-logical-assignment-operators { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-chaining { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-catch-binding { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-parameters { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-async-generator-functions { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-object-rest-spread { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-dotall-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-unicode-property-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-named-capturing-groups-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-async-to-generator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-template-literals { "ie":"10", "ios":"9", "safari":"7" }
-  transform-literals { "firefox":"49", "ie":"10", "safari":"7" }
-  transform-function-name { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-arrow-functions { "ie":"10", "ios":"9", "safari":"7" }
-  transform-block-scoped-functions { "ie":"10", "ios":"9", "safari":"7" }
-  transform-classes { "ie":"10", "ios":"9", "safari":"7" }
-  transform-object-super { "ie":"10", "ios":"9", "safari":"7" }
-  transform-shorthand-properties { "ie":"10", "safari":"7" }
-  transform-duplicate-keys { "ie":"10", "safari":"7" }
-  transform-computed-properties { "ie":"10", "safari":"7" }
-  transform-for-of { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-sticky-regex { "ie":"10", "ios":"9", "safari":"7" }
-  transform-unicode-escapes { "firefox":"49", "ie":"10", "safari":"7" }
-  transform-unicode-regex { "ie":"10", "ios":"9", "safari":"7" }
-  transform-spread { "ie":"10", "ios":"9", "safari":"7" }
-  transform-destructuring { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-block-scoping { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-typeof-symbol { "ie":"10", "safari":"7" }
-  transform-new-target { "edge":"13", "ie":"10", "ios":"9", "safari":"7" }
-  transform-regenerator { "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-export-namespace-from { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-modules-commonjs { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-dynamic-import { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
+  proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
+  proposal-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
+  proposal-optional-chaining { chrome, edge, firefox < 74, ie, ios < 13.4, safari < 13.1 }
+  proposal-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
+  proposal-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
+  transform-parameters { edge < 18, firefox < 53, ie, ios < 10, safari < 10 }
+  proposal-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
+  proposal-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
+  transform-dotall-regex { chrome < 62, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  proposal-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-named-capturing-groups-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-async-to-generator { chrome < 55, edge < 15, firefox < 52, ie, ios < 11, safari < 11 }
+  transform-exponentiation-operator { edge < 14, firefox < 52, ie, ios < 10.3, safari < 10.1 }
+  transform-template-literals { ie, ios < 13, safari < 13 }
+  transform-literals { firefox < 53, ie, safari < 9 }
+  transform-function-name { edge < 79, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-arrow-functions { ie, ios < 10, safari < 10 }
+  transform-block-scoped-functions { ie < 11, ios < 10, safari < 10 }
+  transform-classes { ie, ios < 10, safari < 10 }
+  transform-object-super { ie, ios < 10, safari < 10 }
+  transform-shorthand-properties { ie, safari < 9 }
+  transform-duplicate-keys { ie, safari < 9 }
+  transform-computed-properties { ie, safari < 7.1 }
+  transform-for-of { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-sticky-regex { ie, ios < 10, safari < 10 }
+  transform-unicode-escapes { firefox < 53, ie, safari < 9 }
+  transform-unicode-regex { ie, ios < 12, safari < 12 }
+  transform-spread { ie, ios < 10, safari < 10 }
+  transform-destructuring { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
+  transform-block-scoping { edge < 14, firefox < 51, ie, ios < 11, safari < 11 }
+  transform-typeof-symbol { ie, safari < 9 }
+  transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
+  transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
+  proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "samsung":"8.2" }
-  proposal-private-methods { "samsung":"8.2" }
-  proposal-numeric-separator { "samsung":"8.2" }
-  proposal-logical-assignment-operators { "samsung":"8.2" }
-  proposal-nullish-coalescing-operator { "samsung":"8.2" }
-  proposal-optional-chaining { "samsung":"8.2" }
-  proposal-json-strings { "samsung":"8.2" }
-  proposal-optional-catch-binding { "samsung":"8.2" }
-  syntax-async-generators { "samsung":"8.2" }
-  syntax-object-rest-spread { "samsung":"8.2" }
-  proposal-unicode-property-regex { "samsung":"8.2" }
-  transform-named-capturing-groups-regex { "samsung":"8.2" }
-  proposal-export-namespace-from { "samsung":"8.2" }
-  transform-modules-commonjs { "samsung":"8.2" }
-  proposal-dynamic-import { "samsung":"8.2" }
+  proposal-class-properties { samsung }
+  proposal-private-methods { samsung }
+  proposal-numeric-separator { samsung < 11 }
+  proposal-logical-assignment-operators { samsung }
+  proposal-nullish-coalescing-operator { samsung < 13 }
+  proposal-optional-chaining { samsung }
+  proposal-json-strings { samsung < 9 }
+  proposal-optional-catch-binding { samsung < 9 }
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-unicode-property-regex { samsung < 9 }
+  transform-named-capturing-groups-regex { samsung < 9 }
+  proposal-export-namespace-from { samsung < 11.0 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -16,13 +16,13 @@ Using plugins:
   proposal-optional-chaining { samsung }
   proposal-json-strings { samsung < 9 }
   proposal-optional-catch-binding { samsung < 9 }
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-unicode-property-regex { samsung < 9 }
   transform-named-capturing-groups-regex { samsung < 9 }
   proposal-export-namespace-from { samsung < 11.0 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }
   proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -11,43 +11,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-logical-assignment-operators { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-chaining { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-json-strings { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-catch-binding { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-parameters { "electron":"0.36", "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-object-rest-spread { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-dotall-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-unicode-property-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-named-capturing-groups-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-async-to-generator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-sticky-regex { "electron":"0.36", "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "electron":"0.36", "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-block-scoping { "electron":"0.36", "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "electron":"0.36", "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-modules-commonjs { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-dynamic-import { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
+  proposal-optional-chaining { chrome, electron, ie, node }
+  proposal-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-parameters { electron < 0.37, ie }
+  proposal-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, electron < 3.0, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, electron < 1.6, ie, node < 7.6 }
+  transform-exponentiation-operator { electron < 1.3, ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { electron < 1.2, ie, node < 6.5 }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { electron < 1.2, ie, node < 6.5 }
+  transform-sticky-regex { electron < 0.37, ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { electron < 1.1, ie }
+  transform-spread { ie }
+  transform-destructuring { electron < 1.2, ie, node < 6.5 }
+  transform-block-scoping { electron < 0.37, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { electron < 1.1, ie }
+  proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"71" }
-  proposal-private-methods { "chrome":"71" }
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
@@ -14,13 +14,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
-  transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10", "node":"6" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10", "node":"6" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10", "node":"6" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie, node < 6.5 }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie, node < 6.5 }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie, node < 6.5 }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
@@ -8,25 +8,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "node":"6" }
-  proposal-logical-assignment-operators { "node":"6" }
-  proposal-nullish-coalescing-operator { "node":"6" }
-  proposal-optional-chaining { "node":"6" }
-  proposal-json-strings { "node":"6" }
-  proposal-optional-catch-binding { "node":"6" }
-  proposal-async-generator-functions { "node":"6" }
-  proposal-object-rest-spread { "node":"6" }
-  transform-dotall-regex { "node":"6" }
-  proposal-unicode-property-regex { "node":"6" }
-  transform-named-capturing-groups-regex { "node":"6" }
-  transform-async-to-generator { "node":"6" }
-  transform-exponentiation-operator { "node":"6" }
-  transform-function-name { "node":"6" }
-  transform-for-of { "node":"6" }
-  transform-destructuring { "node":"6" }
-  proposal-export-namespace-from { "node":"6" }
-  transform-modules-commonjs { "node":"6" }
-  proposal-dynamic-import { "node":"6" }
+  proposal-numeric-separator { node < 12.5 }
+  proposal-logical-assignment-operators { node < 15 }
+  proposal-nullish-coalescing-operator { node < 14 }
+  proposal-optional-chaining { node }
+  proposal-json-strings { node < 10 }
+  proposal-optional-catch-binding { node < 10 }
+  proposal-async-generator-functions { node < 10 }
+  proposal-object-rest-spread { node < 8.3 }
+  transform-dotall-regex { node < 8.10 }
+  proposal-unicode-property-regex { node < 10 }
+  transform-named-capturing-groups-regex { node < 10 }
+  transform-async-to-generator { node < 7.6 }
+  transform-exponentiation-operator { node < 7 }
+  transform-function-name { node < 6.5 }
+  transform-for-of { node < 6.5 }
+  transform-destructuring { node < 6.5 }
+  proposal-export-namespace-from { node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
@@ -25,8 +25,8 @@ Using plugins:
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
   proposal-export-namespace-from { node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
@@ -48,8 +48,8 @@ Using plugins:
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
   proposal-export-namespace-from { ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
@@ -8,48 +8,48 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "ie":"6" }
-  proposal-private-methods { "ie":"6" }
-  proposal-numeric-separator { "ie":"6" }
-  proposal-logical-assignment-operators { "ie":"6" }
-  proposal-nullish-coalescing-operator { "ie":"6" }
-  proposal-optional-chaining { "ie":"6" }
-  proposal-json-strings { "ie":"6" }
-  proposal-optional-catch-binding { "ie":"6" }
-  transform-parameters { "ie":"6" }
-  proposal-async-generator-functions { "ie":"6" }
-  proposal-object-rest-spread { "ie":"6" }
-  transform-dotall-regex { "ie":"6" }
-  proposal-unicode-property-regex { "ie":"6" }
-  transform-named-capturing-groups-regex { "ie":"6" }
-  transform-async-to-generator { "ie":"6" }
-  transform-exponentiation-operator { "ie":"6" }
-  transform-template-literals { "ie":"6" }
-  transform-literals { "ie":"6" }
-  transform-function-name { "ie":"6" }
-  transform-arrow-functions { "ie":"6" }
-  transform-block-scoped-functions { "ie":"6" }
-  transform-classes { "ie":"6" }
-  transform-object-super { "ie":"6" }
-  transform-shorthand-properties { "ie":"6" }
-  transform-duplicate-keys { "ie":"6" }
-  transform-computed-properties { "ie":"6" }
-  transform-for-of { "ie":"6" }
-  transform-sticky-regex { "ie":"6" }
-  transform-unicode-escapes { "ie":"6" }
-  transform-unicode-regex { "ie":"6" }
-  transform-spread { "ie":"6" }
-  transform-destructuring { "ie":"6" }
-  transform-block-scoping { "ie":"6" }
-  transform-typeof-symbol { "ie":"6" }
-  transform-new-target { "ie":"6" }
-  transform-regenerator { "ie":"6" }
-  transform-member-expression-literals { "ie":"6" }
-  transform-property-literals { "ie":"6" }
-  transform-reserved-words { "ie":"6" }
-  proposal-export-namespace-from { "ie":"6" }
-  transform-modules-commonjs { "ie":"6" }
-  proposal-dynamic-import { "ie":"6" }
+  proposal-class-properties { ie }
+  proposal-private-methods { ie }
+  proposal-numeric-separator { ie }
+  proposal-logical-assignment-operators { ie }
+  proposal-nullish-coalescing-operator { ie }
+  proposal-optional-chaining { ie }
+  proposal-json-strings { ie }
+  proposal-optional-catch-binding { ie }
+  transform-parameters { ie }
+  proposal-async-generator-functions { ie }
+  proposal-object-rest-spread { ie }
+  transform-dotall-regex { ie }
+  proposal-unicode-property-regex { ie }
+  transform-named-capturing-groups-regex { ie }
+  transform-async-to-generator { ie }
+  transform-exponentiation-operator { ie }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  transform-member-expression-literals { ie < 9 }
+  transform-property-literals { ie < 9 }
+  transform-reserved-words { ie < 9 }
+  proposal-export-namespace-from { ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
@@ -46,7 +46,7 @@ Using plugins:
   transform-property-literals { }
   transform-reserved-words { }
   proposal-export-namespace-from { chrome < 72 }
-  syntax-dynamic-import {}
+  syntax-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
@@ -8,45 +8,45 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"55" }
-  proposal-logical-assignment-operators { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  transform-parameters {}
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  transform-dotall-regex { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
-  transform-async-to-generator {}
-  transform-exponentiation-operator {}
-  transform-template-literals {}
-  transform-literals {}
-  transform-function-name {}
-  transform-arrow-functions {}
-  transform-block-scoped-functions {}
-  transform-classes {}
-  transform-object-super {}
-  transform-shorthand-properties {}
-  transform-duplicate-keys {}
-  transform-computed-properties {}
-  transform-for-of {}
-  transform-sticky-regex {}
-  transform-unicode-escapes {}
-  transform-unicode-regex {}
-  transform-spread {}
-  transform-destructuring {}
-  transform-block-scoping {}
-  transform-typeof-symbol {}
-  transform-new-target {}
-  transform-regenerator {}
-  transform-member-expression-literals {}
-  transform-property-literals {}
-  transform-reserved-words {}
-  proposal-export-namespace-from { "chrome":"55" }
-  syntax-dynamic-import { "chrome":"55" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  transform-parameters { }
+  proposal-async-generator-functions { chrome < 63 }
+  proposal-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  transform-async-to-generator { }
+  transform-exponentiation-operator { }
+  transform-template-literals { }
+  transform-literals { }
+  transform-function-name { }
+  transform-arrow-functions { }
+  transform-block-scoped-functions { }
+  transform-classes { }
+  transform-object-super { }
+  transform-shorthand-properties { }
+  transform-duplicate-keys { }
+  transform-computed-properties { }
+  transform-for-of { }
+  transform-sticky-regex { }
+  transform-unicode-escapes { }
+  transform-unicode-regex { }
+  transform-spread { }
+  transform-destructuring { }
+  transform-block-scoping { }
+  transform-typeof-symbol { }
+  transform-new-target { }
+  transform-regenerator { }
+  transform-member-expression-literals { }
+  transform-property-literals { }
+  transform-reserved-words { }
+  proposal-export-namespace-from { chrome < 72 }
+  syntax-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
@@ -10,43 +10,43 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-logical-assignment-operators { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
-  transform-parameters { "ie":"10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
-  transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-template-literals { "ie":"10" }
-  transform-literals { "ie":"10" }
-  transform-function-name { "ie":"10", "node":"6" }
-  transform-arrow-functions { "ie":"10" }
-  transform-block-scoped-functions { "ie":"10" }
-  transform-classes { "ie":"10" }
-  transform-object-super { "ie":"10" }
-  transform-shorthand-properties { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-for-of { "ie":"10", "node":"6" }
-  transform-sticky-regex { "ie":"10" }
-  transform-unicode-escapes { "ie":"10" }
-  transform-unicode-regex { "ie":"10" }
-  transform-spread { "ie":"10" }
-  transform-destructuring { "ie":"10", "node":"6" }
-  transform-block-scoping { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
-  transform-new-target { "ie":"10" }
-  transform-regenerator { "ie":"10" }
-  proposal-export-namespace-from { "chrome":"54", "ie":"10", "node":"6" }
-  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
+  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  proposal-optional-chaining { chrome, ie, node }
+  proposal-json-strings { chrome < 66, ie, node < 10 }
+  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-parameters { ie }
+  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
+  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-dotall-regex { chrome < 62, ie, node < 8.10 }
+  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
+  transform-async-to-generator { chrome < 55, ie, node < 7.6 }
+  transform-exponentiation-operator { ie, node < 7 }
+  transform-template-literals { ie }
+  transform-literals { ie }
+  transform-function-name { ie, node < 6.5 }
+  transform-arrow-functions { ie }
+  transform-block-scoped-functions { ie < 11 }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { ie, node < 6.5 }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { ie, node < 6.5 }
+  transform-block-scoping { ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { ie }
+  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
@@ -45,8 +45,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { ie }
   proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
@@ -9,24 +9,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "firefox":"52", "node":"7.4" }
-  proposal-logical-assignment-operators { "firefox":"52", "node":"7.4" }
-  proposal-nullish-coalescing-operator { "firefox":"52", "node":"7.4" }
-  proposal-optional-chaining { "firefox":"52", "node":"7.4" }
-  proposal-json-strings { "firefox":"52", "node":"7.4" }
-  proposal-optional-catch-binding { "firefox":"52", "node":"7.4" }
-  proposal-async-generator-functions { "firefox":"52", "node":"7.4" }
-  proposal-object-rest-spread { "firefox":"52", "node":"7.4" }
-  transform-dotall-regex { "firefox":"52", "node":"7.4" }
-  proposal-unicode-property-regex { "firefox":"52", "node":"7.4" }
-  transform-named-capturing-groups-regex { "firefox":"52", "node":"7.4" }
-  transform-literals { "firefox":"52" }
-  transform-function-name { "firefox":"52" }
-  transform-for-of { "firefox":"52" }
-  transform-unicode-escapes { "firefox":"52" }
-  transform-destructuring { "firefox":"52" }
-  proposal-export-namespace-from { "firefox":"52", "node":"7.4" }
-  transform-modules-commonjs { "firefox":"52", "node":"7.4" }
-  proposal-dynamic-import { "firefox":"52", "node":"7.4" }
+  proposal-numeric-separator { firefox < 70, node < 12.5 }
+  proposal-logical-assignment-operators { firefox < 79, node < 15 }
+  proposal-nullish-coalescing-operator { firefox < 72, node < 14 }
+  proposal-optional-chaining { firefox < 74, node }
+  proposal-json-strings { firefox < 62, node < 10 }
+  proposal-optional-catch-binding { firefox < 58, node < 10 }
+  proposal-async-generator-functions { firefox < 57, node < 10 }
+  proposal-object-rest-spread { firefox < 55, node < 8.3 }
+  transform-dotall-regex { firefox < 78, node < 8.10 }
+  proposal-unicode-property-regex { firefox < 78, node < 10 }
+  transform-named-capturing-groups-regex { firefox < 78, node < 10 }
+  transform-literals { firefox < 53 }
+  transform-function-name { firefox < 53 }
+  transform-for-of { firefox < 53 }
+  transform-unicode-escapes { firefox < 53 }
+  transform-destructuring { firefox < 53 }
+  proposal-export-namespace-from { firefox < 80, node < 13.2 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
@@ -26,7 +26,7 @@ Using plugins:
   transform-unicode-escapes { firefox < 53 }
   transform-destructuring { firefox < 53 }
   proposal-export-namespace-from { firefox < 80, node < 13.2 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
@@ -10,16 +10,16 @@ Using modules transform: auto
 Using plugins:
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
-  syntax-numeric-separator {}
+  syntax-numeric-separator
   proposal-logical-assignment-operators { chrome < 85 }
-  syntax-nullish-coalescing-operator {}
+  syntax-nullish-coalescing-operator
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
+  transform-modules-commonjs
+  proposal-dynamic-import
   proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
@@ -8,18 +8,18 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"80" }
-  proposal-private-methods { "chrome":"80" }
-  syntax-numeric-separator { "chrome":"80" }
-  proposal-logical-assignment-operators { "chrome":"80" }
-  syntax-nullish-coalescing-operator { "chrome":"80" }
-  proposal-optional-chaining { "chrome":"80" }
-  syntax-json-strings { "chrome":"80" }
-  syntax-optional-catch-binding { "chrome":"80" }
-  syntax-async-generators { "chrome":"80" }
-  syntax-object-rest-spread { "chrome":"80" }
-  transform-modules-commonjs { "chrome":"80" }
-  proposal-dynamic-import { "chrome":"80" }
-  proposal-export-namespace-from {}
+  proposal-class-properties { chrome < 84 }
+  proposal-private-methods { chrome < 84 }
+  syntax-numeric-separator {}
+  proposal-logical-assignment-operators { chrome < 85 }
+  syntax-nullish-coalescing-operator {}
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
+  proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-class-properties { "chrome":"84" }
-  syntax-numeric-separator { "chrome":"84" }
-  proposal-logical-assignment-operators { "chrome":"84" }
-  syntax-nullish-coalescing-operator { "chrome":"84" }
-  proposal-optional-chaining { "chrome":"84" }
-  syntax-json-strings { "chrome":"84" }
-  syntax-optional-catch-binding { "chrome":"84" }
-  syntax-async-generators { "chrome":"84" }
-  syntax-object-rest-spread { "chrome":"84" }
-  transform-modules-commonjs { "chrome":"84" }
-  proposal-dynamic-import { "chrome":"84" }
-  proposal-export-namespace-from {}
+  syntax-class-properties {}
+  syntax-numeric-separator {}
+  proposal-logical-assignment-operators { chrome < 85 }
+  syntax-nullish-coalescing-operator {}
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
+  proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-class-properties {}
-  syntax-numeric-separator {}
+  syntax-class-properties
+  syntax-numeric-separator
   proposal-logical-assignment-operators { chrome < 85 }
-  syntax-nullish-coalescing-operator {}
+  syntax-nullish-coalescing-operator
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
+  transform-modules-commonjs
+  proposal-dynamic-import
   proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
@@ -15,12 +15,12 @@ Using plugins:
   proposal-json-strings { chrome < 66 }
   proposal-optional-catch-binding { chrome < 66 }
   proposal-async-generator-functions { chrome < 63 }
-  syntax-object-rest-spread {}
+  syntax-object-rest-spread
   transform-dotall-regex { chrome < 62 }
   proposal-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
@@ -8,19 +8,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"60" }
-  proposal-logical-assignment-operators { "chrome":"60" }
-  proposal-nullish-coalescing-operator { "chrome":"60" }
-  proposal-optional-chaining { "chrome":"60" }
-  proposal-json-strings { "chrome":"60" }
-  proposal-optional-catch-binding { "chrome":"60" }
-  proposal-async-generator-functions { "chrome":"60" }
-  syntax-object-rest-spread { "chrome":"60" }
-  transform-dotall-regex { "chrome":"60" }
-  proposal-unicode-property-regex { "chrome":"60" }
-  transform-named-capturing-groups-regex { "chrome":"60" }
-  proposal-export-namespace-from { "chrome":"60" }
-  transform-modules-commonjs { "chrome":"60" }
-  proposal-dynamic-import { "chrome":"60" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  proposal-async-generator-functions { chrome < 63 }
+  syntax-object-rest-spread {}
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
@@ -8,16 +8,16 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator {}
+  syntax-numeric-separator
   proposal-logical-assignment-operators { chrome < 85 }
-  syntax-nullish-coalescing-operator {}
+  syntax-nullish-coalescing-operator
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
+  transform-modules-commonjs
+  proposal-dynamic-import
   proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
@@ -8,16 +8,16 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-numeric-separator { "chrome":"80" }
-  proposal-logical-assignment-operators { "chrome":"80" }
-  syntax-nullish-coalescing-operator { "chrome":"80" }
-  proposal-optional-chaining { "chrome":"80" }
-  syntax-json-strings { "chrome":"80" }
-  syntax-optional-catch-binding { "chrome":"80" }
-  syntax-async-generators { "chrome":"80" }
-  syntax-object-rest-spread { "chrome":"80" }
-  transform-modules-commonjs { "chrome":"80" }
-  proposal-dynamic-import { "chrome":"80" }
-  proposal-export-namespace-from {}
+  syntax-numeric-separator {}
+  proposal-logical-assignment-operators { chrome < 85 }
+  syntax-nullish-coalescing-operator {}
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
+  proposal-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
@@ -10,44 +10,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-class-properties { chrome < 84, firefox, ie }
+  proposal-private-methods { chrome < 84, firefox, ie }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
@@ -10,44 +10,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-class-properties { chrome < 84, firefox, ie }
+  proposal-private-methods { chrome < 84, firefox, ie }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
@@ -20,8 +20,8 @@ Using plugins:
   proposal-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"55" }
-  proposal-logical-assignment-operators { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  transform-dotall-regex { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
-  proposal-export-namespace-from { "chrome":"55" }
-  transform-modules-commonjs { "chrome":"55" }
-  proposal-dynamic-import { "chrome":"55" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  proposal-async-generator-functions { chrome < 63 }
+  proposal-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -8,17 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"71" }
-  proposal-logical-assignment-operators { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  syntax-json-strings { "chrome":"71" }
-  syntax-optional-catch-binding { "chrome":"71" }
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
-  proposal-export-namespace-from { "chrome":"71" }
-  transform-modules-commonjs { "chrome":"71" }
-  proposal-dynamic-import { "chrome":"71" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  syntax-json-strings {}
+  syntax-optional-catch-binding {}
+  syntax-async-generators {}
+  syntax-object-rest-spread {}
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -12,13 +12,13 @@ Using plugins:
   proposal-logical-assignment-operators { chrome < 85 }
   proposal-nullish-coalescing-operator { chrome < 80 }
   proposal-optional-chaining { chrome }
-  syntax-json-strings {}
-  syntax-optional-catch-binding {}
-  syntax-async-generators {}
-  syntax-object-rest-spread {}
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
@@ -10,44 +10,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-class-properties { chrome < 84, firefox, ie }
+  proposal-private-methods { chrome < 84, firefox, ie }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
@@ -46,8 +46,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
@@ -10,44 +10,44 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-properties { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-private-methods { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-class-properties { chrome < 84, firefox, ie }
+  proposal-private-methods { chrome < 84, firefox, ie }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
@@ -20,8 +20,8 @@ Using plugins:
   proposal-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   proposal-export-namespace-from { chrome < 72 }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"55" }
-  proposal-logical-assignment-operators { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  transform-dotall-regex { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
-  proposal-export-namespace-from { "chrome":"55" }
-  transform-modules-commonjs { "chrome":"55" }
-  proposal-dynamic-import { "chrome":"55" }
+  proposal-numeric-separator { chrome < 75 }
+  proposal-logical-assignment-operators { chrome < 85 }
+  proposal-nullish-coalescing-operator { chrome < 80 }
+  proposal-optional-chaining { chrome }
+  proposal-json-strings { chrome < 66 }
+  proposal-optional-catch-binding { chrome < 66 }
+  proposal-async-generator-functions { chrome < 63 }
+  proposal-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  proposal-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  proposal-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
@@ -10,42 +10,42 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-logical-assignment-operators { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-template-literals { "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-arrow-functions { "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
-  transform-unicode-escapes { "firefox":"50", "ie":"11" }
-  transform-unicode-regex { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
-  transform-new-target { "ie":"11" }
-  transform-regenerator { "firefox":"50", "ie":"11" }
-  proposal-export-namespace-from { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
+  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  proposal-optional-chaining { chrome, firefox < 74, ie }
+  proposal-json-strings { chrome < 66, firefox < 62, ie }
+  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-parameters { firefox < 53, ie }
+  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
+  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-dotall-regex { chrome < 62, firefox < 78, ie }
+  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
+  transform-async-to-generator { chrome < 55, firefox < 52, ie }
+  transform-exponentiation-operator { firefox < 52, ie }
+  transform-template-literals { ie }
+  transform-literals { firefox < 53, ie }
+  transform-function-name { firefox < 53, ie }
+  transform-arrow-functions { ie }
+  transform-classes { ie }
+  transform-object-super { ie }
+  transform-shorthand-properties { ie }
+  transform-duplicate-keys { ie }
+  transform-computed-properties { ie }
+  transform-for-of { firefox < 53, ie }
+  transform-sticky-regex { ie }
+  transform-unicode-escapes { firefox < 53, ie }
+  transform-unicode-regex { ie }
+  transform-spread { ie }
+  transform-destructuring { firefox < 53, ie }
+  transform-block-scoping { firefox < 51, ie }
+  transform-typeof-symbol { ie }
+  transform-new-target { ie }
+  transform-regenerator { firefox < 53, ie }
+  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
@@ -44,8 +44,8 @@ Using plugins:
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
@@ -25,7 +25,7 @@ Using plugins:
   transform-unicode-regex { safari < 12 }
   transform-block-scoping { safari < 11 }
   proposal-export-namespace-from { safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "safari":"10" }
-  proposal-logical-assignment-operators { "safari":"10" }
-  proposal-nullish-coalescing-operator { "safari":"10" }
-  proposal-optional-chaining { "safari":"10" }
-  proposal-json-strings { "safari":"10" }
-  proposal-optional-catch-binding { "safari":"10" }
-  proposal-async-generator-functions { "safari":"10" }
-  proposal-object-rest-spread { "safari":"10" }
-  transform-dotall-regex { "safari":"10" }
-  proposal-unicode-property-regex { "safari":"10" }
-  transform-named-capturing-groups-regex { "safari":"10" }
-  transform-async-to-generator { "safari":"10" }
-  transform-exponentiation-operator { "safari":"10" }
-  transform-template-literals { "safari":"10" }
-  transform-unicode-regex { "safari":"10" }
-  transform-block-scoping { "safari":"10" }
-  proposal-export-namespace-from { "safari":"10" }
-  transform-modules-commonjs { "safari":"10" }
-  proposal-dynamic-import { "safari":"10" }
+  proposal-numeric-separator { safari < 13 }
+  proposal-logical-assignment-operators { safari < 14 }
+  proposal-nullish-coalescing-operator { safari < 13.1 }
+  proposal-optional-chaining { safari < 13.1 }
+  proposal-json-strings { safari < 12 }
+  proposal-optional-catch-binding { safari < 11.1 }
+  proposal-async-generator-functions { safari < 12 }
+  proposal-object-rest-spread { safari < 11.1 }
+  transform-dotall-regex { safari < 11.1 }
+  proposal-unicode-property-regex { safari < 11.1 }
+  transform-named-capturing-groups-regex { safari < 11.1 }
+  transform-async-to-generator { safari < 11 }
+  transform-exponentiation-operator { safari < 10.1 }
+  transform-template-literals { safari < 13 }
+  transform-unicode-regex { safari < 12 }
+  transform-block-scoping { safari < 11 }
+  proposal-export-namespace-from { safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
@@ -25,7 +25,7 @@ Using plugins:
   transform-unicode-regex { safari < 12 }
   transform-block-scoping { safari < 11 }
   proposal-export-namespace-from { safari }
-  transform-modules-commonjs {}
-  proposal-dynamic-import {}
+  transform-modules-commonjs
+  proposal-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-numeric-separator { "safari":"10" }
-  proposal-logical-assignment-operators { "safari":"10" }
-  proposal-nullish-coalescing-operator { "safari":"10" }
-  proposal-optional-chaining { "safari":"10" }
-  proposal-json-strings { "safari":"10" }
-  proposal-optional-catch-binding { "safari":"10" }
-  proposal-async-generator-functions { "safari":"10" }
-  proposal-object-rest-spread { "safari":"10" }
-  transform-dotall-regex { "safari":"10" }
-  proposal-unicode-property-regex { "safari":"10" }
-  transform-named-capturing-groups-regex { "safari":"10" }
-  transform-async-to-generator { "safari":"10" }
-  transform-exponentiation-operator { "safari":"10" }
-  transform-template-literals { "safari":"10" }
-  transform-unicode-regex { "safari":"10" }
-  transform-block-scoping { "safari":"10" }
-  proposal-export-namespace-from { "safari":"10" }
-  transform-modules-commonjs { "safari":"10" }
-  proposal-dynamic-import { "safari":"10" }
+  proposal-numeric-separator { safari < 13 }
+  proposal-logical-assignment-operators { safari < 14 }
+  proposal-nullish-coalescing-operator { safari < 13.1 }
+  proposal-optional-chaining { safari < 13.1 }
+  proposal-json-strings { safari < 12 }
+  proposal-optional-catch-binding { safari < 11.1 }
+  proposal-async-generator-functions { safari < 12 }
+  proposal-object-rest-spread { safari < 11.1 }
+  transform-dotall-regex { safari < 11.1 }
+  proposal-unicode-property-regex { safari < 11.1 }
+  transform-named-capturing-groups-regex { safari < 11.1 }
+  transform-async-to-generator { safari < 11 }
+  transform-exponentiation-operator { safari < 10.1 }
+  transform-template-literals { safari < 13 }
+  transform-unicode-regex { safari < 12 }
+  transform-block-scoping { safari < 11 }
+  proposal-export-namespace-from { safari }
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Currently we first print the user's targets, and then we print again the same targets next to each plugin.

This PR modify what we print next to each plugin, by making it for example "this plugin is needed for chrome < 71" rather than "this plugin is needed because your targets include chrome 30". By doing so, it's easier to see how changes in the target browser can affect the loaded plugins.