### PR TITLE
Fixup e2e CI test

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "husky": "^3.0.0",
     "jest": "^26.6.1",
     "lint-staged": "^9.2.0",
-    "lodash": "^4.17.20",
     "mergeiterator": "^1.2.5",
     "prettier": "^2.2.1",
     "rollup": "^2.36.2",

--- a/scripts/integration-tests/e2e-vue-cli.sh
+++ b/scripts/integration-tests/e2e-vue-cli.sh
@@ -14,7 +14,7 @@ source utils/cleanup.sh
 set -x
 
 # Clone vue-cli
-git clone --depth=1 https://github.com/vuejs/vue-cli tmp/vue-cli
+git clone --branch v4 --depth=1 https://github.com/vuejs/vue-cli tmp/vue-cli
 cd tmp/vue-cli || exit
 
 #==============================================================================#

--- a/yarn.lock
+++ b/yarn.lock
@@ -5619,7 +5619,6 @@ __metadata:
     husky: ^3.0.0
     jest: ^26.6.1
     lint-staged: ^9.2.0
-    lodash: ^4.17.20
     mergeiterator: ^1.2.5
     prettier: ^2.2.1
     rollup: ^2.36.2
@@ -10899,7 +10898,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20":
+"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19":
   version: 4.17.20
   resolution: "lodash@npm:4.17.20"
   checksum: c62101d2500c383b5f174a7e9e6fe8098149ddd6e9ccfa85f36d4789446195f5c4afd3cfba433026bcaf3da271256566b04a2bf2618e5a39f6e67f8c12030cb6


### PR DESCRIPTION
Just changing the branch to https://github.com/vuejs/vue-cli/tree/v4 since the default is `dev` and has a breaking change to default targets (understandably) in v5. Should fix the current CI issue?

Should also move it to v5 eventually, but a temp fix given anything can change in `dev`. 