### PR TITLE
fix(ts): raise `TSError` for class accessors with discarding accessibility

### DIFF
--- a/packages/babel-parser/src/parser/base.js
+++ b/packages/babel-parser/src/parser/base.js
@@ -13,7 +13,7 @@ export default class BaseParser {
   declare options: Options;
   declare inModule: boolean;
   declare scope: ScopeHandler<*>;
-  declare classScope: ClassScopeHandler;
+  declare classScope: ClassScopeHandler<*>;
   declare prodParam: ProductionParameterHandler;
   declare expressionScope: ExpressionScopeHandler;
   declare plugins: PluginsMap;

--- a/packages/babel-parser/src/parser/index.js
+++ b/packages/babel-parser/src/parser/index.js
@@ -6,6 +6,7 @@ import type { PluginList } from "../plugin-utils";
 import { getOptions } from "../options";
 import StatementParser from "./statement";
 import ScopeHandler from "../util/scope";
+import ClassScopeHandler from "../util/class-scope";
 
 export type PluginsMap = Map<string, { [string]: any }>;
 
@@ -27,9 +28,13 @@ export default class Parser extends StatementParser {
     this.filename = options.sourceFilename;
   }
 
-  // This can be overwritten, for example, by the TypeScript plugin.
+  // These scope handlers can be overwritten, for example, by the TypeScript plugin.
   getScopeHandler(): Class<ScopeHandler<*>> {
     return ScopeHandler;
+  }
+
+  getClassScopeHandler(): Class<ClassScopeHandler<*>> {
+    return ClassScopeHandler;
   }
 
   parse(): File {

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -6,7 +6,6 @@ import State from "../tokenizer/state";
 import type { Node } from "../types";
 import { lineBreak } from "../util/whitespace";
 import { isIdentifierChar } from "../util/identifier";
-import ClassScopeHandler from "../util/class-scope";
 import ExpressionScopeHandler from "../util/expression-scope";
 import { SCOPE_PROGRAM } from "../util/scopeflags";
 import ProductionParameterHandler, {
@@ -17,6 +16,7 @@ import { Errors, type ErrorTemplate, ErrorCodes } from "./error";
 import type { ParsingError } from "./error";
 /*::
 import type ScopeHandler from "../util/scope";
+import type ClassScopeHandler from "../util/class-scope";
 */
 
 type TryParse<Node, Error, Thrown, Aborted, FailState> = {
@@ -33,6 +33,7 @@ export default class UtilParser extends Tokenizer {
   // Forward-declaration: defined in parser/index.js
   /*::
   +getScopeHandler: () => Class<ScopeHandler<*>>;
+  +getClassScopeHandler: () => Class<ClassScopeHandler<*>>;
   */
 
   // TODO
@@ -374,6 +375,7 @@ export default class UtilParser extends Tokenizer {
     this.prodParam = new ProductionParameterHandler();
 
     const oldClassScope = this.classScope;
+    const ClassScopeHandler = this.getClassScopeHandler();
     this.classScope = new ClassScopeHandler(this.raise.bind(this));
 
     const oldExpressionScope = this.expressionScope;

--- a/packages/babel-parser/src/plugins/typescript/class-scope.js
+++ b/packages/babel-parser/src/plugins/typescript/class-scope.js
@@ -1,0 +1,37 @@
+// @flow
+import * as N from "../../types";
+import ClassScopeHandler, { ClassScope } from "../../util/class-scope";
+import { TSErrors } from ".";
+
+class TypeScriptClassScope extends ClassScope {
+  accessors: Map<string, ?N.Accessibility> = new Map();
+}
+
+export default class TypeScriptClassScopeHandler extends ClassScopeHandler<TypeScriptClassScope> {
+  createScope(): TypeScriptClassScope {
+    return new TypeScriptClassScope();
+  }
+
+  declareAccessor(accessor: N.ClassMethod) {
+    if (accessor.key.type !== "Identifier") {
+      // return for other key types e.g. CallExpression, MemberExpression
+      return;
+    }
+    const key = accessor.key.name;
+
+    const current = this.current();
+
+    const oldAccessibilty = current.accessors.get(key);
+    if (oldAccessibilty) {
+      if (oldAccessibilty !== accessor.accessibility) {
+        this.raise(
+          accessor.start,
+          /* eslint-disable-next-line @babel/development-internal/dry-error-messages */
+          TSErrors.DifferentAccessorAccessibilityModifier,
+        );
+      }
+    } else {
+      current.accessors.set(key, accessor.accessibility);
+    }
+  }
+}

--- a/packages/babel-parser/src/util/class-scope.js
+++ b/packages/babel-parser/src/util/class-scope.js
@@ -19,8 +19,8 @@ export class ClassScope {
   undefinedPrivateNames: Map<string, number> = new Map();
 }
 
-export default class ClassScopeHandler {
-  stack: Array<ClassScope> = [];
+export default class ClassScopeHandler<IClassScope: ClassScope = ClassScope> {
+  stack: Array<IClassScope> = [];
   declare raise: raiseFunction;
   undefinedPrivateNames: Map<string, number> = new Map();
 
@@ -28,12 +28,16 @@ export default class ClassScopeHandler {
     this.raise = raise;
   }
 
-  current(): ClassScope {
+  current(): IClassScope {
     return this.stack[this.stack.length - 1];
   }
 
   enter() {
-    this.stack.push(new ClassScope());
+    this.stack.push(this.createScope());
+  }
+
+  createScope(): ClassScope {
+    return new ClassScope();
   }
 
   exit() {

--- a/packages/babel-parser/test/fixtures/typescript/class/accessors-accessibility/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/accessors-accessibility/input.ts
@@ -1,0 +1,4 @@
+class C {
+  get baz() {}
+  set baz(v) {}
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/accessors-accessibility/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/accessors-accessibility/output.json
@@ -1,0 +1,79 @@
+{
+  "type": "File",
+  "start":0,"end":42,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":42,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":42,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"C"},
+          "name": "C"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":8,"end":42,"loc":{"start":{"line":1,"column":8},"end":{"line":4,"column":1}},
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start":12,"end":24,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":14}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":16,"end":19,"loc":{"start":{"line":2,"column":6},"end":{"line":2,"column":9},"identifierName":"baz"},
+                "name": "baz"
+              },
+              "computed": false,
+              "kind": "get",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":22,"end":24,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":14}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":27,"end":40,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":15}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":31,"end":34,"loc":{"start":{"line":3,"column":6},"end":{"line":3,"column":9},"identifierName":"baz"},
+                "name": "baz"
+              },
+              "computed": false,
+              "kind": "set",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start":35,"end":36,"loc":{"start":{"line":3,"column":10},"end":{"line":3,"column":11},"identifierName":"v"},
+                  "name": "v"
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start":38,"end":40,"loc":{"start":{"line":3,"column":13},"end":{"line":3,"column":15}},
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/accessors-discarding-accessibily/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/accessors-discarding-accessibily/input.ts
@@ -1,0 +1,13 @@
+class C {
+  public get bar() {}
+  set bar(v) {}
+
+  public get foo() {}
+  private set foo(v) {}
+
+  protected get [Symbol.iterator]() {}
+  private set [Symbol.iterator](v) {}
+
+  public get [baz()]() {}
+  private set [baz()](v) {}
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/accessors-discarding-accessibily/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/accessors-discarding-accessibily/output.json
@@ -1,0 +1,270 @@
+{
+  "type": "File",
+  "start":0,"end":229,"loc":{"start":{"line":1,"column":0},"end":{"line":13,"column":1}},
+  "errors": [
+    "SyntaxError: Accessors should have the same accessibilty level. (3:2)",
+    "SyntaxError: Accessors should have the same accessibilty level. (6:2)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":229,"loc":{"start":{"line":1,"column":0},"end":{"line":13,"column":1}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":229,"loc":{"start":{"line":1,"column":0},"end":{"line":13,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"C"},
+          "name": "C"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":8,"end":229,"loc":{"start":{"line":1,"column":8},"end":{"line":13,"column":1}},
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start":12,"end":31,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":21}},
+              "accessibility": "public",
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":23,"end":26,"loc":{"start":{"line":2,"column":13},"end":{"line":2,"column":16},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "kind": "get",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":29,"end":31,"loc":{"start":{"line":2,"column":19},"end":{"line":2,"column":21}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":34,"end":47,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":15}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":38,"end":41,"loc":{"start":{"line":3,"column":6},"end":{"line":3,"column":9},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "kind": "set",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start":42,"end":43,"loc":{"start":{"line":3,"column":10},"end":{"line":3,"column":11},"identifierName":"v"},
+                  "name": "v"
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start":45,"end":47,"loc":{"start":{"line":3,"column":13},"end":{"line":3,"column":15}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":51,"end":70,"loc":{"start":{"line":5,"column":2},"end":{"line":5,"column":21}},
+              "accessibility": "public",
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":62,"end":65,"loc":{"start":{"line":5,"column":13},"end":{"line":5,"column":16},"identifierName":"foo"},
+                "name": "foo"
+              },
+              "computed": false,
+              "kind": "get",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":68,"end":70,"loc":{"start":{"line":5,"column":19},"end":{"line":5,"column":21}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":73,"end":94,"loc":{"start":{"line":6,"column":2},"end":{"line":6,"column":23}},
+              "accessibility": "private",
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":85,"end":88,"loc":{"start":{"line":6,"column":14},"end":{"line":6,"column":17},"identifierName":"foo"},
+                "name": "foo"
+              },
+              "computed": false,
+              "kind": "set",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start":89,"end":90,"loc":{"start":{"line":6,"column":18},"end":{"line":6,"column":19},"identifierName":"v"},
+                  "name": "v"
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start":92,"end":94,"loc":{"start":{"line":6,"column":21},"end":{"line":6,"column":23}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":98,"end":134,"loc":{"start":{"line":8,"column":2},"end":{"line":8,"column":38}},
+              "accessibility": "protected",
+              "static": false,
+              "key": {
+                "type": "MemberExpression",
+                "start":113,"end":128,"loc":{"start":{"line":8,"column":17},"end":{"line":8,"column":32}},
+                "object": {
+                  "type": "Identifier",
+                  "start":113,"end":119,"loc":{"start":{"line":8,"column":17},"end":{"line":8,"column":23},"identifierName":"Symbol"},
+                  "name": "Symbol"
+                },
+                "computed": false,
+                "property": {
+                  "type": "Identifier",
+                  "start":120,"end":128,"loc":{"start":{"line":8,"column":24},"end":{"line":8,"column":32},"identifierName":"iterator"},
+                  "name": "iterator"
+                }
+              },
+              "computed": true,
+              "kind": "get",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":132,"end":134,"loc":{"start":{"line":8,"column":36},"end":{"line":8,"column":38}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":137,"end":172,"loc":{"start":{"line":9,"column":2},"end":{"line":9,"column":37}},
+              "accessibility": "private",
+              "static": false,
+              "key": {
+                "type": "MemberExpression",
+                "start":150,"end":165,"loc":{"start":{"line":9,"column":15},"end":{"line":9,"column":30}},
+                "object": {
+                  "type": "Identifier",
+                  "start":150,"end":156,"loc":{"start":{"line":9,"column":15},"end":{"line":9,"column":21},"identifierName":"Symbol"},
+                  "name": "Symbol"
+                },
+                "computed": false,
+                "property": {
+                  "type": "Identifier",
+                  "start":157,"end":165,"loc":{"start":{"line":9,"column":22},"end":{"line":9,"column":30},"identifierName":"iterator"},
+                  "name": "iterator"
+                }
+              },
+              "computed": true,
+              "kind": "set",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start":167,"end":168,"loc":{"start":{"line":9,"column":32},"end":{"line":9,"column":33},"identifierName":"v"},
+                  "name": "v"
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start":170,"end":172,"loc":{"start":{"line":9,"column":35},"end":{"line":9,"column":37}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":176,"end":199,"loc":{"start":{"line":11,"column":2},"end":{"line":11,"column":25}},
+              "accessibility": "public",
+              "static": false,
+              "key": {
+                "type": "CallExpression",
+                "start":188,"end":193,"loc":{"start":{"line":11,"column":14},"end":{"line":11,"column":19}},
+                "callee": {
+                  "type": "Identifier",
+                  "start":188,"end":191,"loc":{"start":{"line":11,"column":14},"end":{"line":11,"column":17},"identifierName":"baz"},
+                  "name": "baz"
+                },
+                "arguments": []
+              },
+              "computed": true,
+              "kind": "get",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":197,"end":199,"loc":{"start":{"line":11,"column":23},"end":{"line":11,"column":25}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":202,"end":227,"loc":{"start":{"line":12,"column":2},"end":{"line":12,"column":27}},
+              "accessibility": "private",
+              "static": false,
+              "key": {
+                "type": "CallExpression",
+                "start":215,"end":220,"loc":{"start":{"line":12,"column":15},"end":{"line":12,"column":20}},
+                "callee": {
+                  "type": "Identifier",
+                  "start":215,"end":218,"loc":{"start":{"line":12,"column":15},"end":{"line":12,"column":18},"identifierName":"baz"},
+                  "name": "baz"
+                },
+                "arguments": []
+              },
+              "computed": true,
+              "kind": "set",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start":222,"end":223,"loc":{"start":{"line":12,"column":22},"end":{"line":12,"column":23},"identifierName":"v"},
+                  "name": "v"
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start":225,"end":227,"loc":{"start":{"line":12,"column":25},"end":{"line":12,"column":27}},
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/scripts/parser-tests/typescript/allowlist.txt
+++ b/scripts/parser-tests/typescript/allowlist.txt
@@ -138,6 +138,7 @@ dependencyViaImportAlias.ts
 destructuredDeclarationEmit.ts
 divergentAccessors1.ts
 divergentAccessorsTypes1.ts
+divergentAccessorsVisibility1.ts
 doubleUnderscoreExportStarConflict.ts
 duplicateIdentifierBindingElementInParameterDeclaration1.ts
 duplicateIdentifierBindingElementInParameterDeclaration2.ts
@@ -233,6 +234,7 @@ functionDeclarationWithResolutionOfTypeNamedArguments01.ts
 functionExpressionInWithBlock.ts
 functionExpressionWithResolutionOfTypeNamedArguments01.ts
 getterErrorMessageNotDuplicated.ts
+gettersAndSettersAccessibility.ts
 gettersAndSettersErrors.ts
 giant.ts
 globalThisDeclarationEmit.ts
@@ -387,6 +389,7 @@ preserveUnusedImports.ts
 privacyCheckExternalModuleExportAssignmentOfGenericClass.ts
 privacyTopLevelAmbientExternalModuleImportWithExport.ts
 privacyTopLevelAmbientExternalModuleImportWithoutExport.ts
+publicGetterProtectedSetterFromThisParameter.ts
 reExportGlobalDeclaration1.ts
 reExportUndefined1.ts
 reExportUndefined2.ts


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes #13125  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
We override `ClassScopeHandler` in the TS plugin so that it is possible to check for class accessors with different accessibility levels.
In this PR we do not take into account `MemberExpression` and `CallExpression` keys because TS does not return any error for those

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13250"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

