### PR TITLE
Compile static blocks without the intermediate priv field step

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/features.js
+++ b/packages/babel-helper-create-class-features-plugin/src/features.js
@@ -6,6 +6,7 @@ export const FEATURES = Object.freeze({
   privateMethods: 1 << 2,
   decorators: 1 << 3,
   privateIn: 1 << 4,
+  staticBlocks: 1 << 5,
 });
 
 const featuresSameLoose = new Map([
@@ -144,8 +145,8 @@ export function verifyUsedFeatures(path, file) {
     }
   }
 
-  // NOTE: We can't use path.isPrivateMethod() because it isn't supported in <7.2.0
-  if (path.isPrivate() && path.isMethod()) {
+  // NOTE: path.isPrivateMethod() it isn't supported in <7.2.0
+  if (path.isPrivateMethod?.()) {
     if (!hasFeature(file, FEATURES.privateMethods)) {
       throw path.buildCodeFrameError("Class private methods are not enabled.");
     }
@@ -168,6 +169,15 @@ export function verifyUsedFeatures(path, file) {
   if (path.isProperty()) {
     if (!hasFeature(file, FEATURES.fields)) {
       throw path.buildCodeFrameError("Class fields are not enabled.");
+    }
+  }
+
+  if (path.isStaticBlock?.()) {
+    if (!hasFeature(file, FEATURES.staticBlocks)) {
+      throw path.buildCodeFrameError(
+        "Static class blocks are not enabled. " +
+          "Please add `@babel/plugin-proposal-class-static-block` to your configuration.",
+      );
     }
   }
 }

--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -146,19 +146,16 @@ export function createClassFeaturePlugin({
             constructor = path;
           } else {
             elements.push(path);
-            if (path.isProperty() || path.isPrivate()) {
+            if (
+              path.isProperty() ||
+              path.isPrivate() ||
+              path.isStaticBlock?.()
+            ) {
               props.push(path);
             }
           }
 
           if (!isDecorated) isDecorated = hasOwnDecorators(path.node);
-
-          if (path.isStaticBlock?.()) {
-            throw path.buildCodeFrameError(
-              "Compiling class fields and private methods requires compiling class static blocks." +
-                " Please add `@babel/plugin-proposal-class-static-block` to your Babel configuration.",
-            );
-          }
         }
 
         if (!props.length && !isDecorated) return;

--- a/packages/babel-helper-create-class-features-plugin/src/index.js
+++ b/packages/babel-helper-create-class-features-plugin/src/index.js
@@ -154,15 +154,10 @@ export function createClassFeaturePlugin({
           if (!isDecorated) isDecorated = hasOwnDecorators(path.node);
 
           if (path.isStaticBlock?.()) {
-            throw path.buildCodeFrameError(`Incorrect plugin order, \`@babel/plugin-proposal-class-static-block\` should be placed before class features plugins
-{
-  "plugins": [
-    "@babel/plugin-proposal-class-static-block",
-    "@babel/plugin-proposal-private-property-in-object",
-    "@babel/plugin-proposal-private-methods",
-    "@babel/plugin-proposal-class-properties",
-  ]
-}`);
+            throw path.buildCodeFrameError(
+              "Compiling class fields and private methods requires compiling class static blocks." +
+                " Please add `@babel/plugin-proposal-class-static-block` to your Babel configuration.",
+            );
           }
         }
 

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/missing-class-static-blocks-plugin/basic/input.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/missing-class-static-blocks-plugin/basic/input.js
@@ -1,0 +1,4 @@
+class A {
+  #x;
+  static {}
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/missing-class-static-blocks-plugin/basic/options.json
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/missing-class-static-blocks-plugin/basic/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": ["proposal-class-properties", "syntax-class-static-block"],
-  "throws": "Compiling class fields and private methods requires compiling class static blocks. Please add `@babel/plugin-proposal-class-static-block` to your Babel configuration."
+  "throws": "Static class blocks are not enabled. Please add `@babel/plugin-proposal-class-static-block` to your configuration."
 }

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/missing-class-static-blocks-plugin/basic/options.json
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/missing-class-static-blocks-plugin/basic/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["proposal-class-properties", "syntax-class-static-block"],
+  "throws": "Compiling class fields and private methods requires compiling class static blocks. Please add `@babel/plugin-proposal-class-static-block` to your Babel configuration."
+}

--- a/packages/babel-helper-replace-supers/src/index.ts
+++ b/packages/babel-helper-replace-supers/src/index.ts
@@ -281,7 +281,8 @@ export default class ReplaceSupers {
     this.methodPath = path;
     this.isDerivedConstructor =
       path.isClassMethod({ kind: "constructor" }) && !!opts.superRef;
-    this.isStatic = path.isObjectMethod() || path.node.static;
+    this.isStatic =
+      path.isObjectMethod() || path.node.static || path.isStaticBlock?.();
     this.isPrivateMethod = path.isPrivate() && path.isMethod();
 
     this.file = opts.file;

--- a/packages/babel-plugin-proposal-class-static-block/package.json
+++ b/packages/babel-plugin-proposal-class-static-block/package.json
@@ -19,6 +19,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-create-class-features-plugin": "workspace:^7.13.11",
     "@babel/helper-plugin-utils": "workspace:^7.13.0",
     "@babel/plugin-syntax-class-static-block": "workspace:^7.12.13"
   },

--- a/packages/babel-plugin-proposal-class-static-block/src/index.js
+++ b/packages/babel-plugin-proposal-class-static-block/src/index.js
@@ -1,6 +1,11 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxClassStaticBlock from "@babel/plugin-syntax-class-static-block";
 
+import {
+  enableFeature,
+  FEATURES,
+} from "@babel/helper-create-class-features-plugin";
+
 /**
  * Generate a uid that is not in `denyList`
  *
@@ -25,40 +30,42 @@ export default declare(({ types: t, template, assertVersion }) => {
   return {
     name: "proposal-class-static-block",
     inherits: syntaxClassStaticBlock,
+
+    pre() {
+      // Enable this in @babel/helper-create-class-features-plugin, so that it
+      // can be handled by the private fields and methods transform.
+      enableFeature(this.file, FEATURES.staticBlocks, /* loose */ false);
+    },
+
     visitor: {
-      Program(path) {
-        // We run this from the program visitor, so that when transforming private elements
-        // we are sure that static blocks have already been transformed regarless of the
-        // plugins order in the user config.
-        path.traverse({
-          Class(path: NodePath<Class>) {
-            const { scope } = path;
-            const classBody = path.get("body");
-            const privateNames = new Set();
-            const body = classBody.get("body");
-            for (const path of body) {
-              if (path.isPrivate()) {
-                privateNames.add(path.get("key.id").node.name);
-              }
-            }
-            for (const path of body) {
-              if (!path.isStaticBlock()) continue;
-              const staticBlockPrivateId = generateUid(scope, privateNames);
-              privateNames.add(staticBlockPrivateId);
-              const staticBlockRef = t.privateName(
-                t.identifier(staticBlockPrivateId),
-              );
-              path.replaceWith(
-                t.classPrivateProperty(
-                  staticBlockRef,
-                  template.expression.ast`(() => { ${path.node.body} })()`,
-                  [],
-                  /* static */ true,
-                ),
-              );
-            }
-          },
-        });
+      // Run on ClassBody and not on class so that if @babel/helper-create-class-features-plugin
+      // is enabled it can generte optimized output without passing from the intermediate
+      // private fields representation.
+      ClassBody(classBody: NodePath<Class>) {
+        const { scope } = classBody;
+        const privateNames = new Set();
+        const body = classBody.get("body");
+        for (const path of body) {
+          if (path.isPrivate()) {
+            privateNames.add(path.get("key.id").node.name);
+          }
+        }
+        for (const path of body) {
+          if (!path.isStaticBlock()) continue;
+          const staticBlockPrivateId = generateUid(scope, privateNames);
+          privateNames.add(staticBlockPrivateId);
+          const staticBlockRef = t.privateName(
+            t.identifier(staticBlockPrivateId),
+          );
+          path.replaceWith(
+            t.classPrivateProperty(
+              staticBlockRef,
+              template.expression.ast`(() => { ${path.node.body} })()`,
+              [],
+              /* static */ true,
+            ),
+          );
+        }
       },
     },
   };

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-binding/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-binding/output.js
@@ -1,12 +1,9 @@
-var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
-
 class Foo {}
 
 Foo.bar = 42;
-Object.defineProperty(Foo, _, {
-  writable: true,
-  value: (() => {
-    Foo.foo = Foo.bar;
-  })()
-});
+
+(() => {
+  Foo.foo = Foo.bar;
+})();
+
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-declaration/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-declaration/output.js
@@ -1,12 +1,9 @@
-var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
-
 class Foo {}
 
 Foo.bar = 42;
-Object.defineProperty(Foo, _, {
-  writable: true,
-  value: (() => {
-    Foo.foo = Foo.bar;
-  })()
-});
+
+(() => {
+  Foo.foo = Foo.bar;
+})();
+
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/in-class-heritage/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/in-class-heritage/output.js
@@ -1,23 +1,13 @@
-var _class, _2, _temp, _class2, _3, _temp2;
+var _class, _temp, _class2, _temp2;
 
-var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
+class Foo extends (_temp = _class = class extends (_temp2 = _class2 = class Base {}, (() => {
+  _class2.qux = 21;
+})(), _temp2) {}, (() => {
+  _class.bar = 21;
+})(), _temp) {}
 
-class Foo extends (_temp = (_2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_"), _class = class extends (_temp2 = (_3 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_"), _class2 = class Base {}), Object.defineProperty(_class2, _3, {
-  writable: true,
-  value: (() => {
-    _class2.qux = 21;
-  })()
-}), _temp2) {}), Object.defineProperty(_class, _2, {
-  writable: true,
-  value: (() => {
-    _class.bar = 21;
-  })()
-}), _temp) {}
+(() => {
+  Foo.foo = Foo.bar + Foo.qux;
+})();
 
