### PR TITLE
fix(destructuring): preserve loc of original declaration in output

### DIFF
--- a/packages/babel-plugin-transform-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-destructuring/src/index.js
@@ -615,6 +615,7 @@ export default declare((api, options) => {
         if (!variableDeclarationHasPattern(node)) return;
 
         const nodeKind = node.kind;
+        const nodeLoc = node.loc;
         const nodes = [];
         let declar;
 
@@ -664,6 +665,10 @@ export default declare((api, options) => {
           } else {
             // Make sure the original node kind is used for each compound declaration
             node.kind = nodeKind;
+            // Propagate the original declaration node's location
+            if (!node.loc) {
+              node.loc = nodeLoc;
+            }
             nodesOut.push(node);
             tail = t.isVariableDeclaration(node) ? node : null;
           }

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/sourcemap/declaration-loc/input.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/sourcemap/declaration-loc/input.js
@@ -1,0 +1,3 @@
+const fn = (arg) => {
+  var [x, y] = arg;
+}

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/sourcemap/declaration-loc/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/sourcemap/declaration-loc/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-destructuring"]
+}

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/sourcemap/declaration-loc/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/sourcemap/declaration-loc/output.js
@@ -1,0 +1,5 @@
+const fn = arg => {
+  var _arg = babelHelpers.slicedToArray(arg, 2),
+      x = _arg[0],
+      y = _arg[1];
+};

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/sourcemap/declaration-loc/source-mappings.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/sourcemap/declaration-loc/source-mappings.json
@@ -1,0 +1,10 @@
+[{
+  "original": {
+    "line": 2,
+    "column": 2
+  },
+  "generated": {
+    "line": 2,
+    "column": 2
+  }
+}]


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

When transforming a VariableDeclaration with the destructuring plugin, the declaration node currently loses its source location. The resulting source map does not allow the user to set a breakpoint on the declaration line. This can be seen in this example on CodeSandbox: https://codesandbox.io/s/eager-mcclintock-8ozxx

https://user-images.githubusercontent.com/2246565/115276358-d47bf280-a13a-11eb-93fa-e3524adf5655.mov

This PR fixes this case, which according to my local testing restores the ability to set the breakpoint as expected.