### PR TITLE
[Babel 8]: remove module attributes parser/generator support

### DIFF
--- a/packages/babel-generator/src/generators/modules.ts
+++ b/packages/babel-generator/src/generators/modules.ts
@@ -204,15 +204,15 @@ export function ImportDeclaration(this: Printer, node: t.ImportDeclaration) {
   this.print(node.source, node);
 
   this.printAssertions(node);
-  // todo(Babel 8): remove this if branch
-  // `module-attributes` support is discontinued, use `import-assertions` instead.
-  // @ts-expect-error
-  if (node.attributes?.length) {
-    this.space();
-    this.word("with");
-    this.space();
+  if (!process.env.BABEL_8_BREAKING) {
     // @ts-expect-error
-    this.printList(node.attributes, node);
+    if (node.attributes?.length) {
+      this.space();
+      this.word("with");
+      this.space();
+      // @ts-expect-error
+      this.printList(node.attributes, node);
+    }
   }
 
   this.semicolon();

--- a/packages/babel-generator/test/fixtures/types/ModuleAttributes/options.json
+++ b/packages/babel-generator/test/fixtures/types/ModuleAttributes/options.json
@@ -7,5 +7,6 @@
       }
     ]
   ],
-  "sourceType": "module"
+  "sourceType": "module",
+  "BABEL_8_BREAKING": false
 }

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -857,8 +857,6 @@ export default class ExpressionParser extends LValParser {
   ): N.Expression {
     if (node.callee.type === "Import") {
       if (node.arguments.length === 2) {
-        // todo(Babel 8): remove the if condition,
-        // moduleAttributes is renamed to importAssertions
         if (process.env.BABEL_8_BREAKING) {
           this.expectPlugin("importAssertions");
         } else {

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -859,8 +859,12 @@ export default class ExpressionParser extends LValParser {
       if (node.arguments.length === 2) {
         // todo(Babel 8): remove the if condition,
         // moduleAttributes is renamed to importAssertions
-        if (!this.hasPlugin("moduleAttributes")) {
+        if (process.env.BABEL_8_BREAKING) {
           this.expectPlugin("importAssertions");
+        } else {
+          if (!this.hasPlugin("moduleAttributes")) {
+            this.expectPlugin("importAssertions");
+          }
         }
       }
       if (node.arguments.length === 0 || node.arguments.length > 2) {

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -2197,9 +2197,7 @@ export default class StatementParser extends ExpressionParser {
     const assertions = this.maybeParseImportAssertions();
     if (assertions) {
       node.assertions = assertions;
-    }
-    // todo(Babel 8): remove module attributes support
-    else {
+    } else if (!process.env.BABEL_8_BREAKING) {
       const attributes = this.maybeParseModuleAttributes();
       if (attributes) {
         node.attributes = attributes;

--- a/packages/babel-parser/src/plugin-utils.js
+++ b/packages/babel-parser/src/plugin-utils.js
@@ -92,7 +92,7 @@ export function validatePlugins(plugins: PluginList) {
         "`moduleAttributes` has been removed in Babel 8, please use `importAssertions` parser plugin, or `@babel/plugin-syntax-import-assertions`.",
       );
     }
-    if (hasPlugin(plugins, "importAssertions")) {
+    else if (hasPlugin(plugins, "importAssertions")) {
       throw new Error(
         "Cannot combine importAssertions and moduleAttributes plugins.",
       );

--- a/packages/babel-parser/src/plugin-utils.js
+++ b/packages/babel-parser/src/plugin-utils.js
@@ -87,6 +87,11 @@ export function validatePlugins(plugins: PluginList) {
   }
 
   if (hasPlugin(plugins, "moduleAttributes")) {
+    if (process.env.BABEL_8_BREAKING) {
+      throw new Error(
+        "`moduleAttributes` has been removed in Babel 8, please use `importAssertions` parser plugin, or `@babel/plugin-syntax-import-assertions`.",
+      );
+    }
     if (hasPlugin(plugins, "importAssertions")) {
       throw new Error(
         "Cannot combine importAssertions and moduleAttributes plugins.",

--- a/packages/babel-parser/src/plugin-utils.js
+++ b/packages/babel-parser/src/plugin-utils.js
@@ -91,23 +91,24 @@ export function validatePlugins(plugins: PluginList) {
       throw new Error(
         "`moduleAttributes` has been removed in Babel 8, please use `importAssertions` parser plugin, or `@babel/plugin-syntax-import-assertions`.",
       );
-    }
-    else if (hasPlugin(plugins, "importAssertions")) {
-      throw new Error(
-        "Cannot combine importAssertions and moduleAttributes plugins.",
+    } else {
+      if (hasPlugin(plugins, "importAssertions")) {
+        throw new Error(
+          "Cannot combine importAssertions and moduleAttributes plugins.",
+        );
+      }
+      const moduleAttributesVerionPluginOption = getPluginOption(
+        plugins,
+        "moduleAttributes",
+        "version",
       );
-    }
-    const moduleAttributesVerionPluginOption = getPluginOption(
-      plugins,
-      "moduleAttributes",
-      "version",
-    );
-    if (moduleAttributesVerionPluginOption !== "may-2020") {
-      throw new Error(
-        "The 'moduleAttributes' plugin requires a 'version' option," +
-          " representing the last proposal update. Currently, the" +
-          " only supported value is 'may-2020'.",
-      );
+      if (moduleAttributesVerionPluginOption !== "may-2020") {
+        throw new Error(
+          "The 'moduleAttributes' plugin requires a 'version' option," +
+            " representing the last proposal update. Currently, the" +
+            " only supported value is 'may-2020'.",
+        );
+      }
     }
   }
 

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/module-attributes/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/module-attributes/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'moduleAttributes' (1:27)"
+  "throws": "This experimental syntax requires enabling the parser plugin: 'moduleAttributes' (1:27)",
+  "BABEL_8_BREAKING": false
 }

--- a/packages/babel-parser/test/fixtures/experimental/module-attributes/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/module-attributes/options.json
@@ -1,0 +1,3 @@
+{
+  "BABEL_8_BREAKING": false
+}

--- a/packages/babel-parser/test/plugin-options.js
+++ b/packages/babel-parser/test/plugin-options.js
@@ -65,4 +65,13 @@ describe("plugin options", function () {
       expect(getParser(SYNTAX_2, [OPT_1, OPT_2])).toThrow();
     });
   });
+  describe("'moduleAttributes' plugin", () => {
+    (process.env.BABEL_8_BREAKING ? it : it.skip)("removed in Babel 8", () => {
+      expect(
+        getParser("", ["moduleAttributes"]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"\`moduleAttributes\` has been removed in Babel 8, please use \`importAssertions\` parser plugin, or \`@babel/plugin-syntax-import-assertions\`."`,
+      );
+    });
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Major: Breaking Change?  | Y, behind the `BABEL_8_BREAKING` flag
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR removes support of `moduleAttributes`. It was superseded by `importAttributes` when the proposal reaches stage 3. The following behaviours are now implemented behind the `BABEL_8_BREAKING` env flag:

- Babel parser will throw when a parser plugin `moduleAttributes` is provided, in the error message we suggest users migrating to the `importAssertions` plugin
- Babel generator will ignore the `moduleAttributes` related AST node property `attributes`, like we did for other unknown AST properties

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13308"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

