### PR TITLE
_s is not initialized in helpers.iterableToArrayLimit

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1020,7 +1020,7 @@ helpers.iterableToArrayLimit = helper("7.0.0-beta.0")`
     var _d = false;
     var _e = undefined;
     try {
-      for (_i = _i.call(arr), _s; !(_n = (_s = _i.next()).done); _n = true) {
+      for (var _i = _i.call(arr), _s; !(_n = (_s = _i.next()).done); _n = true) {
         _arr.push(_s.value);
         if (i && _arr.length === i) break;
       }


### PR DESCRIPTION
Regression occurred in https://github.com/babel/babel/commit/808d437cf4b94e3e69e0f6185c0a2f2775d799a0