-Object.defineProperty(Foo, _, {
-  writable: true,
-  value: (() => {
-    Foo.foo = Foo.bar + Foo.qux;
-  })()
-});
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/multiple-static-initializers/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/multiple-static-initializers/output.js
@@ -1,26 +1,19 @@
 var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 
-var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
-
-var _2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_2");
-
 class Foo {}
 
 Object.defineProperty(Foo, _bar, {
   writable: true,
   value: 21
 });
-Object.defineProperty(Foo, _, {
-  writable: true,
-  value: (() => {
-    Foo.foo = babelHelpers.classPrivateFieldLooseBase(Foo, _bar)[_bar];
-    Foo.qux1 = Foo.qux;
-  })()
-});
+
+(() => {
+  Foo.foo = babelHelpers.classPrivateFieldLooseBase(Foo, _bar)[_bar];
+  Foo.qux1 = Foo.qux;
+})();
+
 Foo.qux = 21;
-Object.defineProperty(Foo, _2, {
-  writable: true,
-  value: (() => {
-    Foo.qux2 = Foo.qux;
-  })()
-});
+
+(() => {
+  Foo.qux2 = Foo.qux;
+})();

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/name-conflict/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/name-conflict/output.js
@@ -1,17 +1,14 @@
 var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
 
-var _2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_2");
-
 class Foo {}
 
 Object.defineProperty(Foo, _, {
   writable: true,
   value: 42
 });
