### PR TITLE
[babel-types] Update `matchesPattern` to account for `this`

### DIFF
--- a/packages/babel-types/src/validators/matchesPattern.ts
+++ b/packages/babel-types/src/validators/matchesPattern.ts
@@ -1,4 +1,9 @@
-import { isIdentifier, isMemberExpression, isStringLiteral } from "./generated";
+import {
+  isIdentifier,
+  isMemberExpression,
+  isStringLiteral,
+  isThisExpression,
+} from "./generated";
 import type * as t from "..";
 
 /**
@@ -35,6 +40,8 @@ export default function matchesPattern(
       value = node.name;
     } else if (isStringLiteral(node)) {
       value = node.value;
+    } else if (isThisExpression(node)) {
+      value = "this";
     } else {
       return false;
     }

--- a/packages/babel-types/test/misc.js
+++ b/packages/babel-types/test/misc.js
@@ -40,5 +40,13 @@ describe("misc helpers", function () {
       expect(t.matchesPattern(ast, "b.c.d", true)).toBe(false);
       expect(t.matchesPattern(ast, "a.b.c.d.e", true)).toBe(false);
     });
+
+    it("matches this expressions", function () {
+      const ast = parseCode("this.a.b.c.d").expression;
+      expect(t.matchesPattern(ast, "this.a.b.c.d")).toBeTruthy();
+      expect(t.matchesPattern(ast, "this.a.b.c")).toBe(false);
+      expect(t.matchesPattern(ast, "this.b.c.d")).toBe(false);
+      expect(t.matchesPattern(ast, "this.a.b.c.d.e")).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `matchesPattern` does not currently work for expressions that contain `this` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I had noticed that `matchesPattern` currently does not work for MemberExpressions that contain `this`.  This PR addresses the issue by adding a check for `isThisExpression(node)`.  

I'm not sure if this was excluded on purpose, but the change was simple so I figured I'd throw up a PR really quick.  Also added a test case for the fix.  


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13264"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

