### PR TITLE
Only allow `TSParameterProperty` in `ClassMethod` parameters

### DIFF
--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -481,7 +481,7 @@ export interface ForStatement extends BaseNode {
 export interface FunctionDeclaration extends BaseNode {
   type: "FunctionDeclaration";
   id?: Identifier | null;
-  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>;
+  params: Array<Identifier | Pattern | RestElement>;
   body: BlockStatement;
   generator?: boolean;
   async?: boolean;
@@ -497,7 +497,7 @@ export interface FunctionDeclaration extends BaseNode {
 export interface FunctionExpression extends BaseNode {
   type: "FunctionExpression";
   id?: Identifier | null;
-  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>;
+  params: Array<Identifier | Pattern | RestElement>;
   body: BlockStatement;
   generator?: boolean;
   async?: boolean;
@@ -616,7 +616,7 @@ export interface ObjectMethod extends BaseNode {
   type: "ObjectMethod";
   kind: "method" | "get" | "set";
   key: Expression | Identifier | StringLiteral | NumericLiteral;
-  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>;
+  params: Array<Identifier | Pattern | RestElement>;
   body: BlockStatement;
   computed: boolean;
   generator?: boolean;
@@ -756,7 +756,7 @@ export interface ArrayPattern extends BaseNode {
 
 export interface ArrowFunctionExpression extends BaseNode {
   type: "ArrowFunctionExpression";
-  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>;
+  params: Array<Identifier | Pattern | RestElement>;
   body: BlockStatement | Expression;
   async?: boolean;
   expression: boolean;
@@ -1658,7 +1658,7 @@ export interface TSDeclareFunction extends BaseNode {
   type: "TSDeclareFunction";
   id?: Identifier | null;
   typeParameters?: TSTypeParameterDeclaration | Noop | null;
-  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>;
+  params: Array<Identifier | Pattern | RestElement>;
   returnType?: TSTypeAnnotation | Noop | null;
   async?: boolean;
   declare?: boolean | null;

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -133,9 +133,7 @@ export function forStatement(
 }
 export function functionDeclaration(
   id: t.Identifier | null | undefined,
-  params: Array<
-    t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
-  >,
+  params: Array<t.Identifier | t.Pattern | t.RestElement>,
   body: t.BlockStatement,
   generator?: boolean,
   async?: boolean,
@@ -144,9 +142,7 @@ export function functionDeclaration(
 }
 export function functionExpression(
   id: t.Identifier | null | undefined,
-  params: Array<
-    t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
-  >,
+  params: Array<t.Identifier | t.Pattern | t.RestElement>,
   body: t.BlockStatement,
   generator?: boolean,
   async?: boolean,
@@ -226,9 +222,7 @@ export function objectExpression(
 export function objectMethod(
   kind: "method" | "get" | "set" | undefined,
   key: t.Expression | t.Identifier | t.StringLiteral | t.NumericLiteral,
-  params: Array<
-    t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
-  >,
+  params: Array<t.Identifier | t.Pattern | t.RestElement>,
   body: t.BlockStatement,
   computed?: boolean,
   generator?: boolean,
@@ -338,9 +332,7 @@ export function arrayPattern(
   return builder("ArrayPattern", ...arguments);
 }
 export function arrowFunctionExpression(
-  params: Array<
-    t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
-  >,
+  params: Array<t.Identifier | t.Pattern | t.RestElement>,
   body: t.BlockStatement | t.Expression,
   async?: boolean,
 ): t.ArrowFunctionExpression {
@@ -1093,9 +1085,7 @@ export { tsParameterProperty as tSParameterProperty };
 export function tsDeclareFunction(
   id: t.Identifier | null | undefined,
   typeParameters: t.TSTypeParameterDeclaration | t.Noop | null | undefined,
-  params: Array<
-    t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
-  >,
+  params: Array<t.Identifier | t.Pattern | t.RestElement>,
   returnType?: t.TSTypeAnnotation | t.Noop | null,
 ): t.TSDeclareFunction {
   return builder("TSDeclareFunction", ...arguments);

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -353,14 +353,7 @@ export const functionCommon = {
   params: {
     validate: chain(
       assertValueType("array"),
-      assertEach(
-        assertNodeType(
-          "Identifier",
-          "Pattern",
-          "RestElement",
-          "TSParameterProperty",
-        ),
-      ),
+      assertEach(assertNodeType("Identifier", "Pattern", "RestElement")),
     ),
   },
   generator: {
@@ -1743,6 +1736,19 @@ export const classMethodOrPropertyCommon = {
 export const classMethodOrDeclareMethodCommon = {
   ...functionCommon,
   ...classMethodOrPropertyCommon,
+  params: {
+    validate: chain(
+      assertValueType("array"),
+      assertEach(
+        assertNodeType(
+          "Identifier",
+          "Pattern",
+          "RestElement",
+          "TSParameterProperty",
+        ),
+      ),
+    ),
+  },
   kind: {
     validate: assertOneOf("get", "set", "method", "constructor"),
     default: "method",


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

Hello everyone 👋

This is related to #12061 where ts parameter properties were restricted to class constructors only. So this throws right now correctly:

```ts
function A (readonly x) {}
```

The types though were still saying that `FunctionExpression`, `FunctionDeclaration`, `ArrowFunctionExpression`, `ObjectMethod` and `TSDeclareFunction` could contain `TSParameterProperty` in their parameters.
The only valid places I think should be `ClassMethod` and `TSDeclareMethod`.

So this change does that. Does this sound correct to you?

This is only a breaking change if anyone was attempting to generate invalid code or uses parser version <7.12.0, which did allow the syntax mentioned above.



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13349"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

