### PR TITLE
Improve `isIdentifierName` performance

### DIFF
--- a/packages/babel-helper-validator-identifier/.npmignore
+++ b/packages/babel-helper-validator-identifier/.npmignore
@@ -1,3 +1,4 @@
+benchmark
 src
 test
 *.log

--- a/packages/babel-helper-validator-identifier/benchmark/identifier.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/identifier.bench.mjs
@@ -1,0 +1,3 @@
+import "./isIdentifierChar.bench.mjs";
+import "./isIdentifierStart.bench.mjs";
+import "./isIdentifierName.bench.mjs";

--- a/packages/babel-helper-validator-identifier/benchmark/isIdentifierChar.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/isIdentifierChar.bench.mjs
@@ -5,40 +5,27 @@ import { report } from "./util.mjs";
 
 const suite = new Benchmark.Suite();
 
-suite.add("baseline#isIdentifierChar on 4 ASCII characters", () => {
-  baseline.isIdentifierChar(0x61);
-  baseline.isIdentifierChar(0x7b);
-  baseline.isIdentifierChar(0x5f);
-  baseline.isIdentifierChar(0x24);
-});
+function benchCases(implementation, name) {
+  suite.add(name + "#isIdentifierChar on 4 ASCII characters", () => {
+    implementation.isIdentifierChar(0x61);
+    implementation.isIdentifierChar(0x7b);
+    implementation.isIdentifierChar(0x5f);
+    implementation.isIdentifierChar(0x24);
+  });
 
-suite.add("baseline#isIdentifierChar on 4 non-ASCII characters", () => {
-  baseline.isIdentifierChar(0x80);
-  baseline.isIdentifierChar(0x4e00);
-  baseline.isIdentifierChar(0xffff);
-  baseline.isIdentifierChar(0x10000);
-});
+  suite.add(name + "#isIdentifierChar on 4 non-ASCII characters", () => {
+    implementation.isIdentifierChar(0x80);
+    implementation.isIdentifierChar(0x4e00);
+    implementation.isIdentifierChar(0xffff);
+    implementation.isIdentifierChar(0x10000);
+  });
 
-suite.add("baseline#isIdentifierChar on TIP character", () => {
-  baseline.isIdentifierChar(0x30000);
-});
+  suite.add(name + "#isIdentifierChar on TIP character", () => {
+    implementation.isIdentifierChar(0x30000);
+  });
+}
 
-suite.add("current#isIdentifierChar on 4 ASCII characters", () => {
-  current.isIdentifierChar(0x61);
-  current.isIdentifierChar(0x7b);
-  current.isIdentifierChar(0x5f);
-  current.isIdentifierChar(0x24);
-});
-
-suite.add("current#isIdentifierChar on 4 non-ASCII characters", () => {
-  current.isIdentifierChar(0x80);
-  current.isIdentifierChar(0x4e00);
-  current.isIdentifierChar(0xffff);
-  current.isIdentifierChar(0x10000);
-});
-
-suite.add("current#isIdentifierChar on TIP character", () => {
-  current.isIdentifierChar(0x30000);
-});
+benchCases(baseline, "baseline");
+benchCases(current, "current");
 
 suite.on("cycle", report).run();

--- a/packages/babel-helper-validator-identifier/benchmark/isIdentifierChar.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/isIdentifierChar.bench.mjs
@@ -1,0 +1,44 @@
+import Benchmark from "benchmark";
+import baseline from "@babel/helper-validator-identifier-baseline";
+import current from "../lib/index.js";
+import { report } from "./util.mjs";
+
+const suite = new Benchmark.Suite();
+
+suite.add("baseline#isIdentifierChar on 4 ASCII characters", () => {
+  baseline.isIdentifierChar(0x61);
+  baseline.isIdentifierChar(0x7b);
+  baseline.isIdentifierChar(0x5f);
+  baseline.isIdentifierChar(0x24);
+});
+
+suite.add("baseline#isIdentifierChar on 4 non-ASCII characters", () => {
+  baseline.isIdentifierChar(0x80);
+  baseline.isIdentifierChar(0x4e00);
+  baseline.isIdentifierChar(0xffff);
+  baseline.isIdentifierChar(0x10000);
+});
+
+suite.add("baseline#isIdentifierChar on TIP character", () => {
+  baseline.isIdentifierChar(0x30000);
+});
+
+suite.add("current#isIdentifierChar on 4 ASCII characters", () => {
+  current.isIdentifierChar(0x61);
+  current.isIdentifierChar(0x7b);
+  current.isIdentifierChar(0x5f);
+  current.isIdentifierChar(0x24);
+});
+
+suite.add("current#isIdentifierChar on 4 non-ASCII characters", () => {
+  current.isIdentifierChar(0x80);
+  current.isIdentifierChar(0x4e00);
+  current.isIdentifierChar(0xffff);
+  current.isIdentifierChar(0x10000);
+});
+
+suite.add("current#isIdentifierChar on TIP character", () => {
+  current.isIdentifierChar(0x30000);
+});
+
+suite.on("cycle", report).run();

