### PR TITLE
chore(eslint-tests): add missing dependency `@babel/core`

### DIFF
--- a/eslint/babel-eslint-tests/package.json
+++ b/eslint/babel-eslint-tests/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
+    "@babel/core": "workspace:^7.14.3",
     "@babel/eslint-parser": "workspace:^7.14.3",
     "@babel/preset-react": "workspace:^7.13.13",
     "dedent": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,7 +203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@workspace:*, @babel/core@workspace:^7.12.13, @babel/core@workspace:^7.13.15, @babel/core@workspace:packages/babel-core":
+"@babel/core@workspace:*, @babel/core@workspace:^7.12.13, @babel/core@workspace:^7.13.15, @babel/core@workspace:^7.14.3, @babel/core@workspace:packages/babel-core":
   version: 0.0.0-use.local
   resolution: "@babel/core@workspace:packages/babel-core"
   dependencies:
@@ -311,6 +311,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/eslint-tests@workspace:eslint/babel-eslint-tests"
   dependencies:
+    "@babel/core": "workspace:^7.14.3"
     "@babel/eslint-parser": "workspace:^7.14.3"
     "@babel/preset-react": "workspace:^7.13.13"
     dedent: ^0.7.0


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Yes, internal / tests
| License                  | MIT

In https://github.com/babel/babel/pull/13199 [`@babel/preset-react@workspace:packages/babel-preset-react` was added as a dependency to `@babel/eslint-tests`](https://github.com/babel/babel/pull/13199/files#diff-b4dbd6cce9ba335c6ab5dd895903589a2fc0c514b821d4314fcf87bc67ab4ac3R9) but `@babel/core@workspace:packages/babel-core` wasn't which means that due to hoisting its peer dependency is satisfied by `@babel/core@npm:7.14.0` from the root. This doesn't seem to have caused any issues but was caught by our e2e tests.

https://github.com/yarnpkg/berry/runs/2602594164?check_suite_focus=true#step:6:36
```
➤ YN0001: │ Error: .→v:@babel/preset-react@workspace:packages/babel-preset-react - broken peer promise: expected @babel/core@workspace:packages/babel-core but found @babel/core@npm:7.14.0, after hoisting finished:
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13355"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