-Object.defineProperty(Foo, _2, {
-  writable: true,
-  value: (() => {
-    Foo.foo = babelHelpers.classPrivateFieldLooseBase(Foo, _)[_];
-  })()
-});
+
+(() => {
+  Foo.foo = babelHelpers.classPrivateFieldLooseBase(Foo, _)[_];
+})();
+
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/super-static-block/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/super-static-block/output.js
@@ -1,26 +1,17 @@
-var _class, _2, _temp;
+var _class, _temp;
 
-var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
-
-class Foo extends (_temp = (_2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_"), _class = class {}), Object.defineProperty(_class, _2, {
-  writable: true,
-  value: (() => {
-    _class.bar = 42;
-  })()
-}), _temp) {}
+class Foo extends (_temp = _class = class {}, (() => {
+  _class.bar = 42;
+})(), _temp) {}
 
 Foo.bar = 21;
-Object.defineProperty(Foo, _, {
-  writable: true,
-  value: (() => {
-    var _class2, _3, _temp2;
 
-    Foo.foo = (_temp2 = (_3 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_"), _class2 = class {}), Object.defineProperty(_class2, _3, {
-      writable: true,
-      value: (() => {
-        _class2.bar = 42;
-      })()
-    }), _temp2).bar;
-  })()
-});
+(() => {
+  var _class2, _temp2;
+
+  Foo.foo = (_temp2 = _class2 = class {}, (() => {
+    _class2.bar = 42;
+  })(), _temp2).bar;
+})();
+
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/class-binding/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/class-binding/output.js
@@ -1,10 +1,9 @@
 class Foo {}
 
 babelHelpers.defineProperty(Foo, "bar", 42);
