### PR TITLE
chore: bump eslint-visitor-keys

### DIFF
--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "eslint-scope": "^5.1.0",
-    "eslint-visitor-keys": "^1.3.0",
+    "eslint-visitor-keys": "^2.1.0",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   },
   "devDependencies": {

--- a/eslint/babel-eslint-parser/src/visitor-keys.js
+++ b/eslint/babel-eslint-parser/src/visitor-keys.js
@@ -8,10 +8,9 @@ export const newTypes = {
   Literal: ESLINT_VISITOR_KEYS.Literal,
   MethodDefinition: ["decorators"].concat(ESLINT_VISITOR_KEYS.MethodDefinition),
   Property: ["decorators"].concat(ESLINT_VISITOR_KEYS.Property),
-  // todo: remove this when Acorn supports class properties
-  PropertyDefinition: t.VISITOR_KEYS.ClassProperty,
-  // todo: remove this when Acorn supports class properties
-  PrivateIdentifier: [],
+  PropertyDefinition: ["decorators"].concat(
+    ESLINT_VISITOR_KEYS.PropertyDefinition,
+  ),
 };
 
 // AST Types that shares `"type"` property with Babel but have different shape

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,7 +239,7 @@ __metadata:
     dedent: ^0.7.0
     eslint: ^7.5.0
     eslint-scope: ^5.1.0
-    eslint-visitor-keys: ^1.3.0
+    eslint-visitor-keys: ^2.1.0
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   peerDependencies:
     "@babel/core": ">=7.11.0"
@@ -7698,10 +7698,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "eslint-visitor-keys@npm:2.0.0"
-  checksum: 429dabdcab3c1cf5e65d44843afc513398d4ee32a37f93edc93bb5ba59a12b78fa67d87ff23c752c170b5e4f9085050f45b3c036cdfb23d40a724f2614048140
+"eslint-visitor-keys@npm:^2.0.0, eslint-visitor-keys@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "eslint-visitor-keys@npm:2.1.0"
+  checksum: 75eaae9006f5bcb9d1e09641719b840b83c4758f5f25bc06a0e94918d78658d0f19691bdc2e3b100604d0fe2d1eb94a2aab287ba24ad2f02f87cacdccb86c2e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Bump `eslint-visitor-keys` to 2.1.0
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The breaking changes between `eslint-visitor-keys` from 1.3.0 .. 2.1.0 is to drop support for Node <10, which does not affect `@babel/eslint-parser` since we require `"^10.13.0 || ^12.13.0 || >=14.0.0"`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13272"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

