### PR TITLE
[ts] Default `typeAnnotation` of `TSTypePredicate` to `null`

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1242,6 +1242,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           if (thisTypePredicate.type === "TSThisType") {
             node.parameterName = (thisTypePredicate: N.TsThisType);
             node.asserts = true;
+            (node: N.TsTypePredicate).typeAnnotation = null;
             thisTypePredicate = this.finishNode(node, "TSTypePredicate");
           } else {
             this.resetStartLocationFromNode(thisTypePredicate, node);
@@ -1264,6 +1265,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           // : asserts foo
           node.parameterName = this.parseIdentifier();
           node.asserts = asserts;
+          (node: N.TsTypePredicate).typeAnnotation = null;
           t.typeAnnotation = this.finishNode(node, "TSTypePredicate");
           return this.finishNode(t, "TSTypeAnnotation");
         }

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1347,7 +1347,7 @@ export type TsTypeReference = TsTypeBase & {
 export type TsTypePredicate = TsTypeBase & {
   type: "TSTypePredicate",
   parameterName: Identifier | TsThisType,
-  typeAnnotation: TsTypeAnnotation,
+  typeAnnotation: TsTypeAnnotation | null,
   asserts: boolean,
 };
 

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/arrow-function/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/arrow-function/output.json
@@ -99,7 +99,8 @@
                     "start":106,"end":111,"loc":{"start":{"line":2,"column":42},"end":{"line":2,"column":47},"identifierName":"value"},
                     "name": "value"
                   },
-                  "asserts": true
+                  "asserts": true,
+                  "typeAnnotation": null
                 }
               },
               "id": null,

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-this/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-this/output.json
@@ -45,7 +45,8 @@
                     "type": "TSThisType",
                     "start":25,"end":29,"loc":{"start":{"line":2,"column":15},"end":{"line":2,"column":19}}
                   },
-                  "asserts": true
+                  "asserts": true,
+                  "typeAnnotation": null
                 }
               },
               "body": {

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var/output.json
@@ -44,7 +44,8 @@
               "start":57,"end":62,"loc":{"start":{"line":1,"column":57},"end":{"line":1,"column":62},"identifierName":"value"},
               "name": "value"
             },
-            "asserts": true
+            "asserts": true,
+            "typeAnnotation": null
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration/output.json
@@ -97,7 +97,8 @@
               "start":108,"end":113,"loc":{"start":{"line":2,"column":44},"end":{"line":2,"column":49},"identifierName":"value"},
               "name": "value"
             },
-            "asserts": true
+            "asserts": true,
+            "typeAnnotation": null
           }
         },
         "body": {

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/invalid-escaped-asserts-keyword/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/invalid-escaped-asserts-keyword/output.json
@@ -47,7 +47,8 @@
               "start":62,"end":67,"loc":{"start":{"line":1,"column":62},"end":{"line":1,"column":67},"identifierName":"value"},
               "name": "value"
             },
-            "asserts": true
+            "asserts": true,
+            "typeAnnotation": null
           }
         }
       }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We should consider that `typeAnnotation` in `TsTypePredicate` is nullable. Also align AST with typescript-estree (ref: https://github.com/typescript-eslint/typescript-eslint/blob/21d1b62a0b84b502d2cf12674b3d141994a3ffd4/packages/typescript-estree/tests/ast-alignment/utils.ts#L154-L158).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13354"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

