### PR TITLE
fix: don't deduplicate comments with same start index

### DIFF
--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -44,7 +44,6 @@ class Printer {
   _printStack: Array<t.Node> = [];
   _indent: number = 0;
   _insideAux: boolean = false;
-  _printedCommentStarts: any = {};
   _parenPushNewlineState: any = null;
   _noLineTerminator: boolean = false;
   _printAuxAfterOnNextUserNode: boolean = false;
@@ -597,11 +596,6 @@ class Printer {
 
     if (this._printedComments.has(comment)) return;
     this._printedComments.add(comment);
-
-    if (comment.start != null) {
-      if (this._printedCommentStarts[comment.start]) return;
-      this._printedCommentStarts[comment.start] = true;
-    }
 
     const isBlockComment = comment.type === "CommentBlock";
 

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -348,6 +348,20 @@ describe("generation", function () {
     const output = generate(type).code;
     expect(output).toBe("(infer T)[]");
   });
+
+  it("should not deduplicate comments with same start index", () => {
+    const code1 = "/*#__PURE__*/ a();";
+    const code2 = "/*#__PURE__*/ b();";
+
+    const ast1 = parse(code1).program;
+    const ast2 = parse(code2).program;
+
+    const ast = t.program([...ast1.body, ...ast2.body]);
+
+    expect(generate(ast).code).toBe(
+      "/*#__PURE__*/\na();\n\n/*#__PURE__*/\nb();",
+    );
+  });
 });
 
 describe("programmatic generation", function () {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12769  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | No <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

__Input code__

```js
const template = require('@babel/template');
const generator = require('@babel/generator');
const t = require("@babel/types");

const createStatement = template.statement("/*#__PURE__*/ foo()", {
  preserveComments: true,
});

const result = t.program([createStatement(), createStatement()]);

console.log(generator.default(result).code);
```

__Expected behavior__

```js
/*#__PURE__*/
foo();
/*#__PURE__*/
foo();
```

__Current behavior__

```js
/*#__PURE__*/
foo();
foo();
```

This PR includes following changes:

- Generate comments with same start index (Fixes #12769)
- Clone comments in cloneNode (Moved to #13178)
