### PR TITLE
fix: preserve tokensLength in tryParse

### DIFF
--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -216,6 +216,10 @@ export default class UtilParser extends Tokenizer {
       if (this.state.errors.length > oldState.errors.length) {
         const failState = this.state;
         this.state = oldState;
+        // The tokensLength should be preserved on error recovery mode
+        // since parser does not halt and instead it will parse the
+        // remaining tokens
+        this.state.tokensLength = failState.tokensLength;
         return {
           node,
           error: (failState.errors[oldState.errors.length]: SyntaxError),

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -216,8 +216,8 @@ export default class UtilParser extends Tokenizer {
       if (this.state.errors.length > oldState.errors.length) {
         const failState = this.state;
         this.state = oldState;
-        // The tokensLength should be preserved on error recovery mode
-        // since parser does not halt and instead it will parse the
+        // tokensLength should be preserved during error recovery mode
+        // since the parser does not halt and will instead parse the
         // remaining tokens
         this.state.tokensLength = failState.tokensLength;
         return {

--- a/packages/babel-parser/test/fixtures/flow/typecasts/fail-without-parens-jsx-tokens-true/input.js
+++ b/packages/babel-parser/test/fixtures/flow/typecasts/fail-without-parens-jsx-tokens-true/input.js
@@ -1,0 +1,1 @@
+<div propA={[key: value]} />

--- a/packages/babel-parser/test/fixtures/flow/typecasts/fail-without-parens-jsx-tokens-true/options.json
+++ b/packages/babel-parser/test/fixtures/flow/typecasts/fail-without-parens-jsx-tokens-true/options.json
@@ -1,0 +1,4 @@
+{
+  "tokens": true,
+  "plugins": ["jsx", "flow"]
+}

--- a/packages/babel-parser/test/fixtures/flow/typecasts/fail-without-parens-jsx-tokens-true/output.json
+++ b/packages/babel-parser/test/fixtures/flow/typecasts/fail-without-parens-jsx-tokens-true/output.json
@@ -1,0 +1,292 @@
+{
+  "type": "File",
+  "start":0,"end":28,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":28}},
+  "errors": [
+    "SyntaxError: The type cast expression is expected to be wrapped with parenthesis. (1:16)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":28,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":28}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":28,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":28}},
+        "expression": {
+          "type": "JSXElement",
+          "start":0,"end":28,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":28}},
+          "openingElement": {
+            "type": "JSXOpeningElement",
+            "start":0,"end":28,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":28}},
+            "name": {
+              "type": "JSXIdentifier",
+              "start":1,"end":4,"loc":{"start":{"line":1,"column":1},"end":{"line":1,"column":4}},
+              "name": "div"
+            },
+            "attributes": [
+              {
+                "type": "JSXAttribute",
+                "start":5,"end":25,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":25}},
+                "name": {
+                  "type": "JSXIdentifier",
+                  "start":5,"end":10,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":10}},
+                  "name": "propA"
+                },
+                "value": {
+                  "type": "JSXExpressionContainer",
+                  "start":11,"end":25,"loc":{"start":{"line":1,"column":11},"end":{"line":1,"column":25}},
+                  "expression": {
+                    "type": "ArrayExpression",
+                    "start":12,"end":24,"loc":{"start":{"line":1,"column":12},"end":{"line":1,"column":24}},
+                    "elements": [
+                      {
+                        "type": "TypeCastExpression",
+                        "start":13,"end":23,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":23}},
+                        "expression": {
+                          "type": "Identifier",
+                          "start":13,"end":16,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":16},"identifierName":"key"},
+                          "name": "key"
+                        },
+                        "typeAnnotation": {
+                          "type": "TypeAnnotation",
+                          "start":16,"end":23,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":23}},
+                          "typeAnnotation": {
+                            "type": "GenericTypeAnnotation",
+                            "start":18,"end":23,"loc":{"start":{"line":1,"column":18},"end":{"line":1,"column":23}},
+                            "typeParameters": null,
+                            "id": {
+                              "type": "Identifier",
+                              "start":18,"end":23,"loc":{"start":{"line":1,"column":18},"end":{"line":1,"column":23},"identifierName":"value"},
+                              "name": "value"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ],
+            "selfClosing": true
+          },
+          "closingElement": null,
+          "children": []
+        }
+      }
+    ],
+    "directives": []
+  },
+  "tokens": [
+    {
+      "type": {
+        "label": "jsxTagStart",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start":0,"end":1,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":1}}
+    },
+    {
+      "type": {
+        "label": "jsxName",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "div",
+      "start":1,"end":4,"loc":{"start":{"line":1,"column":1},"end":{"line":1,"column":4}}
+    },
+    {
+      "type": {
+        "label": "jsxName",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "propA",
+      "start":5,"end":10,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":10}}
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start":10,"end":11,"loc":{"start":{"line":1,"column":10},"end":{"line":1,"column":11}}
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start":11,"end":12,"loc":{"start":{"line":1,"column":11},"end":{"line":1,"column":12}}
+    },
+    {
+      "type": {
+        "label": "[",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start":12,"end":13,"loc":{"start":{"line":1,"column":12},"end":{"line":1,"column":13}}
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "key",
+      "start":13,"end":16,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":16}}
+    },
+    {
+      "type": {
+        "label": ":",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start":16,"end":17,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":17}}
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "value",
+      "start":18,"end":23,"loc":{"start":{"line":1,"column":18},"end":{"line":1,"column":23}}
+    },
+    {
+      "type": {
+        "label": "]",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start":23,"end":24,"loc":{"start":{"line":1,"column":23},"end":{"line":1,"column":24}}
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start":24,"end":25,"loc":{"start":{"line":1,"column":24},"end":{"line":1,"column":25}}
+    },
+    {
+      "type": {
+        "label": "/",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": 10,
+        "updateContext": null
+      },
+      "value": "/",
+      "start":26,"end":27,"loc":{"start":{"line":1,"column":26},"end":{"line":1,"column":27}}
+    },
+    {
+      "type": {
+        "label": "jsxTagEnd",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start":27,"end":28,"loc":{"start":{"line":1,"column":27},"end":{"line":1,"column":28}}
+    },
+    {
+      "type": {
+        "label": "eof",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start":28,"end":28,"loc":{"start":{"line":1,"column":28},"end":{"line":1,"column":28}}
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13322 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we preserve `state.tokensLength` (derived from `this.tokens`) on raising errors when `errorRecovery: true`, because the parser will parse remaining tokens. We do not reset the parser state when `tryParse` successfully returns, so when `errorRecovery` is `true`, we should not reset `state.tokensLength`, too.

Technically #13256 does not introduce this regression but it reveals the fact that the parser unexpectedly eats tokens when errors are thrown in recovery mode.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13326"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

