### PR TITLE
Remove remaining `lodash` dependencies

### DIFF
--- a/eslint/babel-eslint-plugin/package.json
+++ b/eslint/babel-eslint-plugin/package.json
@@ -40,7 +40,7 @@
     "eslint-rule-composer": "^0.3.0"
   },
   "devDependencies": {
-    "eslint": "^7.5.0",
-    "lodash": "^4.17.20"
+    "clone-deep": "^4.0.1",
+    "eslint": "^7.5.0"
   }
 }

--- a/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
@@ -1,4 +1,4 @@
-import cloneDeep from "lodash/cloneDeep";
+import cloneDeep from "clone-deep";
 import rule from "../../src/rules/no-invalid-this";
 import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
 

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -28,7 +28,6 @@
     "convert-source-map": "^1.1.0",
     "fs-readdir-recursive": "^1.1.0",
     "glob": "^7.0.0",
-    "lodash": "^4.17.19",
     "make-dir": "^2.1.0",
     "slash": "condition:BABEL_8_BREAKING ? ^3.0.0 : ^2.0.0",
     "source-map": "^0.5.0"

--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -1,6 +1,5 @@
 // @flow
 
-import debounce from "lodash/debounce";
 import slash from "slash";
 import path from "path";
 import fs from "fs";
@@ -135,7 +134,7 @@ export default async function ({
   let compiledFiles = 0;
   let startTime = null;
 
-  const logSuccess = debounce(
+  const logSuccess = util.debounce(
     function () {
       if (startTime === null) {
         // This should never happen, but just in case it's better

--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -134,27 +134,23 @@ export default async function ({
   let compiledFiles = 0;
   let startTime = null;
 
-  const logSuccess = util.debounce(
-    function () {
-      if (startTime === null) {
-        // This should never happen, but just in case it's better
-        // to ignore the log message rather than making @babel/cli crash.
-        return;
-      }
+  const logSuccess = util.debounce(function () {
+    if (startTime === null) {
+      // This should never happen, but just in case it's better
+      // to ignore the log message rather than making @babel/cli crash.
+      return;
+    }
 
-      const diff = process.hrtime(startTime);
+    const diff = process.hrtime(startTime);
 
-      console.log(
-        `Successfully compiled ${compiledFiles} ${
-          compiledFiles !== 1 ? "files" : "file"
-        } with Babel (${diff[0] * 1e3 + Math.round(diff[1] / 1e6)}ms).`,
-      );
-      compiledFiles = 0;
-      startTime = null;
-    },
-    100,
-    { trailing: true },
-  );
+    console.log(
+      `Successfully compiled ${compiledFiles} ${
+        compiledFiles !== 1 ? "files" : "file"
+      } with Babel (${diff[0] * 1e3 + Math.round(diff[1] / 1e6)}ms).`,
+    );
+    compiledFiles = 0;
+    startTime = null;
+  }, 100);
 
   if (!cliOptions.skipInitialBuild) {
     if (cliOptions.deleteDirOnStart) {

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -141,3 +141,17 @@ export function withExtension(filename: string, ext: string = ".js") {
   const newBasename = path.basename(filename, path.extname(filename)) + ext;
   return path.join(path.dirname(filename), newBasename);
 }
+
+export function debounce(fn, time) {
+  let timer;
+  const clear = () => clearTimeout(timer);
+  function debounced() {
+    clear();
+    timer = setTimeout(fn, time);
+  }
+  debounced.flush = () => {
+    clear();
+    fn();
+  };
+  return debounced;
+}

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -144,13 +144,12 @@ export function withExtension(filename: string, ext: string = ".js") {
 
 export function debounce(fn, time) {
   let timer;
-  const clear = () => clearTimeout(timer);
   function debounced() {
-    clear();
+    clearTimeout(timer);
     timer = setTimeout(fn, time);
   }
   debounced.flush = () => {
-    clear();
+    clearTimeout(timer);
     fn();
   };
   return debounced;

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -142,7 +142,7 @@ export function withExtension(filename: string, ext: string = ".js") {
   return path.join(path.dirname(filename), newBasename);
 }
 
-export function debounce(fn, time) {
+export function debounce(fn: () => void, time: number) {
   let timer;
   function debounced() {
     clearTimeout(timer);

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -68,7 +68,6 @@
     "@babel/helper-transform-fixture-test-runner": "workspace:*",
     "@types/convert-source-map": "^1.5.1",
     "@types/debug": "^4.1.0",
-    "@types/lodash": "^4.14.150",
     "@types/resolve": "^1.3.2",
     "@types/semver": "^5.4.0",
     "@types/source-map": "^0.5.0"

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -27,7 +27,6 @@
     "@babel/helper-fixtures": "workspace:*",
     "@babel/parser": "workspace:*",
     "@types/jsesc": "^2.5.0",
-    "@types/lodash": "^4.14.150",
     "@types/source-map": "^0.5.0"
   }
 }

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-2/input.mjs
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-2/input.mjs
@@ -1,4 +1,4 @@
-import last from "lodash/last"
+import last from "lo-dash/last"
 
 export default class Container {
   last(key) {

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-2/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-2/output.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _last2 = babelHelpers.interopRequireDefault(require("lodash/last"));
+var _last2 = babelHelpers.interopRequireDefault(require("lo-dash/last"));
 
 let Container = /*#__PURE__*/function () {
   function Container() {

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -17,8 +17,8 @@
     "./lib/nodeWrapper.js": "./lib/browser.js"
   },
   "dependencies": {
+    "clone-deep": "^4.0.1",
     "find-cache-dir": "condition:BABEL_8_BREAKING ? ^3.3.1 : ^2.0.0",
-    "lodash": "^4.17.19",
     "make-dir": "^2.1.0",
     "pirates": "^4.0.0",
     "source-map-support": "^0.5.16"

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -1,4 +1,4 @@
-import deepClone from "lodash/cloneDeep";
+import cloneDeep from "clone-deep";
 import sourceMapSupport from "source-map-support";
 import * as registerCache from "./cache";
 import * as babel from "@babel/core";
@@ -42,7 +42,7 @@ function compile(code, filename) {
     // sourceRoot can be overwritten
     {
       sourceRoot: path.dirname(filename) + path.sep,
-      ...deepClone(transformOpts),
+      ...cloneDeep(transformOpts),
       filename,
     },
   );

--- a/packages/babel-register/test/fixtures/internal-modules/index.js
+++ b/packages/babel-register/test/fixtures/internal-modules/index.js
@@ -22,7 +22,6 @@ register( {
 
 console.log(
   JSON.stringify({
-    convertSourceMap: require('convert-source-map').fromObject.toString(),
-    isPlainObject: require('lodash/isPlainObject').toString()
+    convertSourceMap: require('convert-source-map').fromObject.toString()
   })
 );

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -198,8 +198,7 @@ describe("@babel/register", function () {
 
   test("transforms modules used within register", callback => {
     // Need a clean environment without `convert-source-map`
-    // and `lodash/isPlainObject` already in the require cache,
-    // so we spawn a separate process
+    // already in the require cache, so we spawn a separate process
 
     spawnNode([internalModulesTestFile], output => {
       let err;

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -204,9 +204,8 @@ describe("@babel/register", function () {
       let err;
 
       try {
-        const { convertSourceMap, isPlainObject } = JSON.parse(output);
+        const { convertSourceMap } = JSON.parse(output);
         expect(convertSourceMap).toMatch("/* transformed */");
-        expect(isPlainObject).toMatch("/* transformed */");
       } catch (e) {
         err = e;
       }

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -25,13 +25,11 @@
   },
   "dependencies": {
     "@babel/helper-validator-identifier": "workspace:^7.12.11",
-    "lodash": "^4.17.19",
     "to-fast-properties": "^2.0.0"
   },
   "devDependencies": {
     "@babel/generator": "workspace:*",
     "@babel/parser": "workspace:*",
-    "@types/lodash": "^4.14.162",
     "chalk": "^4.1.0"
   }
 }

--- a/packages/babel-types/src/converters/valueToNode.ts
+++ b/packages/babel-types/src/converters/valueToNode.ts
@@ -1,4 +1,3 @@
-import isPlainObject from "lodash/isPlainObject";
 import isValidIdentifier from "../validators/isValidIdentifier";
 import {
   identifier,
@@ -25,15 +24,27 @@ export default valueToNode as {
   (value: RegExp): t.RegExpLiteral;
   (value: ReadonlyArray<unknown>): t.ArrayExpression;
 
-  // this throws with objects that are not PlainObject according to lodash,
+  // this throws with objects that are not plain objects,
   // or if there are non-valueToNode-able values
   (value: object): t.ObjectExpression;
 
   (value: unknown): t.Expression;
 };
 
+const objectToString: (value: object) => string = Function.call.bind(
+  Object.prototype.toString,
+);
+
 function isRegExp(value): value is RegExp {
-  return Object.prototype.toString.call(value) === "[object RegExp]";
+  return objectToString(value) === "[object RegExp]";
+}
+
+function isPlainObject(value): value is object {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === null || proto === Object.prototype;
 }
 
 function valueToNode(value: unknown): t.Expression {

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,7 +94,6 @@ __metadata:
     convert-source-map: ^1.1.0
     fs-readdir-recursive: ^1.1.0
     glob: ^7.0.0
-    lodash: ^4.17.19
     make-dir: ^2.1.0
     rimraf: ^3.0.0
     slash: "condition:BABEL_8_BREAKING ? ^3.0.0 : ^2.0.0"
@@ -213,7 +212,6 @@ __metadata:
     "@babel/types": "workspace:^7.13.14"
     "@types/convert-source-map": ^1.5.1
     "@types/debug": ^4.1.0
-    "@types/lodash": ^4.14.150
     "@types/resolve": ^1.3.2
     "@types/semver": ^5.4.0
     "@types/source-map": ^0.5.0
@@ -274,9 +272,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/eslint-plugin@workspace:eslint/babel-eslint-plugin"
   dependencies:
+    clone-deep: ^4.0.1
     eslint: ^7.5.0
     eslint-rule-composer: ^0.3.0
-    lodash: ^4.17.20
   peerDependencies:
     "@babel/eslint-parser": ">=7.11.0"
     eslint: ">=7.5.0"
@@ -331,7 +329,6 @@ __metadata:
     "@babel/parser": "workspace:*"
     "@babel/types": "workspace:^7.13.0"
     "@types/jsesc": ^2.5.0
-    "@types/lodash": ^4.14.150
     "@types/source-map": ^0.5.0
     jsesc: "condition: BABEL_8_BREAKING ? ^3.0.2 : ^2.5.1"
     source-map: ^0.5.0
@@ -3286,8 +3283,8 @@ __metadata:
     "@babel/core": "workspace:*"
     "@babel/plugin-transform-modules-commonjs": "workspace:*"
     browserify: ^16.5.2
+    clone-deep: ^4.0.1
     find-cache-dir: "condition:BABEL_8_BREAKING ? ^3.3.1 : ^2.0.0"
-    lodash: ^4.17.19
     make-dir: ^2.1.0
     pirates: ^4.0.0
     source-map-support: ^0.5.16
@@ -3519,9 +3516,7 @@ __metadata:
     "@babel/generator": "workspace:*"
     "@babel/helper-validator-identifier": "workspace:^7.12.11"
     "@babel/parser": "workspace:*"
-    "@types/lodash": ^4.14.162
     chalk: ^4.1.0
-    lodash: ^4.17.19
     to-fast-properties: ^2.0.0
   languageName: unknown
   linkType: soft
@@ -4139,13 +4134,6 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 66e9ac0143ec521522c7bb670301e9836ee886207eeed1aab6d4854a1b19b404ab3a54cd8d449f9b1f13acc357f540be96f8ac2d1e86e301eab52ae0f9a4066f
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:^4.14.150, @types/lodash@npm:^4.14.162":
-  version: 4.14.168
-  resolution: "@types/lodash@npm:4.14.168"
-  checksum: 9a4e25f89fc035b9f0388f1f7be85e5eff49f9e6db0d93432c9a89fce0916f8a89db4e8290415f7ea02de6b00d3573826378dcb655b7b2d20530a6e8d6dd6fd0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/13134
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We were only using a very small number of functions from lodash, so we can avoid depending on it.

This PR still uses an external `clone-deep` implementation, but it has 10M weekly downloads (so it's battle-tested) and it's about 60% smaller than `lodash/cloneDeep`.