### PR TITLE
Mark `WeakMap`s of private fields as pure

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -18,6 +18,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-annotate-as-pure": "workspace:^7.12.13",
     "@babel/helper-function-name": "workspace:^7.12.13",
     "@babel/helper-member-expression-to-functions": "workspace:^7.13.0",
     "@babel/helper-optimise-call-expression": "workspace:^7.12.13",

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-private-methods/loose-false/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-private-methods/loose-false/output.js
@@ -1,4 +1,4 @@
-var _privateMethod = new WeakSet();
+var _privateMethod = /*#__PURE__*/new WeakSet();
 
 class X {
   constructor() {

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-private-methods/loose-true/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-private-methods/loose-true/output.js
@@ -1,4 +1,4 @@
-var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+var _privateMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateMethod");
 
 class X {
   constructor() {

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/replace-supers/method/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/replace-supers/method/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakSet();
+var _foo = /*#__PURE__*/new WeakSet();
 
 class A extends B {
   constructor(...args) {

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/fixtures/basic/class-private-integration-optional-chaining/output.mjs
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/fixtures/basic/class-private-integration-optional-chaining/output.mjs
@@ -1,4 +1,4 @@
-var _m = new WeakMap();
+var _m = /*#__PURE__*/new WeakMap();
 
 class C {
   constructor() {

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/fixtures/basic/class-private-integration/output.mjs
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/fixtures/basic/class-private-integration/output.mjs
@@ -1,4 +1,4 @@
-var _m = new WeakMap();
+var _m = /*#__PURE__*/new WeakMap();
 
 class C {
   constructor() {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-private-method/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-private-method/output.js
@@ -1,4 +1,4 @@
-var _g = new WeakSet();
+var _g = /*#__PURE__*/new WeakSet();
 
 class C {
   constructor() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/assignment/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/assignment/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 var Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/call/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 var Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/canonical/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/canonical/output.js
@@ -1,6 +1,6 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _y = babelHelpers.classPrivateFieldLooseKey("y");
+var _y = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("y");
 
 var Point = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/constructor-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/constructor-collision/output.js
@@ -1,6 +1,6 @@
 var foo = "bar";
 
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 var Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/declaration-order/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/declaration-order/output.js
@@ -1,4 +1,4 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
 var C = function C() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
@@ -1,4 +1,4 @@
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
@@ -1,4 +1,4 @@
-var _prop = babelHelpers.classPrivateFieldLooseKey("prop");
+var _prop = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("prop");
 
 var Foo = function Foo() {
   "use strict";
@@ -10,7 +10,7 @@ var Foo = function Foo() {
   });
 };
 
-var _prop2 = babelHelpers.classPrivateFieldLooseKey("prop");
+var _prop2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("prop");
 
 var Bar = /*#__PURE__*/function (_Foo) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-1/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-1/output.js
@@ -1,4 +1,4 @@
-var _client = babelHelpers.classPrivateFieldLooseKey("client");
+var _client = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("client");
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-2/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-2/output.js
@@ -1,4 +1,4 @@
-var _client = babelHelpers.classPrivateFieldLooseKey("client");
+var _client = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("client");
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-3/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-3/output.js
@@ -1,4 +1,4 @@
-var _client = babelHelpers.classPrivateFieldLooseKey("client");
+var _client = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("client");
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-static/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern-static/output.js
@@ -1,4 +1,4 @@
-var _client = babelHelpers.classPrivateFieldLooseKey("client");
+var _client = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("client");
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-array-pattern/output.js
@@ -1,4 +1,4 @@
-var _client = babelHelpers.classPrivateFieldLooseKey("client");
+var _client = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("client");
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-1/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-1/output.js
@@ -1,4 +1,4 @@
-var _client = babelHelpers.classPrivateFieldLooseKey("client");
+var _client = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("client");
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-2/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-2/output.js
@@ -1,4 +1,4 @@
-var _client = babelHelpers.classPrivateFieldLooseKey("client");
+var _client = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("client");
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-3/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-3/output.js
@@ -1,4 +1,4 @@
-var _client = babelHelpers.classPrivateFieldLooseKey("client");
+var _client = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("client");
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-static/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern-static/output.js
@@ -1,4 +1,4 @@
-var _client = babelHelpers.classPrivateFieldLooseKey("client");
+var _client = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("client");
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/destructuring-object-pattern/output.js
@@ -1,4 +1,4 @@
-var _client = babelHelpers.classPrivateFieldLooseKey("client");
+var _client = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("client");
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/extracted-this/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/extracted-this/output.js
@@ -1,8 +1,8 @@
 var foo = "bar";
 
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
-var _baz = babelHelpers.classPrivateFieldLooseKey("baz");
+var _baz = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("baz");
 
 var Foo = function Foo(_foo) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
@@ -1,4 +1,4 @@
-var _scopedFunctionWithThis = babelHelpers.classPrivateFieldLooseKey("scopedFunctionWithThis");
+var _scopedFunctionWithThis = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("scopedFunctionWithThis");
 
 var Child = /*#__PURE__*/function (_Parent) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/instance-undefined/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/instance-undefined/output.js
@@ -1,4 +1,4 @@
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 var Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/instance/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/instance/output.js
@@ -1,4 +1,4 @@
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 var Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/logical-assignment/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/logical-assignment/output.js
@@ -1,8 +1,8 @@
-var _nullish = babelHelpers.classPrivateFieldLooseKey("nullish");
+var _nullish = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("nullish");
 
-var _and = babelHelpers.classPrivateFieldLooseKey("and");
+var _and = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("and");
 
-var _or = babelHelpers.classPrivateFieldLooseKey("or");
+var _or = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("or");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/multiple/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/multiple/output.js
@@ -1,6 +1,6 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _y = babelHelpers.classPrivateFieldLooseKey("y");
+var _y = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("y");
 
 var Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/native-classes/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/native-classes/output.js
@@ -1,6 +1,6 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed-redeclared/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 var Foo = /*#__PURE__*/function () {
   "use strict";
@@ -16,7 +16,7 @@ var Foo = /*#__PURE__*/function () {
     value: function test() {
       var _babelHelpers$classPr;
 
-      var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+      var _foo2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
       _babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo2)[_foo2];
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-computed/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 var Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 var Foo = /*#__PURE__*/function () {
   "use strict";
@@ -18,7 +18,7 @@ var Foo = /*#__PURE__*/function () {
 
       var _babelHelpers$classPr;
 
-      var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+      var _foo2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
       var Nested = /*#__PURE__*/function (_ref) {
         babelHelpers.inherits(Nested, _ref);
@@ -38,7 +38,7 @@ var Foo = /*#__PURE__*/function () {
         }
 
         return Nested;
-      }((_foo3 = babelHelpers.classPrivateFieldLooseKey("foo"), _babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo3)[_foo3], /*#__PURE__*/function () {
+      }((_foo3 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), _babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo3)[_foo3], /*#__PURE__*/function () {
         function _class2() {
           babelHelpers.classCallCheck(this, _class2);
           Object.defineProperty(this, _foo3, {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 var Foo = /*#__PURE__*/function () {
   "use strict";
@@ -16,7 +16,7 @@ var Foo = /*#__PURE__*/function () {
     value: function test() {
       var _babelHelpers$classPr;
 
-      var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+      var _foo2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
       var Nested = /*#__PURE__*/function (_ref) {
         babelHelpers.inherits(Nested, _ref);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-other-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-other-redeclared/output.js
@@ -1,6 +1,6 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 var Foo = /*#__PURE__*/function () {
   "use strict";
@@ -20,7 +20,7 @@ var Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _bar2 = babelHelpers.classPrivateFieldLooseKey("bar");
+      var _bar2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
       var Nested = /*#__PURE__*/function () {
         function Nested() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class-redeclared/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 var Foo = /*#__PURE__*/function () {
   "use strict";
@@ -14,7 +14,7 @@ var Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+      var _foo2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
       var Nested = /*#__PURE__*/function () {
         function Nested() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/nested-class/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 var Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/non-block-arrow-func/output.mjs
@@ -1,7 +1,7 @@
 export default (param => {
   var _class, _props, _temp;
 
-  return _temp = (_props = babelHelpers.classPrivateFieldLooseKey("props"), _class = class App {
+  return _temp = (_props = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("props"), _class = class App {
     getParam() {
       return param;
     }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-before-member-call-with-transform/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-before-member-call-with-transform/output.js
@@ -1,8 +1,8 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _m = babelHelpers.classPrivateFieldLooseKey("m");
+var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-before-member-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-before-member-call/output.js
@@ -1,8 +1,8 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _m = babelHelpers.classPrivateFieldLooseKey("m");
+var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-before-property-with-transform/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-before-property-with-transform/output.js
@@ -1,6 +1,6 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-before-property/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-before-property/output.js
@@ -1,6 +1,6 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-cast-to-boolean/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-cast-to-boolean/output.js
@@ -1,4 +1,4 @@
-var _a = babelHelpers.classPrivateFieldLooseKey("a");
+var _a = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("a");
 
 class C {
   static testIf(o) {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-delete-property-with-transform/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-delete-property-with-transform/output.js
@@ -1,6 +1,6 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-delete-property/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-delete-property/output.js
@@ -1,6 +1,6 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-in-function-param-with-transform/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-in-function-param-with-transform/output.js
@@ -1,8 +1,8 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _m = babelHelpers.classPrivateFieldLooseKey("m");
+var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-in-function-param/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-in-function-param/output.js
@@ -1,8 +1,8 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _m = babelHelpers.classPrivateFieldLooseKey("m");
+var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-spread-arguments/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-spread-arguments/output.js
@@ -1,4 +1,4 @@
-var _m = babelHelpers.classPrivateFieldLooseKey("m");
+var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-with-transform/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-with-transform/output.js
@@ -1,8 +1,8 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _m = babelHelpers.classPrivateFieldLooseKey("m");
+var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call/output.js
@@ -1,8 +1,8 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _m = babelHelpers.classPrivateFieldLooseKey("m");
+var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-optional-member-call-with-transform/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-optional-member-call-with-transform/output.js
@@ -1,8 +1,8 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _m = babelHelpers.classPrivateFieldLooseKey("m");
+var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-optional-member-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-optional-member-call/output.js
@@ -1,8 +1,8 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _m = babelHelpers.classPrivateFieldLooseKey("m");
+var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-optional-property-with-transform/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-optional-property-with-transform/output.js
@@ -1,6 +1,6 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-optional-property/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/optional-chain-optional-property/output.js
@@ -1,6 +1,6 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/parenthesized-optional-member-call-with-transform/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/parenthesized-optional-member-call-with-transform/output.js
@@ -1,6 +1,6 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _m = babelHelpers.classPrivateFieldLooseKey("m");
+var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/private-in-derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/private-in-derived/output.js
@@ -1,4 +1,4 @@
-var _outer = babelHelpers.classPrivateFieldLooseKey("outer");
+var _outer = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("outer");
 
 var Outer = function Outer() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reevaluated/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reevaluated/output.js
@@ -1,7 +1,7 @@
 function classFactory() {
   var _class, _foo, _bar, _temp;
 
-  return _temp = (_foo = babelHelpers.classPrivateFieldLooseKey("foo"), _bar = babelHelpers.classPrivateFieldLooseKey("bar"), _class = class Foo {
+  return _temp = (_foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar"), _class = class Foo {
     constructor() {
       Object.defineProperty(this, _foo, {
         writable: true,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reference-in-other-property/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reference-in-other-property/output.js
@@ -1,8 +1,8 @@
-var _two = babelHelpers.classPrivateFieldLooseKey("two");
+var _two = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("two");
 
-var _private = babelHelpers.classPrivateFieldLooseKey("private");
+var _private = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("private");
 
-var _four = babelHelpers.classPrivateFieldLooseKey("four");
+var _four = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("four");
 
 var Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-call/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 var Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-export/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-export/output.mjs
@@ -1,4 +1,4 @@
-var _property = babelHelpers.classPrivateFieldLooseKey("property");
+var _property = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("property");
 
 export class MyClass {}
 Object.defineProperty(MyClass, _property, {
@@ -6,7 +6,7 @@ Object.defineProperty(MyClass, _property, {
   value: value
 });
 
-var _property2 = babelHelpers.classPrivateFieldLooseKey("property");
+var _property2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("property");
 
 export default class MyClass2 {}
 Object.defineProperty(MyClass2, _property2, {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-infer-name/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-infer-name/output.js
@@ -1,6 +1,6 @@
 var _class, _num, _temp;
 
-var Foo = (_temp = (_num = babelHelpers.classPrivateFieldLooseKey("num"), _class = class Foo {}), Object.defineProperty(_class, _num, {
+var Foo = (_temp = (_num = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("num"), _class = class Foo {}), Object.defineProperty(_class, _num, {
   writable: true,
   value: 0
 }), _temp);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-inherited/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-inherited/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Base {
   static getThis() {
@@ -24,7 +24,7 @@ Object.defineProperty(Base, _foo, {
   value: 1
 });
 
-var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Sub1 extends Base {
   static update(val) {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-this/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-this/output.js
@@ -1,6 +1,6 @@
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
-var _getA = babelHelpers.classPrivateFieldLooseKey("getA");
+var _getA = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getA");
 
 var A = function A() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-undefined/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-undefined/output.js
@@ -1,4 +1,4 @@
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 class Foo {
   static test() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static/output.js
@@ -1,4 +1,4 @@
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 class Foo {
   static test() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-expression/output.js
@@ -1,4 +1,4 @@
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-statement/output.js
@@ -1,4 +1,4 @@
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/update/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/update/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 var Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/1-helpermemberexpressionfunction/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/1-helpermemberexpressionfunction/output.js
@@ -1,4 +1,4 @@
-var _arr = new WeakMap();
+var _arr = /*#__PURE__*/new WeakMap();
 
 var D = /*#__PURE__*/function () {
   "use strict";
@@ -23,7 +23,7 @@ var D = /*#__PURE__*/function () {
   return D;
 }();
 
-var _p = new WeakMap();
+var _p = /*#__PURE__*/new WeakMap();
 
 var C = /*#__PURE__*/function () {
   "use strict";
@@ -48,7 +48,7 @@ var C = /*#__PURE__*/function () {
   return C;
 }();
 
-var _arr2 = new WeakMap();
+var _arr2 = /*#__PURE__*/new WeakMap();
 
 var E = /*#__PURE__*/function () {
   "use strict";
@@ -73,7 +73,7 @@ var E = /*#__PURE__*/function () {
   return E;
 }();
 
-var _ar = new WeakMap();
+var _ar = /*#__PURE__*/new WeakMap();
 
 var F = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/assignment/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/assignment/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/call/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/canonical/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/canonical/output.js
@@ -1,6 +1,6 @@
-var _x = new WeakMap();
+var _x = /*#__PURE__*/new WeakMap();
 
-var _y = new WeakMap();
+var _y = /*#__PURE__*/new WeakMap();
 
 var Point = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/constructor-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/constructor-collision/output.js
@@ -1,6 +1,6 @@
 var foo = "bar";
 
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/declaration-order/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/declaration-order/output.js
@@ -1,4 +1,4 @@
-var _x = new WeakMap();
+var _x = /*#__PURE__*/new WeakMap();
 
 var C = function C() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
@@ -1,4 +1,4 @@
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
@@ -1,4 +1,4 @@
-var _prop = new WeakMap();
+var _prop = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo() {
   "use strict";
@@ -11,7 +11,7 @@ var Foo = function Foo() {
   });
 };
 
-var _prop2 = new WeakMap();
+var _prop2 = /*#__PURE__*/new WeakMap();
 
 var Bar = /*#__PURE__*/function (_Foo) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-1/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-1/output.js
@@ -1,4 +1,4 @@
-var _client = new WeakMap();
+var _client = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-2/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-2/output.js
@@ -1,4 +1,4 @@
-var _client = new WeakMap();
+var _client = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-3/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern-3/output.js
@@ -1,4 +1,4 @@
-var _client = new WeakMap();
+var _client = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-array-pattern/output.js
@@ -1,4 +1,4 @@
-var _client = new WeakMap();
+var _client = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-1/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-1/output.js
@@ -1,4 +1,4 @@
-var _client = new WeakMap();
+var _client = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-2/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-2/output.js
@@ -1,4 +1,4 @@
-var _client = new WeakMap();
+var _client = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-3/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern-3/output.js
@@ -1,4 +1,4 @@
-var _client = new WeakMap();
+var _client = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/destructuring-object-pattern/output.js
@@ -1,4 +1,4 @@
-var _client = new WeakMap();
+var _client = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo(props) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/extracted-this/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/extracted-this/output.js
@@ -1,8 +1,8 @@
 var foo = "bar";
 
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
-var _baz = new WeakMap();
+var _baz = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo(_foo) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
@@ -1,4 +1,4 @@
-var _scopedFunctionWithThis = new WeakMap();
+var _scopedFunctionWithThis = /*#__PURE__*/new WeakMap();
 
 var Child = /*#__PURE__*/function (_Parent) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/instance-undefined/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/instance-undefined/output.js
@@ -1,4 +1,4 @@
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/instance/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/instance/output.js
@@ -1,4 +1,4 @@
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/logical-assignment/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/logical-assignment/output.js
@@ -1,8 +1,8 @@
-var _nullish = new WeakMap();
+var _nullish = /*#__PURE__*/new WeakMap();
 
-var _and = new WeakMap();
+var _and = /*#__PURE__*/new WeakMap();
 
-var _or = new WeakMap();
+var _or = /*#__PURE__*/new WeakMap();
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/multiple/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/multiple/output.js
@@ -1,6 +1,6 @@
-var _x = new WeakMap();
+var _x = /*#__PURE__*/new WeakMap();
 
-var _y = new WeakMap();
+var _y = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/native-classes/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/native-classes/output.js
@@ -1,4 +1,4 @@
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed-redeclared/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function () {
   "use strict";
@@ -17,7 +17,7 @@ var Foo = /*#__PURE__*/function () {
     value: function test() {
       var _babelHelpers$classPr;
 
-      var _foo2 = new WeakMap();
+      var _foo2 = /*#__PURE__*/new WeakMap();
 
       _babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo2);
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-computed/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function () {
   "use strict";
@@ -19,7 +19,7 @@ var Foo = /*#__PURE__*/function () {
 
       var _babelHelpers$classPr;
 
-      var _foo2 = new WeakMap();
+      var _foo2 = /*#__PURE__*/new WeakMap();
 
       var Nested = /*#__PURE__*/function (_ref) {
         babelHelpers.inherits(Nested, _ref);
@@ -41,7 +41,7 @@ var Foo = /*#__PURE__*/function () {
         }
 
         return Nested;
-      }((_foo3 = new WeakMap(), _babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo3), /*#__PURE__*/function () {
+      }((_foo3 = /*#__PURE__*/new WeakMap(), _babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo3), /*#__PURE__*/function () {
         function _class2() {
           babelHelpers.classCallCheck(this, _class2);
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function () {
   "use strict";
@@ -17,7 +17,7 @@ var Foo = /*#__PURE__*/function () {
     value: function test() {
       var _babelHelpers$classPr;
 
-      var _foo2 = new WeakMap();
+      var _foo2 = /*#__PURE__*/new WeakMap();
 
       var Nested = /*#__PURE__*/function (_ref) {
         babelHelpers.inherits(Nested, _ref);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-other-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-other-redeclared/output.js
@@ -1,6 +1,6 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function () {
   "use strict";
@@ -22,7 +22,7 @@ var Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _bar2 = new WeakMap();
+      var _bar2 = /*#__PURE__*/new WeakMap();
 
       var Nested = /*#__PURE__*/function () {
         function Nested() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-redeclared/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class-redeclared/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function () {
   "use strict";
@@ -15,7 +15,7 @@ var Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _foo2 = new WeakMap();
+      var _foo2 = /*#__PURE__*/new WeakMap();
 
       var Nested = /*#__PURE__*/function () {
         function Nested() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/nested-class/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-delete-property-with-transform/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-delete-property-with-transform/output.js
@@ -1,6 +1,6 @@
-var _x = babelHelpers.classPrivateFieldLooseKey("x");
+var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 
-var _self = babelHelpers.classPrivateFieldLooseKey("self");
+var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 
 class Foo {
   static getSelf() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-member-optional-call-spread-arguments/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/optional-chain-member-optional-call-spread-arguments/output.js
@@ -1,4 +1,4 @@
-var _m = new WeakMap();
+var _m = /*#__PURE__*/new WeakMap();
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/private-in-derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/private-in-derived/output.js
@@ -1,4 +1,4 @@
-var _outer = new WeakMap();
+var _outer = /*#__PURE__*/new WeakMap();
 
 var Outer = function Outer() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reevaluated/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reevaluated/output.js
@@ -1,7 +1,7 @@
 function classFactory() {
   var _class, _foo, _temp, _bar;
 
-  return _temp = (_foo = new WeakMap(), _class = class Foo {
+  return _temp = (_foo = /*#__PURE__*/new WeakMap(), _class = class Foo {
     constructor() {
       _foo.set(this, {
         writable: true,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reference-in-other-property/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reference-in-other-property/output.js
@@ -1,8 +1,8 @@
-var _two = new WeakMap();
+var _two = /*#__PURE__*/new WeakMap();
 
-var _private = new WeakMap();
+var _private = /*#__PURE__*/new WeakMap();
 
-var _four = new WeakMap();
+var _four = /*#__PURE__*/new WeakMap();
 
 var Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T7364/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T7364/output.mjs
@@ -1,4 +1,4 @@
-var _myAsyncMethod = new WeakMap();
+var _myAsyncMethod = /*#__PURE__*/new WeakMap();
 
 class MyClass {
   constructor() {
@@ -20,7 +20,7 @@ class MyClass {
 
 }
 
-var _myAsyncMethod2 = new WeakMap();
+var _myAsyncMethod2 = /*#__PURE__*/new WeakMap();
 
 (class MyClass2 {
   constructor() {
@@ -42,7 +42,7 @@ var _myAsyncMethod2 = new WeakMap();
 
 });
 
-var _myAsyncMethod3 = new WeakMap();
+var _myAsyncMethod3 = /*#__PURE__*/new WeakMap();
 
 export default class MyClass3 {
   constructor() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
@@ -14,7 +14,7 @@ var A = /*#__PURE__*/function () {
   return A;
 }();
 
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 var B = /*#__PURE__*/function (_A) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
@@ -1,4 +1,4 @@
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
@@ -1,4 +1,4 @@
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/update/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/update/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 var Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/8882/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/8882/output.js
@@ -5,7 +5,7 @@ for (let i = 0; i <= 10; ++i) {
 
   let _i;
 
-  classes.push((_temp = (_bar = new WeakMap(), _i = i, _class = class A {
+  classes.push((_temp = (_bar = /*#__PURE__*/new WeakMap(), _i = i, _class = class A {
     constructor() {
       babelHelpers.defineProperty(this, _i, `computed field ${i}`);
 

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-binding/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-binding/output.js
@@ -1,4 +1,4 @@
-var _ = babelHelpers.classPrivateFieldLooseKey("_");
+var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
 
 class Foo {}
 

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-declaration/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-declaration/output.js
@@ -1,4 +1,4 @@
-var _ = babelHelpers.classPrivateFieldLooseKey("_");
+var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
 
 class Foo {}
 

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/in-class-heritage/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/in-class-heritage/output.js
@@ -1,8 +1,8 @@
 var _class, _2, _temp, _class2, _3, _temp2;
 
-var _ = babelHelpers.classPrivateFieldLooseKey("_");
+var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
 
-class Foo extends (_temp = (_2 = babelHelpers.classPrivateFieldLooseKey("_"), _class = class extends (_temp2 = (_3 = babelHelpers.classPrivateFieldLooseKey("_"), _class2 = class Base {}), Object.defineProperty(_class2, _3, {
+class Foo extends (_temp = (_2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_"), _class = class extends (_temp2 = (_3 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_"), _class2 = class Base {}), Object.defineProperty(_class2, _3, {
   writable: true,
   value: (() => {
     _class2.qux = 21;

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/multiple-static-initializers/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/multiple-static-initializers/output.js
@@ -1,8 +1,8 @@
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
-var _ = babelHelpers.classPrivateFieldLooseKey("_");
+var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
 
-var _2 = babelHelpers.classPrivateFieldLooseKey("_2");
+var _2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_2");
 
 class Foo {}
 

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/name-conflict/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/name-conflict/output.js
@@ -1,6 +1,6 @@
-var _ = babelHelpers.classPrivateFieldLooseKey("_");
+var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
 
-var _2 = babelHelpers.classPrivateFieldLooseKey("_2");
+var _2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_2");
 
 class Foo {}
 

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/super-static-block/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/super-static-block/output.js
@@ -1,8 +1,8 @@
 var _class, _2, _temp;
 
-var _ = babelHelpers.classPrivateFieldLooseKey("_");
+var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
 
-class Foo extends (_temp = (_2 = babelHelpers.classPrivateFieldLooseKey("_"), _class = class {}), Object.defineProperty(_class, _2, {
+class Foo extends (_temp = (_2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_"), _class = class {}), Object.defineProperty(_class, _2, {
   writable: true,
   value: (() => {
     _class.bar = 42;
@@ -15,7 +15,7 @@ Object.defineProperty(Foo, _, {
   value: (() => {
     var _class2, _3, _temp2;
 
-    Foo.foo = (_temp2 = (_3 = babelHelpers.classPrivateFieldLooseKey("_"), _class2 = class {}), Object.defineProperty(_class2, _3, {
+    Foo.foo = (_temp2 = (_3 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_"), _class2 = class {}), Object.defineProperty(_class2, _3, {
       writable: true,
       value: (() => {
         _class2.bar = 42;

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/basic/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/get-only-setter/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/reassignment/output.js
@@ -1,6 +1,6 @@
 var counter = 0;
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/updates/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/basic/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/get-only-setter/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/set-only-getter/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/updates/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/basic/output.js
@@ -1,6 +1,6 @@
-var _privateField = new WeakMap();
+var _privateField = /*#__PURE__*/new WeakMap();
 
-var _privateFieldValue = new WeakMap();
+var _privateFieldValue = /*#__PURE__*/new WeakMap();
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/get-only-setter/output.js
@@ -1,6 +1,6 @@
-var _privateField = new WeakMap();
+var _privateField = /*#__PURE__*/new WeakMap();
 
-var _privateFieldValue = new WeakMap();
+var _privateFieldValue = /*#__PURE__*/new WeakMap();
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/reassignment/output.js
@@ -1,6 +1,6 @@
 var results = [];
 
-var _privateFieldValue = new WeakMap();
+var _privateFieldValue = /*#__PURE__*/new WeakMap();
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
@@ -1,6 +1,6 @@
-var _privateField = new WeakMap();
+var _privateField = /*#__PURE__*/new WeakMap();
 
-var _privateFieldValue = new WeakMap();
+var _privateFieldValue = /*#__PURE__*/new WeakMap();
 
 class Cl {
   get self() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/updates/output.js
@@ -1,6 +1,6 @@
-var _privateField = new WeakMap();
+var _privateField = /*#__PURE__*/new WeakMap();
 
-var _privateFieldValue = new WeakMap();
+var _privateFieldValue = /*#__PURE__*/new WeakMap();
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/assumption-constantSuper/private-method-super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/assumption-constantSuper/private-method-super/output.js
@@ -5,7 +5,7 @@ class Base {
 
 }
 
-var _privateMethod = new WeakSet();
+var _privateMethod = /*#__PURE__*/new WeakSet();
 
 class Sub extends Base {
   constructor(...args) {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/get-set/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/get-set/output.js
@@ -1,6 +1,6 @@
-var _privateField = new WeakMap();
+var _privateField = /*#__PURE__*/new WeakMap();
 
-var _getSet = new WeakMap();
+var _getSet = /*#__PURE__*/new WeakMap();
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/set-get/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/set-get/output.js
@@ -1,6 +1,6 @@
-var _privateField = new WeakMap();
+var _privateField = /*#__PURE__*/new WeakMap();
 
-var _getSet = new WeakMap();
+var _getSet = /*#__PURE__*/new WeakMap();
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/assignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/assignment/output.js
@@ -1,4 +1,4 @@
-var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+var _privateMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateMethod");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/async/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/before-fields/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/before-fields/output.js
@@ -1,6 +1,6 @@
-var _priv = babelHelpers.classPrivateFieldLooseKey("priv");
+var _priv = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("priv");
 
-var _method = babelHelpers.classPrivateFieldLooseKey("method");
+var _method = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("method");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/class-expression/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/class-expression/output.js
@@ -1,6 +1,6 @@
 var _foo;
 
-console.log((_foo = babelHelpers.classPrivateFieldLooseKey("foo"), class A {
+console.log((_foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), class A {
   constructor() {
     Object.defineProperty(this, _foo, {
       value: _foo2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/context/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/context/output.js
@@ -1,4 +1,4 @@
-var _getStatus = babelHelpers.classPrivateFieldLooseKey("getStatus");
+var _getStatus = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getStatus");
 
 class Foo {
   constructor(status) {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/exfiltrated/output.js
@@ -1,6 +1,6 @@
 var exfiltrated;
 
-var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+var _privateMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateMethod");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/generator/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/reassignment/output.js
@@ -1,6 +1,6 @@
 var counter = 0;
 
-var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+var _privateMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateMethod");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/output.js
@@ -5,7 +5,7 @@ class Base {
 
 }
 
-var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+var _privateMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateMethod");
 
 class Sub extends Base {
   constructor(...args) {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/assignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/assignment/output.js
@@ -1,4 +1,4 @@
-var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+var _privateMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateMethod");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/async/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/before-fields/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/before-fields/output.js
@@ -1,6 +1,6 @@
-var _priv = babelHelpers.classPrivateFieldLooseKey("priv");
+var _priv = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("priv");
 
-var _method = babelHelpers.classPrivateFieldLooseKey("method");
+var _method = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("method");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/class-expression/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/class-expression/output.js
@@ -1,6 +1,6 @@
 var _foo;
 
-console.log((_foo = babelHelpers.classPrivateFieldLooseKey("foo"), class A {
+console.log((_foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), class A {
   constructor() {
     Object.defineProperty(this, _foo, {
       value: _foo2

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/context/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/context/output.js
@@ -1,4 +1,4 @@
-var _getStatus = babelHelpers.classPrivateFieldLooseKey("getStatus");
+var _getStatus = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getStatus");
 
 class Foo {
   constructor(status) {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/exfiltrated/output.js
@@ -1,6 +1,6 @@
 let exfiltrated;
 
-var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+var _privateMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateMethod");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/generator/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/output.js
@@ -5,7 +5,7 @@ class Base {
 
 }
 
-var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
+var _privateMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateMethod");
 
 class Sub extends Base {
   constructor(...args) {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/assignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/assignment/output.js
@@ -1,4 +1,4 @@
-var _privateMethod = new WeakSet();
+var _privateMethod = /*#__PURE__*/new WeakSet();
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/async/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakSet();
+var _foo = /*#__PURE__*/new WeakSet();
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/before-fields/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/before-fields/output.js
@@ -1,6 +1,6 @@
-var _priv = new WeakMap();
+var _priv = /*#__PURE__*/new WeakMap();
 
-var _method = new WeakSet();
+var _method = /*#__PURE__*/new WeakSet();
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/class-expression/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/class-expression/output.js
@@ -1,6 +1,6 @@
 var _foo;
 
-console.log((_foo = new WeakSet(), class A {
+console.log((_foo = /*#__PURE__*/new WeakSet(), class A {
   constructor() {
     _foo.add(this);
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/context/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/context/output.js
@@ -1,4 +1,4 @@
-var _getStatus = new WeakSet();
+var _getStatus = /*#__PURE__*/new WeakSet();
 
 class Foo {
   constructor(status) {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/exfiltrated/output.js
@@ -1,6 +1,6 @@
 var exfiltrated;
 
-var _privateMethod = new WeakSet();
+var _privateMethod = /*#__PURE__*/new WeakSet();
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/generator/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakSet();
+var _foo = /*#__PURE__*/new WeakSet();
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/read-only/output.js
@@ -1,4 +1,4 @@
-var _method = new WeakSet();
+var _method = /*#__PURE__*/new WeakSet();
 
 class A {
   self() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/reassignment/output.js
@@ -1,6 +1,6 @@
 var results = [];
 
-var _privateFieldValue = new WeakSet();
+var _privateFieldValue = /*#__PURE__*/new WeakSet();
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/output.js
@@ -5,7 +5,7 @@ class Base {
 
 }
 
-var _privateMethod = new WeakSet();
+var _privateMethod = /*#__PURE__*/new WeakSet();
 
 class Sub extends Base {
   constructor(...args) {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/basic/output.js
@@ -1,4 +1,4 @@
-var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+var _privateStaticMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
 
 class Cl {
   static staticMethod2() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/class-check/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/class-check/output.js
@@ -1,4 +1,4 @@
-var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+var _privateStaticMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
 
 class Cl {
   publicMethod(checked) {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/class-expression/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/class-expression/output.js
@@ -1,6 +1,6 @@
 var _class, _foo, _temp;
 
-console.log((_temp = (_foo = babelHelpers.classPrivateFieldLooseKey("foo"), _class = class A {
+console.log((_temp = (_foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), _class = class A {
   method() {
     babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/exfiltrated/output.js
@@ -1,6 +1,6 @@
 var exfiltrated;
 
-var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+var _privateStaticMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/generator/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Cl {
   test() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/reassignment/output.js
@@ -1,4 +1,4 @@
-var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+var _privateStaticMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/output.js
@@ -5,7 +5,7 @@ class Base {
 
 }
 
-var _subStaticPrivateMethod = babelHelpers.classPrivateFieldLooseKey("subStaticPrivateMethod");
+var _subStaticPrivateMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("subStaticPrivateMethod");
 
 class Sub extends Base {
   static basePublicStaticMethod() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/this/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/this/output.js
@@ -5,9 +5,9 @@ class A {
 
 }
 
-var _getA = babelHelpers.classPrivateFieldLooseKey("getA");
+var _getA = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getA");
 
-var _getB = babelHelpers.classPrivateFieldLooseKey("getB");
+var _getB = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getB");
 
 class B extends A {
   static get b() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/async/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/async/output.js
@@ -1,4 +1,4 @@
-var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+var _privateStaticMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
 
 class Cl {
   test() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/basic/output.js
@@ -1,4 +1,4 @@
-var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+var _privateStaticMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
 
 class Cl {
   static staticMethod2() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-check/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-check/output.js
@@ -1,4 +1,4 @@
-var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+var _privateStaticMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
 
 class Cl {
   publicMethod(checked) {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-expression/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-expression/output.js
@@ -1,6 +1,6 @@
 var _class, _foo, _temp;
 
-console.log((_temp = (_foo = babelHelpers.classPrivateFieldLooseKey("foo"), _class = class A {
+console.log((_temp = (_foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), _class = class A {
   method() {
     babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/exfiltrated/output.js
@@ -1,6 +1,6 @@
 let exfiltrated;
 
-var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+var _privateStaticMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/generator/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/generator/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Cl {
   test() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/reassignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/reassignment/output.js
@@ -1,4 +1,4 @@
-var _privateStaticMethod = babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
+var _privateStaticMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticMethod");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/output.js
@@ -5,7 +5,7 @@ class Base {
 
 }
 
-var _subStaticPrivateMethod = babelHelpers.classPrivateFieldLooseKey("subStaticPrivateMethod");
+var _subStaticPrivateMethod = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("subStaticPrivateMethod");
 
 class Sub extends Base {
   static basePublicStaticMethod() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/output.js
@@ -5,9 +5,9 @@ class A {
 
 }
 
-var _getA = babelHelpers.classPrivateFieldLooseKey("getA");
+var _getA = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getA");
 
-var _getB = babelHelpers.classPrivateFieldLooseKey("getB");
+var _getB = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getB");
 
 class B extends A {
   static get b() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/basic/output.js
@@ -1,6 +1,6 @@
-var _PRIVATE_STATIC_FIELD = babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
+var _PRIVATE_STATIC_FIELD = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
 
-var _privateStaticFieldValue = babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
+var _privateStaticFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
 
 class Cl {
   static getValue() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/destructure-set/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/destructure-set/output.js
@@ -1,6 +1,6 @@
-var _p = babelHelpers.classPrivateFieldLooseKey("p");
+var _p = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("p");
 
-var _q = babelHelpers.classPrivateFieldLooseKey("q");
+var _q = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("q");
 
 class C {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/get-only-setter/output.js
@@ -1,6 +1,6 @@
-var _PRIVATE_STATIC_FIELD = babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
+var _PRIVATE_STATIC_FIELD = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
 
-var _privateStaticFieldValue = babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
+var _privateStaticFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
 
 class Cl {
   static getPrivateStaticFieldValue() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/set-only-getter/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/updates/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   static publicGetPrivateField() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/output.js
@@ -1,6 +1,6 @@
-var _PRIVATE_STATIC_FIELD = babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
+var _PRIVATE_STATIC_FIELD = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
 
-var _privateStaticFieldValue = babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
+var _privateStaticFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
 
 class Cl {
   static getValue() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/output.js
@@ -1,6 +1,6 @@
-var _p = babelHelpers.classPrivateFieldLooseKey("p");
+var _p = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("p");
 
-var _q = babelHelpers.classPrivateFieldLooseKey("q");
+var _q = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("q");
 
 class C {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/output.js
@@ -1,6 +1,6 @@
-var _PRIVATE_STATIC_FIELD = babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
+var _PRIVATE_STATIC_FIELD = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
 
-var _privateStaticFieldValue = babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
+var _privateStaticFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
 
 class Cl {
   static getPrivateStaticFieldValue() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/set-only-getter/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   constructor() {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/output.js
@@ -1,6 +1,6 @@
-var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
+var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 
-var _privateFieldValue = babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 
 class Cl {
   static publicGetPrivateField() {

--- a/packages/babel-plugin-proposal-private-property-in-object/package.json
+++ b/packages/babel-plugin-proposal-private-property-in-object/package.json
@@ -17,7 +17,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "@babel/helper-compilation-targets": "workspace:^7.12.17",
+    "@babel/helper-annotate-as-pure": "workspace:^7.12.13",
     "@babel/helper-create-class-features-plugin": "workspace:^7.13.0",
     "@babel/helper-plugin-utils": "workspace:^7.13.0",
     "@babel/plugin-syntax-private-property-in-object": "workspace:^7.13.0"

--- a/packages/babel-plugin-proposal-private-property-in-object/src/index.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/src/index.js
@@ -5,6 +5,7 @@ import {
   FEATURES,
   injectInitialization as injectConstructorInit,
 } from "@babel/helper-create-class-features-plugin";
+import annotateAsPure from "@babel/helper-annotate-as-pure";
 
 export default declare(({ assertVersion, types: t, template }, { loose }) => {
   assertVersion(7);
@@ -72,7 +73,10 @@ export default declare(({ assertVersion, types: t, template }, { loose }) => {
 
       inject(reference, template.expression.ast`${t.cloneNode(id)}.add(this)`);
 
-      outerClass.insertBefore(template.ast`var ${id} = new WeakSet()`);
+      const newExpr = t.newExpression(t.identifier("WeakSet"), []);
+      annotateAsPure(newExpr);
+
+      outerClass.insertBefore(template.ast`var ${id} = ${newExpr}`);
     }
 
     return t.cloneNode(id);

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/accessor/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/compiled-classes/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/compiled-classes/output.js
@@ -1,6 +1,6 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/field/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/field/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-other-redeclared/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-other-redeclared/output.js
@@ -1,6 +1,6 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 class Foo {
   constructor() {
@@ -15,7 +15,7 @@ class Foo {
   }
 
   test() {
-    var _bar2 = babelHelpers.classPrivateFieldLooseKey("bar");
+    var _bar2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
     class Nested {
       constructor() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-redeclared/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class-redeclared/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Foo {
   constructor() {
@@ -9,7 +9,7 @@ class Foo {
   }
 
   test() {
-    var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+    var _foo2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
     class Nested {
       constructor() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/nested-class/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-accessor/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Foo {
   test(other) {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-field/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-field/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Foo {
   test(other) {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/static-method/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class Foo {
   test(other) {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/accessor/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/field/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/field/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/method/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/native-classes/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/native-classes/output.js
@@ -1,4 +1,4 @@
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/nested-class-other-redeclared/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/nested-class-other-redeclared/output.js
@@ -1,6 +1,6 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
-var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
 let Foo = /*#__PURE__*/function () {
   "use strict";
@@ -20,7 +20,7 @@ let Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _bar2 = babelHelpers.classPrivateFieldLooseKey("bar");
+      var _bar2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
       let Nested = /*#__PURE__*/function () {
         function Nested() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/nested-class-redeclared/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/nested-class-redeclared/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 let Foo = /*#__PURE__*/function () {
   "use strict";
@@ -14,7 +14,7 @@ let Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+      var _foo2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
       let Nested = /*#__PURE__*/function () {
         function Nested() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/nested-class/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/nested-class/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/static-accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/static-accessor/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/static-field/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/static-field/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/static-method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private-loose/static-method/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/accessor/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/field/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/field/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/method/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakSet();
+var _foo = /*#__PURE__*/new WeakSet();
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/native-classes/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/native-classes/output.js
@@ -1,4 +1,4 @@
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/nested-class-other-redeclared/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/nested-class-other-redeclared/output.js
@@ -1,6 +1,6 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
-var _bar = new WeakMap();
+var _bar = /*#__PURE__*/new WeakMap();
 
 let Foo = /*#__PURE__*/function () {
   "use strict";
@@ -22,7 +22,7 @@ let Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _bar2 = new WeakMap();
+      var _bar2 = /*#__PURE__*/new WeakMap();
 
       let Nested = /*#__PURE__*/function () {
         function Nested() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/nested-class-redeclared/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/nested-class-redeclared/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 let Foo = /*#__PURE__*/function () {
   "use strict";
@@ -15,7 +15,7 @@ let Foo = /*#__PURE__*/function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test() {
-      var _foo2 = new WeakMap();
+      var _foo2 = /*#__PURE__*/new WeakMap();
 
       let Nested = /*#__PURE__*/function () {
         function Nested() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/nested-class/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/private/nested-class/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 let Foo = /*#__PURE__*/function () {
   "use strict";

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/accessor/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/accessor/output.js
@@ -1,4 +1,4 @@
-var _FooBrandCheck = new WeakSet();
+var _FooBrandCheck = /*#__PURE__*/new WeakSet();
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/class-expression-in-default-param/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/class-expression-in-default-param/output.js
@@ -1,7 +1,7 @@
 (x = (() => {
   var _fooBrandCheck;
 
-  return _fooBrandCheck = new WeakSet(), class {
+  return _fooBrandCheck = /*#__PURE__*/new WeakSet(), class {
     #foo = void _fooBrandCheck.add(this);
 
     test(other) {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/class-expression-instance/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/class-expression-instance/output.js
@@ -1,7 +1,7 @@
 function fn() {
   var _privBrandCheck;
 
-  return new (_privBrandCheck = new WeakSet(), class {
+  return new (_privBrandCheck = /*#__PURE__*/new WeakSet(), class {
     #priv = void _privBrandCheck.add(this);
 
     method(obj) {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/class-expression-static/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/class-expression-static/output.js
@@ -1,7 +1,7 @@
 function fn() {
   var _privBrandCheck;
 
-  return new (_privBrandCheck = new WeakSet(), class {
+  return new (_privBrandCheck = /*#__PURE__*/new WeakSet(), class {
     static #priv = void _privBrandCheck.add(this);
 
     method(obj) {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/field/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/field/output.js
@@ -1,6 +1,6 @@
 var _temp;
 
-var _fooBrandCheck = new WeakSet();
+var _fooBrandCheck = /*#__PURE__*/new WeakSet();
 
 class Foo {
   #foo = (_temp = 1, _fooBrandCheck.add(this), _temp);

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/half-constructed-instance/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/half-constructed-instance/output.js
@@ -1,10 +1,10 @@
 var _temp, _temp2;
 
-var _FBrandCheck = new WeakSet();
+var _FBrandCheck = /*#__PURE__*/new WeakSet();
 
-var _xBrandCheck = new WeakSet();
+var _xBrandCheck = /*#__PURE__*/new WeakSet();
 
-var _yBrandCheck = new WeakSet();
+var _yBrandCheck = /*#__PURE__*/new WeakSet();
 
 class F {
   m() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/half-constructed-static/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/half-constructed-static/output.js
@@ -1,8 +1,8 @@
 var _temp, _temp2;
 
-var _xBrandCheck = new WeakSet();
+var _xBrandCheck = /*#__PURE__*/new WeakSet();
 
-var _yBrandCheck = new WeakSet();
+var _yBrandCheck = /*#__PURE__*/new WeakSet();
 
 class F {
   static m() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/method/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/method/output.js
@@ -1,4 +1,4 @@
-var _FooBrandCheck = new WeakSet();
+var _FooBrandCheck = /*#__PURE__*/new WeakSet();
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/multiple-checks/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/multiple-checks/output.js
@@ -1,6 +1,6 @@
-var _xBrandCheck = new WeakSet();
+var _xBrandCheck = /*#__PURE__*/new WeakSet();
 
-var _ABrandCheck = new WeakSet();
+var _ABrandCheck = /*#__PURE__*/new WeakSet();
 
 class A {
   #x = (_ABrandCheck.add(this), void _xBrandCheck.add(this));

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/nested-class-other-redeclared/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/nested-class-other-redeclared/output.js
@@ -1,8 +1,8 @@
 var _temp, _temp3;
 
-var _fooBrandCheck = new WeakSet();
+var _fooBrandCheck = /*#__PURE__*/new WeakSet();
 
-var _barBrandCheck2 = new WeakSet();
+var _barBrandCheck2 = /*#__PURE__*/new WeakSet();
 
 class Foo {
   #foo = (_temp = 1, _fooBrandCheck.add(this), _temp);
@@ -11,7 +11,7 @@ class Foo {
   test() {
     var _temp2;
 
-    var _barBrandCheck = new WeakSet();
+    var _barBrandCheck = /*#__PURE__*/new WeakSet();
 
     class Nested {
       #bar = (_temp2 = 2, _barBrandCheck.add(this), _temp2);

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/nested-class-redeclared/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/nested-class-redeclared/output.js
@@ -1,6 +1,6 @@
 var _temp2;
 
-var _fooBrandCheck2 = new WeakSet();
+var _fooBrandCheck2 = /*#__PURE__*/new WeakSet();
 
 class Foo {
   #foo = (_temp2 = 1, _fooBrandCheck2.add(this), _temp2);
@@ -8,7 +8,7 @@ class Foo {
   test() {
     var _temp;
 
-    var _fooBrandCheck = new WeakSet();
+    var _fooBrandCheck = /*#__PURE__*/new WeakSet();
 
     class Nested {
       #foo = (_temp = 2, _fooBrandCheck.add(this), _temp);

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/nested-class/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/nested-class/output.js
@@ -1,6 +1,6 @@
 var _temp;
 
-var _fooBrandCheck = new WeakSet();
+var _fooBrandCheck = /*#__PURE__*/new WeakSet();
 
 class Foo {
   #foo = (_temp = 1, _fooBrandCheck.add(this), _temp);

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/static-field/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/static-field/output.js
@@ -1,6 +1,6 @@
 var _temp;
 
-var _fooBrandCheck = new WeakSet();
+var _fooBrandCheck = /*#__PURE__*/new WeakSet();
 
 class Foo {
   static #foo = (_temp = 1, _fooBrandCheck.add(this), _temp);

--- a/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/static-shadowed-binding/output.js
+++ b/packages/babel-plugin-proposal-private-property-in-object/test/fixtures/to-native-fields/static-shadowed-binding/output.js
@@ -1,4 +1,4 @@
-var _fooBrandCheck = new WeakSet();
+var _fooBrandCheck = /*#__PURE__*/new WeakSet();
 
 class A {
   static #foo = void _fooBrandCheck.add(this);

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/methods-loose-preset-not-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/methods-loose-preset-not-loose/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class A {
   constructor() {

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/preset-loose-no-plugins/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/preset-loose-no-plugins/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class A {
   constructor() {

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/preset-not-loose-no-plugins/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/preset-not-loose-no-plugins/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakSet();
+var _foo = /*#__PURE__*/new WeakSet();
 
 class A {
   constructor() {

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-loose-preset-not-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-loose-preset-not-loose/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class A {
   constructor() {

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-not-loose-preset-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-not-loose-preset-loose/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakSet();
+var _foo = /*#__PURE__*/new WeakSet();
 
 class A {
   constructor() {

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-loose-preset-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-loose-preset-loose/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class A {
   constructor() {

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-loose-preset-not-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-loose-preset-not-loose/output.js
@@ -1,4 +1,4 @@
-var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
 
 class A {
   constructor() {

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-not-loose-preset-loose/output.js
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-not-loose-preset-loose/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakSet();
+var _foo = /*#__PURE__*/new WeakSet();
 
 class A {
   constructor() {

--- a/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-chrome-90/output.js
+++ b/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-chrome-90/output.js
@@ -1,4 +1,4 @@
-var _fooBrandCheck = new WeakSet();
+var _fooBrandCheck = /*#__PURE__*/new WeakSet();
 
 class A {
   #foo = void _fooBrandCheck.add(this);

--- a/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-firefox-70/output.js
+++ b/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-firefox-70/output.js
@@ -1,4 +1,4 @@
-var _foo = new WeakMap();
+var _foo = /*#__PURE__*/new WeakMap();
 
 class A {
   constructor() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -393,7 +393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@workspace:^7.12.17, @babel/helper-compilation-targets@workspace:^7.13.13, @babel/helper-compilation-targets@workspace:^7.13.16, @babel/helper-compilation-targets@workspace:^7.13.8, @babel/helper-compilation-targets@workspace:packages/babel-helper-compilation-targets":
+"@babel/helper-compilation-targets@workspace:^7.13.13, @babel/helper-compilation-targets@workspace:^7.13.16, @babel/helper-compilation-targets@workspace:^7.13.8, @babel/helper-compilation-targets@workspace:packages/babel-helper-compilation-targets":
   version: 0.0.0-use.local
   resolution: "@babel/helper-compilation-targets@workspace:packages/babel-helper-compilation-targets"
   dependencies:
@@ -1440,7 +1440,7 @@ __metadata:
   resolution: "@babel/plugin-proposal-private-property-in-object@workspace:packages/babel-plugin-proposal-private-property-in-object"
   dependencies:
     "@babel/core": "workspace:*"
-    "@babel/helper-compilation-targets": "workspace:^7.12.17"
+    "@babel/helper-annotate-as-pure": "workspace:^7.12.13"
     "@babel/helper-create-class-features-plugin": "workspace:^7.13.0"
     "@babel/helper-plugin-test-runner": "workspace:*"
     "@babel/helper-plugin-utils": "workspace:^7.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,6 +427,7 @@ __metadata:
   resolution: "@babel/helper-create-class-features-plugin@workspace:packages/babel-helper-create-class-features-plugin"
   dependencies:
     "@babel/core": "workspace:*"
+    "@babel/helper-annotate-as-pure": "workspace:^7.12.13"
     "@babel/helper-function-name": "workspace:^7.12.13"
     "@babel/helper-member-expression-to-functions": "workspace:^7.13.0"
     "@babel/helper-optimise-call-expression": "workspace:^7.12.13"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13193
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The `/*#__PURE__*/` annotation lets terser strip away those `WeakMap`s when the class is unused. The `classPrivateFieldLooseKey` isn't technically pure (since it uses a global counter), but it can still be safely removed by terser.