### PR TITLE
fix: Typo in `@babel/helper-create-class-features-plugin`

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/features.js
+++ b/packages/babel-helper-create-class-features-plugin/src/features.js
@@ -11,10 +11,7 @@ export const FEATURES = Object.freeze({
 const featuresSameLoose = new Map([
   [FEATURES.fields, "@babel/plugin-proposal-class-properties"],
   [FEATURES.privateMethods, "@babel/plugin-proposal-private-methods"],
-  [
-    FEATURES.privateIn,
-    "@babel/plugin-proposal-private-property-in-object",
-  ],
+  [FEATURES.privateIn, "@babel/plugin-proposal-private-property-in-object"],
 ]);
 
 // We can't use a symbol because this needs to always be the same, even if

--- a/packages/babel-helper-create-class-features-plugin/src/features.js
+++ b/packages/babel-helper-create-class-features-plugin/src/features.js
@@ -13,7 +13,7 @@ const featuresSameLoose = new Map([
   [FEATURES.privateMethods, "@babel/plugin-proposal-private-methods"],
   [
     FEATURES.privateIn,
-    "@babel/plugin-proposal-private-private-property-in-object",
+    "@babel/plugin-proposal-private-property-in-object",
   ],
 ]);
 


### PR DESCRIPTION
Fixes #13236

Replace line:
babel/packages/babel-helper-create-class-features-plugin/src/features.js

Line 16 in 672a586

 "@babel/plugin-proposal-private-private-property-in-object"

with

"@babel/plugin-proposal-private-property-in-object",

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13237"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