-var _ = {
-  writable: true,
-  value: (() => {
-    Foo.foo = Foo.bar;
-  })()
-};
+
+(() => {
+  Foo.foo = Foo.bar;
+})();
+
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/class-declaration/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/class-declaration/output.js
@@ -1,10 +1,9 @@
 class Foo {}
 
 babelHelpers.defineProperty(Foo, "bar", 42);
-var _ = {
-  writable: true,
-  value: (() => {
-    Foo.foo = Foo.bar;
-  })()
-};
+
+(() => {
+  Foo.foo = Foo.bar;
+})();
+
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/in-class-heritage/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/in-class-heritage/output.js
@@ -1,21 +1,13 @@
-var _class, _temp, _2, _class2, _temp2, _3;
+var _class, _temp, _class2, _temp2;
 
-class Foo extends (_temp = _class = class extends (_temp2 = _class2 = class Base {}, _3 = {
-  writable: true,
-  value: (() => {
-    _class2.qux = 21;
-  })()
-}, _temp2) {}, _2 = {
-  writable: true,
-  value: (() => {
-    _class.bar = 21;
-  })()
-}, _temp) {}
+class Foo extends (_temp = _class = class extends (_temp2 = _class2 = class Base {}, (() => {
+  _class2.qux = 21;
+})(), _temp2) {}, (() => {
+  _class.bar = 21;
+})(), _temp) {}
 
-var _ = {
-  writable: true,
-  value: (() => {
-    Foo.foo = Foo.bar + Foo.qux;
-  })()
-};
+(() => {
+  Foo.foo = Foo.bar + Foo.qux;
+})();
+
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/multiple-static-initializers/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/multiple-static-initializers/output.js
@@ -4,17 +4,14 @@ var _bar = {
   writable: true,
   value: 21
 };
-var _ = {
-  writable: true,
-  value: (() => {
-    Foo.foo = babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _bar);
-    Foo.qux1 = Foo.qux;
-  })()
-};
+
+(() => {
+  Foo.foo = babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _bar);
+  Foo.qux1 = Foo.qux;
+})();
+
 babelHelpers.defineProperty(Foo, "qux", 21);
-var _2 = {
-  writable: true,
-  value: (() => {
-    Foo.qux2 = Foo.qux;
-  })()
-};
+
+(() => {
+  Foo.qux2 = Foo.qux;
+})();

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/name-conflict/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/name-conflict/output.js
@@ -4,10 +4,9 @@ var _ = {
   writable: true,
   value: 42
 };
