### PR TITLE
Fix multiple parsing errors in `@babel/eslint-parser`

### DIFF
--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -5,9 +5,11 @@ import { fileURLToPath } from "url";
 import { createRequire } from "module";
 import { parseForESLint } from "../lib/index.cjs";
 
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
 const BABEL_OPTIONS = {
   configFile: path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
+    dirname,
     "../../babel-eslint-shared-fixtures/config/babel.config.js",
   ),
 };
@@ -75,7 +77,7 @@ describe("Babel and Espree", () => {
     expect(babelAST).toEqual(espreeAST);
   }
 
-  beforeAll(async () => {
+  beforeAll(() => {
     const require = createRequire(import.meta.url);
 
     // Use the version of Espree that is a dependency of
@@ -88,7 +90,7 @@ describe("Babel and Espree", () => {
   });
 
   describe("compatibility", () => {
-    it("should allow ast.analyze to be called without options", function () {
+    it("should allow ast.analyze to be called without options", () => {
       const ast = parseForESLint("`test`", {
         eslintScopeManager: true,
         eslintVisitorKeys: true,
@@ -97,6 +99,16 @@ describe("Babel and Espree", () => {
       expect(() => {
         escope.analyze(ast);
       }).not.toThrow(new TypeError("Should allow no options argument."));
+    });
+
+    it("should not crash when `loadPartialConfigSync` returns `null`", () => {
+      const thunk = () =>
+        parseForESLint("`test`", {
+          eslintScopeManager: true,
+          eslintVisitorKeys: true,
+          babelOptions: { filename: "test.js", ignore: [/./] },
+        });
+      expect(thunk).not.toThrow();
     });
   });
 


### PR DESCRIPTION
This PR fixes several parsing errors which occurred in `@babel/eslint-parser`, in particular when a file was ignored.

Related issue: https://github.com/babel/babel/issues/13331

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/issues/13331
| Patch: Bug Fix?          | ❔
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

### Changes

*  **eslint-parser**:
    *  Implement fallback when normalizing config
    *  Add corresponding test case

cc @JLHwung @nicolo-ribaudo @fedeci 

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13338"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

