### PR TITLE
fix(parser): [Babel8] Align error codes between Flow and TypeScript

### DIFF
--- a/packages/babel-parser/src/parser/error.js
+++ b/packages/babel-parser/src/parser/error.js
@@ -28,17 +28,30 @@ export type ErrorTemplates = {
   [key: string]: ErrorTemplate,
 };
 
+type SyntaxPlugin = "flow" | "typescript" | "jsx" | typeof undefined;
+
+function keepReasonCodeCompat(reasonCode: string, syntaxPlugin: SyntaxPlugin) {
+  if (!process.env.BABEL_8_BREAKING) {
+    // For consistency in TypeScript and Flow error codes
+    if (syntaxPlugin === "flow" && reasonCode === "PatternIsOptional") {
+      return "OptionalBindingPattern";
+    }
+  }
+  return reasonCode;
+}
+
 export function makeErrorTemplates(
   messages: {
     [key: string]: string,
   },
   code: ErrorCode,
+  syntaxPlugin?: SyntaxPlugin,
 ): ErrorTemplates {
   const templates: ErrorTemplates = {};
   Object.keys(messages).forEach(reasonCode => {
     templates[reasonCode] = Object.freeze({
       code,
-      reasonCode,
+      reasonCode: keepReasonCodeCompat(reasonCode, syntaxPlugin),
       template: messages[reasonCode],
     });
   });

--- a/packages/babel-parser/src/plugins/flow/index.js
+++ b/packages/babel-parser/src/plugins/flow/index.js
@@ -137,6 +137,7 @@ const FlowErrors = makeErrorTemplates(
     UnterminatedFlowComment: "Unterminated flow-comment.",
   },
   /* code */ ErrorCodes.SyntaxError,
+  /* syntaxPlugin */ "flow",
 );
 /* eslint-disable sort-keys */
 

--- a/packages/babel-parser/src/plugins/flow/index.js
+++ b/packages/babel-parser/src/plugins/flow/index.js
@@ -99,7 +99,7 @@ const FlowErrors = makeErrorTemplates(
       "`declare module` cannot be used inside another `declare module`.",
     NestedFlowComment:
       "Cannot have a flow comment inside another flow comment.",
-    OptionalBindingPattern:
+    PatternIsOptional:
       "A binding pattern parameter cannot be optional in an implementation signature.",
     SetterMayNotHaveThisParam: "A setter cannot have a `this` parameter.",
     SpreadVariance: "Spread properties cannot have variance.",
@@ -2532,7 +2532,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     parseAssignableListItemTypes(param: N.Pattern): N.Pattern {
       if (this.eat(tt.question)) {
         if (param.type !== "Identifier") {
-          this.raise(param.start, FlowErrors.OptionalBindingPattern);
+          this.raise(param.start, FlowErrors.PatternIsOptional);
         }
         if (this.isThisParam(param)) {
           this.raise(param.start, FlowErrors.ThisParamMayNotBeOptional);

--- a/packages/babel-parser/src/plugins/jsx/index.js
+++ b/packages/babel-parser/src/plugins/jsx/index.js
@@ -40,6 +40,7 @@ const JsxErrors = makeErrorTemplates(
       "Adjacent JSX elements must be wrapped in an enclosing tag. Did you want a JSX fragment <>...</>?",
   },
   /* code */ ErrorCodes.SyntaxError,
+  /* syntaxPlugin */ "jsx",
 );
 /* eslint-disable sort-keys */
 

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -156,6 +156,7 @@ const TSErrors = makeErrorTemplates(
       "Name in a signature must be an Identifier, ObjectPattern or ArrayPattern, instead got %0.",
   },
   /* code */ ErrorCodes.SyntaxError,
+  /* syntaxPlugin */ "typescript",
 );
 /* eslint-disable sort-keys */
 

--- a/packages/babel-parser/test/error-codes.js
+++ b/packages/babel-parser/test/error-codes.js
@@ -18,4 +18,25 @@ describe("error codes", function () {
     expect(error.code).toBe("BABEL_PARSER_SYNTAX_ERROR");
     expect(error.reasonCode).toBe("MissingSemicolon");
   });
+  it("consistent reasonCode between Flow and TypeScript in Babel 8", () => {
+    const code = `function f([]?) {}`;
+    const {
+      errors: [tsError],
+    } = parse(code, {
+      errorRecovery: true,
+      plugins: ["typescript"],
+    });
+    const {
+      errors: [flowError],
+    } = parse(code, {
+      errorRecovery: true,
+      plugins: ["flow"],
+    });
+    expect(flowError.reasonCode).toBe(
+      process.env.BABEL_8_BREAKING
+        ? tsError.reasonCode
+        : "OptionalBindingPattern",
+    );
+    expect(flowError.message).toBe(tsError.message);
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  N
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Errors with exactly the same message had different error codes, so align them.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13294"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

