### PR TITLE
fix: add js-tokens to depsUsing__esModuleAndDefaultExport

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -448,7 +448,9 @@ function pluginPackageJsonMacro({ types: t }) {
 
 function pluginNodeImportInteropRollup({ types: t }) {
   const depsUsing__esModuleAndDefaultExport = src =>
-    src.startsWith("babel-plugin-polyfill-") || src === "regenerator-transform";
+    src.startsWith("babel-plugin-polyfill-") ||
+    src === "regenerator-transform" ||
+    src === "js-tokens";
 
   return {
     visitor: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -450,7 +450,7 @@ function pluginNodeImportInteropRollup({ types: t }) {
   const depsUsing__esModuleAndDefaultExport = src =>
     src.startsWith("babel-plugin-polyfill-") ||
     src === "regenerator-transform" ||
-    src === "js-tokens";
+    (!bool(process.env.BABEL_8_BREAKING) && src === "js-tokens");
 
   return {
     visitor: {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Got building error when I run a babel parser test that does not match its fixture:

```
TypeError: Cannot read property 'exec' of undefined

      170 |     let match;
      171 |
    > 172 |     while (match = _jsTokens.default.default.exec(text)) {
          |                                              ^
      173 |       const token = _jsTokens.default.matchToToken(match);
      174 |
      175 |       yield {

      at tokenize (packages/babel-highlight/lib/index.js:172:46)
          at tokenize.next (<anonymous>)
      at highlightTokens (packages/babel-highlight/lib/index.js:189:3)
      at highlight (packages/babel-highlight/lib/index.js:217:12)
      at codeFrameColumns (packages/babel-code-frame/lib/index.js:107:65)
```

Added `js-tokens` since we use both default named import in https://github.com/babel/babel/blob/3b55e8877ce378616395f0d6ec7bfbe5a2a9a1be/packages/babel-highlight/src/index.ts#L205-L206

This issue does not affect the published package since we are not using `pluginNodeImportInteropRollup` on `@babel/hightlight`, so I mark this PR as internal.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13240"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

