### PR TITLE
codecov: token not required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,6 @@ jobs:
           yarn test:esm
       - name: Upload coverage report
         uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: Build Babel Artifacts


### PR DESCRIPTION
Via https://github.com/marketplace/actions/codecov (and https://about.codecov.io/security-update/)

![image](https://user-images.githubusercontent.com/588473/114910645-24ca1c00-9dec-11eb-8cb7-2cd92f5142e0.png)