### PR TITLE
Support iterating generators in browsers without `Symbol`

### DIFF
--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7199/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7199/output.js
@@ -12,7 +12,7 @@ function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o =
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
 
-function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _iterableToArrayLimit(arr, i) { var _i = arr && (typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]); if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (_i = _i.call(arr), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/integration/array-rest/exec.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/integration/array-rest/exec.js
@@ -1,0 +1,25 @@
+let iterable = function* fn() {
+  yield 0;
+  yield 1;
+  yield 2;
+}();
+
+let iteratorMethod = iterable[Symbol.iterator];
+iterable[Symbol.iterator] = undefined;
+
+expect(() => {
+  let [_, ...res] = iterable;
+}).toThrow(/non-iterable/);
+
+// In older envs, regenerator uses @@iterator.
+// In those browser Babel must delegate to Array.from, which
+// needs to be polyfilled by the user and support @@iterator.
+iterable["@@iterator"] = iteratorMethod;
+Array.from = (it) => {
+  var i = it["@@iterator"](), arr = [], r;
+  while (!(r = it.next()).done) arr.push(r.value);
+  return arr;
+};
+
+let [_, ...res] = iterable;
+expect(res).toEqual([1, 2]);

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/integration/array-rest/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/integration/array-rest/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-regenerator", "transform-destructuring"]
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/integration/array-spread/exec.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/integration/array-spread/exec.js
@@ -1,0 +1,25 @@
+let iterable = function* fn() {
+  yield 1;
+  yield 2;
+}();
+
+let iteratorMethod = iterable[Symbol.iterator];
+iterable[Symbol.iterator] = undefined;
+
+expect(() => {
+  [...iterable];
+}).toThrow(/non-iterable/);
+
+// In older envs, regenerator uses @@iterator.
+// In those browser Babel must delegate to Array.from, which
+// needs to be polyfilled by the user and support @@iterator.
+iterable["@@iterator"] = iteratorMethod;
+Array.from = (it) => {
+  var i = it["@@iterator"](), arr = [], r;
+  while (!(r = it.next()).done) arr.push(r.value);
+  return arr;
+};
+
+let res = [...iterable];
+
+expect(res).toEqual([1, 2]);

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/integration/array-spread/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/integration/array-spread/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-regenerator", "transform-spread"]
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/integration/for-of/exec.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/integration/for-of/exec.js
@@ -1,0 +1,19 @@
+let iterable = function* fn() {
+  yield 1;
+  yield 2;
+}();
+
+let iteratorMethod = iterable[Symbol.iterator];
+iterable[Symbol.iterator] = undefined;
+
+expect(() => {
+  for (let x of iterable);
+}).toThrow(/non-iterable/);
+
+// In older envs, regenerator uses @@iterator.
+iterable["@@iterator"] = iteratorMethod;
+
+let res = [];
+for (let x of iterable) res.push(x);
+
+expect(res).toEqual([1, 2]);

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/integration/for-of/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/integration/for-of/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-regenerator", "transform-for-of"]
+}

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/non-iterable/exec.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/non-iterable/exec.js
@@ -1,6 +1,6 @@
 var o = {};
 
-expect(() => [...undefined]).toThrow(/undefined is not iterable/);
+expect(() => [...undefined]).toThrow(/undefined is not iterable|property 'Symbol(Symbol.iterator)' of undefined/);
 
 expect(() => [...o]).toThrow(/spread non-iterable/);
 

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/non-iterable/exec.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/non-iterable/exec.js
@@ -1,6 +1,6 @@
 var o = {};
 
-expect(() => [...undefined]).toThrow(/undefined is not iterable|property 'Symbol(Symbol.iterator)' of undefined/);
+expect(() => [...undefined]).toThrow(/undefined is not iterable|property 'Symbol\(Symbol\.iterator\)' of undefined/);
 
 expect(() => [...o]).toThrow(/spread non-iterable/);
 

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/non-iterable/exec.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/non-iterable/exec.js
@@ -1,6 +1,6 @@
 var o = {};
 
