### PR TITLE
Update lodash version for fixing security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "husky": "^3.0.0",
     "jest": "^26.6.1",
     "lint-staged": "^9.2.0",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "mergeiterator": "^1.2.5",
     "prettier": "^2.2.1",
     "rollup": "^2.47.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5644,7 +5644,7 @@ __metadata:
     husky: ^3.0.0
     jest: ^26.6.1
     lint-staged: ^9.2.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     mergeiterator: ^1.2.5
     prettier: ^2.2.1
     rollup: ^2.47.0
@@ -10942,7 +10942,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.4":
+"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 4983720b9abca930a4a46f18db163d7dad8dd00dbed6db0cc7b499b33b717cce69f80928b27bbb1ff2cbd3b19d251ee90669a8b5ea466072ca81c2ebe91e7468


### PR DESCRIPTION


| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | No
| Any Dependency Changes?  | Yes
| License                  | MIT

While doing an audit in our production we saw high vulnerability issues(command injection) related to babel. Looking further into the issue we found that lodash which is getting used in babel latest version is outdated and hence cause those vulnerabilities. Lodash has already fixed these issues and hence babel can also move to the latest version of lodash which is `4.17.21`. Posting few links below to have a better understanding for everyone. 


https://github.com/advisories/GHSA-35jh-r3h4-6jhm

https://snyk.io/vuln/SNYK-JS-LODASH-1040724


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13289"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

