### PR TITLE
Remove warnings about `loose` mode for class feats in tests

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/options.json
@@ -1,3 +1,7 @@
 {
-  "presets": [["env", { "targets": { "browsers": "ie 6" } }]]
+  "plugins": [
+    ["proposal-class-properties", { "loose": true }],
+    "transform-classes",
+    "transform-arrow-functions"
+  ]
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
@@ -1,6 +1,6 @@
 var _scopedFunctionWithThis = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("scopedFunctionWithThis");
 
-var Child = /*#__PURE__*/function (_Parent) {
+let Child = /*#__PURE__*/function (_Parent) {
   "use strict";
 
   babelHelpers.inherits(Child, _Parent);
@@ -14,7 +14,7 @@ var Child = /*#__PURE__*/function (_Parent) {
     _this = _super.call(this);
     Object.defineProperty(babelHelpers.assertThisInitialized(_this), _scopedFunctionWithThis, {
       writable: true,
-      value: function value() {
+      value: function () {
         _this.name = {};
       }
     });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/options.json
@@ -1,4 +1,7 @@
 {
-  "plugins": [["proposal-class-properties", { "loose": true }]],
-  "presets": [["env", { "targets": { "browsers": "ie 6" } }]]
+  "plugins": [
+    ["proposal-class-properties", { "loose": true }],
+    "transform-classes",
+    "transform-arrow-functions"
+  ]
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/output.js
@@ -1,4 +1,4 @@
-var Child = /*#__PURE__*/function (_Parent) {
+let Child = /*#__PURE__*/function (_Parent) {
   "use strict";
 
   babelHelpers.inherits(Child, _Parent);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-constructors/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-constructors/options.json
@@ -1,7 +1,10 @@
 {
+  "assumptions": {
+    "setPublicClassFields": true
+  },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    ["proposal-class-properties", { "loose": true }]
+    "proposal-class-properties"
   ]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-constructors/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-constructors/options.json
@@ -3,8 +3,5 @@
     "setPublicClassFields": true
   },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
-  "plugins": [
-    ["proposal-decorators", { "legacy": true }],
-    "proposal-class-properties"
-  ]
+  "plugins": [["proposal-decorators", { "legacy": true }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-export-default/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-export-default/options.json
@@ -1,7 +1,10 @@
 {
+  "assumptions": {
+    "setPublicClassFields": true
+  },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    ["proposal-class-properties", { "loose": true }]
+    "proposal-class-properties"
   ]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-export-default/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-export-default/options.json
@@ -3,8 +3,5 @@
     "setPublicClassFields": true
   },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
-  "plugins": [
-    ["proposal-decorators", { "legacy": true }],
-    "proposal-class-properties"
-  ]
+  "plugins": [["proposal-decorators", { "legacy": true }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-ordering/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-ordering/options.json
@@ -1,7 +1,10 @@
 {
+  "assumptions": {
+    "setPublicClassFields": true
+  },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    ["proposal-class-properties", { "loose": true }]
+    "proposal-class-properties"
   ]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-ordering/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-ordering/options.json
@@ -3,8 +3,5 @@
     "setPublicClassFields": true
   },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
-  "plugins": [
-    ["proposal-decorators", { "legacy": true }],
-    "proposal-class-properties"
-  ]
+  "plugins": [["proposal-decorators", { "legacy": true }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-methods/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-methods/options.json
@@ -1,8 +1,11 @@
 {
+  "assumptions": {
+    "setPublicClassFields": true
+  },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    ["proposal-class-properties", { "loose": true }],
+    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-methods/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-methods/options.json
@@ -5,7 +5,6 @@
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-properties/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-properties/options.json
@@ -1,8 +1,11 @@
 {
+  "assumptions": {
+    "setPublicClassFields": true
+  },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    ["proposal-class-properties", { "loose": true }],
+    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-properties/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-properties/options.json
@@ -5,7 +5,6 @@
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-static-methods/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-static-methods/options.json
@@ -1,8 +1,11 @@
 {
+  "assumptions": {
+    "setPublicClassFields": true
+  },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    ["proposal-class-properties", { "loose": true }],
+    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-static-methods/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-static-methods/options.json
@@ -5,7 +5,6 @@
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-static-properties/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-static-properties/options.json
@@ -1,8 +1,11 @@
 {
+  "assumptions": {
+    "setPublicClassFields": true
+  },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    ["proposal-class-properties", { "loose": true }],
+    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-static-properties/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-static-properties/options.json
@@ -5,7 +5,6 @@
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-methods/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-methods/options.json
@@ -1,8 +1,11 @@
 {
+  "assumptions": {
+    "setPublicClassFields": true
+  },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    ["proposal-class-properties", { "loose": true }],
+    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-methods/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-methods/options.json
@@ -5,7 +5,6 @@
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-ordering/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-ordering/options.json
@@ -1,7 +1,10 @@
 {
+  "assumptions": {
+    "setPublicClassFields": true
+  },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    ["proposal-class-properties", { "loose": true }]
+    "proposal-class-properties"
   ]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-ordering/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-ordering/options.json
@@ -3,8 +3,5 @@
     "setPublicClassFields": true
   },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
-  "plugins": [
-    ["proposal-decorators", { "legacy": true }],
-    "proposal-class-properties"
-  ]
+  "plugins": [["proposal-decorators", { "legacy": true }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-properties/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-properties/options.json
@@ -1,8 +1,11 @@
 {
+  "assumptions": {
+    "setPublicClassFields": true
+  },
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    ["proposal-class-properties", { "loose": true }],
+    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-properties/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-object-properties/options.json
@@ -5,7 +5,6 @@
   "presets": [["env", { "targets": { "browsers": "ie 6" } }]],
   "plugins": [
     ["proposal-decorators", { "legacy": true }],
-    "proposal-class-properties",
     ["babel-plugin-polyfill-es-shims", { "method": "usage-global", "targets": {
       "node": "current"
     }}]


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I noticed different warnings in `make test` since 7.14.0, caused by mismatching `loose` options for the various class features plugins. This PR fixes it.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13301"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