--- a/packages/babel-helper-validator-identifier/benchmark/isIdentifierName.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/isIdentifierName.bench.mjs
@@ -5,34 +5,26 @@ import { report } from "./util.mjs";
 
 const suite = new Benchmark.Suite();
 
-suite.add("baseline#isIdentifierName on 2 short ASCII words", () => {
-  baseline.isIdentifierName("aforementioned");
-  baseline.isIdentifierName("zap cannon");
-});
+function benchCases(implementation, name) {
+  suite.add(name + "#isIdentifierName on 2 short ASCII words", () => {
+    implementation.isIdentifierName("aforementioned");
+    implementation.isIdentifierName("zap cannon");
+  });
 
-suite.add("baseline#isIdentifierName on 1 long ASCII words", () => {
-  baseline.isIdentifierName("Pneumonoultramicroscopicsilicovolcanoconiosis");
-});
+  suite.add(name + "isIdentifierName on 1 long ASCII words", () => {
+    implementation.isIdentifierName(
+      "Pneumonoultramicroscopicsilicovolcanoconiosis"
+    );
+  });
 
-suite.add("baseline#isIdentifierName on 3 non-ASCII words", () => {
-  baseline.isIdentifierName("مذكور أعلاه");
-  baseline.isIdentifierName("cañón de zap");
-  baseline.isIdentifierName("𠡦𠧋𡆠囝〇𠁈𢘑𤯔𠀑埊");
-});
+  suite.add(name + "isIdentifierName on 3 non-ASCII words", () => {
+    implementation.isIdentifierName("مذكور أعلاه");
+    implementation.isIdentifierName("cañón de zap");
+    implementation.isIdentifierName("𠡦𠧋𡆠囝〇𠁈𢘑𤯔𠀑埊");
+  });
+}
 
-suite.add("current#isIdentifierName on 2 short ASCII words", () => {
-  current.isIdentifierName("aforementioned");
-  current.isIdentifierName("zap cannon");
-});
-
-suite.add("current#isIdentifierName on 1 long ASCII words", () => {
-  current.isIdentifierName("Pneumonoultramicroscopicsilicovolcanoconiosis");
-});
-
-suite.add("current#isIdentifierName on 3 non-ASCII words", () => {
-  current.isIdentifierName("مذكور أعلاه");
-  current.isIdentifierName("cañón de zap");
-  current.isIdentifierName("𠡦𠧋𡆠囝〇𠁈𢘑𤯔𠀑埊");
-});
+benchCases(baseline, "baseline");
+benchCases(current, "current");
 
 suite.on("cycle", report).run();

--- a/packages/babel-helper-validator-identifier/benchmark/isIdentifierName.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/isIdentifierName.bench.mjs
@@ -11,13 +11,13 @@ function benchCases(implementation, name) {
     implementation.isIdentifierName("zap cannon");
   });
 
