### PR TITLE
Better error for `export * as ns` without the correct plugin

### DIFF
--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/noInterop-loose/export-namespace-without-plugin/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/noInterop-loose/export-namespace-without-plugin/input.mjs
@@ -1,0 +1,2 @@
+export * as ns from "./foo";
+

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/noInterop-loose/export-namespace-without-plugin/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/noInterop-loose/export-namespace-without-plugin/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Export namespace should be first transformed by `@babel/plugin-proposal-export-namespace-from`."
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/noInterop-loose/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/noInterop-loose/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    ["transform-modules-commonjs", { "noInterop": true, "loose": true }]
+  ]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13273 
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR provides better errors when an `export * as ns` is seen on module transforms.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13296"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

