### PR TITLE
Do not skip requeued path

### DIFF
--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -251,13 +251,11 @@ export function setKey(this: NodePath, key) {
 export function requeue(this: NodePath, pathToQueue = this) {
   if (pathToQueue.removed) return;
 
-  // TODO: Uncomment in Babel 8. If a path is skipped, and then replaced with a
+  // If a path is skipped, and then replaced with a
   // new one, the new one shouldn't probably be skipped.
-  // Note that this currently causes an infinite loop because of
-  // packages/babel-plugin-transform-block-scoping/src/tdz.js#L52-L59
-  // (b5b8055cc00756f94bf71deb45f288738520ee3c)
-  //
-  // pathToQueue.shouldSkip = false;
+  if (process.env.BABEL_8_BREAKING) {
+    pathToQueue.shouldSkip = false;
+  }
 
   // TODO(loganfsmyth): This should be switched back to queue in parent contexts
   // automatically once #2892 and #4135 have been resolved. See #4140.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Transform-block-scoping falls to infinite loop when we ignore `shouldSkip` of a requeued path
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Y, behind the `BABEL_8_BREAKING` flag
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When a NodePath is skipped and then requeued, we should ignore the `shouldSkip` otherwise it will not be visited. This is a breaking change because it breaks `transform-block-scoping`. The intention of `path.skip` in block-scoping is to avoid revisiting the transformed AST node. In this PR we check whether an AST node is visited before processing. In this way `transform-block-scoping` can work with both Babel 7 and Babel 8.