-  suite.add(name + "isIdentifierName on 1 long ASCII words", () => {
+  suite.add(name + "#isIdentifierName on 1 long ASCII words", () => {
     implementation.isIdentifierName(
       "Pneumonoultramicroscopicsilicovolcanoconiosis"
     );
   });
 
-  suite.add(name + "isIdentifierName on 3 non-ASCII words", () => {
+  suite.add(name + "#isIdentifierName on 3 non-ASCII words", () => {
     implementation.isIdentifierName("مذكور أعلاه");
     implementation.isIdentifierName("cañón de zap");
     implementation.isIdentifierName("𠡦𠧋𡆠囝〇𠁈𢘑𤯔𠀑埊");

--- a/packages/babel-helper-validator-identifier/benchmark/isIdentifierName.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/isIdentifierName.bench.mjs
@@ -1,0 +1,38 @@
+import Benchmark from "benchmark";
+import baseline from "@babel/helper-validator-identifier-baseline";
+import current from "../lib/index.js";
+import { report } from "./util.mjs";
+
+const suite = new Benchmark.Suite();
+
+suite.add("baseline#isIdentifierName on 2 short ASCII words", () => {
+  baseline.isIdentifierName("aforementioned");
+  baseline.isIdentifierName("zap cannon");
+});
+
+suite.add("baseline#isIdentifierName on 1 long ASCII words", () => {
+  baseline.isIdentifierName("Pneumonoultramicroscopicsilicovolcanoconiosis");
+});
+
+suite.add("baseline#isIdentifierName on 3 non-ASCII words", () => {
+  baseline.isIdentifierName("مذكور أعلاه");
+  baseline.isIdentifierName("cañón de zap");
+  baseline.isIdentifierName("𠡦𠧋𡆠囝〇𠁈𢘑𤯔𠀑埊");
+});
+
+suite.add("current#isIdentifierName on 2 short ASCII words", () => {
+  current.isIdentifierName("aforementioned");
+  current.isIdentifierName("zap cannon");
+});
+
+suite.add("current#isIdentifierName on 1 long ASCII words", () => {
+  current.isIdentifierName("Pneumonoultramicroscopicsilicovolcanoconiosis");
+});
+
+suite.add("current#isIdentifierName on 3 non-ASCII words", () => {
+  current.isIdentifierName("مذكور أعلاه");
+  current.isIdentifierName("cañón de zap");
+  current.isIdentifierName("𠡦𠧋𡆠囝〇𠁈𢘑𤯔𠀑埊");
+});
+
+suite.on("cycle", report).run();

--- a/packages/babel-helper-validator-identifier/benchmark/isIdentifierStart.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/isIdentifierStart.bench.mjs
@@ -5,40 +5,27 @@ import { report } from "./util.mjs";
 
 const suite = new Benchmark.Suite();
 
-suite.add("baseline#isIdentifierStart on 4 ASCII characters", () => {
-  baseline.isIdentifierStart(0x61);
-  baseline.isIdentifierStart(0x7b);
-  baseline.isIdentifierStart(0x5f);
-  baseline.isIdentifierStart(0x24);
-});
+function benchCases(implementation, name) {
+  suite.add(name + "#isIdentifierStart on 4 ASCII characters", () => {
+    implementation.isIdentifierStart(0x61);
+    implementation.isIdentifierStart(0x7b);
+    implementation.isIdentifierStart(0x5f);
+    implementation.isIdentifierStart(0x24);
+  });
 
-suite.add("baseline#isIdentifierStart on 4 non-ASCII characters", () => {
-  baseline.isIdentifierStart(0x80);
-  baseline.isIdentifierStart(0x4e00);
-  baseline.isIdentifierStart(0xffff);
-  baseline.isIdentifierStart(0x10000);
-});
+  suite.add(name + "#isIdentifierStart on 4 non-ASCII characters", () => {
+    implementation.isIdentifierStart(0x80);
+    implementation.isIdentifierStart(0x4e00);
+    implementation.isIdentifierStart(0xffff);
+    implementation.isIdentifierStart(0x10000);
+  });
 
-suite.add("baseline#isIdentifierStart on TIP character", () => {
-  baseline.isIdentifierStart(0x30000);
-});
+  suite.add(name + "#isIdentifierStart on TIP character", () => {
+    implementation.isIdentifierStart(0x30000);
+  });
+}
 
-suite.add("current#isIdentifierStart on 4 ASCII characters", () => {
-  current.isIdentifierStart(0x61);
-  current.isIdentifierStart(0x7b);
-  current.isIdentifierStart(0x5f);
-  current.isIdentifierStart(0x24);
-});
-
-suite.add("current#isIdentifierStart on 4 non-ASCII characters", () => {
-  current.isIdentifierStart(0x80);
-  current.isIdentifierStart(0x4e00);
-  current.isIdentifierStart(0xffff);
-  current.isIdentifierStart(0x10000);
-});
-
-suite.add("current#isIdentifierStart on TIP character", () => {
-  current.isIdentifierStart(0x30000);
-});
+benchCases(baseline, "baseline");
+benchCases(current, "current");
 
 suite.on("cycle", report).run();

--- a/packages/babel-helper-validator-identifier/benchmark/isIdentifierStart.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/isIdentifierStart.bench.mjs
@@ -1,0 +1,44 @@
+import Benchmark from "benchmark";
+import baseline from "@babel/helper-validator-identifier-baseline";
+import current from "../lib/index.js";
+import { report } from "./util.mjs";
+
+const suite = new Benchmark.Suite();
+
+suite.add("baseline#isIdentifierStart on 4 ASCII characters", () => {
+  baseline.isIdentifierStart(0x61);
+  baseline.isIdentifierStart(0x7b);
+  baseline.isIdentifierStart(0x5f);
+  baseline.isIdentifierStart(0x24);
+});
+
+suite.add("baseline#isIdentifierStart on 4 non-ASCII characters", () => {
+  baseline.isIdentifierStart(0x80);
+  baseline.isIdentifierStart(0x4e00);
+  baseline.isIdentifierStart(0xffff);
+  baseline.isIdentifierStart(0x10000);
+});
+
+suite.add("baseline#isIdentifierStart on TIP character", () => {
+  baseline.isIdentifierStart(0x30000);
+});
+
+suite.add("current#isIdentifierStart on 4 ASCII characters", () => {
+  current.isIdentifierStart(0x61);
+  current.isIdentifierStart(0x7b);
+  current.isIdentifierStart(0x5f);
+  current.isIdentifierStart(0x24);
+});
+
+suite.add("current#isIdentifierStart on 4 non-ASCII characters", () => {
+  current.isIdentifierStart(0x80);
+  current.isIdentifierStart(0x4e00);
+  current.isIdentifierStart(0xffff);
+  current.isIdentifierStart(0x10000);
+});
+
+suite.add("current#isIdentifierStart on TIP character", () => {
+  current.isIdentifierStart(0x30000);
+});
+
+suite.on("cycle", report).run();

--- a/packages/babel-helper-validator-identifier/benchmark/isKeyword.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/isKeyword.bench.mjs
@@ -1,0 +1,36 @@
+import Benchmark from "benchmark";
+import baseline from "@babel/helper-validator-identifier-baseline";
+import current from "../lib/index.js";
+import { report } from "./util.mjs";
+
+const suite = new Benchmark.Suite();
+
+suite.add("baseline#isKeyword on 4 keywords", () => {
+  baseline.isKeyword("debugger");
+  baseline.isKeyword("throw");
+  baseline.isKeyword("extends");
+  baseline.isKeyword("instanceof");
+});
+
+suite.add("baseline#isKeyword on 4 non-keywords", () => {
+  baseline.isKeyword("debuggerr");
+  baseline.isKeyword("threw");
+  baseline.isKeyword("extend");
+  baseline.isKeyword("instanceOf");
+});
+
+suite.add("current#isKeyword on 4 keywords", () => {
+  current.isKeyword("debugger");
+  current.isKeyword("throw");
+  current.isKeyword("extends");
+  current.isKeyword("instanceof");
+});
+
+suite.add("current#isKeyword on 4 non-keywords", () => {
+  current.isKeyword("debuggerr");
+  current.isKeyword("threw");
+  current.isKeyword("extend");
+  current.isKeyword("instanceOf");
+});
+
+suite.on("cycle", report).run();

--- a/packages/babel-helper-validator-identifier/benchmark/isKeyword.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/isKeyword.bench.mjs
@@ -5,32 +5,23 @@ import { report } from "./util.mjs";
 
 const suite = new Benchmark.Suite();
 
-suite.add("baseline#isKeyword on 4 keywords", () => {
-  baseline.isKeyword("debugger");
-  baseline.isKeyword("throw");
-  baseline.isKeyword("extends");
-  baseline.isKeyword("instanceof");
-});
+function benchCases(implementation, name) {
+  suite.add(name + "#isKeyword on 4 keywords", () => {
+    implementation.isKeyword("debugger");
+    implementation.isKeyword("throw");
+    implementation.isKeyword("extends");
+    implementation.isKeyword("instanceof");
+  });
 
-suite.add("baseline#isKeyword on 4 non-keywords", () => {
-  baseline.isKeyword("debuggerr");
-  baseline.isKeyword("threw");
-  baseline.isKeyword("extend");
-  baseline.isKeyword("instanceOf");
-});
+  suite.add(name + "#isKeyword on 4 non-keywords", () => {
+    implementation.isKeyword("debuggerr");
+    implementation.isKeyword("threw");
+    implementation.isKeyword("extend");
+    implementation.isKeyword("instanceOf");
+  });
+}
 
-suite.add("current#isKeyword on 4 keywords", () => {
-  current.isKeyword("debugger");
-  current.isKeyword("throw");
-  current.isKeyword("extends");
-  current.isKeyword("instanceof");
-});
-
-suite.add("current#isKeyword on 4 non-keywords", () => {
-  current.isKeyword("debuggerr");
-  current.isKeyword("threw");
-  current.isKeyword("extend");
-  current.isKeyword("instanceOf");
-});
+benchCases(baseline, "baseline");
+benchCases(current, "current");
 
 suite.on("cycle", report).run();

--- a/packages/babel-helper-validator-identifier/benchmark/isStrictBindReservedWord.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/isStrictBindReservedWord.bench.mjs
@@ -5,32 +5,23 @@ import { report } from "./util.mjs";
 
 const suite = new Benchmark.Suite();
 
-suite.add("baseline#isStrictBindReservedWord on 4 keywords", () => {
-  baseline.isStrictBindReservedWord("arguments");
-  baseline.isStrictBindReservedWord("eval");
-  baseline.isStrictBindReservedWord("implements");
-  baseline.isStrictBindReservedWord("instanceof");
-});
+function benchCases(implementation, name) {
+  suite.add(name + "#isStrictBindReservedWord on 4 keywords", () => {
+    implementation.isStrictBindReservedWord("arguments");
+    implementation.isStrictBindReservedWord("eval");
+    implementation.isStrictBindReservedWord("implements");
+    implementation.isStrictBindReservedWord("instanceof");
+  });
 
-suite.add("baseline#isStrictBindReservedWord on 4 non-keywords", () => {
-  baseline.isStrictBindReservedWord("argumentss");
-  baseline.isStrictBindReservedWord("evals");
-  baseline.isStrictBindReservedWord("implement");
-  baseline.isStrictBindReservedWord("instanceOf");
-});
+  suite.add(name + "#isStrictBindReservedWord on 4 non-keywords", () => {
+    implementation.isStrictBindReservedWord("argumentss");
+    implementation.isStrictBindReservedWord("evals");
+    implementation.isStrictBindReservedWord("implement");
+    implementation.isStrictBindReservedWord("instanceOf");
+  });
+}
 
-suite.add("current#isStrictBindReservedWord on 4 keywords", () => {
-  current.isStrictBindReservedWord("arguments");
-  current.isStrictBindReservedWord("eval");
-  current.isStrictBindReservedWord("implements");
-  current.isStrictBindReservedWord("instanceof");
-});
-
-suite.add("current#isStrictBindReservedWord on 4 non-keywords", () => {
-  current.isStrictBindReservedWord("argumentss");
-  current.isStrictBindReservedWord("evals");
-  current.isStrictBindReservedWord("implement");
-  current.isStrictBindReservedWord("instanceOf");
-});
+benchCases(baseline, "baseline");
+benchCases(current, "current");
 
 suite.on("cycle", report).run({ async: false });

--- a/packages/babel-helper-validator-identifier/benchmark/isStrictBindReservedWord.bench.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/isStrictBindReservedWord.bench.mjs
@@ -1,0 +1,36 @@
+import Benchmark from "benchmark";
+import baseline from "@babel/helper-validator-identifier-baseline";
+import current from "../lib/index.js";
+import { report } from "./util.mjs";
+
+const suite = new Benchmark.Suite();
+
+suite.add("baseline#isStrictBindReservedWord on 4 keywords", () => {
+  baseline.isStrictBindReservedWord("arguments");
+  baseline.isStrictBindReservedWord("eval");
+  baseline.isStrictBindReservedWord("implements");
+  baseline.isStrictBindReservedWord("instanceof");
+});
+
+suite.add("baseline#isStrictBindReservedWord on 4 non-keywords", () => {
+  baseline.isStrictBindReservedWord("argumentss");
+  baseline.isStrictBindReservedWord("evals");
+  baseline.isStrictBindReservedWord("implement");
+  baseline.isStrictBindReservedWord("instanceOf");
+});
+
+suite.add("current#isStrictBindReservedWord on 4 keywords", () => {
+  current.isStrictBindReservedWord("arguments");
+  current.isStrictBindReservedWord("eval");
+  current.isStrictBindReservedWord("implements");
+  current.isStrictBindReservedWord("instanceof");
+});
+
+suite.add("current#isStrictBindReservedWord on 4 non-keywords", () => {
+  current.isStrictBindReservedWord("argumentss");
+  current.isStrictBindReservedWord("evals");
+  current.isStrictBindReservedWord("implement");
+  current.isStrictBindReservedWord("instanceOf");
+});
+
+suite.on("cycle", report).run({ async: false });

--- a/packages/babel-helper-validator-identifier/benchmark/util.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/util.mjs
@@ -1,0 +1,13 @@
+export function report(event) {
+  const bench = event.target;
+  const factor = bench.hz < 100 ? 100 : 1;
+  const timeMs = bench.stats.mean * 1000;
+  const time =
+    timeMs < 10
+      ? `${Math.round(timeMs * 1000) / 1000}ms`
+      : `${Math.round(timeMs)}ms`;
+  const msg = `${bench.name}: ${
+    Math.round(bench.hz * factor) / factor
+  } ops/sec ±${Math.round(bench.stats.rme * 100) / 100}% (${time})`;
+  console.log(msg);
+}

--- a/packages/babel-helper-validator-identifier/package.json
+++ b/packages/babel-helper-validator-identifier/package.json
@@ -14,7 +14,9 @@
   "main": "./lib/index.js",
   "exports": "./lib/index.js",
   "devDependencies": {
-    "charcodes": "^0.2.0",
-    "unicode-13.0.0": "^0.8.0"
+    "@babel/helper-validator-identifier-baseline": "npm:@babel/helper-validator-identifier@7.10.4",
+    "@unicode/unicode-13.0.0": "^1.0.6",
+    "benchmark": "^2.1.4",
+    "charcodes": "^0.2.0"
   }
 }

--- a/packages/babel-helper-validator-identifier/scripts/generate-identifier-regex.js
+++ b/packages/babel-helper-validator-identifier/scripts/generate-identifier-regex.js
@@ -4,14 +4,14 @@
 // https://tc39.github.io/ecma262/#sec-conformance
 const version = "13.0.0";
 
-const start = require("unicode-" +
+const start = require("@unicode/unicode-" +
   version +
   "/Binary_Property/ID_Start/code-points.js").filter(function (ch) {
   return ch > 0x7f;
 });
 let last = -1;
 const cont = [0x200c, 0x200d].concat(
-  require("unicode-" +
+  require("@unicode/unicode-" +
     version +
     "/Binary_Property/ID_Continue/code-points.js").filter(function (ch) {
     return ch > 0x7f && search(start, ch, last + 1) == -1;

--- a/packages/babel-helper-validator-identifier/src/identifier.ts
+++ b/packages/babel-helper-validator-identifier/src/identifier.ts
@@ -84,16 +84,22 @@ export function isIdentifierChar(code: number): boolean {
 // Test whether a given string is a valid identifier name
 
 export function isIdentifierName(name: string): boolean {
+  let isFirst = true;
   for (let i = 0; i < name.length; ) {
-    const cp = name.codePointAt(i);
-    if (i === 0) {
+    let cp = name.charCodeAt(i);
+    if ((cp & 0xfc00) === 0xd800 && i + 1 < name.length) {
+      const trail = name.charCodeAt(++i);
+      cp = 0x10000 + ((cp & 0x3ff) << 10) + (trail & 0x3ff);
+    }
+    ++i;
+    if (isFirst) {
+      isFirst = false;
       if (!isIdentifierStart(cp)) {
         return false;
       }
     } else if (!isIdentifierChar(cp)) {
       return false;
     }
-    i += cp > 0xffff ? 2 : 1;
   }
-  return !!name;
+  return !isFirst;
 }

--- a/packages/babel-helper-validator-identifier/src/identifier.ts
+++ b/packages/babel-helper-validator-identifier/src/identifier.ts
@@ -84,17 +84,16 @@ export function isIdentifierChar(code: number): boolean {
 // Test whether a given string is a valid identifier name
 
 export function isIdentifierName(name: string): boolean {
-  let isFirst = true;
-  for (const char of Array.from(name)) {
-    const cp = char.codePointAt(0);
-    if (isFirst) {
+  for (let i = 0; i < name.length; ) {
+    const cp = name.codePointAt(i);
+    if (i === 0) {
       if (!isIdentifierStart(cp)) {
         return false;
       }
-      isFirst = false;
     } else if (!isIdentifierChar(cp)) {
       return false;
     }
+    i += cp > 0xffff ? 2 : 1;
   }
-  return !isFirst;
+  return !!name;
 }

--- a/packages/babel-helper-validator-identifier/src/identifier.ts
+++ b/packages/babel-helper-validator-identifier/src/identifier.ts
@@ -86,10 +86,16 @@ export function isIdentifierChar(code: number): boolean {
 export function isIdentifierName(name: string): boolean {
   let isFirst = true;
   for (let i = 0; i < name.length; i++) {
+    // The implementation is based on
+    // https://source.chromium.org/chromium/chromium/src/+/master:v8/src/builtins/builtins-string-gen.cc;l=1455;drc=221e331b49dfefadbc6fa40b0c68e6f97606d0b3;bpv=0;bpt=1
+    // We reimplement `codePointAt` because `codePointAt` is a V8 builtin which is not inlined by TurboFan (as of M91)
+    // since `name` is mostly ASCII, an inlined `charCodeAt` wins here
     let cp = name.charCodeAt(i);
     if ((cp & 0xfc00) === 0xd800 && i + 1 < name.length) {
       const trail = name.charCodeAt(++i);
-      cp = 0x10000 + ((cp & 0x3ff) << 10) + (trail & 0x3ff);
+      if ((trail & 0xfc00) === 0xdc00) {
+        cp = 0x10000 + ((cp & 0x3ff) << 10) + (trail & 0x3ff);
+      }
     }
     if (isFirst) {
       isFirst = false;

--- a/packages/babel-helper-validator-identifier/src/identifier.ts
+++ b/packages/babel-helper-validator-identifier/src/identifier.ts
@@ -85,13 +85,12 @@ export function isIdentifierChar(code: number): boolean {
 
 export function isIdentifierName(name: string): boolean {
   let isFirst = true;
-  for (let i = 0; i < name.length; ) {
+  for (let i = 0; i < name.length; i++) {
     let cp = name.charCodeAt(i);
     if ((cp & 0xfc00) === 0xd800 && i + 1 < name.length) {
       const trail = name.charCodeAt(++i);
       cp = 0x10000 + ((cp & 0x3ff) << 10) + (trail & 0x3ff);
     }
-    ++i;
     if (isFirst) {
       isFirst = false;
       if (!isIdentifierStart(cp)) {

--- a/packages/babel-helper-validator-identifier/test/identifier.spec.js
+++ b/packages/babel-helper-validator-identifier/test/identifier.spec.js
@@ -4,7 +4,17 @@ describe("isIdentifierName", function () {
   it("returns false if provided string is empty", function () {
     expect(isIdentifierName("")).toBe(false);
   });
-  it.each(["hello", "$", "ゆゆ式", "$20", "hello20", "_", "if"])(
+  it.each([
+    "hello",
+    "$",
+    "ゆゆ式",
+    "$20",
+    "hello20",
+    "_",
+    "if",
+    "_\u200c",
+    "_\u200d",
+  ])(
     "returns true if provided string %p is an IdentifierName",
     function (word) {
       expect(isIdentifierName(word)).toBe(true);
@@ -18,5 +28,14 @@ describe("isIdentifierName", function () {
   );
   it("supports astral symbols", function () {
     expect(isIdentifierName("x\uDB40\uDDD5")).toBe(true);
+  });
+  it("supports Unicode 13", () => {
+    expect(isIdentifierName("\u{30000}")).toBe(true);
+  });
+  it("supports Unicode 12", () => {
+    expect(isIdentifierName("\u{10fe0}")).toBe(true);
+  });
+  it("supports Unicode 11", () => {
+    expect(isIdentifierName("\u{10f00}")).toBe(true);
   });
 });

--- a/packages/babel-helper-validator-identifier/test/identifier.spec.js
+++ b/packages/babel-helper-validator-identifier/test/identifier.spec.js
@@ -20,7 +20,7 @@ describe("isIdentifierName", function () {
       expect(isIdentifierName(word)).toBe(true);
     },
   );
-  it.each(["+hello", "0$", "-ゆゆ式", "#_", "_#"])(
+  it.each(["+hello", "0$", "-ゆゆ式", "#_", "_#", "\ud800\ud800"])(
     "returns false if provided string %p is not an IdentifierName",
     function (word) {
       expect(isIdentifierName(word)).toBe(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -805,6 +805,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@babel/helper-validator-identifier-baseline@npm:@babel/helper-validator-identifier@7.10.4":
+  version: 7.10.4
+  resolution: "@babel/helper-validator-identifier@npm:7.10.4"
+  checksum: 25098ef842e3ffecdd9a7216f6173da7ad7be1b0b3e454a9f6965055154b9ad7a4acd2f218ba3d2efc0821bdab97837b3cb815844af7d72f66f89d446a54efc6
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.12.11":
   version: 7.12.11
   resolution: "@babel/helper-validator-identifier@npm:7.12.11"
@@ -816,8 +823,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-validator-identifier@workspace:packages/babel-helper-validator-identifier"
   dependencies:
+    "@babel/helper-validator-identifier-baseline": "npm:@babel/helper-validator-identifier@7.10.4"
+    "@unicode/unicode-13.0.0": ^1.0.6
+    benchmark: ^2.1.4
     charcodes: ^0.2.0
-    unicode-13.0.0: ^0.8.0
   languageName: unknown
   linkType: soft
 
@@ -4325,6 +4334,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unicode/unicode-13.0.0@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "@unicode/unicode-13.0.0@npm:1.0.6"
+  checksum: 8971f6f8d302b4cb7e95db6225f4482301b21981c95062209851f1ebc93c392bbf5861029a8f761a857193fb10453cd4043ae376d15a52aed46fd1ada56825d9
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/ast@npm:1.11.0":
   version: 1.11.0
   resolution: "@webassemblyjs/ast@npm:1.11.0"
@@ -5620,6 +5636,16 @@ __metadata:
   dependencies:
     tweetnacl: ^0.14.3
   checksum: 3f57eb99bbc02352f68ff31e446997f4d21cc9a5e5286449dc1fe0116ec5dac5a4aa538967d45714fa9320312d2be8d16126f2d357da1dd40a3d546b96e097ed
+  languageName: node
+  linkType: hard
+
+"benchmark@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "benchmark@npm:2.1.4"
+  dependencies:
+    lodash: ^4.17.4
+    platform: ^1.3.3
+  checksum: 3d3d8f4771b7f9b17f1a967b8f5e70319930fcec2691b35418062342bfbbd1a3221b3129aaf5938fc6a85703837f8cdf2f6875349c158c5aa574b6eb36ab6baa
   languageName: node
   linkType: hard
 
@@ -10838,10 +10864,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20":
-  version: 4.17.20
-  resolution: "lodash@npm:4.17.20"
-  checksum: c62101d2500c383b5f174a7e9e6fe8098149ddd6e9ccfa85f36d4789446195f5c4afd3cfba433026bcaf3da271256566b04a2bf2618e5a39f6e67f8c12030cb6
+"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.4":
+  version: 4.17.21
+  resolution: "lodash@npm:4.17.21"
+  checksum: 4983720b9abca930a4a46f18db163d7dad8dd00dbed6db0cc7b499b33b717cce69f80928b27bbb1ff2cbd3b19d251ee90669a8b5ea466072ca81c2ebe91e7468
   languageName: node
   linkType: hard
 
@@ -12228,6 +12254,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"platform@npm:^1.3.3":
+  version: 1.3.6
+  resolution: "platform@npm:1.3.6"
+  checksum: d4d10d5a55476c6d369b03e02b31df50a4e7f1c565efabe707379b8a119709fb2a66dec090ab7fe520a30b767fe3791e3c4a5aba985918e51a17df45e469189f
+  languageName: node
+  linkType: hard
+
 "please-upgrade-node@npm:^3.1.1, please-upgrade-node@npm:^3.2.0":
   version: 3.2.0
   resolution: "please-upgrade-node@npm:3.2.0"
@@ -12673,9 +12706,9 @@ fsevents@^1.2.7:
   linkType: hard
 
 "regenerate@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "regenerate@npm:1.4.0"
-  checksum: d797b035730c0b5cbb7c230220b6a34610f84c1ea2369f0025292613c1ec88068cd87819fccf9c08f002670f26d59e63bbc309358181a6186f7fda185e93618a
+  version: 1.4.2
+  resolution: "regenerate@npm:1.4.2"
+  checksum: 54275a99effd8a439bcdd88942b61f68a769133df841e90d94df9ae7c250cb6537c0a28dd913116539772b3415edbcb3c8d81c22275595d3755cf0353976dfa4
   languageName: node
   linkType: hard
 
@@ -14641,13 +14674,6 @@ typescript@~4.2.3:
     object.reduce: ^1.0.0
     undertaker-registry: ^1.0.0
   checksum: 8fd661579a6a3dfdedb853344f10d4191b1db8e11c7b5ef21a9a9ecf17f4052db58511a4de46391c4f29e6ce6577ec2a2e016dc9d288b834ee756db2e550c406
-  languageName: node
-  linkType: hard
-
-"unicode-13.0.0@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "unicode-13.0.0@npm:0.8.0"
-  checksum: 5a1b05faae6d92b408ba7dadc05ce5eaf6e9695257487b513ec5b67117b717e98c120f768efafb9da7e9d4a880e8f06ad4f1f8ccdf553c071875007a4cfca7b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Added benchmark to `devDependencies`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Results from my local machine
```sh
$ node packages/babel-helper-validator-identifier/benchmark/isIdentifierName.bench.mjs
```

```
baseline#isIdentifierName on 2 short ASCII words: 2819979 ops/sec ±1.14% (0ms)
baselineisIdentifierName on 1 long ASCII words: 1486317 ops/sec ±0.4% (0.001ms)
baselineisIdentifierName on 3 non-ASCII words: 250140 ops/sec ±0.38% (0.004ms)
current#isIdentifierName on 2 short ASCII words: 7775830 ops/sec ±0.38% (0ms)
currentisIdentifierName on 1 long ASCII words: 4291478 ops/sec ±0.33% (0ms)
currentisIdentifierName on 3 non-ASCII words: 245762 ops/sec ±0.53% (0.004ms)
```

Initially meant to test per-package benchmark setup, this PR sees up to 3x improvement for ASCII words. The function is not used by `@babel/parser` internally, instead it is exported via `@babel/types` and used in systemjs and JSX transforms.

This PR also adds more test cases to `isIdentifier*`.