-expect(() => [...undefined]).toThrow(/spread non-iterable/);
+expect(() => [...undefined]).toThrow(/undefined is not iterable/);
 
 expect(() => [...o]).toThrow(/spread non-iterable/);
 

--- a/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-shippedProposals/output.js
@@ -42,7 +42,7 @@ function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerat
 
 function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; var wrappedAwait = value instanceof _AwaitValue; Promise.resolve(wrappedAwait ? value.wrapped : value).then(function (arg) { if (wrappedAwait) { resume(key === "return" ? "return" : "next", arg); return; } settle(result.done ? "return" : "normal", arg); }, function (err) { resume("throw", err); }); } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen["return"] !== "function") { this["return"] = undefined; } }
 
-if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
+_AsyncGenerator.prototype[typeof Symbol === "function" && Symbol.asyncIterator || "@@asyncIterator"] = function () { return this; };
 
 _AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
 

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-shippedProposals/output.js
@@ -42,7 +42,7 @@ function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerat
 
 function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; var wrappedAwait = value instanceof _AwaitValue; Promise.resolve(wrappedAwait ? value.wrapped : value).then(function (arg) { if (wrappedAwait) { resume(key === "return" ? "return" : "next", arg); return; } settle(result.done ? "return" : "normal", arg); }, function (err) { resume("throw", err); }); } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen["return"] !== "function") { this["return"] = undefined; } }
 
-if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
+_AsyncGenerator.prototype[typeof Symbol === "function" && Symbol.asyncIterator || "@@asyncIterator"] = function () { return this; };
 
 _AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
 

--- a/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
@@ -1,6 +1,6 @@
 import _Symbol from "@babel/runtime-corejs2/core-js/symbol";
-import _isIterable from "@babel/runtime-corejs2/core-js/is-iterable";
+import _Symbol$iterator from "@babel/runtime-corejs2/core-js/symbol/iterator";
 import _Array$from from "@babel/runtime-corejs2/core-js/array/from";
 export default function _iterableToArray(iter) {
-  if (typeof _Symbol !== "undefined" && _isIterable(Object(iter))) return _Array$from(iter);
+  if (typeof _Symbol !== "undefined" && iter[_Symbol$iterator] != null || iter["@@iterator"] != null) return _Array$from(iter);
 }

--- a/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/iterableToArray.js
@@ -1,11 +1,11 @@
 var _Symbol = require("@babel/runtime-corejs2/core-js/symbol");
 
-var _isIterable = require("@babel/runtime-corejs2/core-js/is-iterable");
+var _Symbol$iterator = require("@babel/runtime-corejs2/core-js/symbol/iterator");
 
 var _Array$from = require("@babel/runtime-corejs2/core-js/array/from");
 
 function _iterableToArray(iter) {
-  if (typeof _Symbol !== "undefined" && _isIterable(Object(iter))) return _Array$from(iter);
+  if (typeof _Symbol !== "undefined" && iter[_Symbol$iterator] != null || iter["@@iterator"] != null) return _Array$from(iter);
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime/helpers/esm/iterableToArray.js
@@ -1,3 +1,3 @@
 export default function _iterableToArray(iter) {
-  if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter);
+  if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
 }

--- a/packages/babel-runtime/helpers/iterableToArray.js
+++ b/packages/babel-runtime/helpers/iterableToArray.js
@@ -1,5 +1,5 @@
 function _iterableToArray(iter) {
-  if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter);
+  if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
 }
 
 module.exports = _iterableToArray;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/13128
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In browsers without `Symbol` support and without a `Symbol` polyfill, regenerator uses `@@iterator`/`@@asyncIterator` to mark (async) generators as iterable. ([ref](https://github.com/facebook/regenerator/blob/dbbddd9bd8c099ed1cdfcecdd077b8b4e7f43042/packages/runtime/runtime.js#L15-L16))

Since from a user point of view regenerator is effectively part of Babel (because we use it by default in `@babel/preset-env`), we should make sure that it works well with the other plugins.

This PR adds checks for `@@iterator`/`@@asyncIterator` in the spread and for-of helpers, so that they work with compiled generators.