### PR TITLE
chore: add class-static-block test262 mapping

### DIFF
--- a/scripts/parser-tests/test262/index.js
+++ b/scripts/parser-tests/test262/index.js
@@ -16,6 +16,7 @@ const ignoredFeatures = [
   "Array.prototype.values",
   "ArrayBuffer",
   "align-detached-buffer-semantics-with-web-reality",
+  "arbitrary-module-namespace-names",
   "async-functions",
   "async-iteration",
   "arrow-function",
@@ -24,6 +25,12 @@ const ignoredFeatures = [
   "BigInt",
   "caller",
   "class",
+  "class-fields-private",
+  "class-fields-public",
+  "class-methods-private",
+  "class-static-fields-private",
+  "class-static-fields-public",
+  "class-static-methods-private",
   "cleanupSome",
   "coalesce-expression",
   "computed-property-names",
@@ -145,14 +152,8 @@ const ignoredFeatures = [
 const ignoredTests = ["built-ins/RegExp/", "language/literals/regexp/"];
 
 const featuresToPlugins = {
-  "arbitrary-module-namespace-names": "moduleStringNames",
-  "class-fields-private": "classPrivateProperties",
   "class-fields-private-in": "privateIn",
-  "class-fields-public": "classProperties",
-  "class-methods-private": "classPrivateMethods",
-  "class-static-fields-public": "classProperties",
-  "class-static-fields-private": "classPrivateProperties",
-  "class-static-methods-private": "classPrivateMethods",
+  "class-static-block": "classStaticBlock",
   "top-level-await": "topLevelAwait",
 };
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Add mapping of `class-static-block` for test262, it is not yet merged: https://github.com/tc39/test262/pull/2968 but I don't expect the feature name will be changed. We add mapping eagerly so babel-bot will pick up automatically after it gets merged.

Also moved those materialized features to `ignoreFeatures` -- they are always enabled in Babel parser.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13313"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

