### PR TITLE
Publish `@babel/traverse` `.d.ts` in e2e-breaking tests

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -39,6 +39,10 @@ const buildTypingsWatchGlob = [
   "./packages/babel-types/scripts/generators/*.js",
 ];
 
+function bool(val) {
+  return !val && val !== "0" && val !== "false";
+}
+
 /**
  * map source code path to the generated artifacts path
  * @example
@@ -466,7 +470,10 @@ const libBundles = [
   dest: "lib",
 }));
 
-const dtsBundles = ["packages/babel-types"];
+const dtsBundles = [
+  "packages/babel-types",
+  bool(process.env.BABEL_8_BREAKING) && "packages/babel-traverse",
+].filter(Boolean);
 
 const standaloneBundle = [
   {

--- a/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
+++ b/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
@@ -512,7 +512,6 @@ function getLocalExportMetadata(
         declaration.isFunctionDeclaration() ||
         declaration.isClassDeclaration()
       ) {
-        // @ts-expect-error todo(flow->ts): improve babel-types
         getLocalMetadata(declaration.get("id")).names.push("default");
       } else {
         // These should have been removed by the nameAnonymousExports() call.

--- a/packages/babel-traverse/src/hub.ts
+++ b/packages/babel-traverse/src/hub.ts
@@ -1,10 +1,11 @@
 import type Scope from "./scope";
+import type * as t from "@babel/types";
 
 export interface HubInterface {
   getCode(): string | void;
   getScope(): Scope | void;
   addHelper(name: string): any;
-  buildError(node: any, msg: string, Error: new () => Error): Error;
+  buildError(node: t.Node, msg: string, Error: ErrorConstructor): Error;
 }
 
 export default class Hub implements HubInterface {
@@ -16,7 +17,7 @@ export default class Hub implements HubInterface {
     throw new Error("Helpers are not supported by the default hub.");
   }
 
-  buildError(node, msg, Error = TypeError): Error {
+  buildError(node, msg: string, Error = TypeError): Error {
     return new Error(msg);
   }
 }

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -316,11 +316,13 @@ function get<T extends t.Node, K extends keyof T>(
   this: NodePath<T>,
   key: K,
   context?: boolean | TraversalContext,
-): T[K] extends Array<t.Node | null | undefined>
-  ? Array<NodePath<T[K][number]>>
-  : T[K] extends t.Node | null | undefined
-  ? NodePath<T[K]>
-  : never;
+): /* prettier-ignore */ (
+    T[K] extends Array<t.Node>        ? Array<NodePath<T[K][number]>>
+  : T[K] extends Array<t.Node | null> ? Array<NodePath<Exclude<T[K][number], null & T[K][number]>> | null>
+  : T[K] extends t.Node               ? NodePath<T[K]>
+  : T[K] extends t.Node | null        ? null
+  : never
+);
 
 function get<T extends t.Node>(
   this: NodePath<T>,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The e2e breaking tests are failing because the `@babel/traverse` type definitions on DefinitelyTyped are not compatible with the `@babel/types@8` type definitions. Let's see if this fixes it.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13332"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

