### PR TITLE
Fix printing of single-param async arrow function with comments

### DIFF
--- a/packages/babel-generator/src/generators/methods.ts
+++ b/packages/babel-generator/src/generators/methods.ts
@@ -119,9 +119,11 @@ export function ArrowFunctionExpression(
   ) {
     if (
       (this.format.retainLines || node.async) &&
-      node.loc &&
-      node.body.loc &&
-      node.loc.start.line < node.body.loc.start.line
+      ((node.loc &&
+        node.body.loc &&
+        node.loc.start.line < node.body.loc.start.line) ||
+        firstParam.leadingComments?.length ||
+        firstParam.trailingComments?.length)
     ) {
       this.token("(");
       if (firstParam.loc && firstParam.loc.start.line > node.loc.start.line) {

--- a/packages/babel-generator/test/fixtures/comments/async-arrow-single-param-with-comments/input.js
+++ b/packages/babel-generator/test/fixtures/comments/async-arrow-single-param-with-comments/input.js
@@ -1,0 +1,5 @@
+async (/** @type {any} */ arg) => {};
+
+async (arg /* trailing */) => {};
+
+async (/** @type {any} */ arg /* trailing */) => {};

--- a/packages/babel-generator/test/fixtures/comments/async-arrow-single-param-with-comments/output.js
+++ b/packages/babel-generator/test/fixtures/comments/async-arrow-single-param-with-comments/output.js
@@ -1,0 +1,13 @@
+async (
+/** @type {any} */
+arg) => {};
+
+async (arg
+/* trailing */
+) => {};
+
+async (
+/** @type {any} */
+arg
+/* trailing */
+) => {};

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -819,7 +819,13 @@ suites.forEach(function (testSuite) {
                 console.log(`New test file created: ${expected.loc}`);
                 fs.writeFileSync(expected.loc, result.code);
               } else {
-                expect(result.code).toBe(expected.code);
+                try {
+                  expect(result.code).toBe(expected.code);
+                } catch (e) {
+                  if (!process.env.OVERWRITE) throw e;
+                  console.log(`Updated test file: ${expected.loc}`);
+                  fs.writeFileSync(expected.loc, result.code);
+                }
               }
             }
           }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #12500
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No
| License                  | MIT

This PR ensures that the parameter of a single-parameter async arrow function is printed inside parentheses if the parameter has leading or trailing comments. Without the parentheses, the generated code is not interpreted correctly and results in a syntax error. See #12500 for the original report of this problem.

It's not clear to me why so much care went into ensuring that single-argument functions don't include unnecessary parentheses - this code could be simplified and made much more robust if we were willing to unconditionally add parentheses around all arrow function parameters. I'd be happy to make that change, but I figured I'd check in with the maintainers first in case there's a good reason that parentheses are omitted if possible.

I also added support for an `OVERWRITE` environment variable for the `babel-generator` tests - the instructions in https://github.com/babel/babel/issues/12500#issuecomment-817381618 said that this should work, but support was missing from this particular test suite. Happy to pull this into a separate PR if requested.