### PR TITLE
Add `runFixtureTestsWithoutExactASTMatch` in parser test runner

### DIFF
--- a/packages/babel-parser/test/estree-throws.js
+++ b/packages/babel-parser/test/estree-throws.js
@@ -1,9 +1,13 @@
 import path from "path";
-import { runThrowTestsWithEstree } from "./helpers/runFixtureTests";
+import { runFixtureTestsWithoutExactASTMatch } from "./helpers/runFixtureTests";
 import { parse } from "../lib";
 import { fileURLToPath } from "url";
 
-runThrowTestsWithEstree(
+runFixtureTestsWithoutExactASTMatch(
   path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures"),
-  parse,
+  (input, options = {}) => {
+    options.plugins = options.plugins || [];
+    options.plugins.push("estree");
+    return parse(input, options);
+  },
 );

--- a/packages/babel-parser/test/helpers/runFixtureTests.js
+++ b/packages/babel-parser/test/helpers/runFixtureTests.js
@@ -81,15 +81,26 @@ export function runFixtureTests(fixturesPath, parseFunction) {
   });
 }
 
-export function runThrowTestsWithEstree(fixturesPath, parseFunction) {
+/**
+ * Run Fixture test without an exact AST match. If the output.json does not contain
+ * "errors", it asserts the actual output does not have "errors". If the output.json
+ * have "errors", it asserts the actual output have the same "errors".
+ *
+ * This routine is used to test parser options that have impact on the AST shape but
+ * does not change the syntax
+ * @param {*} fixturesPath The path to the fixture root
+ * @param {*} parseFunction The customized parseFunction, different global test options
+ * should be implemented here
+ */
+export function runFixtureTestsWithoutExactASTMatch(
+  fixturesPath,
+  parseFunction,
+) {
   const fixtures = getFixtures(fixturesPath);
 
   Object.keys(fixtures).forEach(function (name) {
     fixtures[name].forEach(function (testSuite) {
       testSuite.tests.forEach(function (task) {
-        task.options.plugins = task.options.plugins || [];
-        task.options.plugins.push("estree");
-
         const testFn = task.disabled ? it.skip : it;
 
         testFn(name + "/" + testSuite.title + "/" + task.title, function () {

--- a/packages/babel-parser/test/helpers/runFixtureTests.js
+++ b/packages/babel-parser/test/helpers/runFixtureTests.js
@@ -146,7 +146,7 @@ function save(test, ast) {
  generated from `getFixtures`
  * @param {*} parseFunction A parser with the same interface of `@babel/parser#parse`
  * @param {boolean} [compareErrorsOnly=false] Whether we should only compare the "errors"
- * of generated ast against the expected AST. Used for `runThrowTestsWithEstree` where an
+ * of generated ast against the expected AST. Used for `runFixtureTestsWithoutExactASTMatch` where an
  * ESTree AST is generated but we want to make sure `@babel/parser` still throws expected
  * recoverable errors on given code locations.
  * @returns {void}
@@ -191,13 +191,20 @@ function runTest(test, parseFunction, compareErrorsOnly = false) {
   if (ast.comments && !ast.comments.length) delete ast.comments;
   if (ast.errors && !ast.errors.length) delete ast.errors;
 
-  if (!test.expect.code && !opts.throws && !process.env.CI) {
+  if (
+    !test.expect.code &&
+    !opts.throws &&
+    !process.env.CI &&
+    !compareErrorsOnly
+  ) {
     test.expect.loc += "on";
     return save(test, ast);
   }
 
+  const shouldOverWrite = process.env.OVERWRITE && !compareErrorsOnly;
+
   if (opts.throws) {
-    if (process.env.OVERWRITE) {
+    if (shouldOverWrite) {
       const fn = path.dirname(test.expect.loc) + "/options.json";
       test.options = test.options || {};
       delete test.options.throws;
@@ -223,7 +230,7 @@ function runTest(test, parseFunction, compareErrorsOnly = false) {
     const mis = misMatch(JSON.parse(test.expect.code), ast);
 
     if (mis) {
-      if (process.env.OVERWRITE) {
+      if (shouldOverWrite) {
         return save(test, ast);
       }
       throw new Error(mis);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR introduces a small refactor over Babel parser fixture test runner. It extracts `runFixtureTestsWithoutExactASTMatch` so we can run the test routine to different Babel parser options.

Also fixed the issue that `estree-throw` will overwrite the fixtures when `process.env.OVERWRITE` is ture-ish.