### PR TITLE
Workaround GitHub issue templates bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: "🐛 Bug Report 2"
+name: "🐛 Bug Report"
 description: "If something isn't working as expected 🤔."
 title: "[Bug]: "
 labels: ["i: needs triage"]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
 
   - type: checkboxes
     attributes:
-      label: "\uA0"
+      label: "\u00A0"
       options:
         - label: Would you like to work on a fix?
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
   - type: checkboxes
     id: input1
     attributes:
-      label: "🐛"
+      label: "💻"
       options:
         - label: Would you like to work on a fix?
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,9 +8,8 @@ body:
       value: Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
 
   - type: checkboxes
-    id: input1
     attributes:
-      label: ""
+      label: " "
       options:
         - label: Would you like to work on a fix?
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,6 +8,7 @@ body:
       value: Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
 
   - type: checkboxes
+    id: input1
     attributes:
       label: "🐛"
       options:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
 
   - type: checkboxes
     attributes:
-      label: "\u00A0"
+      label: "🐛"
       options:
         - label: Would you like to work on a fix?
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
 
   - type: checkboxes
     attributes:
-      label: " "
+      label: "\uA0"
       options:
         - label: Would you like to work on a fix?
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: "🐛 Bug Report"
+name: "🐛 Bug Report 2"
 description: "If something isn't working as expected 🤔."
 title: "[Bug]: "
 labels: ["i: needs triage"]
@@ -8,6 +8,7 @@ body:
       value: Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
 
   - type: checkboxes
+    id: input1
     attributes:
       label: ""
       options:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
-name: "🚀 Feature Request"
+name: "🚀 Feature Request 2"
 description: "I have a specific suggestion for Babel!"
-title: ""
 labels: ["i: needs triage", "i: enhancement"]
 body:
   - type: markdown
@@ -8,6 +7,7 @@ body:
       value: Thanks for taking the time to suggest a new feature! Please fill out this form as completely as possible.
 
   - type: checkboxes
+    id: input1
     attributes:
       label: ""
       description: |

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
   - type: checkboxes
     id: input1
     attributes:
-      label: ""
+      label: "💻"
       description: |
         Check this if you would like to implement a PR, we are more than happy to help you go through the process
       options:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-name: "🚀 Feature Request 2"
+name: "🚀 Feature Request"
 description: "I have a specific suggestion for Babel!"
 labels: ["i: needs triage", "i: enhancement"]
 body:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/pull/13168#issuecomment-822884717
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The `id` should be optional according to the docs, but GitHub reports an error if we don't specify it.
If we specify the `id` with an empty label, GH uses the `id` as the `label` so I had to add a non-empty label (I chose a PC emoji).