### PR TITLE
Faster identifier tokenizing

### DIFF
--- a/packages/babel-parser/benchmark/many-identifiers/1-length.bench.mjs
+++ b/packages/babel-parser/benchmark/many-identifiers/1-length.bench.mjs
@@ -1,0 +1,23 @@
+import Benchmark from "benchmark";
+import baseline from "@babel-baseline/parser";
+import current from "../../lib/index.js";
+import { report } from "../util.mjs";
+
+const suite = new Benchmark.Suite();
+function createInput(length) {
+  return "a;".repeat(length);
+}
+current.parse("a");
+function benchCases(name, implementation, options) {
+  for (const length of [64, 128, 256, 512, 1024]) {
+    const input = createInput(length);
+    suite.add(`${name} ${length} length-1 identifiers`, () => {
+      implementation.parse(input, options);
+    });
+  }
+}
+
+benchCases("baseline", baseline);
+benchCases("current", current);
+
+suite.on("cycle", report).run();

--- a/packages/babel-parser/benchmark/many-identifiers/2-length.bench.mjs
+++ b/packages/babel-parser/benchmark/many-identifiers/2-length.bench.mjs
@@ -1,0 +1,23 @@
+import Benchmark from "benchmark";
+import baseline from "@babel-baseline/parser";
+import current from "../../lib/index.js";
+import { report } from "../util.mjs";
+
+const suite = new Benchmark.Suite();
+function createInput(length) {
+  return "aa;".repeat(length);
+}
+current.parse("a");
+function benchCases(name, implementation, options) {
+  for (const length of [64, 128, 256, 512, 1024]) {
+    const input = createInput(length);
+    suite.add(`${name} ${length} length-2 identifiers`, () => {
+      implementation.parse(input, options);
+    });
+  }
+}
+
+benchCases("baseline", baseline);
+benchCases("current", current);
+
+suite.on("cycle", report).run();

--- a/packages/babel-parser/src/tokenizer/context.js
+++ b/packages/babel-parser/src/tokenizer/context.js
@@ -76,10 +76,6 @@ tt.name.updateContext = function (prevType) {
     }
   }
   this.state.exprAllowed = allowed;
-
-  if (this.state.isIterator) {
-    this.state.isIterator = false;
-  }
 };
 
 tt.braceL.updateContext = function (prevType) {

--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -64,7 +64,6 @@ export default class State {
   noAnonFunctionType: boolean = false;
   inPropertyName: boolean = false;
   hasFlowComment: boolean = false;
-  isIterator: boolean = false;
   isAmbientContext: boolean = false;
   inAbstractClass: boolean = false;
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

<s>This PR includes commits on #13256 , see [here](https://github.com/babel/babel/pull/13262/files/56d64f13082f15da6e7e8a1fb5ce8a5a67d933e6..a20aef9d1b50c1923449d51d8d555e7e99c36254) for the real diff.</s> Edits: already rebased.

This PR 

1) moves the flow iterator `@@iterator` parsing to the flow plugin and simplifies the tokenizer state. It turns out we don't actually need to access `this.state.isIterator` as long as we have a dedicated code path for Flow iterator. So `state.isIterator` is removed.

2) passes through the identifier start so we don't have to re-read the input source and test with `isIdentifierChar`

Currently, when parsing a length-3 input `ab;`, `this.input.codePointAt` is called for 5 times:

| Seq | Position | Character | Context |
| --- | --- | --- | --- |
| 1 | 0 | "a" | `getTokenFromCode` |
| 2 | 0 | "a" | `readWord1` |
| 3 | 1 | "b" | `readWord1` |
| 4 | 2 | ";" | `readWord1` |
| 5 | 2 | ";" | `getTokenFromCode` |

This PR passes through the read code point `0x61` in sequence 1 for `readWord1` so we can avoid reading again in sequence 2. Now if we are parsing `ab;`, only 4 `codePointAt` call will be issued (1, 3, 4, 5). As we can see, the margin is diminishing for longer identifier names.

Although we could do the same for escaped identifiers, I don't think it worths the efforts because escaped identifiers are rare.

### Benchmark results

Combing these two tricks we see up to 4.5% performance gain on length-1 identifiers (Best case).
```
$ node --predictable ./benchmark/many-identifiers/1-length.bench.mjs
baseline 64 length-1 identifiers: 15836 ops/sec ±67.43% (0.063ms)
baseline 128 length-1 identifiers: 16041 ops/sec ±2.09% (0.062ms)
baseline 256 length-1 identifiers: 8463 ops/sec ±1.48% (0.118ms)
baseline 512 length-1 identifiers: 4261 ops/sec ±1.21% (0.235ms)
baseline 1024 length-1 identifiers: 2165 ops/sec ±1.03% (0.462ms)
current 64 length-1 identifiers: 20153 ops/sec ±81.04% (0.05ms)
current 128 length-1 identifiers: 17915 ops/sec ±0.48% (0.056ms)
current 256 length-1 identifiers: 8844 ops/sec ±0.96% (0.113ms)
current 512 length-1 identifiers: 4410 ops/sec ±1.42% (0.227ms)
current 1024 length-1 identifiers: 2191 ops/sec ±1.22% (0.456ms)
```

up to 2.5% performance gain on length-2 identifiers
```
$ node --predictable ./benchmark/many-identifiers/2-length.bench.mjs
baseline 64 length-2 identifiers: 20141 ops/sec ±66.04% (0.05ms)
baseline 128 length-2 identifiers: 15641 ops/sec ±1.62% (0.064ms)
baseline 256 length-2 identifiers: 7981 ops/sec ±1.06% (0.125ms)
baseline 512 length-2 identifiers: 3959 ops/sec ±1.11% (0.253ms)
baseline 1024 length-2 identifiers: 1935 ops/sec ±1.47% (0.517ms)
current 64 length-2 identifiers: 21245 ops/sec ±63.76% (0.047ms)
current 128 length-2 identifiers: 15943 ops/sec ±1.32% (0.063ms)
current 256 length-2 identifiers: 8079 ops/sec ±1.23% (0.124ms)
current 512 length-2 identifiers: 4064 ops/sec ±0.99% (0.246ms)
current 1024 length-2 identifiers: 2051 ops/sec ±0.2% (0.488ms)
```

and no significant performance gain on length-20 identifiers. Note that in predictable mode, the first bench suite always has significant variant and should not be taken into account.
```
baseline 64 length-20 identifiers: 14220 ops/sec ±69.35% (0.07ms)
baseline 128 length-20 identifiers: 11560 ops/sec ±0.96% (0.087ms)
baseline 256 length-20 identifiers: 5885 ops/sec ±0.54% (0.17ms)
baseline 512 length-20 identifiers: 2902 ops/sec ±1.38% (0.345ms)
baseline 1024 length-20 identifiers: 1429 ops/sec ±1.43% (0.7ms)
current 64 length-20 identifiers: 16010 ops/sec ±55.29% (0.062ms)
current 128 length-20 identifiers: 11621 ops/sec ±1.02% (0.086ms)
current 256 length-20 identifiers: 5901 ops/sec ±0.5% (0.169ms)
current 512 length-20 identifiers: 2906 ops/sec ±0.91% (0.344ms)
current 1024 length-20 identifiers: 1417 ops/sec ±2.47% (0.706ms)
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13262"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

