### PR TITLE
feat: add `noIncompleteNsImportDetection` assumption to `plugin-transform-modules-commonjs`

### DIFF
--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -265,6 +265,7 @@ export const assumptionsNames = new Set<string>([
   "mutableTemplateObject",
   "noClassCalls",
   "noDocumentAll",
+  "noIncompleteNsImportDetection",
   "noNewArrows",
   "objectRestNoSymbols",
   "privateFieldsAsProperties",

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -46,7 +46,7 @@ export function createClassFeaturePlugin({
   feature,
   loose,
   manipulateOptions,
-  // TODO(Babel 8): Remove the default falue
+  // TODO(Babel 8): Remove the default value
   api = { assumption: () => void 0 },
 }: Options) {
   const setPublicClassFields = api.assumption("setPublicClassFields");

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.js
@@ -40,6 +40,8 @@ export default declare((api, options) => {
     api.assumption("constantReexports") ?? options.loose;
   const enumerableModuleMeta =
     api.assumption("enumerableModuleMeta") ?? options.loose;
+  const noIncompleteNsImportDetection =
+    api.assumption("noIncompleteNsImportDetection") ?? false;
 
   if (
     typeof lazy !== "boolean" &&
@@ -186,6 +188,7 @@ export default declare((api, options) => {
                 /\.mjs$/.test(state.filename)
                   ? mjsStrictNamespace
                   : strictNamespace,
+              noIncompleteNsImportDetection,
             },
           );
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export-default/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export-default/input.mjs
@@ -1,0 +1,1 @@
+export default foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export-default/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export-default/output.js
@@ -1,0 +1,7 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var _default = foo;
+exports.default = _default;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export-from/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export-from/input.mjs
@@ -1,0 +1,1 @@
+export { foo } from "foo";

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export-from/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export-from/options.json
@@ -1,0 +1,7 @@
+{
+  "assumptions": {
+    "noIncompleteNsImportDetection": true,
+    "constantReexports": true
+  },
+  "plugins": ["transform-modules-commonjs"]
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export-from/output.js
@@ -1,0 +1,9 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _foo = require("foo");
+
+exports.foo = _foo.foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export/input.mjs
@@ -1,0 +1,1 @@
+export var foo = 2;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/export/output.js
@@ -1,0 +1,7 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var foo = 2;
+exports.foo = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumptions-noIncompleteNsImportDetection/options.json
@@ -1,0 +1,6 @@
+{
+  "assumptions": {
+    "noIncompleteNsImportDetection": true
+  },
+  "plugins": ["transform-modules-commonjs"]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes #13278 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | babel/website#2545
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
We add a new assumption to let the user opt-out of export variable hoisting when transforming ES modules to commonjs.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13290"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

