### PR TITLE
Prevent ForOfStatement from printing the forbidden sequence "for ( async of"

### DIFF
--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -276,6 +276,15 @@ export function LogicalExpression(node: any, parent: any): boolean {
   }
 }
 
+export function Identifier(node: t.Identifier, parent: t.Node): boolean {
+  // ECMAScript specifically forbids a for-of loop from starting with the
+  // token sequence "for ( async of", because it would be ambiguous with
+  // "for (async of => {};;)", so we need to add extra parentheses.
+  return (
+    node.name === "async" && t.isForOfStatement(parent) && node === parent.left
+  );
+}
+
 // Walk up the print stack to determine if our node can come first
 // in statement.
 function isFirstInStatement(

--- a/packages/babel-generator/test/fixtures/edgecase/for-async-of/input.js
+++ b/packages/babel-generator/test/fixtures/edgecase/for-async-of/input.js
@@ -1,0 +1,7 @@
+for ((async) of []);
+
+for ((async) of async) async;
+
+for (\u0061sync of []);
+
+for (async in []);

--- a/packages/babel-generator/test/fixtures/edgecase/for-async-of/output.js
+++ b/packages/babel-generator/test/fixtures/edgecase/for-async-of/output.js
@@ -1,0 +1,7 @@
+for ((async) of []);
+
+for ((async) of async) async;
+
+for ((async) of []);
+
+for (async in []);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13207 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

If we detect that a `ForOfStatement`'s left-hand-side is an identifier named `async`, print extra parentheses around the identifier to avoid this edge-case in the ECMAScript grammar.
