### PR TITLE
Support objects from other contexts in `t.valueToNode`

### DIFF
--- a/packages/babel-types/src/converters/valueToNode.ts
+++ b/packages/babel-types/src/converters/valueToNode.ts
@@ -48,6 +48,9 @@ function isPlainObject(value): value is object {
     return false;
   }
   const proto = Object.getPrototypeOf(value);
+  // Object.prototype's __proto__ is null. Every other class's __proto__.__proto__ is
+  // not null by default. We cannot check if proto === Object.prototype because it
+  // could come from another realm.
   return proto === null || Object.getPrototypeOf(proto) === null;
 }
 

--- a/packages/babel-types/src/converters/valueToNode.ts
+++ b/packages/babel-types/src/converters/valueToNode.ts
@@ -40,11 +40,15 @@ function isRegExp(value): value is RegExp {
 }
 
 function isPlainObject(value): value is object {
-  if (typeof value !== "object" || value === null) {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Object.prototype.toString.call(value) !== "[object Object]"
+  ) {
     return false;
   }
   const proto = Object.getPrototypeOf(value);
-  return proto === null || proto === Object.prototype;
+  return proto === null || Object.getPrototypeOf(proto) === null;
 }
 
 function valueToNode(value: unknown): t.Expression {

--- a/packages/babel-types/test/regressions.js
+++ b/packages/babel-types/test/regressions.js
@@ -15,11 +15,10 @@ describe("regressions", () => {
     const script = new vm.Script(`this.obj = { foo: 2 }`);
     script.runInNewContext(context);
 
-    expect(t.valueToNode(context.obj)).toEqual({
+    expect(t.valueToNode(context.obj)).toMatchObject({
       properties: [
         {
           computed: false,
-          decorators: null,
           key: { name: "foo", type: "Identifier" },
           shorthand: false,
           type: "ObjectProperty",

--- a/packages/babel-types/test/regressions.js
+++ b/packages/babel-types/test/regressions.js
@@ -1,4 +1,5 @@
 import * as t from "../lib";
+import * as vm from "vm";
 
 describe("regressions", () => {
   const babel7 = process.env.BABEL_TYPES_8_BREAKING ? it.skip : it;
@@ -7,5 +8,25 @@ describe("regressions", () => {
     expect(() => {
       t.file(t.program([]), [{ type: "Line" }]);
     }).not.toThrow();
+  });
+
+  it(".valueToNode works with objects from different contexts", () => {
+    const context = {};
+    const script = new vm.Script(`this.obj = { foo: 2 }`);
+    script.runInNewContext(context);
+
+    expect(t.valueToNode(context.obj)).toEqual({
+      properties: [
+        {
+          computed: false,
+          decorators: null,
+          key: { name: "foo", type: "Identifier" },
+          shorthand: false,
+          type: "ObjectProperty",
+          value: { type: "NumericLiteral", value: 2 },
+        },
+      ],
+      type: "ObjectExpression",
+    });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13263
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I think this is the same as what lodash does at https://github.com/lodash/lodash/blob/2da024c3b4f9947a48517639de7560457cd4ec6c/isPlainObject.js#L37-L41, but in a less complicated way.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13275"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

