### PR TITLE
fix: add default value for browserslist config path

### DIFF
--- a/packages/babel-helper-compilation-targets/src/index.js
+++ b/packages/babel-helper-compilation-targets/src/index.js
@@ -179,6 +179,7 @@ export default function getTargets(
   options: GetTargetsOption = {},
 ): Targets {
   let { browsers, esmodules } = inputTargets;
+  const { configPath = "." } = options;
 
   validateBrowsers(browsers);
 
@@ -193,7 +194,7 @@ export default function getTargets(
   if (!browsers && shouldSearchForConfig) {
     browsers = browserslist.loadConfig({
       config: options.configFile,
-      path: options.configPath,
+      path: configPath,
       env: options.browserslistEnv,
     });
     if (browsers == null) {

--- a/packages/babel-helper-compilation-targets/test/load-browserslist-package-json/load-browserslist-package-json.spec.js
+++ b/packages/babel-helper-compilation-targets/test/load-browserslist-package-json/load-browserslist-package-json.spec.js
@@ -1,0 +1,19 @@
+import getTargets from "../..";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const oldCwd = process.cwd();
+
+beforeAll(() => {
+  process.chdir(path.dirname(fileURLToPath(import.meta.url)));
+});
+
+afterAll(() => {
+  process.chdir(oldCwd);
+});
+
+it("loads packageJson.browserslist", () => {
+  const actual = getTargets({}, {});
+
+  expect(actual).toEqual({ chrome: "4.0.0" });
+});

--- a/packages/babel-helper-compilation-targets/test/load-browserslist-package-json/package.json
+++ b/packages/babel-helper-compilation-targets/test/load-browserslist-package-json/package.json
@@ -1,0 +1,3 @@
+{
+  "browserslist": "chrome 4"
+}

--- a/packages/babel-helper-compilation-targets/test/load-browserslistrc/.browserslistrc
+++ b/packages/babel-helper-compilation-targets/test/load-browserslistrc/.browserslistrc
@@ -1,0 +1,4 @@
+chrome 4
+
+[development]
+chrome 88

--- a/packages/babel-helper-compilation-targets/test/load-browserslistrc/load-browserslistrc.spec.js
+++ b/packages/babel-helper-compilation-targets/test/load-browserslistrc/load-browserslistrc.spec.js
@@ -1,0 +1,30 @@
+import getTargets from "../..";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const oldCwd = process.cwd();
+
+beforeAll(() => {
+  process.chdir(path.dirname(fileURLToPath(import.meta.url)));
+});
+
+afterAll(() => {
+  process.chdir(oldCwd);
+});
+
+it("loads browserslistrc", () => {
+  const actual = getTargets({}, {});
+
+  expect(actual).toEqual({ chrome: "4.0.0" });
+});
+
+it("loads browserslistrc and respects browserslistEnv", () => {
+  const actual = getTargets(
+    {},
+    {
+      browserslistEnv: "development",
+    },
+  );
+
+  expect(actual).toEqual({ chrome: "88.0.0" });
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes [recent](https://github.com/babel/babel/runs/2348000530) CI vue e2e error (hopefully). Closes #13154 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Thanks to investigations from @sodatea (https://github.com/babel/babel/pull/13154#issuecomment-820273232), the vue-cli e2e error caught a regression introduced in https://github.com/babel/babel/pull/12189. When we switched from `browserslist` to `browserslist.loadConfig`, we should add default value for `configPath` like browserslist did here: https://github.com/browserslist/browserslist/blob/98d5352e06/index.js#L406-L408

I have added new tests on unspecified `configPath`. 

Disclaimer: I didn't run `vue-cli` e2e tests, let's see if CI can be green.