### PR TITLE
refactor: use FunctionParent on visiting var scope

### DIFF
--- a/packages/babel-helper-hoist-variables/src/index.ts
+++ b/packages/babel-helper-hoist-variables/src/index.ts
@@ -19,7 +19,7 @@ const visitor = {
     if (state.kind === "let") path.skip();
   },
 
-  Function(path: NodePath) {
+  FunctionParent(path: NodePath) {
     path.skip();
   },
 

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -175,7 +175,7 @@ const letReferenceBlockVisitor = traverse.visitors.merge([
         state.loopDepth--;
       },
     },
-    Function(path, state) {
+    FunctionParent(path, state) {
       // References to block-scoped variables only require added closures if it's
       // possible for the code to run more than once -- otherwise it is safe to
       // simply rename the variables.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Based on https://github.com/babel/babel/pull/13151#discussion_r613396863, we should use `FunctionParent` when we intend to visit those AST nodes starting a new `var` scope. This PR does not have observable behaviour changes since currently `Function` equals to `FunctionParent`.