-var _2 = {
-  writable: true,
-  value: (() => {
-    Foo.foo = babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _);
-  })()
-};
+
+(() => {
+  Foo.foo = babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _);
+})();
+
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/plugin-ordering.test.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/plugin-ordering.test.js
@@ -26,12 +26,9 @@ describe("plugin ordering", () => {
 
       class Foo {}
 
-      var _ = {
-        writable: true,
-        value: (() => {
-          Foo.foo = Foo.bar;
-        })()
-      };
+      (() => {
+        Foo.foo = Foo.bar;
+      })();
 
       _defineProperty(Foo, \\"bar\\", 42);"
     `);

--- a/packages/babel-plugin-proposal-class-static-block/test/plugin-ordering.test.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/plugin-ordering.test.js
@@ -2,15 +2,15 @@ import * as babel from "@babel/core";
 import proposalClassStaticBlock from "..";
 
 describe("plugin ordering", () => {
-  it("should throw when @babel/plugin-proposal-class-static-block is after class features plugin", () => {
+  it("should work when @babel/plugin-proposal-class-static-block is after class features plugin", () => {
     const source = `class Foo {
-  static {
-    this.foo = Foo.bar;
-  }
-  static bar = 42;
-}
-`;
-    expect(() => {
+      static {
+        this.foo = Foo.bar;
+      }
+      static bar = 42;
+    }
+    `;
+    expect(
       babel.transform(source, {
         filename: "example.js",
         highlightCode: false,
@@ -20,22 +20,20 @@ describe("plugin ordering", () => {
           "@babel/plugin-proposal-class-properties",
           proposalClassStaticBlock,
         ],
-      });
-    })
-      .toThrow(`Incorrect plugin order, \`@babel/plugin-proposal-class-static-block\` should be placed before class features plugins
-{
-  "plugins": [
-    "@babel/plugin-proposal-class-static-block",
-    "@babel/plugin-proposal-private-property-in-object",
-    "@babel/plugin-proposal-private-methods",
-    "@babel/plugin-proposal-class-properties",
-  ]
-}
-  1 | class Foo {
-> 2 |   static {
-    |   ^
-  3 |     this.foo = Foo.bar;
-  4 |   }
-  5 |   static bar = 42;`);
+      }).code,
+    ).toMatchInlineSnapshot(`
+      "function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+      class Foo {}
+
+      var _ = {
+        writable: true,
+        value: (() => {
+          Foo.foo = Foo.bar;
+        })()
+      };
+
+      _defineProperty(Foo, \\"bar\\", 42);"
+    `);
   });
 });

--- a/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-firefox-70/output.js
+++ b/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-firefox-70/output.js
@@ -10,9 +10,6 @@ class A {
 
 }
 
-var _ = {
-  writable: true,
-  value: (() => {
-    register(A, _foo.has(A));
-  })()
-};
+(() => {
+  register(A, _foo.has(A));
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,6 +1111,7 @@ __metadata:
   resolution: "@babel/plugin-proposal-class-static-block@workspace:packages/babel-plugin-proposal-class-static-block"
   dependencies:
     "@babel/core": "workspace:*"
+    "@babel/helper-create-class-features-plugin": "workspace:^7.13.11"
     "@babel/helper-plugin-test-runner": "workspace:*"
     "@babel/helper-plugin-utils": "workspace:^7.13.0"
     "@babel/plugin-syntax-class-static-block": "workspace:^7.12.13"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/13293
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Consider this config:
```json
{
  "presets": [
     {
       "plugins": ["proposal-class-static-block", "proposal-private-methods", "proposal-class-properties"]
     },
     "@babel/preset-env"
  ]
}
```

Until Babel 7.14.0, this was fine: the `proposal-class-static-block` was enabled before the other class features plugins, so that it could compile static blocks to private fields.

However, starting from Babel 7.14.0 `@babel/preset-env` automatically enabled the class fields and private methods plugins: the new effective order is
```json
- proposal-private-methods
- proposal-class-properties
- proposal-class-static-block
- proposal-private-methods
- proposal-class-properties
```

This breaks, because the `proposal-class-properties` plugin runs before `proposal-class-static-block` (and the only way to workaround it is to change the presets order in the user config).

We can avoid this problem by transforming static blocks in `Program:enter`: it's safe, because the transform is quite self-contained so it doesn't cause problem if there are some proposals between the program node and the class node.

Regardless of the behavior change introduced in 7.14.0, this is something that makes it easier to configure Babel since it's one less thing our users have to worry about.

I hope to properly solve this problem with something like https://github.com/babel/babel/pull/13260.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13297"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

