### PR TITLE
Pass assumptions set in presets to plugins

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@babel/helper-transform-fixture-test-runner": "workspace:*",
+    "@babel/plugin-transform-modules-commonjs": "workspace:*",
     "@types/convert-source-map": "^1.5.1",
     "@types/debug": "^4.1.0",
     "@types/resolve": "^1.3.2",

--- a/packages/babel-core/src/config/full.ts
+++ b/packages/babel-core/src/config/full.ts
@@ -68,10 +68,9 @@ export default gensync<(inputOpts: unknown) => ResolvedConfig | null>(
       throw new Error("Assertion failure - plugins and presets exist");
     }
 
-    const pluginContext: Context.FullPlugin = {
+    const presetContext: Context.FullPreset = {
       ...context,
       targets: options.targets,
-      assumptions: options.assumptions ?? {},
     };
 
     const toDescriptor = (item: PluginItem) => {
@@ -110,7 +109,7 @@ export default gensync<(inputOpts: unknown) => ResolvedConfig | null>(
                 presets.push({
                   preset: yield* loadPresetDescriptor(
                     descriptor,
-                    pluginContext,
+                    presetContext,
                   ),
                   pass: [],
                 });
@@ -118,7 +117,7 @@ export default gensync<(inputOpts: unknown) => ResolvedConfig | null>(
                 presets.unshift({
                   preset: yield* loadPresetDescriptor(
                     descriptor,
-                    pluginContext,
+                    presetContext,
                   ),
                   pass: pluginDescriptorsPass,
                 });
@@ -167,6 +166,11 @@ export default gensync<(inputOpts: unknown) => ResolvedConfig | null>(
 
     const opts: any = optionDefaults;
     mergeOptions(opts, options);
+
+    const pluginContext: Context.FullPlugin = {
+      ...presetContext,
+      assumptions: opts.assumptions ?? {},
+    };
 
     yield* enhanceError(context, function* loadPluginDescriptors() {
       pluginDescriptorsByPass[0].unshift(...initialPluginsDescriptors);

--- a/packages/babel-core/test/assumptions.js
+++ b/packages/babel-core/test/assumptions.js
@@ -1,6 +1,7 @@
 import path from "path";
 import { fileURLToPath } from "url";
 import { loadOptions as loadOptionsOrig, transformSync } from "../lib";
+import pluginCommonJS from "@babel/plugin-transform-modules-commonjs";
 
 const cwd = path.dirname(fileURLToPath(import.meta.url));
 
@@ -99,6 +100,47 @@ describe("assumptions", () => {
     });
 
     expect(assumptionFn).toBeUndefined();
+  });
+
+  // https://github.com/babel/babel/issues/13316
+  describe("assumptions set in presets are visible from plugins - #13316", () => {
+    function presetEnumerableModuleMeta() {
+      return { assumptions: { enumerableModuleMeta: true } };
+    }
+
+    it("unit", () => {
+      let enumerableModuleMeta;
+
+      loadOptions({
+        configFile: false,
+        presets: [presetEnumerableModuleMeta],
+        plugins: [
+          function extractEnumerableModuleMeta(api) {
+            enumerableModuleMeta = api.assumption("enumerableModuleMeta");
+            return { visitor: {} };
+          },
+        ],
+      });
+
+      expect(enumerableModuleMeta).toBe(true);
+    });
+
+    it("integration", () => {
+      const { code } = transformSync(`export const foo = 1;`, {
+        configFile: false,
+        presets: [presetEnumerableModuleMeta],
+        plugins: [pluginCommonJS],
+      });
+
+      expect(code).toMatchInlineSnapshot(`
+        "\\"use strict\\";
+
+        exports.__esModule = true;
+        exports.foo = void 0;
+        const foo = 1;
+        exports.foo = foo;"
+      `);
+    });
   });
 
   describe("plugin cache", () => {

--- a/packages/babel-core/test/assumptions.js
+++ b/packages/babel-core/test/assumptions.js
@@ -108,21 +108,37 @@ describe("assumptions", () => {
       return { assumptions: { enumerableModuleMeta: true } };
     }
 
-    it("unit", () => {
-      let enumerableModuleMeta;
+    function pluginExtractEnumerableModuleMeta(api, options) {
+      options.enumerableModuleMeta = api.assumption("enumerableModuleMeta");
+      return { visitor: {} };
+    }
+
+    it("plugin defined outside preset", () => {
+      const ref = {};
 
       loadOptions({
         configFile: false,
         presets: [presetEnumerableModuleMeta],
-        plugins: [
-          function extractEnumerableModuleMeta(api) {
-            enumerableModuleMeta = api.assumption("enumerableModuleMeta");
-            return { visitor: {} };
-          },
+        plugins: [[pluginExtractEnumerableModuleMeta, ref]],
+      });
+
+      expect(ref.enumerableModuleMeta).toBe(true);
+    });
+
+    it("plugin defined inside preset", () => {
+      const ref = {};
+
+      loadOptions({
+        configFile: false,
+        presets: [
+          () => ({
+            assumptions: { enumerableModuleMeta: true },
+            plugins: [[pluginExtractEnumerableModuleMeta, ref]],
+          }),
         ],
       });
 
-      expect(enumerableModuleMeta).toBe(true);
+      expect(ref.enumerableModuleMeta).toBe(true);
     });
 
     it("integration", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,6 +214,7 @@ __metadata:
     "@babel/helper-transform-fixture-test-runner": "workspace:*"
     "@babel/helpers": "workspace:^7.14.0"
     "@babel/parser": "workspace:^7.14.2"
+    "@babel/plugin-transform-modules-commonjs": "workspace:*"
     "@babel/template": "workspace:^7.12.13"
     "@babel/traverse": "workspace:^7.14.2"
     "@babel/types": "workspace:^7.14.2"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/13316
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The problem was that we where building the plugin API context using `assumptions` coming from the config options, completely ignoring the `assumptions` set by presets.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13321"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

