### PR TITLE
fix: Don't load browserslist in block-hoist-plugin

### DIFF
--- a/packages/babel-core/src/transformation/block-hoist-plugin.ts
+++ b/packages/babel-core/src/transformation/block-hoist-plugin.ts
@@ -21,7 +21,6 @@ export default function loadBlockHoistPlugin(): Plugin {
 
   return LOADED_PLUGIN;
 }
-
 function priority(bodyNode) {
   const priority = bodyNode?._blockHoist;
   if (priority == null) return 1;

--- a/packages/babel-core/src/transformation/block-hoist-plugin.ts
+++ b/packages/babel-core/src/transformation/block-hoist-plugin.ts
@@ -22,10 +22,6 @@ export default function loadBlockHoistPlugin(): Plugin {
   return LOADED_PLUGIN;
 }
 
-export function resetBlockHoistPlugin(): void {
-  LOADED_PLUGIN = undefined;
-}
-
 function priority(bodyNode) {
   const priority = bodyNode?._blockHoist;
   if (priority == null) return 1;

--- a/packages/babel-core/src/transformation/block-hoist-plugin.ts
+++ b/packages/babel-core/src/transformation/block-hoist-plugin.ts
@@ -12,6 +12,7 @@ export default function loadBlockHoistPlugin(): Plugin {
     const config = loadConfig.sync({
       babelrc: false,
       configFile: false,
+      browserslistConfigFile: false,
       plugins: [blockHoistPlugin],
     });
     LOADED_PLUGIN = config ? config.passes[0][0] : undefined;
@@ -20,6 +21,11 @@ export default function loadBlockHoistPlugin(): Plugin {
 
   return LOADED_PLUGIN;
 }
+
+export function resetBlockHoistPlugin(): void {
+  LOADED_PLUGIN = undefined;
+}
+
 function priority(bodyNode) {
   const priority = bodyNode?._blockHoist;
   if (priority == null) return 1;

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -8,8 +8,6 @@ import { fileURLToPath } from "url";
 import presetEnv from "../../babel-preset-env";
 import pluginSyntaxFlow from "../../babel-plugin-syntax-flow";
 import pluginFlowStripTypes from "../../babel-plugin-transform-flow-strip-types";
-import * as helperCompilationTargets from "../../babel-helper-compilation-targets";
-import { resetBlockHoistPlugin } from "../lib/transformation/block-hoist-plugin";
 
 const cwd = path.dirname(fileURLToPath(import.meta.url));
 
@@ -172,38 +170,6 @@ describe("api", function () {
       "foo();",
     );
     expect(options).toEqual({ babelrc: false });
-  });
-
-  describe("browserslistConfigFile", function () {
-    afterEach(function () {
-      jest.restoreAllMocks();
-    });
-
-    it("passes `ignoreBrowserslistConfig` to getTargets when browserslistConfigFile is false", function () {
-      const realGetTargets = helperCompilationTargets.default;
-      const getTargets = jest
-        .spyOn(helperCompilationTargets, "default")
-        .mockImplementation((inputTargets, options) => {
-          if (options.ignoreBrowserslistConfig !== true) {
-            throw new Error(
-              `getTargets should not be called with ignoreBrowserslistConfig set to a value other than true but called with '${options.ignoreBrowserslistsConfig}'`,
-            );
-          }
-
-          return realGetTargets(inputTargets, options);
-        });
-
-      const options = {
-        babelrc: false,
-        browserslistConfigFile: false,
-      };
-      resetBlockHoistPlugin(); // Force reload the plugin
-
-      Object.freeze(options);
-      transformFileSync(cwd + "/fixtures/api/file.js", options);
-
-      expect(getTargets).toHaveBeenCalled();
-    });
   });
 
   it("transformFromAst should not mutate the AST", function () {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | No Tests as discussed
| Documentation PR Link    | -
| Any Dependency Changes?  |
| License                  | MIT

7.13.0 introduced the new option `browserslistConfigFile` in #12189. The documentation specifies that the option toggles whatever babel looks for a browserslists configuration or not. 

> Toggles whether or not browserslist config sources are used, which includes searching for any browserslist files or referencing the browserslist key inside package.json. This is useful for projects that use a browserslist config for files that won't be compiled with Babel.

This works fine, except that the `block-hoist-plugin` loads a configuration without setting the `browserslistConfigFile` to false. 

The `block-hoist-plugin` should set the `browserslistConfigFile` to `false` to prevent babel from loading (or looking for) a `browserslists` config when users explicitly disabled this functionality. The `block-hoist-plugin` makes no use of the browserslist itself, which is why the change should be fine.
