### PR TITLE
Fix const violations in ESM imports when transformed to CJS

### DIFF
--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
@@ -358,13 +358,13 @@ const rewriteReferencesVisitor: Visitor<RewriteReferencesVisitorState> = {
       const loopBodyScope = path.get("body").scope;
       for (const name of Object.keys(t.getOuterBindingIdentifiers(left))) {
         if (programScope.getBinding(name) === scope.getBinding(name)) {
-          if (exported.get(name)) {
+          if (exported.has(name)) {
             didTransformExport = true;
             if (loopBodyScope.hasOwnBinding(name)) {
               loopBodyScope.rename(name);
             }
           }
-          if (imported.get(name) && !importConstViolationName) {
+          if (imported.has(name) && !importConstViolationName) {
             importConstViolationName = name;
           }
         }

--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
@@ -350,23 +350,26 @@ const rewriteReferencesVisitor: Visitor<RewriteReferencesVisitorState> = {
   ) {
     const { scope, node } = path;
     const { left } = node;
-    const { exported, scope: programScope } = this;
+    const { exported, imported, scope: programScope } = this;
 
     if (!t.isVariableDeclaration(left)) {
-      let didTransform = false;
+      let didTransformExport = false,
+        importConstViolationName;
       const loopBodyScope = path.get("body").scope;
       for (const name of Object.keys(t.getOuterBindingIdentifiers(left))) {
-        if (
-          exported.get(name) &&
-          programScope.getBinding(name) === scope.getBinding(name)
-        ) {
-          didTransform = true;
-          if (loopBodyScope.hasOwnBinding(name)) {
-            loopBodyScope.rename(name);
+        if (programScope.getBinding(name) === scope.getBinding(name)) {
+          if (exported.get(name)) {
+            didTransformExport = true;
+            if (loopBodyScope.hasOwnBinding(name)) {
+              loopBodyScope.rename(name);
+            }
+          }
+          if (imported.get(name) && !importConstViolationName) {
+            importConstViolationName = name;
           }
         }
       }
-      if (!didTransform) {
+      if (!didTransformExport && !importConstViolationName) {
         return;
       }
 
@@ -374,10 +377,6 @@ const rewriteReferencesVisitor: Visitor<RewriteReferencesVisitorState> = {
       const bodyPath = path.get("body");
 
       const newLoopId = scope.generateUidIdentifierBasedOnNode(left);
-      bodyPath.unshiftContainer(
-        "body",
-        t.expressionStatement(t.assignmentExpression("=", left, newLoopId)),
-      );
       path
         .get("left")
         .replaceWith(
@@ -386,6 +385,19 @@ const rewriteReferencesVisitor: Visitor<RewriteReferencesVisitorState> = {
           ]),
         );
       scope.registerDeclaration(path.get("left"));
+
+      if (didTransformExport) {
+        bodyPath.unshiftContainer(
+          "body",
+          t.expressionStatement(t.assignmentExpression("=", left, newLoopId)),
+        );
+      }
+      if (importConstViolationName) {
+        bodyPath.unshiftContainer(
+          "body",
+          t.expressionStatement(buildImportThrow(importConstViolationName)),
+        );
+      }
     }
   },
 };

--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
@@ -354,8 +354,7 @@ const rewriteReferencesVisitor: Visitor<RewriteReferencesVisitorState> = {
 
     if (!t.isVariableDeclaration(left)) {
       let didTransform = false;
-      const bodyPath = path.get("body");
-      const loopBodyScope = bodyPath.scope;
+      const loopBodyScope = path.get("body").scope;
       for (const name of Object.keys(t.getOuterBindingIdentifiers(left))) {
         if (
           exported.get(name) &&
@@ -370,6 +369,10 @@ const rewriteReferencesVisitor: Visitor<RewriteReferencesVisitorState> = {
       if (!didTransform) {
         return;
       }
+
+      path.ensureBlock();
+      const bodyPath = path.get("body");
+
       const newLoopId = scope.generateUidIdentifierBasedOnNode(left);
       bodyPath.unshiftContainer(
         "body",

--- a/packages/babel-helper-simple-access/src/index.ts
+++ b/packages/babel-helper-simple-access/src/index.ts
@@ -100,12 +100,29 @@ const simpleAssignmentVisitor = {
         return;
       }
 
-      path.node.right = t.binaryExpression(
-        path.node.operator.slice(0, -1),
-        t.cloneNode(path.node.left),
-        path.node.right,
-      );
-      path.node.operator = "=";
+      const operator = path.node.operator.slice(0, -1);
+      if (["&&", "||", "??"].includes(operator)) {
+        // (foo &&= bar) => (foo && foo = bar)
+        path.replaceWith(
+          t.logicalExpression(
+            operator,
+            path.node.left,
+            t.assignmentExpression(
+              "=",
+              t.cloneNode(path.node.left),
+              path.node.right,
+            ),
+          ),
+        );
+      } else {
+        // (foo += bar) => (foo = foo + bar)
+        path.node.right = t.binaryExpression(
+          operator,
+          t.cloneNode(path.node.left),
+          path.node.right,
+        );
+        path.node.operator = "=";
+      }
     },
   },
 };

--- a/packages/babel-helper-simple-access/src/index.ts
+++ b/packages/babel-helper-simple-access/src/index.ts
@@ -101,7 +101,8 @@ const simpleAssignmentVisitor = {
       }
 
       const operator = path.node.operator.slice(0, -1);
-      if (["&&", "||", "??"].includes(operator)) {
+      if (t.LOGICAL_OPERATORS.includes(operator)) {
+        // &&, ||, ??
         // (foo &&= bar) => (foo && foo = bar)
         path.replaceWith(
           t.logicalExpression(

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/for-of-in-export/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/for-of-in-export/input.mjs
@@ -16,6 +16,8 @@ for ([foo, [...foo]] of []) {
     let foo;
 }
 
+for (foo of []) ;
+
 {
     let foo;
     for(foo of []) {}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/for-of-in-export/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/for-of-in-export/output.js
@@ -58,6 +58,11 @@ for (let _ref2 of []) {
   let _foo8;
 }
 
+for (let _foo9 of []) {
+  exports.bar = exports.foo = foo = _foo9;
+  ;
+}
+
 {
   let foo;
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/input.mjs
@@ -35,3 +35,13 @@ Baz &&= 4;
 Foo++;
 Bar++;
 Baz++;
+
+for (Foo in {}) ;
+for (Bar in {}) {}
+for (Baz of []) {
+	let Baz;
+}
+
+for ({Foo} in {}) {}
+for ([Bar] in {}) {}
+for ([...Baz] in {}) {}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/input.mjs
@@ -15,3 +15,23 @@ Baz = 44;
 ({prop: Foo} = {});
 ({prop: Bar} = {});
 ({prop: Baz} = {});
+
+Foo += 2;
+Bar += 2;
+Baz += 2;
+
+Foo >>>= 3;
+Bar >>>= 3;
+Baz >>>= 3;
+
+Foo &&= 4;
+Bar &&= 4;
+Baz &&= 4;
+
+--Foo;
+--Bar;
+--Baz;
+
+Foo++;
+Bar++;
+Baz++;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/output.js
@@ -6,6 +6,8 @@ var Bar = _interopRequireDefault(require("bar"));
 
 var _baz = require("baz");
 
+var _Baz;
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 _foo.default = (42, function () {
@@ -47,3 +49,48 @@ _baz.Baz = (44, function () {
 } = ({}, function () {
   throw new Error('"' + "Baz" + '" is read-only.');
 }()));
+_foo.default = (_foo.default + 2, function () {
+  throw new Error('"' + "Foo" + '" is read-only.');
+}());
+Bar = (Bar + 2, function () {
+  throw new Error('"' + "Bar" + '" is read-only.');
+}());
+_baz.Baz = (_baz.Baz + 2, function () {
+  throw new Error('"' + "Baz" + '" is read-only.');
+}());
+_foo.default = (_foo.default >>> 3, function () {
+  throw new Error('"' + "Foo" + '" is read-only.');
+}());
+Bar = (Bar >>> 3, function () {
+  throw new Error('"' + "Bar" + '" is read-only.');
+}());
+_baz.Baz = (_baz.Baz >>> 3, function () {
+  throw new Error('"' + "Baz" + '" is read-only.');
+}());
+_foo.default && (_foo.default = (4, function () {
+  throw new Error('"' + "Foo" + '" is read-only.');
+}()));
+Bar && (Bar = (4, function () {
+  throw new Error('"' + "Bar" + '" is read-only.');
+}()));
+_baz.Baz && (_baz.Baz = (4, function () {
+  throw new Error('"' + "Baz" + '" is read-only.');
+}()));
+_foo.default = (_foo.default - 1, function () {
+  throw new Error('"' + "Foo" + '" is read-only.');
+}());
+Bar = (Bar - 1, function () {
+  throw new Error('"' + "Bar" + '" is read-only.');
+}());
+_baz.Baz = (_baz.Baz - 1, function () {
+  throw new Error('"' + "Baz" + '" is read-only.');
+}());
+_foo.default = (_foo.default + 1, function () {
+  throw new Error('"' + "Foo" + '" is read-only.');
+}());
+Bar = (Bar + 1, function () {
+  throw new Error('"' + "Bar" + '" is read-only.');
+}());
+_Baz = +_baz.Baz, _baz.Baz = (_Baz + 1, function () {
+  throw new Error('"' + "Baz" + '" is read-only.');
+}()), _Baz;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/output.js
@@ -6,8 +6,6 @@ var Bar = _interopRequireDefault(require("bar"));
 
 var _baz = require("baz");
 
-var _Baz;
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 _foo.default = (42, function () {
@@ -91,6 +89,46 @@ _foo.default = (_foo.default + 1, function () {
 Bar = (Bar + 1, function () {
   throw new Error('"' + "Bar" + '" is read-only.');
 }());
-_Baz = +_baz.Baz, _baz.Baz = (_Baz + 1, function () {
+_baz.Baz = (_baz.Baz + 1, function () {
   throw new Error('"' + "Baz" + '" is read-only.');
-}()), _Baz;
+}());
+
+for (let _Foo in {}) {
+  (function () {
+    throw new Error('"' + "Foo" + '" is read-only.');
+  })();
+
+  ;
+}
+
+for (let _Bar in {}) {
+  (function () {
+    throw new Error('"' + "Bar" + '" is read-only.');
+  })();
+}
+
+for (let _Baz of []) {
+  (function () {
+    throw new Error('"' + "Baz" + '" is read-only.');
+  })();
+
+  let Baz;
+}
+
+for (let _Foo2 in {}) {
+  (function () {
+    throw new Error('"' + "Foo" + '" is read-only.');
+  })();
+}
+
+for (let _ref in {}) {
+  (function () {
+    throw new Error('"' + "Bar" + '" is read-only.');
+  })();
+}
+
+for (let _ref2 in {}) {
+  (function () {
+    throw new Error('"' + "Baz" + '" is read-only.');
+  })();
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No issue filed
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | n/a
| Any Dependency Changes?  | No
| License                  | MIT

This PR fixes similar cases to #13248 in [plugin-transform-modules-commonjs](https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs) relating to const violations with `import` statements.

e.g.:

```js
import x from 'foo';
x = 1;
```

This PR:

1. Fixes compilation error if `import x from 'foo'; x &&= 1;`
2. Adds const violation errors for `import x from 'foo'; for ( x in {} ) {}`
3. Fixes a small bug with for loops without a block statement e.g. `export let x = 1; for ( x in {} ) x();`
4. Adds more tests for assignments

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13258"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

