### PR TITLE
perf: avoid loadFullConfig when creating block hoist plugin

### DIFF
--- a/packages/babel-core/src/transformation/block-hoist-plugin.ts
+++ b/packages/babel-core/src/transformation/block-hoist-plugin.ts
@@ -1,6 +1,5 @@
-import loadConfig from "../config";
-
-import type { Plugin } from "../config";
+import traverse from "@babel/traverse";
+import Plugin from "../config/plugin";
 
 let LOADED_PLUGIN: Plugin | void;
 
@@ -9,14 +8,13 @@ export default function loadBlockHoistPlugin(): Plugin {
     // Lazy-init the internal plugin to remove the init-time circular
     // dependency between plugins being passed @babel/core's export object,
     // which loads this file, and this 'loadConfig' loading plugins.
-    const config = loadConfig.sync({
-      babelrc: false,
-      configFile: false,
-      browserslistConfigFile: false,
-      plugins: [blockHoistPlugin],
-    });
-    LOADED_PLUGIN = config ? config.passes[0][0] : undefined;
-    if (!LOADED_PLUGIN) throw new Error("Assertion failure");
+    LOADED_PLUGIN = new Plugin(
+      {
+        ...blockHoistPlugin,
+        visitor: traverse.explode(blockHoistPlugin.visitor),
+      },
+      {},
+    );
   }
 
   return LOADED_PLUGIN;

--- a/packages/babel-core/src/transformation/block-hoist-plugin.ts
+++ b/packages/babel-core/src/transformation/block-hoist-plugin.ts
@@ -5,9 +5,7 @@ let LOADED_PLUGIN: Plugin | void;
 
 export default function loadBlockHoistPlugin(): Plugin {
   if (!LOADED_PLUGIN) {
-    // Lazy-init the internal plugin to remove the init-time circular
-    // dependency between plugins being passed @babel/core's export object,
-    // which loads this file, and this 'loadConfig' loading plugins.
+    // cache the loaded blockHoist plugin plugin
     LOADED_PLUGIN = new Plugin(
       {
         ...blockHoistPlugin,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Improve performance of loading block hoist plugin. The benchmark is conducted after removing the `LOADED_PLUGIN` cache:

```
current load block-hoist plugin: 622750 ops/sec ±1.82% (0.002ms)
baseline load block-hoist plugin: 12027 ops/sec ±7.69% (0.083ms)
```

For this reason I didn't add the [benchmark files](https://github.com/JLHwung/babel/commit/7f7714d8ee2348448232bd1894924baec758e7b4) since the it can not be run without modifying the source.

Creating the plugin from constructor is 50x faster than hooking into `loadConfig`. However, since we already cache it, it would probably not have any real world performance changes. The benefit of this PR is that we don't have to maintain the parameters of `loadConfig.sync`.