### PR TITLE
improve builder performance in @babel/types

### DIFF
--- a/packages/babel-types/scripts/generators/builders.js
+++ b/packages/babel-types/scripts/generators/builders.js
@@ -51,12 +51,20 @@ function generateBuilderArgs(type) {
     }
 
     if (builderNames.includes(fieldName)) {
+      const field = definitions.NODE_FIELDS[type][fieldName];
+
+      const def =
+        field.default !== undefined
+          ? Array.isArray(field.default)
+            ? "[]"
+            : JSON.stringify(field.default)
+          : undefined;
       const bindingIdentifierName = t.toBindingIdentifierName(fieldName);
       if (areAllRemainingFieldsNullable(fieldName, builderNames, fields)) {
         args.push(
           `${bindingIdentifierName}${
-            isNullable(field) ? "?:" : ":"
-          } ${typeAnnotation}`
+            isNullable(field) && !def ? "?:" : ":"
+          } ${typeAnnotation}${def ? `= ${def}` : ""}`
         );
       } else {
         args.push(
@@ -114,14 +122,7 @@ import type * as t from "../..";
 
       if (builderNames.includes(fieldName)) {
         const bindingIdentifierName = t.toBindingIdentifierName(fieldName);
-        if (isNullable(field)) {
-          objectFields.push([
-            fieldName,
-            `${bindingIdentifierName} === undefined ? ${defaultExpression()} : ${bindingIdentifierName}`,
-          ]);
-        } else {
-          objectFields.push([fieldName, bindingIdentifierName]);
-        }
+        objectFields.push([fieldName, bindingIdentifierName]);
       } else {
         objectFields.push([fieldName, defaultExpression()]);
       }

--- a/packages/babel-types/scripts/generators/builders.js
+++ b/packages/babel-types/scripts/generators/builders.js
@@ -118,10 +118,11 @@ import type * as t from "../..";
   Object.keys(definitions.DEPRECATED_KEYS).forEach(type => {
     const newType = definitions.DEPRECATED_KEYS[type];
     const formatedBuilderName = formatBuilderName(type);
+    const formatedNewBuilderName = formatBuilderName(newType);
     output += `/** @deprecated */
-function ${type}(...args: Array<any>): any {
+function ${type}(...args: Parameters<typeof ${formatedNewBuilderName}>): any {
   console.trace("The node type ${type} has been renamed to ${newType}");
-  return builder("${type}", ...args);
+  return ${formatedNewBuilderName}(...args);
 }
 export { ${type} as ${formatedBuilderName} };\n`;
     // This is needed for backwards compatibility.

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -2,22 +2,34 @@
  * This file is auto-generated! Do not modify it directly.
  * To re-generate run 'make build'
  */
-import builder from "../builder";
+import validateNode from "../validateNode";
 import type * as t from "../..";
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 export function arrayExpression(
   elements?: Array<null | t.Expression | t.SpreadElement>,
-): t.ArrayExpression {
-  return builder("ArrayExpression", ...arguments);
+) {
+  const node = {
+    type: "ArrayExpression",
+    elements: elements === undefined ? [] : elements,
+  } as t.ArrayExpression;
+  validateNode(node);
+  return node;
 }
 export function assignmentExpression(
   operator: string,
   left: t.LVal,
   right: t.Expression,
-): t.AssignmentExpression {
-  return builder("AssignmentExpression", ...arguments);
+) {
+  const node = {
+    type: "AssignmentExpression",
+    operator: operator,
+    left: left,
+    right: right,
+  } as t.AssignmentExpression;
+  validateNode(node);
+  return node;
 }
 export function binaryExpression(
   operator:
@@ -45,91 +57,185 @@ export function binaryExpression(
     | "<=",
   left: t.Expression | t.PrivateName,
   right: t.Expression,
-): t.BinaryExpression {
-  return builder("BinaryExpression", ...arguments);
+) {
+  const node = {
+    type: "BinaryExpression",
+    operator: operator,
+    left: left,
+    right: right,
+  } as t.BinaryExpression;
+  validateNode(node);
+  return node;
 }
-export function interpreterDirective(value: string): t.InterpreterDirective {
-  return builder("InterpreterDirective", ...arguments);
+export function interpreterDirective(value: string) {
+  const node = {
+    type: "InterpreterDirective",
+    value: value,
+  } as t.InterpreterDirective;
+  validateNode(node);
+  return node;
 }
-export function directive(value: t.DirectiveLiteral): t.Directive {
-  return builder("Directive", ...arguments);
+export function directive(value: t.DirectiveLiteral) {
+  const node = {
+    type: "Directive",
+    value: value,
+  } as t.Directive;
+  validateNode(node);
+  return node;
 }
-export function directiveLiteral(value: string): t.DirectiveLiteral {
-  return builder("DirectiveLiteral", ...arguments);
+export function directiveLiteral(value: string) {
+  const node = {
+    type: "DirectiveLiteral",
+    value: value,
+  } as t.DirectiveLiteral;
+  validateNode(node);
+  return node;
 }
 export function blockStatement(
   body: Array<t.Statement>,
   directives?: Array<t.Directive>,
-): t.BlockStatement {
-  return builder("BlockStatement", ...arguments);
+) {
+  const node = {
+    type: "BlockStatement",
+    body: body,
+    directives: directives === undefined ? [] : directives,
+  } as t.BlockStatement;
+  validateNode(node);
+  return node;
 }
-export function breakStatement(label?: t.Identifier | null): t.BreakStatement {
-  return builder("BreakStatement", ...arguments);
+export function breakStatement(label?: t.Identifier | null) {
+  const node = {
+    type: "BreakStatement",
+    label: label === undefined ? null : label,
+  } as t.BreakStatement;
+  validateNode(node);
+  return node;
 }
 export function callExpression(
   callee: t.Expression | t.V8IntrinsicIdentifier,
   _arguments: Array<
     t.Expression | t.SpreadElement | t.JSXNamespacedName | t.ArgumentPlaceholder
   >,
-): t.CallExpression {
-  return builder("CallExpression", ...arguments);
+) {
+  const node = {
+    type: "CallExpression",
+    callee: callee,
+    arguments: _arguments,
+    optional: null,
+    typeArguments: null,
+    typeParameters: null,
+  } as t.CallExpression;
+  validateNode(node);
+  return node;
 }
 export function catchClause(
   param: t.Identifier | t.ArrayPattern | t.ObjectPattern | null | undefined,
   body: t.BlockStatement,
-): t.CatchClause {
-  return builder("CatchClause", ...arguments);
+) {
+  const node = {
+    type: "CatchClause",
+    param: param === undefined ? null : param,
+    body: body,
+  } as t.CatchClause;
+  validateNode(node);
+  return node;
 }
 export function conditionalExpression(
   test: t.Expression,
   consequent: t.Expression,
   alternate: t.Expression,
-): t.ConditionalExpression {
-  return builder("ConditionalExpression", ...arguments);
+) {
+  const node = {
+    type: "ConditionalExpression",
+    test: test,
+    consequent: consequent,
+    alternate: alternate,
+  } as t.ConditionalExpression;
+  validateNode(node);
+  return node;
 }
-export function continueStatement(
-  label?: t.Identifier | null,
-): t.ContinueStatement {
-  return builder("ContinueStatement", ...arguments);
+export function continueStatement(label?: t.Identifier | null) {
+  const node = {
+    type: "ContinueStatement",
+    label: label === undefined ? null : label,
+  } as t.ContinueStatement;
+  validateNode(node);
+  return node;
 }
-export function debuggerStatement(): t.DebuggerStatement {
-  return builder("DebuggerStatement", ...arguments);
+export function debuggerStatement() {
+  const node = {
+    type: "DebuggerStatement",
+  } as t.DebuggerStatement;
+  validateNode(node);
+  return node;
 }
-export function doWhileStatement(
-  test: t.Expression,
-  body: t.Statement,
-): t.DoWhileStatement {
-  return builder("DoWhileStatement", ...arguments);
+export function doWhileStatement(test: t.Expression, body: t.Statement) {
+  const node = {
+    type: "DoWhileStatement",
+    test: test,
+    body: body,
+  } as t.DoWhileStatement;
+  validateNode(node);
+  return node;
 }
-export function emptyStatement(): t.EmptyStatement {
-  return builder("EmptyStatement", ...arguments);
+export function emptyStatement() {
+  const node = {
+    type: "EmptyStatement",
+  } as t.EmptyStatement;
+  validateNode(node);
+  return node;
 }
-export function expressionStatement(
-  expression: t.Expression,
-): t.ExpressionStatement {
-  return builder("ExpressionStatement", ...arguments);
+export function expressionStatement(expression: t.Expression) {
+  const node = {
+    type: "ExpressionStatement",
+    expression: expression,
+  } as t.ExpressionStatement;
+  validateNode(node);
+  return node;
 }
 export function file(
   program: t.Program,
   comments?: Array<t.CommentBlock | t.CommentLine> | null,
   tokens?: Array<any> | null,
-): t.File {
-  return builder("File", ...arguments);
+) {
+  const node = {
+    type: "File",
+    program: program,
+    comments: comments === undefined ? null : comments,
+    tokens: tokens === undefined ? null : tokens,
+  } as t.File;
+  validateNode(node);
+  return node;
 }
 export function forInStatement(
   left: t.VariableDeclaration | t.LVal,
   right: t.Expression,
   body: t.Statement,
-): t.ForInStatement {
-  return builder("ForInStatement", ...arguments);
+) {
+  const node = {
+    type: "ForInStatement",
+    left: left,
+    right: right,
+    body: body,
+  } as t.ForInStatement;
+  validateNode(node);
+  return node;
 }
 export function forStatement(
   init: t.VariableDeclaration | t.Expression | null | undefined,
   test: t.Expression | null | undefined,
   update: t.Expression | null | undefined,
   body: t.Statement,
-): t.ForStatement {
-  return builder("ForStatement", ...arguments);
+) {
+  const node = {
+    type: "ForStatement",
+    init: init === undefined ? null : init,
+    test: test === undefined ? null : test,
+    update: update === undefined ? null : update,
+    body: body,
+  } as t.ForStatement;
+  validateNode(node);
+  return node;
 }
 export function functionDeclaration(
   id: t.Identifier | null | undefined,
@@ -137,8 +243,20 @@ export function functionDeclaration(
   body: t.BlockStatement,
   generator?: boolean,
   async?: boolean,
-): t.FunctionDeclaration {
-  return builder("FunctionDeclaration", ...arguments);
+) {
+  const node = {
+    type: "FunctionDeclaration",
+    id: id === undefined ? null : id,
+    params: params,
+    body: body,
+    generator: generator === undefined ? false : generator,
+    async: async === undefined ? false : async,
+    declare: null,
+    returnType: null,
+    typeParameters: null,
+  } as t.FunctionDeclaration;
+  validateNode(node);
+  return node;
 }
 export function functionExpression(
   id: t.Identifier | null | undefined,
@@ -146,78 +264,167 @@ export function functionExpression(
   body: t.BlockStatement,
   generator?: boolean,
   async?: boolean,
-): t.FunctionExpression {
-  return builder("FunctionExpression", ...arguments);
+) {
+  const node = {
+    type: "FunctionExpression",
+    id: id === undefined ? null : id,
+    params: params,
+    body: body,
+    generator: generator === undefined ? false : generator,
+    async: async === undefined ? false : async,
+    returnType: null,
+    typeParameters: null,
+  } as t.FunctionExpression;
+  validateNode(node);
+  return node;
 }
-export function identifier(name: string): t.Identifier {
-  return builder("Identifier", ...arguments);
+export function identifier(name: string) {
+  const node = {
+    type: "Identifier",
+    name: name,
+    decorators: null,
+    optional: null,
+    typeAnnotation: null,
+  } as t.Identifier;
+  validateNode(node);
+  return node;
 }
 export function ifStatement(
   test: t.Expression,
   consequent: t.Statement,
   alternate?: t.Statement | null,
-): t.IfStatement {
-  return builder("IfStatement", ...arguments);
+) {
+  const node = {
+    type: "IfStatement",
+    test: test,
+    consequent: consequent,
+    alternate: alternate === undefined ? null : alternate,
+  } as t.IfStatement;
+  validateNode(node);
+  return node;
 }
-export function labeledStatement(
-  label: t.Identifier,
-  body: t.Statement,
-): t.LabeledStatement {
-  return builder("LabeledStatement", ...arguments);
+export function labeledStatement(label: t.Identifier, body: t.Statement) {
+  const node = {
+    type: "LabeledStatement",
+    label: label,
+    body: body,
+  } as t.LabeledStatement;
+  validateNode(node);
+  return node;
 }
-export function stringLiteral(value: string): t.StringLiteral {
-  return builder("StringLiteral", ...arguments);
+export function stringLiteral(value: string) {
+  const node = {
+    type: "StringLiteral",
+    value: value,
+  } as t.StringLiteral;
+  validateNode(node);
+  return node;
 }
-export function numericLiteral(value: number): t.NumericLiteral {
-  return builder("NumericLiteral", ...arguments);
+export function numericLiteral(value: number) {
+  const node = {
+    type: "NumericLiteral",
+    value: value,
+  } as t.NumericLiteral;
+  validateNode(node);
+  return node;
 }
-export function nullLiteral(): t.NullLiteral {
-  return builder("NullLiteral", ...arguments);
+export function nullLiteral() {
+  const node = {
+    type: "NullLiteral",
+  } as t.NullLiteral;
+  validateNode(node);
+  return node;
 }
-export function booleanLiteral(value: boolean): t.BooleanLiteral {
-  return builder("BooleanLiteral", ...arguments);
+export function booleanLiteral(value: boolean) {
+  const node = {
+    type: "BooleanLiteral",
+    value: value,
+  } as t.BooleanLiteral;
+  validateNode(node);
+  return node;
 }
-export function regExpLiteral(
-  pattern: string,
-  flags?: string,
-): t.RegExpLiteral {
-  return builder("RegExpLiteral", ...arguments);
+export function regExpLiteral(pattern: string, flags?: string) {
+  const node = {
+    type: "RegExpLiteral",
+    pattern: pattern,
+    flags: flags === undefined ? "" : flags,
+  } as t.RegExpLiteral;
+  validateNode(node);
+  return node;
 }
 export function logicalExpression(
   operator: "||" | "&&" | "??",
   left: t.Expression,
   right: t.Expression,
-): t.LogicalExpression {
-  return builder("LogicalExpression", ...arguments);
+) {
+  const node = {
+    type: "LogicalExpression",
+    operator: operator,
+    left: left,
+    right: right,
+  } as t.LogicalExpression;
+  validateNode(node);
+  return node;
 }
 export function memberExpression(
   object: t.Expression,
   property: t.Expression | t.Identifier | t.PrivateName,
   computed?: boolean,
   optional?: true | false | null,
-): t.MemberExpression {
-  return builder("MemberExpression", ...arguments);
+) {
+  const node = {
+    type: "MemberExpression",
+    object: object,
+    property: property,
+    computed: computed === undefined ? false : computed,
+    optional: optional === undefined ? null : optional,
+  } as t.MemberExpression;
+  validateNode(node);
+  return node;
 }
 export function newExpression(
   callee: t.Expression | t.V8IntrinsicIdentifier,
   _arguments: Array<
     t.Expression | t.SpreadElement | t.JSXNamespacedName | t.ArgumentPlaceholder
   >,
-): t.NewExpression {
-  return builder("NewExpression", ...arguments);
+) {
+  const node = {
+    type: "NewExpression",
+    callee: callee,
+    arguments: _arguments,
+    optional: null,
+    typeArguments: null,
+    typeParameters: null,
+  } as t.NewExpression;
+  validateNode(node);
+  return node;
 }
 export function program(
   body: Array<t.Statement>,
   directives?: Array<t.Directive>,
   sourceType?: "script" | "module",
   interpreter?: t.InterpreterDirective | null,
-): t.Program {
-  return builder("Program", ...arguments);
+) {
+  const node = {
+    type: "Program",
+    body: body,
+    directives: directives === undefined ? [] : directives,
+    sourceType: sourceType === undefined ? "script" : sourceType,
+    interpreter: interpreter === undefined ? null : interpreter,
+    sourceFile: null,
+  } as t.Program;
+  validateNode(node);
+  return node;
 }
 export function objectExpression(
   properties: Array<t.ObjectMethod | t.ObjectProperty | t.SpreadElement>,
-): t.ObjectExpression {
-  return builder("ObjectExpression", ...arguments);
+) {
+  const node = {
+    type: "ObjectExpression",
+    properties: properties,
+  } as t.ObjectExpression;
+  validateNode(node);
+  return node;
 }
 export function objectMethod(
   kind: "method" | "get" | "set" | undefined,
@@ -227,8 +434,22 @@ export function objectMethod(
   computed?: boolean,
   generator?: boolean,
   async?: boolean,
-): t.ObjectMethod {
-  return builder("ObjectMethod", ...arguments);
+) {
+  const node = {
+    type: "ObjectMethod",
+    kind: kind === undefined ? "method" : kind,
+    key: key,
+    params: params,
+    body: body,
+    computed: computed === undefined ? false : computed,
+    generator: generator === undefined ? false : generator,
+    async: async === undefined ? false : async,
+    decorators: null,
+    returnType: null,
+    typeParameters: null,
+  } as t.ObjectMethod;
+  validateNode(node);
+  return node;
 }
 export function objectProperty(
   key: t.Expression | t.Identifier | t.StringLiteral | t.NumericLiteral,
@@ -236,107 +457,215 @@ export function objectProperty(
   computed?: boolean,
   shorthand?: boolean,
   decorators?: Array<t.Decorator> | null,
-): t.ObjectProperty {
-  return builder("ObjectProperty", ...arguments);
+) {
+  const node = {
+    type: "ObjectProperty",
+    key: key,
+    value: value,
+    computed: computed === undefined ? false : computed,
+    shorthand: shorthand === undefined ? false : shorthand,
+    decorators: decorators === undefined ? null : decorators,
+  } as t.ObjectProperty;
+  validateNode(node);
+  return node;
 }
-export function restElement(argument: t.LVal): t.RestElement {
-  return builder("RestElement", ...arguments);
+export function restElement(argument: t.LVal) {
+  const node = {
+    type: "RestElement",
+    argument: argument,
+    decorators: null,
+    typeAnnotation: null,
+  } as t.RestElement;
+  validateNode(node);
+  return node;
 }
-export function returnStatement(
-  argument?: t.Expression | null,
-): t.ReturnStatement {
-  return builder("ReturnStatement", ...arguments);
+export function returnStatement(argument?: t.Expression | null) {
+  const node = {
+    type: "ReturnStatement",
+    argument: argument === undefined ? null : argument,
+  } as t.ReturnStatement;
+  validateNode(node);
+  return node;
 }
-export function sequenceExpression(
-  expressions: Array<t.Expression>,
-): t.SequenceExpression {
-  return builder("SequenceExpression", ...arguments);
+export function sequenceExpression(expressions: Array<t.Expression>) {
+  const node = {
+    type: "SequenceExpression",
+    expressions: expressions,
+  } as t.SequenceExpression;
+  validateNode(node);
+  return node;
 }
-export function parenthesizedExpression(
-  expression: t.Expression,
-): t.ParenthesizedExpression {
-  return builder("ParenthesizedExpression", ...arguments);
+export function parenthesizedExpression(expression: t.Expression) {
+  const node = {
+    type: "ParenthesizedExpression",
+    expression: expression,
+  } as t.ParenthesizedExpression;
+  validateNode(node);
+  return node;
 }
 export function switchCase(
   test: t.Expression | null | undefined,
   consequent: Array<t.Statement>,
-): t.SwitchCase {
-  return builder("SwitchCase", ...arguments);
+) {
+  const node = {
+    type: "SwitchCase",
+    test: test === undefined ? null : test,
+    consequent: consequent,
+  } as t.SwitchCase;
+  validateNode(node);
+  return node;
 }
 export function switchStatement(
   discriminant: t.Expression,
   cases: Array<t.SwitchCase>,
-): t.SwitchStatement {
-  return builder("SwitchStatement", ...arguments);
+) {
+  const node = {
+    type: "SwitchStatement",
+    discriminant: discriminant,
+    cases: cases,
+  } as t.SwitchStatement;
+  validateNode(node);
+  return node;
 }
-export function thisExpression(): t.ThisExpression {
-  return builder("ThisExpression", ...arguments);
+export function thisExpression() {
+  const node = {
+    type: "ThisExpression",
+  } as t.ThisExpression;
+  validateNode(node);
+  return node;
 }
-export function throwStatement(argument: t.Expression): t.ThrowStatement {
-  return builder("ThrowStatement", ...arguments);
+export function throwStatement(argument: t.Expression) {
+  const node = {
+    type: "ThrowStatement",
+    argument: argument,
+  } as t.ThrowStatement;
+  validateNode(node);
+  return node;
 }
 export function tryStatement(
   block: t.BlockStatement,
   handler?: t.CatchClause | null,
   finalizer?: t.BlockStatement | null,
-): t.TryStatement {
-  return builder("TryStatement", ...arguments);
+) {
+  const node = {
+    type: "TryStatement",
+    block: block,
+    handler: handler === undefined ? null : handler,
+    finalizer: finalizer === undefined ? null : finalizer,
+  } as t.TryStatement;
+  validateNode(node);
+  return node;
 }
 export function unaryExpression(
   operator: "void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof",
   argument: t.Expression,
   prefix?: boolean,
-): t.UnaryExpression {
-  return builder("UnaryExpression", ...arguments);
+) {
+  const node = {
+    type: "UnaryExpression",
+    operator: operator,
+    argument: argument,
+    prefix: prefix === undefined ? true : prefix,
+  } as t.UnaryExpression;
+  validateNode(node);
+  return node;
 }
 export function updateExpression(
   operator: "++" | "--",
   argument: t.Expression,
   prefix?: boolean,
-): t.UpdateExpression {
-  return builder("UpdateExpression", ...arguments);
+) {
+  const node = {
+    type: "UpdateExpression",
+    operator: operator,
+    argument: argument,
+    prefix: prefix === undefined ? false : prefix,
+  } as t.UpdateExpression;
+  validateNode(node);
+  return node;
 }
 export function variableDeclaration(
   kind: "var" | "let" | "const",
   declarations: Array<t.VariableDeclarator>,
-): t.VariableDeclaration {
-  return builder("VariableDeclaration", ...arguments);
+) {
+  const node = {
+    type: "VariableDeclaration",
+    kind: kind,
+    declarations: declarations,
+    declare: null,
+  } as t.VariableDeclaration;
+  validateNode(node);
+  return node;
 }
-export function variableDeclarator(
-  id: t.LVal,
-  init?: t.Expression | null,
-): t.VariableDeclarator {
-  return builder("VariableDeclarator", ...arguments);
+export function variableDeclarator(id: t.LVal, init?: t.Expression | null) {
+  const node = {
+    type: "VariableDeclarator",
+    id: id,
+    init: init === undefined ? null : init,
+    definite: null,
+  } as t.VariableDeclarator;
+  validateNode(node);
+  return node;
 }
-export function whileStatement(
-  test: t.Expression,
-  body: t.Statement,
-): t.WhileStatement {
-  return builder("WhileStatement", ...arguments);
+export function whileStatement(test: t.Expression, body: t.Statement) {
+  const node = {
+    type: "WhileStatement",
+    test: test,
+    body: body,
+  } as t.WhileStatement;
+  validateNode(node);
+  return node;
 }
-export function withStatement(
-  object: t.Expression,
-  body: t.Statement,
-): t.WithStatement {
-  return builder("WithStatement", ...arguments);
+export function withStatement(object: t.Expression, body: t.Statement) {
+  const node = {
+    type: "WithStatement",
+    object: object,
+    body: body,
+  } as t.WithStatement;
+  validateNode(node);
+  return node;
 }
 export function assignmentPattern(
   left: t.Identifier | t.ObjectPattern | t.ArrayPattern | t.MemberExpression,
   right: t.Expression,
-): t.AssignmentPattern {
-  return builder("AssignmentPattern", ...arguments);
+) {
+  const node = {
+    type: "AssignmentPattern",
+    left: left,
+    right: right,
+    decorators: null,
+    typeAnnotation: null,
+  } as t.AssignmentPattern;
+  validateNode(node);
+  return node;
 }
-export function arrayPattern(
-  elements: Array<null | t.PatternLike>,
-): t.ArrayPattern {
-  return builder("ArrayPattern", ...arguments);
+export function arrayPattern(elements: Array<null | t.PatternLike>) {
+  const node = {
+    type: "ArrayPattern",
+    elements: elements,
+    decorators: null,
+    typeAnnotation: null,
+  } as t.ArrayPattern;
+  validateNode(node);
+  return node;
 }
 export function arrowFunctionExpression(
   params: Array<t.Identifier | t.Pattern | t.RestElement>,
   body: t.BlockStatement | t.Expression,
   async?: boolean,
-): t.ArrowFunctionExpression {
-  return builder("ArrowFunctionExpression", ...arguments);
+) {
+  const node = {
+    type: "ArrowFunctionExpression",
+    params: params,
+    body: body,
+    async: async === undefined ? false : async,
+    expression: null,
+    generator: false,
+    returnType: null,
+    typeParameters: null,
+  } as t.ArrowFunctionExpression;
+  validateNode(node);
+  return node;
 }
 export function classBody(
   body: Array<
@@ -347,29 +676,65 @@ export function classBody(
     | t.TSDeclareMethod
     | t.TSIndexSignature
   >,
-): t.ClassBody {
-  return builder("ClassBody", ...arguments);
+) {
+  const node = {
+    type: "ClassBody",
+    body: body,
+  } as t.ClassBody;
+  validateNode(node);
+  return node;
 }
 export function classExpression(
   id: t.Identifier | null | undefined,
   superClass: t.Expression | null | undefined,
   body: t.ClassBody,
   decorators?: Array<t.Decorator> | null,
-): t.ClassExpression {
-  return builder("ClassExpression", ...arguments);
+) {
+  const node = {
+    type: "ClassExpression",
+    id: id === undefined ? null : id,
+    superClass: superClass === undefined ? null : superClass,
+    body: body,
+    decorators: decorators === undefined ? null : decorators,
+    implements: null,
+    mixins: null,
+    superTypeParameters: null,
+    typeParameters: null,
+  } as t.ClassExpression;
+  validateNode(node);
+  return node;
 }
 export function classDeclaration(
   id: t.Identifier,
   superClass: t.Expression | null | undefined,
   body: t.ClassBody,
   decorators?: Array<t.Decorator> | null,
-): t.ClassDeclaration {
-  return builder("ClassDeclaration", ...arguments);
+) {
+  const node = {
+    type: "ClassDeclaration",
+    id: id,
+    superClass: superClass === undefined ? null : superClass,
+    body: body,
+    decorators: decorators === undefined ? null : decorators,
+    abstract: null,
+    declare: null,
+    implements: null,
+    mixins: null,
+    superTypeParameters: null,
+    typeParameters: null,
+  } as t.ClassDeclaration;
+  validateNode(node);
+  return node;
 }
-export function exportAllDeclaration(
-  source: t.StringLiteral,
-): t.ExportAllDeclaration {
-  return builder("ExportAllDeclaration", ...arguments);
+export function exportAllDeclaration(source: t.StringLiteral) {
+  const node = {
+    type: "ExportAllDeclaration",
+    source: source,
+    assertions: null,
+    exportKind: null,
+  } as t.ExportAllDeclaration;
+  validateNode(node);
+  return node;
 }
 export function exportDefaultDeclaration(
   declaration:
@@ -377,8 +742,13 @@ export function exportDefaultDeclaration(
     | t.TSDeclareFunction
     | t.ClassDeclaration
     | t.Expression,
-): t.ExportDefaultDeclaration {
-  return builder("ExportDefaultDeclaration", ...arguments);
+) {
+  const node = {
+    type: "ExportDefaultDeclaration",
+    declaration: declaration,
+  } as t.ExportDefaultDeclaration;
+  validateNode(node);
+  return node;
 }
 export function exportNamedDeclaration(
   declaration?: t.Declaration | null,
@@ -386,52 +756,99 @@ export function exportNamedDeclaration(
     t.ExportSpecifier | t.ExportDefaultSpecifier | t.ExportNamespaceSpecifier
   >,
   source?: t.StringLiteral | null,
-): t.ExportNamedDeclaration {
-  return builder("ExportNamedDeclaration", ...arguments);
+) {
+  const node = {
+    type: "ExportNamedDeclaration",
+    declaration: declaration === undefined ? null : declaration,
+    specifiers: specifiers === undefined ? [] : specifiers,
+    source: source === undefined ? null : source,
+    assertions: null,
+    exportKind: null,
+  } as t.ExportNamedDeclaration;
+  validateNode(node);
+  return node;
 }
 export function exportSpecifier(
   local: t.Identifier,
   exported: t.Identifier | t.StringLiteral,
-): t.ExportSpecifier {
-  return builder("ExportSpecifier", ...arguments);
+) {
+  const node = {
+    type: "ExportSpecifier",
+    local: local,
+    exported: exported,
+  } as t.ExportSpecifier;
+  validateNode(node);
+  return node;
 }
 export function forOfStatement(
   left: t.VariableDeclaration | t.LVal,
   right: t.Expression,
   body: t.Statement,
   _await?: boolean,
-): t.ForOfStatement {
-  return builder("ForOfStatement", ...arguments);
+) {
+  const node = {
+    type: "ForOfStatement",
+    left: left,
+    right: right,
+    body: body,
+    await: _await === undefined ? false : _await,
+  } as t.ForOfStatement;
+  validateNode(node);
+  return node;
 }
 export function importDeclaration(
   specifiers: Array<
     t.ImportSpecifier | t.ImportDefaultSpecifier | t.ImportNamespaceSpecifier
   >,
   source: t.StringLiteral,
-): t.ImportDeclaration {
-  return builder("ImportDeclaration", ...arguments);
+) {
+  const node = {
+    type: "ImportDeclaration",
+    specifiers: specifiers,
+    source: source,
+    assertions: null,
+    importKind: null,
+  } as t.ImportDeclaration;
+  validateNode(node);
+  return node;
 }
-export function importDefaultSpecifier(
-  local: t.Identifier,
-): t.ImportDefaultSpecifier {
-  return builder("ImportDefaultSpecifier", ...arguments);
+export function importDefaultSpecifier(local: t.Identifier) {
+  const node = {
+    type: "ImportDefaultSpecifier",
+    local: local,
+  } as t.ImportDefaultSpecifier;
+  validateNode(node);
+  return node;
 }
-export function importNamespaceSpecifier(
-  local: t.Identifier,
-): t.ImportNamespaceSpecifier {
-  return builder("ImportNamespaceSpecifier", ...arguments);
+export function importNamespaceSpecifier(local: t.Identifier) {
+  const node = {
+    type: "ImportNamespaceSpecifier",
+    local: local,
+  } as t.ImportNamespaceSpecifier;
+  validateNode(node);
+  return node;
 }
 export function importSpecifier(
   local: t.Identifier,
   imported: t.Identifier | t.StringLiteral,
-): t.ImportSpecifier {
-  return builder("ImportSpecifier", ...arguments);
+) {
+  const node = {
+    type: "ImportSpecifier",
+    local: local,
+    imported: imported,
+    importKind: null,
+  } as t.ImportSpecifier;
+  validateNode(node);
+  return node;
 }
-export function metaProperty(
-  meta: t.Identifier,
-  property: t.Identifier,
-): t.MetaProperty {
-  return builder("MetaProperty", ...arguments);
+export function metaProperty(meta: t.Identifier, property: t.Identifier) {
+  const node = {
+    type: "MetaProperty",
+    meta: meta,
+    property: property,
+  } as t.MetaProperty;
+  validateNode(node);
+  return node;
 }
 export function classMethod(
   kind: "get" | "set" | "method" | "constructor" | undefined,
@@ -444,67 +861,153 @@ export function classMethod(
   _static?: boolean,
   generator?: boolean,
   async?: boolean,
-): t.ClassMethod {
-  return builder("ClassMethod", ...arguments);
+) {
+  const node = {
+    type: "ClassMethod",
+    kind: kind === undefined ? "method" : kind,
+    key: key,
+    params: params,
+    body: body,
+    computed: computed === undefined ? false : computed,
+    static: _static === undefined ? false : _static,
+    generator: generator === undefined ? false : generator,
+    async: async === undefined ? false : async,
+    abstract: null,
+    access: null,
+    accessibility: null,
+    decorators: null,
+    optional: null,
+    override: false,
+    returnType: null,
+    typeParameters: null,
+  } as t.ClassMethod;
+  validateNode(node);
+  return node;
 }
 export function objectPattern(
   properties: Array<t.RestElement | t.ObjectProperty>,
-): t.ObjectPattern {
-  return builder("ObjectPattern", ...arguments);
+) {
+  const node = {
+    type: "ObjectPattern",
+    properties: properties,
+    decorators: null,
+    typeAnnotation: null,
+  } as t.ObjectPattern;
+  validateNode(node);
+  return node;
 }
-export function spreadElement(argument: t.Expression): t.SpreadElement {
-  return builder("SpreadElement", ...arguments);
+export function spreadElement(argument: t.Expression) {
+  const node = {
+    type: "SpreadElement",
+    argument: argument,
+  } as t.SpreadElement;
+  validateNode(node);
+  return node;
 }
-function _super(): t.Super {
-  return builder("Super", ...arguments);
+function _super() {
+  const node = {
+    type: "Super",
+  } as t.Super;
+  validateNode(node);
+  return node;
 }
 export { _super as super };
 export function taggedTemplateExpression(
   tag: t.Expression,
   quasi: t.TemplateLiteral,
-): t.TaggedTemplateExpression {
-  return builder("TaggedTemplateExpression", ...arguments);
+) {
+  const node = {
+    type: "TaggedTemplateExpression",
+    tag: tag,
+    quasi: quasi,
+    typeParameters: null,
+  } as t.TaggedTemplateExpression;
+  validateNode(node);
+  return node;
 }
 export function templateElement(
   value: { raw: string; cooked?: string },
   tail?: boolean,
-): t.TemplateElement {
-  return builder("TemplateElement", ...arguments);
+) {
+  const node = {
+    type: "TemplateElement",
+    value: value,
+    tail: tail === undefined ? false : tail,
+  } as t.TemplateElement;
+  validateNode(node);
+  return node;
 }
 export function templateLiteral(
   quasis: Array<t.TemplateElement>,
   expressions: Array<t.Expression | t.TSType>,
-): t.TemplateLiteral {
-  return builder("TemplateLiteral", ...arguments);
+) {
+  const node = {
+    type: "TemplateLiteral",
+    quasis: quasis,
+    expressions: expressions,
+  } as t.TemplateLiteral;
+  validateNode(node);
+  return node;
 }
 export function yieldExpression(
   argument?: t.Expression | null,
   delegate?: boolean,
-): t.YieldExpression {
-  return builder("YieldExpression", ...arguments);
+) {
+  const node = {
+    type: "YieldExpression",
+    argument: argument === undefined ? null : argument,
+    delegate: delegate === undefined ? false : delegate,
+  } as t.YieldExpression;
+  validateNode(node);
+  return node;
 }
-export function awaitExpression(argument: t.Expression): t.AwaitExpression {
-  return builder("AwaitExpression", ...arguments);
+export function awaitExpression(argument: t.Expression) {
+  const node = {
+    type: "AwaitExpression",
+    argument: argument,
+  } as t.AwaitExpression;
+  validateNode(node);
+  return node;
 }
-function _import(): t.Import {
-  return builder("Import", ...arguments);
+function _import() {
+  const node = {
+    type: "Import",
+  } as t.Import;
+  validateNode(node);
+  return node;
 }
 export { _import as import };
-export function bigIntLiteral(value: string): t.BigIntLiteral {
-  return builder("BigIntLiteral", ...arguments);
+export function bigIntLiteral(value: string) {
+  const node = {
+    type: "BigIntLiteral",
+    value: value,
+  } as t.BigIntLiteral;
+  validateNode(node);
+  return node;
 }
-export function exportNamespaceSpecifier(
-  exported: t.Identifier,
-): t.ExportNamespaceSpecifier {
-  return builder("ExportNamespaceSpecifier", ...arguments);
+export function exportNamespaceSpecifier(exported: t.Identifier) {
+  const node = {
+    type: "ExportNamespaceSpecifier",
+    exported: exported,
+  } as t.ExportNamespaceSpecifier;
+  validateNode(node);
+  return node;
 }
 export function optionalMemberExpression(
   object: t.Expression,
   property: t.Expression | t.Identifier,
   computed: boolean | undefined,
   optional: boolean,
-): t.OptionalMemberExpression {
-  return builder("OptionalMemberExpression", ...arguments);
+) {
+  const node = {
+    type: "OptionalMemberExpression",
+    object: object,
+    property: property,
+    computed: computed === undefined ? false : computed,
+    optional: optional,
+  } as t.OptionalMemberExpression;
+  validateNode(node);
+  return node;
 }
 export function optionalCallExpression(
   callee: t.Expression,
@@ -512,166 +1015,344 @@ export function optionalCallExpression(
     t.Expression | t.SpreadElement | t.JSXNamespacedName | t.ArgumentPlaceholder
   >,
   optional: boolean,
-): t.OptionalCallExpression {
-  return builder("OptionalCallExpression", ...arguments);
+) {
+  const node = {
+    type: "OptionalCallExpression",
+    callee: callee,
+    arguments: _arguments,
+    optional: optional,
+    typeArguments: null,
+    typeParameters: null,
+  } as t.OptionalCallExpression;
+  validateNode(node);
+  return node;
 }
-export function anyTypeAnnotation(): t.AnyTypeAnnotation {
-  return builder("AnyTypeAnnotation", ...arguments);
+export function anyTypeAnnotation() {
+  const node = {
+    type: "AnyTypeAnnotation",
+  } as t.AnyTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function arrayTypeAnnotation(
-  elementType: t.FlowType,
-): t.ArrayTypeAnnotation {
-  return builder("ArrayTypeAnnotation", ...arguments);
+export function arrayTypeAnnotation(elementType: t.FlowType) {
+  const node = {
+    type: "ArrayTypeAnnotation",
+    elementType: elementType,
+  } as t.ArrayTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function booleanTypeAnnotation(): t.BooleanTypeAnnotation {
-  return builder("BooleanTypeAnnotation", ...arguments);
+export function booleanTypeAnnotation() {
+  const node = {
+    type: "BooleanTypeAnnotation",
+  } as t.BooleanTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function booleanLiteralTypeAnnotation(
-  value: boolean,
-): t.BooleanLiteralTypeAnnotation {
-  return builder("BooleanLiteralTypeAnnotation", ...arguments);
+export function booleanLiteralTypeAnnotation(value: boolean) {
+  const node = {
+    type: "BooleanLiteralTypeAnnotation",
+    value: value,
+  } as t.BooleanLiteralTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function nullLiteralTypeAnnotation(): t.NullLiteralTypeAnnotation {
-  return builder("NullLiteralTypeAnnotation", ...arguments);
+export function nullLiteralTypeAnnotation() {
+  const node = {
+    type: "NullLiteralTypeAnnotation",
+  } as t.NullLiteralTypeAnnotation;
+  validateNode(node);
+  return node;
 }
 export function classImplements(
   id: t.Identifier,
   typeParameters?: t.TypeParameterInstantiation | null,
-): t.ClassImplements {
-  return builder("ClassImplements", ...arguments);
+) {
+  const node = {
+    type: "ClassImplements",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+  } as t.ClassImplements;
+  validateNode(node);
+  return node;
 }
 export function declareClass(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined,
   _extends: Array<t.InterfaceExtends> | null | undefined,
   body: t.ObjectTypeAnnotation,
-): t.DeclareClass {
-  return builder("DeclareClass", ...arguments);
+) {
+  const node = {
+    type: "DeclareClass",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    extends: _extends === undefined ? null : _extends,
+    body: body,
+    implements: null,
+    mixins: null,
+  } as t.DeclareClass;
+  validateNode(node);
+  return node;
 }
-export function declareFunction(id: t.Identifier): t.DeclareFunction {
-  return builder("DeclareFunction", ...arguments);
+export function declareFunction(id: t.Identifier) {
+  const node = {
+    type: "DeclareFunction",
+    id: id,
+    predicate: null,
+  } as t.DeclareFunction;
+  validateNode(node);
+  return node;
 }
 export function declareInterface(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined,
   _extends: Array<t.InterfaceExtends> | null | undefined,
   body: t.ObjectTypeAnnotation,
-): t.DeclareInterface {
-  return builder("DeclareInterface", ...arguments);
+) {
+  const node = {
+    type: "DeclareInterface",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    extends: _extends === undefined ? null : _extends,
+    body: body,
+    implements: null,
+    mixins: null,
+  } as t.DeclareInterface;
+  validateNode(node);
+  return node;
 }
 export function declareModule(
   id: t.Identifier | t.StringLiteral,
   body: t.BlockStatement,
   kind?: "CommonJS" | "ES" | null,
-): t.DeclareModule {
-  return builder("DeclareModule", ...arguments);
+) {
+  const node = {
+    type: "DeclareModule",
+    id: id,
+    body: body,
+    kind: kind === undefined ? null : kind,
+  } as t.DeclareModule;
+  validateNode(node);
+  return node;
 }
-export function declareModuleExports(
-  typeAnnotation: t.TypeAnnotation,
-): t.DeclareModuleExports {
-  return builder("DeclareModuleExports", ...arguments);
+export function declareModuleExports(typeAnnotation: t.TypeAnnotation) {
+  const node = {
+    type: "DeclareModuleExports",
+    typeAnnotation: typeAnnotation,
+  } as t.DeclareModuleExports;
+  validateNode(node);
+  return node;
 }
 export function declareTypeAlias(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined,
   right: t.FlowType,
-): t.DeclareTypeAlias {
-  return builder("DeclareTypeAlias", ...arguments);
+) {
+  const node = {
+    type: "DeclareTypeAlias",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    right: right,
+  } as t.DeclareTypeAlias;
+  validateNode(node);
+  return node;
 }
 export function declareOpaqueType(
   id: t.Identifier,
   typeParameters?: t.TypeParameterDeclaration | null,
   supertype?: t.FlowType | null,
-): t.DeclareOpaqueType {
-  return builder("DeclareOpaqueType", ...arguments);
+) {
+  const node = {
+    type: "DeclareOpaqueType",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    supertype: supertype === undefined ? null : supertype,
+  } as t.DeclareOpaqueType;
+  validateNode(node);
+  return node;
 }
-export function declareVariable(id: t.Identifier): t.DeclareVariable {
-  return builder("DeclareVariable", ...arguments);
+export function declareVariable(id: t.Identifier) {
+  const node = {
+    type: "DeclareVariable",
+    id: id,
+  } as t.DeclareVariable;
+  validateNode(node);
+  return node;
 }
 export function declareExportDeclaration(
   declaration?: t.Flow | null,
   specifiers?: Array<t.ExportSpecifier | t.ExportNamespaceSpecifier> | null,
   source?: t.StringLiteral | null,
-): t.DeclareExportDeclaration {
-  return builder("DeclareExportDeclaration", ...arguments);
+) {
+  const node = {
+    type: "DeclareExportDeclaration",
+    declaration: declaration === undefined ? null : declaration,
+    specifiers: specifiers === undefined ? null : specifiers,
+    source: source === undefined ? null : source,
+    default: null,
+  } as t.DeclareExportDeclaration;
+  validateNode(node);
+  return node;
 }
-export function declareExportAllDeclaration(
-  source: t.StringLiteral,
-): t.DeclareExportAllDeclaration {
-  return builder("DeclareExportAllDeclaration", ...arguments);
+export function declareExportAllDeclaration(source: t.StringLiteral) {
+  const node = {
+    type: "DeclareExportAllDeclaration",
+    source: source,
+    exportKind: null,
+  } as t.DeclareExportAllDeclaration;
+  validateNode(node);
+  return node;
 }
-export function declaredPredicate(value: t.Flow): t.DeclaredPredicate {
-  return builder("DeclaredPredicate", ...arguments);
+export function declaredPredicate(value: t.Flow) {
+  const node = {
+    type: "DeclaredPredicate",
+    value: value,
+  } as t.DeclaredPredicate;
+  validateNode(node);
+  return node;
 }
-export function existsTypeAnnotation(): t.ExistsTypeAnnotation {
-  return builder("ExistsTypeAnnotation", ...arguments);
+export function existsTypeAnnotation() {
+  const node = {
+    type: "ExistsTypeAnnotation",
+  } as t.ExistsTypeAnnotation;
+  validateNode(node);
+  return node;
 }
 export function functionTypeAnnotation(
   typeParameters: t.TypeParameterDeclaration | null | undefined,
   params: Array<t.FunctionTypeParam>,
   rest: t.FunctionTypeParam | null | undefined,
   returnType: t.FlowType,
-): t.FunctionTypeAnnotation {
-  return builder("FunctionTypeAnnotation", ...arguments);
+) {
+  const node = {
+    type: "FunctionTypeAnnotation",
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    params: params,
+    rest: rest === undefined ? null : rest,
+    returnType: returnType,
+    this: null,
+  } as t.FunctionTypeAnnotation;
+  validateNode(node);
+  return node;
 }
 export function functionTypeParam(
   name: t.Identifier | null | undefined,
   typeAnnotation: t.FlowType,
-): t.FunctionTypeParam {
-  return builder("FunctionTypeParam", ...arguments);
+) {
+  const node = {
+    type: "FunctionTypeParam",
+    name: name === undefined ? null : name,
+    typeAnnotation: typeAnnotation,
+    optional: null,
+  } as t.FunctionTypeParam;
+  validateNode(node);
+  return node;
 }
 export function genericTypeAnnotation(
   id: t.Identifier | t.QualifiedTypeIdentifier,
   typeParameters?: t.TypeParameterInstantiation | null,
-): t.GenericTypeAnnotation {
-  return builder("GenericTypeAnnotation", ...arguments);
+) {
+  const node = {
+    type: "GenericTypeAnnotation",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+  } as t.GenericTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function inferredPredicate(): t.InferredPredicate {
-  return builder("InferredPredicate", ...arguments);
+export function inferredPredicate() {
+  const node = {
+    type: "InferredPredicate",
+  } as t.InferredPredicate;
+  validateNode(node);
+  return node;
 }
 export function interfaceExtends(
   id: t.Identifier | t.QualifiedTypeIdentifier,
   typeParameters?: t.TypeParameterInstantiation | null,
-): t.InterfaceExtends {
-  return builder("InterfaceExtends", ...arguments);
+) {
+  const node = {
+    type: "InterfaceExtends",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+  } as t.InterfaceExtends;
+  validateNode(node);
+  return node;
 }
 export function interfaceDeclaration(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined,
   _extends: Array<t.InterfaceExtends> | null | undefined,
   body: t.ObjectTypeAnnotation,
-): t.InterfaceDeclaration {
-  return builder("InterfaceDeclaration", ...arguments);
+) {
+  const node = {
+    type: "InterfaceDeclaration",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    extends: _extends === undefined ? null : _extends,
+    body: body,
+    implements: null,
+    mixins: null,
+  } as t.InterfaceDeclaration;
+  validateNode(node);
+  return node;
 }
 export function interfaceTypeAnnotation(
   _extends: Array<t.InterfaceExtends> | null | undefined,
   body: t.ObjectTypeAnnotation,
-): t.InterfaceTypeAnnotation {
-  return builder("InterfaceTypeAnnotation", ...arguments);
+) {
+  const node = {
+    type: "InterfaceTypeAnnotation",
+    extends: _extends === undefined ? null : _extends,
+    body: body,
+  } as t.InterfaceTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function intersectionTypeAnnotation(
-  types: Array<t.FlowType>,
-): t.IntersectionTypeAnnotation {
-  return builder("IntersectionTypeAnnotation", ...arguments);
+export function intersectionTypeAnnotation(types: Array<t.FlowType>) {
+  const node = {
+    type: "IntersectionTypeAnnotation",
+    types: types,
+  } as t.IntersectionTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function mixedTypeAnnotation(): t.MixedTypeAnnotation {
-  return builder("MixedTypeAnnotation", ...arguments);
+export function mixedTypeAnnotation() {
+  const node = {
+    type: "MixedTypeAnnotation",
+  } as t.MixedTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function emptyTypeAnnotation(): t.EmptyTypeAnnotation {
-  return builder("EmptyTypeAnnotation", ...arguments);
+export function emptyTypeAnnotation() {
+  const node = {
+    type: "EmptyTypeAnnotation",
+  } as t.EmptyTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function nullableTypeAnnotation(
-  typeAnnotation: t.FlowType,
-): t.NullableTypeAnnotation {
-  return builder("NullableTypeAnnotation", ...arguments);
+export function nullableTypeAnnotation(typeAnnotation: t.FlowType) {
+  const node = {
+    type: "NullableTypeAnnotation",
+    typeAnnotation: typeAnnotation,
+  } as t.NullableTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function numberLiteralTypeAnnotation(
-  value: number,
-): t.NumberLiteralTypeAnnotation {
-  return builder("NumberLiteralTypeAnnotation", ...arguments);
+export function numberLiteralTypeAnnotation(value: number) {
+  const node = {
+    type: "NumberLiteralTypeAnnotation",
+    value: value,
+  } as t.NumberLiteralTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function numberTypeAnnotation(): t.NumberTypeAnnotation {
-  return builder("NumberTypeAnnotation", ...arguments);
+export function numberTypeAnnotation() {
+  const node = {
+    type: "NumberTypeAnnotation",
+  } as t.NumberTypeAnnotation;
+  validateNode(node);
+  return node;
 }
 export function objectTypeAnnotation(
   properties: Array<t.ObjectTypeProperty | t.ObjectTypeSpreadProperty>,
@@ -679,8 +1360,18 @@ export function objectTypeAnnotation(
   callProperties?: Array<t.ObjectTypeCallProperty> | null,
   internalSlots?: Array<t.ObjectTypeInternalSlot> | null,
   exact?: boolean,
-): t.ObjectTypeAnnotation {
-  return builder("ObjectTypeAnnotation", ...arguments);
+) {
+  const node = {
+    type: "ObjectTypeAnnotation",
+    properties: properties,
+    indexers: indexers === undefined ? null : indexers,
+    callProperties: callProperties === undefined ? null : callProperties,
+    internalSlots: internalSlots === undefined ? null : internalSlots,
+    exact: exact === undefined ? false : exact,
+    inexact: null,
+  } as t.ObjectTypeAnnotation;
+  validateNode(node);
+  return node;
 }
 export function objectTypeInternalSlot(
   id: t.Identifier,
@@ -688,115 +1379,231 @@ export function objectTypeInternalSlot(
   optional: boolean,
   _static: boolean,
   method: boolean,
-): t.ObjectTypeInternalSlot {
-  return builder("ObjectTypeInternalSlot", ...arguments);
+) {
+  const node = {
+    type: "ObjectTypeInternalSlot",
+    id: id,
+    value: value,
+    optional: optional,
+    static: _static,
+    method: method,
+  } as t.ObjectTypeInternalSlot;
+  validateNode(node);
+  return node;
 }
-export function objectTypeCallProperty(
-  value: t.FlowType,
-): t.ObjectTypeCallProperty {
-  return builder("ObjectTypeCallProperty", ...arguments);
+export function objectTypeCallProperty(value: t.FlowType) {
+  const node = {
+    type: "ObjectTypeCallProperty",
+    value: value,
+    static: null,
+  } as t.ObjectTypeCallProperty;
+  validateNode(node);
+  return node;
 }
 export function objectTypeIndexer(
   id: t.Identifier | null | undefined,
   key: t.FlowType,
   value: t.FlowType,
   variance?: t.Variance | null,
-): t.ObjectTypeIndexer {
-  return builder("ObjectTypeIndexer", ...arguments);
+) {
+  const node = {
+    type: "ObjectTypeIndexer",
+    id: id === undefined ? null : id,
+    key: key,
+    value: value,
+    variance: variance === undefined ? null : variance,
+    static: null,
+  } as t.ObjectTypeIndexer;
+  validateNode(node);
+  return node;
 }
 export function objectTypeProperty(
   key: t.Identifier | t.StringLiteral,
   value: t.FlowType,
   variance?: t.Variance | null,
-): t.ObjectTypeProperty {
-  return builder("ObjectTypeProperty", ...arguments);
+) {
+  const node = {
+    type: "ObjectTypeProperty",
+    key: key,
+    value: value,
+    variance: variance === undefined ? null : variance,
+    kind: null,
+    method: null,
+    optional: null,
+    proto: null,
+    static: null,
+  } as t.ObjectTypeProperty;
+  validateNode(node);
+  return node;
 }
-export function objectTypeSpreadProperty(
-  argument: t.FlowType,
-): t.ObjectTypeSpreadProperty {
-  return builder("ObjectTypeSpreadProperty", ...arguments);
+export function objectTypeSpreadProperty(argument: t.FlowType) {
+  const node = {
+    type: "ObjectTypeSpreadProperty",
+    argument: argument,
+  } as t.ObjectTypeSpreadProperty;
+  validateNode(node);
+  return node;
 }
 export function opaqueType(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined,
   supertype: t.FlowType | null | undefined,
   impltype: t.FlowType,
-): t.OpaqueType {
-  return builder("OpaqueType", ...arguments);
+) {
+  const node = {
+    type: "OpaqueType",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    supertype: supertype === undefined ? null : supertype,
+    impltype: impltype,
+  } as t.OpaqueType;
+  validateNode(node);
+  return node;
 }
 export function qualifiedTypeIdentifier(
   id: t.Identifier,
   qualification: t.Identifier | t.QualifiedTypeIdentifier,
-): t.QualifiedTypeIdentifier {
-  return builder("QualifiedTypeIdentifier", ...arguments);
+) {
+  const node = {
+    type: "QualifiedTypeIdentifier",
+    id: id,
+    qualification: qualification,
+  } as t.QualifiedTypeIdentifier;
+  validateNode(node);
+  return node;
 }
-export function stringLiteralTypeAnnotation(
-  value: string,
-): t.StringLiteralTypeAnnotation {
-  return builder("StringLiteralTypeAnnotation", ...arguments);
+export function stringLiteralTypeAnnotation(value: string) {
+  const node = {
+    type: "StringLiteralTypeAnnotation",
+    value: value,
+  } as t.StringLiteralTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function stringTypeAnnotation(): t.StringTypeAnnotation {
-  return builder("StringTypeAnnotation", ...arguments);
+export function stringTypeAnnotation() {
+  const node = {
+    type: "StringTypeAnnotation",
+  } as t.StringTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function symbolTypeAnnotation(): t.SymbolTypeAnnotation {
-  return builder("SymbolTypeAnnotation", ...arguments);
+export function symbolTypeAnnotation() {
+  const node = {
+    type: "SymbolTypeAnnotation",
+  } as t.SymbolTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function thisTypeAnnotation(): t.ThisTypeAnnotation {
-  return builder("ThisTypeAnnotation", ...arguments);
+export function thisTypeAnnotation() {
+  const node = {
+    type: "ThisTypeAnnotation",
+  } as t.ThisTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function tupleTypeAnnotation(
-  types: Array<t.FlowType>,
-): t.TupleTypeAnnotation {
-  return builder("TupleTypeAnnotation", ...arguments);
+export function tupleTypeAnnotation(types: Array<t.FlowType>) {
+  const node = {
+    type: "TupleTypeAnnotation",
+    types: types,
+  } as t.TupleTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function typeofTypeAnnotation(
-  argument: t.FlowType,
-): t.TypeofTypeAnnotation {
-  return builder("TypeofTypeAnnotation", ...arguments);
+export function typeofTypeAnnotation(argument: t.FlowType) {
+  const node = {
+    type: "TypeofTypeAnnotation",
+    argument: argument,
+  } as t.TypeofTypeAnnotation;
+  validateNode(node);
+  return node;
 }
 export function typeAlias(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined,
   right: t.FlowType,
-): t.TypeAlias {
-  return builder("TypeAlias", ...arguments);
+) {
+  const node = {
+    type: "TypeAlias",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    right: right,
+  } as t.TypeAlias;
+  validateNode(node);
+  return node;
 }
-export function typeAnnotation(typeAnnotation: t.FlowType): t.TypeAnnotation {
-  return builder("TypeAnnotation", ...arguments);
+export function typeAnnotation(typeAnnotation: t.FlowType) {
+  const node = {
+    type: "TypeAnnotation",
+    typeAnnotation: typeAnnotation,
+  } as t.TypeAnnotation;
+  validateNode(node);
+  return node;
 }
 export function typeCastExpression(
   expression: t.Expression,
   typeAnnotation: t.TypeAnnotation,
-): t.TypeCastExpression {
-  return builder("TypeCastExpression", ...arguments);
+) {
+  const node = {
+    type: "TypeCastExpression",
+    expression: expression,
+    typeAnnotation: typeAnnotation,
+  } as t.TypeCastExpression;
+  validateNode(node);
+  return node;
 }
 export function typeParameter(
   bound?: t.TypeAnnotation | null,
   _default?: t.FlowType | null,
   variance?: t.Variance | null,
-): t.TypeParameter {
-  return builder("TypeParameter", ...arguments);
+) {
+  const node = {
+    type: "TypeParameter",
+    bound: bound === undefined ? null : bound,
+    default: _default === undefined ? null : _default,
+    variance: variance === undefined ? null : variance,
+    name: null,
+  } as t.TypeParameter;
+  validateNode(node);
+  return node;
 }
-export function typeParameterDeclaration(
-  params: Array<t.TypeParameter>,
-): t.TypeParameterDeclaration {
-  return builder("TypeParameterDeclaration", ...arguments);
+export function typeParameterDeclaration(params: Array<t.TypeParameter>) {
+  const node = {
+    type: "TypeParameterDeclaration",
+    params: params,
+  } as t.TypeParameterDeclaration;
+  validateNode(node);
+  return node;
 }
-export function typeParameterInstantiation(
-  params: Array<t.FlowType>,
-): t.TypeParameterInstantiation {
-  return builder("TypeParameterInstantiation", ...arguments);
+export function typeParameterInstantiation(params: Array<t.FlowType>) {
+  const node = {
+    type: "TypeParameterInstantiation",
+    params: params,
+  } as t.TypeParameterInstantiation;
+  validateNode(node);
+  return node;
 }
-export function unionTypeAnnotation(
-  types: Array<t.FlowType>,
-): t.UnionTypeAnnotation {
-  return builder("UnionTypeAnnotation", ...arguments);
+export function unionTypeAnnotation(types: Array<t.FlowType>) {
+  const node = {
+    type: "UnionTypeAnnotation",
+    types: types,
+  } as t.UnionTypeAnnotation;
+  validateNode(node);
+  return node;
 }
-export function variance(kind: "minus" | "plus"): t.Variance {
-  return builder("Variance", ...arguments);
+export function variance(kind: "minus" | "plus") {
+  const node = {
+    type: "Variance",
+    kind: kind,
+  } as t.Variance;
+  validateNode(node);
+  return node;
 }
-export function voidTypeAnnotation(): t.VoidTypeAnnotation {
-  return builder("VoidTypeAnnotation", ...arguments);
+export function voidTypeAnnotation() {
+  const node = {
+    type: "VoidTypeAnnotation",
+  } as t.VoidTypeAnnotation;
+  validateNode(node);
+  return node;
 }
 export function enumDeclaration(
   id: t.Identifier,
@@ -805,58 +1612,115 @@ export function enumDeclaration(
     | t.EnumNumberBody
     | t.EnumStringBody
     | t.EnumSymbolBody,
-): t.EnumDeclaration {
-  return builder("EnumDeclaration", ...arguments);
+) {
+  const node = {
+    type: "EnumDeclaration",
+    id: id,
+    body: body,
+  } as t.EnumDeclaration;
+  validateNode(node);
+  return node;
 }
-export function enumBooleanBody(
-  members: Array<t.EnumBooleanMember>,
-): t.EnumBooleanBody {
-  return builder("EnumBooleanBody", ...arguments);
+export function enumBooleanBody(members: Array<t.EnumBooleanMember>) {
+  const node = {
+    type: "EnumBooleanBody",
+    members: members,
+    explicitType: null,
+    hasUnknownMembers: null,
+  } as t.EnumBooleanBody;
+  validateNode(node);
+  return node;
 }
-export function enumNumberBody(
-  members: Array<t.EnumNumberMember>,
-): t.EnumNumberBody {
-  return builder("EnumNumberBody", ...arguments);
+export function enumNumberBody(members: Array<t.EnumNumberMember>) {
+  const node = {
+    type: "EnumNumberBody",
+    members: members,
+    explicitType: null,
+    hasUnknownMembers: null,
+  } as t.EnumNumberBody;
+  validateNode(node);
+  return node;
 }
 export function enumStringBody(
   members: Array<t.EnumStringMember | t.EnumDefaultedMember>,
-): t.EnumStringBody {
-  return builder("EnumStringBody", ...arguments);
+) {
+  const node = {
+    type: "EnumStringBody",
+    members: members,
+    explicitType: null,
+    hasUnknownMembers: null,
+  } as t.EnumStringBody;
+  validateNode(node);
+  return node;
 }
-export function enumSymbolBody(
-  members: Array<t.EnumDefaultedMember>,
-): t.EnumSymbolBody {
-  return builder("EnumSymbolBody", ...arguments);
+export function enumSymbolBody(members: Array<t.EnumDefaultedMember>) {
+  const node = {
+    type: "EnumSymbolBody",
+    members: members,
+    hasUnknownMembers: null,
+  } as t.EnumSymbolBody;
+  validateNode(node);
+  return node;
 }
-export function enumBooleanMember(id: t.Identifier): t.EnumBooleanMember {
-  return builder("EnumBooleanMember", ...arguments);
+export function enumBooleanMember(id: t.Identifier) {
+  const node = {
+    type: "EnumBooleanMember",
+    id: id,
+    init: null,
+  } as t.EnumBooleanMember;
+  validateNode(node);
+  return node;
 }
-export function enumNumberMember(
-  id: t.Identifier,
-  init: t.NumericLiteral,
-): t.EnumNumberMember {
-  return builder("EnumNumberMember", ...arguments);
+export function enumNumberMember(id: t.Identifier, init: t.NumericLiteral) {
+  const node = {
+    type: "EnumNumberMember",
+    id: id,
+    init: init,
+  } as t.EnumNumberMember;
+  validateNode(node);
+  return node;
 }
-export function enumStringMember(
-  id: t.Identifier,
-  init: t.StringLiteral,
-): t.EnumStringMember {
-  return builder("EnumStringMember", ...arguments);
+export function enumStringMember(id: t.Identifier, init: t.StringLiteral) {
+  const node = {
+    type: "EnumStringMember",
+    id: id,
+    init: init,
+  } as t.EnumStringMember;
+  validateNode(node);
+  return node;
 }
-export function enumDefaultedMember(id: t.Identifier): t.EnumDefaultedMember {
-  return builder("EnumDefaultedMember", ...arguments);
+export function enumDefaultedMember(id: t.Identifier) {
+  const node = {
+    type: "EnumDefaultedMember",
+    id: id,
+  } as t.EnumDefaultedMember;
+  validateNode(node);
+  return node;
 }
 export function indexedAccessType(
   objectType: t.FlowType,
   indexType: t.FlowType,
-): t.IndexedAccessType {
-  return builder("IndexedAccessType", ...arguments);
+) {
+  const node = {
+    type: "IndexedAccessType",
+    objectType: objectType,
+    indexType: indexType,
+  } as t.IndexedAccessType;
+  validateNode(node);
+  return node;
 }
 export function optionalIndexedAccessType(
   objectType: t.FlowType,
   indexType: t.FlowType,
-): t.OptionalIndexedAccessType {
-  return builder("OptionalIndexedAccessType", ...arguments);
+) {
+  const node = {
+    type: "OptionalIndexedAccessType",
+    objectType: objectType,
+    indexType: indexType,
+    optional: null,
+  } as t.OptionalIndexedAccessType;
+  validateNode(node);
+  return node;
 }
 export function jsxAttribute(
   name: t.JSXIdentifier | t.JSXNamespacedName,
@@ -866,14 +1730,25 @@ export function jsxAttribute(
     | t.StringLiteral
     | t.JSXExpressionContainer
     | null,
-): t.JSXAttribute {
-  return builder("JSXAttribute", ...arguments);
+) {
+  const node = {
+    type: "JSXAttribute",
+    name: name,
+    value: value === undefined ? null : value,
+  } as t.JSXAttribute;
+  validateNode(node);
+  return node;
 }
 export { jsxAttribute as jSXAttribute };
 export function jsxClosingElement(
   name: t.JSXIdentifier | t.JSXMemberExpression | t.JSXNamespacedName,
-): t.JSXClosingElement {
-  return builder("JSXClosingElement", ...arguments);
+) {
+  const node = {
+    type: "JSXClosingElement",
+    name: name,
+  } as t.JSXClosingElement;
+  validateNode(node);
+  return node;
 }
 export { jsxClosingElement as jSXClosingElement };
 export function jsxElement(
@@ -887,58 +1762,113 @@ export function jsxElement(
     | t.JSXFragment
   >,
   selfClosing?: boolean | null,
-): t.JSXElement {
-  return builder("JSXElement", ...arguments);
+) {
+  const node = {
+    type: "JSXElement",
+    openingElement: openingElement,
+    closingElement: closingElement === undefined ? null : closingElement,
+    children: children,
+    selfClosing: selfClosing === undefined ? null : selfClosing,
+  } as t.JSXElement;
+  validateNode(node);
+  return node;
 }
 export { jsxElement as jSXElement };
-export function jsxEmptyExpression(): t.JSXEmptyExpression {
-  return builder("JSXEmptyExpression", ...arguments);
+export function jsxEmptyExpression() {
+  const node = {
+    type: "JSXEmptyExpression",
+  } as t.JSXEmptyExpression;
+  validateNode(node);
+  return node;
 }
 export { jsxEmptyExpression as jSXEmptyExpression };
 export function jsxExpressionContainer(
   expression: t.Expression | t.JSXEmptyExpression,
-): t.JSXExpressionContainer {
-  return builder("JSXExpressionContainer", ...arguments);
+) {
+  const node = {
+    type: "JSXExpressionContainer",
+    expression: expression,
+  } as t.JSXExpressionContainer;
+  validateNode(node);
+  return node;
 }
 export { jsxExpressionContainer as jSXExpressionContainer };
-export function jsxSpreadChild(expression: t.Expression): t.JSXSpreadChild {
-  return builder("JSXSpreadChild", ...arguments);
+export function jsxSpreadChild(expression: t.Expression) {
+  const node = {
+    type: "JSXSpreadChild",
+    expression: expression,
+  } as t.JSXSpreadChild;
+  validateNode(node);
+  return node;
 }
 export { jsxSpreadChild as jSXSpreadChild };
-export function jsxIdentifier(name: string): t.JSXIdentifier {
-  return builder("JSXIdentifier", ...arguments);
+export function jsxIdentifier(name: string) {
+  const node = {
+    type: "JSXIdentifier",
+    name: name,
+  } as t.JSXIdentifier;
+  validateNode(node);
+  return node;
 }
 export { jsxIdentifier as jSXIdentifier };
 export function jsxMemberExpression(
   object: t.JSXMemberExpression | t.JSXIdentifier,
   property: t.JSXIdentifier,
-): t.JSXMemberExpression {
-  return builder("JSXMemberExpression", ...arguments);
+) {
+  const node = {
+    type: "JSXMemberExpression",
+    object: object,
+    property: property,
+  } as t.JSXMemberExpression;
+  validateNode(node);
+  return node;
 }
 export { jsxMemberExpression as jSXMemberExpression };
 export function jsxNamespacedName(
   namespace: t.JSXIdentifier,
   name: t.JSXIdentifier,
-): t.JSXNamespacedName {
-  return builder("JSXNamespacedName", ...arguments);
+) {
+  const node = {
+    type: "JSXNamespacedName",
+    namespace: namespace,
+    name: name,
+  } as t.JSXNamespacedName;
+  validateNode(node);
+  return node;
 }
 export { jsxNamespacedName as jSXNamespacedName };
 export function jsxOpeningElement(
   name: t.JSXIdentifier | t.JSXMemberExpression | t.JSXNamespacedName,
   attributes: Array<t.JSXAttribute | t.JSXSpreadAttribute>,
   selfClosing?: boolean,
-): t.JSXOpeningElement {
-  return builder("JSXOpeningElement", ...arguments);
+) {
+  const node = {
+    type: "JSXOpeningElement",
+    name: name,
+    attributes: attributes,
+    selfClosing: selfClosing === undefined ? false : selfClosing,
+    typeParameters: null,
+  } as t.JSXOpeningElement;
+  validateNode(node);
+  return node;
 }
 export { jsxOpeningElement as jSXOpeningElement };
-export function jsxSpreadAttribute(
-  argument: t.Expression,
-): t.JSXSpreadAttribute {
-  return builder("JSXSpreadAttribute", ...arguments);
+export function jsxSpreadAttribute(argument: t.Expression) {
+  const node = {
+    type: "JSXSpreadAttribute",
+    argument: argument,
+  } as t.JSXSpreadAttribute;
+  validateNode(node);
+  return node;
 }
 export { jsxSpreadAttribute as jSXSpreadAttribute };
-export function jsxText(value: string): t.JSXText {
-  return builder("JSXText", ...arguments);
+export function jsxText(value: string) {
+  const node = {
+    type: "JSXText",
+    value: value,
+  } as t.JSXText;
+  validateNode(node);
+  return node;
 }
 export { jsxText as jSXText };
 export function jsxFragment(
@@ -951,20 +1881,39 @@ export function jsxFragment(
     | t.JSXElement
     | t.JSXFragment
   >,
-): t.JSXFragment {
-  return builder("JSXFragment", ...arguments);
+) {
+  const node = {
+    type: "JSXFragment",
+    openingFragment: openingFragment,
+    closingFragment: closingFragment,
+    children: children,
+  } as t.JSXFragment;
+  validateNode(node);
+  return node;
 }
 export { jsxFragment as jSXFragment };
-export function jsxOpeningFragment(): t.JSXOpeningFragment {
-  return builder("JSXOpeningFragment", ...arguments);
+export function jsxOpeningFragment() {
+  const node = {
+    type: "JSXOpeningFragment",
+  } as t.JSXOpeningFragment;
+  validateNode(node);
+  return node;
 }
 export { jsxOpeningFragment as jSXOpeningFragment };
-export function jsxClosingFragment(): t.JSXClosingFragment {
-  return builder("JSXClosingFragment", ...arguments);
+export function jsxClosingFragment() {
+  const node = {
+    type: "JSXClosingFragment",
+  } as t.JSXClosingFragment;
+  validateNode(node);
+  return node;
 }
 export { jsxClosingFragment as jSXClosingFragment };
-export function noop(): t.Noop {
-  return builder("Noop", ...arguments);
+export function noop() {
+  const node = {
+    type: "Noop",
+  } as t.Noop;
+  validateNode(node);
+  return node;
 }
 export function placeholder(
   expectedNode:
@@ -977,20 +1926,38 @@ export function placeholder(
     | "ClassBody"
     | "Pattern",
   name: t.Identifier,
-): t.Placeholder {
-  return builder("Placeholder", ...arguments);
+) {
+  const node = {
+    type: "Placeholder",
+    expectedNode: expectedNode,
+    name: name,
+  } as t.Placeholder;
+  validateNode(node);
+  return node;
 }
-export function v8IntrinsicIdentifier(name: string): t.V8IntrinsicIdentifier {
-  return builder("V8IntrinsicIdentifier", ...arguments);
+export function v8IntrinsicIdentifier(name: string) {
+  const node = {
+    type: "V8IntrinsicIdentifier",
+    name: name,
+  } as t.V8IntrinsicIdentifier;
+  validateNode(node);
+  return node;
 }
-export function argumentPlaceholder(): t.ArgumentPlaceholder {
-  return builder("ArgumentPlaceholder", ...arguments);
+export function argumentPlaceholder() {
+  const node = {
+    type: "ArgumentPlaceholder",
+  } as t.ArgumentPlaceholder;
+  validateNode(node);
+  return node;
 }
-export function bindExpression(
-  object: t.Expression,
-  callee: t.Expression,
-): t.BindExpression {
-  return builder("BindExpression", ...arguments);
+export function bindExpression(object: t.Expression, callee: t.Expression) {
+  const node = {
+    type: "BindExpression",
+    object: object,
+    callee: callee,
+  } as t.BindExpression;
+  validateNode(node);
+  return node;
 }
 export function classProperty(
   key: t.Identifier | t.StringLiteral | t.NumericLiteral | t.Expression,
@@ -999,29 +1966,65 @@ export function classProperty(
   decorators?: Array<t.Decorator> | null,
   computed?: boolean,
   _static?: boolean,
-): t.ClassProperty {
-  return builder("ClassProperty", ...arguments);
+) {
+  const node = {
+    type: "ClassProperty",
+    key: key,
+    value: value === undefined ? null : value,
+    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    decorators: decorators === undefined ? null : decorators,
+    computed: computed === undefined ? false : computed,
+    static: _static === undefined ? false : _static,
+    abstract: null,
+    accessibility: null,
+    declare: null,
+    definite: null,
+    optional: null,
+    override: false,
+    readonly: null,
+  } as t.ClassProperty;
+  validateNode(node);
+  return node;
 }
-export function pipelineTopicExpression(
-  expression: t.Expression,
-): t.PipelineTopicExpression {
-  return builder("PipelineTopicExpression", ...arguments);
+export function pipelineTopicExpression(expression: t.Expression) {
+  const node = {
+    type: "PipelineTopicExpression",
+    expression: expression,
+  } as t.PipelineTopicExpression;
+  validateNode(node);
+  return node;
 }
-export function pipelineBareFunction(
-  callee: t.Expression,
-): t.PipelineBareFunction {
-  return builder("PipelineBareFunction", ...arguments);
+export function pipelineBareFunction(callee: t.Expression) {
+  const node = {
+    type: "PipelineBareFunction",
+    callee: callee,
+  } as t.PipelineBareFunction;
+  validateNode(node);
+  return node;
 }
-export function pipelinePrimaryTopicReference(): t.PipelinePrimaryTopicReference {
-  return builder("PipelinePrimaryTopicReference", ...arguments);
+export function pipelinePrimaryTopicReference() {
+  const node = {
+    type: "PipelinePrimaryTopicReference",
+  } as t.PipelinePrimaryTopicReference;
+  validateNode(node);
+  return node;
 }
 export function classPrivateProperty(
   key: t.PrivateName,
   value: t.Expression | null | undefined,
   decorators: Array<t.Decorator> | null | undefined,
   _static: any,
-): t.ClassPrivateProperty {
-  return builder("ClassPrivateProperty", ...arguments);
+) {
+  const node = {
+    type: "ClassPrivateProperty",
+    key: key,
+    value: value === undefined ? null : value,
+    decorators: decorators === undefined ? null : decorators,
+    static: _static,
+    typeAnnotation: null,
+  } as t.ClassPrivateProperty;
+  validateNode(node);
+  return node;
 }
 export function classPrivateMethod(
   kind: "get" | "set" | "method" | "constructor" | undefined,
@@ -1031,55 +2034,129 @@ export function classPrivateMethod(
   >,
   body: t.BlockStatement,
   _static?: boolean,
-): t.ClassPrivateMethod {
-  return builder("ClassPrivateMethod", ...arguments);
+) {
+  const node = {
+    type: "ClassPrivateMethod",
+    kind: kind === undefined ? "method" : kind,
+    key: key,
+    params: params,
+    body: body,
+    static: _static === undefined ? false : _static,
+    abstract: null,
+    access: null,
+    accessibility: null,
+    async: false,
+    computed: false,
+    decorators: null,
+    generator: false,
+    optional: null,
+    override: false,
+    returnType: null,
+    typeParameters: null,
+  } as t.ClassPrivateMethod;
+  validateNode(node);
+  return node;
 }
 export function importAttribute(
   key: t.Identifier | t.StringLiteral,
   value: t.StringLiteral,
-): t.ImportAttribute {
-  return builder("ImportAttribute", ...arguments);
+) {
+  const node = {
+    type: "ImportAttribute",
+    key: key,
+    value: value,
+  } as t.ImportAttribute;
+  validateNode(node);
+  return node;
 }
-export function decorator(expression: t.Expression): t.Decorator {
-  return builder("Decorator", ...arguments);
+export function decorator(expression: t.Expression) {
+  const node = {
+    type: "Decorator",
+    expression: expression,
+  } as t.Decorator;
+  validateNode(node);
+  return node;
 }
-export function doExpression(
-  body: t.BlockStatement,
-  async?: boolean,
-): t.DoExpression {
-  return builder("DoExpression", ...arguments);
+export function doExpression(body: t.BlockStatement, async?: boolean) {
+  const node = {
+    type: "DoExpression",
+    body: body,
+    async: async === undefined ? false : async,
+  } as t.DoExpression;
+  validateNode(node);
+  return node;
 }
-export function exportDefaultSpecifier(
-  exported: t.Identifier,
-): t.ExportDefaultSpecifier {
-  return builder("ExportDefaultSpecifier", ...arguments);
+export function exportDefaultSpecifier(exported: t.Identifier) {
+  const node = {
+    type: "ExportDefaultSpecifier",
+    exported: exported,
+  } as t.ExportDefaultSpecifier;
+  validateNode(node);
+  return node;
 }
-export function privateName(id: t.Identifier): t.PrivateName {
-  return builder("PrivateName", ...arguments);
+export function privateName(id: t.Identifier) {
+  const node = {
+    type: "PrivateName",
+    id: id,
+  } as t.PrivateName;
+  validateNode(node);
+  return node;
 }
 export function recordExpression(
   properties: Array<t.ObjectProperty | t.SpreadElement>,
-): t.RecordExpression {
-  return builder("RecordExpression", ...arguments);
+) {
+  const node = {
+    type: "RecordExpression",
+    properties: properties,
+  } as t.RecordExpression;
+  validateNode(node);
+  return node;
 }
 export function tupleExpression(
   elements?: Array<t.Expression | t.SpreadElement>,
-): t.TupleExpression {
-  return builder("TupleExpression", ...arguments);
+) {
+  const node = {
+    type: "TupleExpression",
+    elements: elements === undefined ? [] : elements,
+  } as t.TupleExpression;
+  validateNode(node);
+  return node;
 }
-export function decimalLiteral(value: string): t.DecimalLiteral {
-  return builder("DecimalLiteral", ...arguments);
+export function decimalLiteral(value: string) {
+  const node = {
+    type: "DecimalLiteral",
+    value: value,
+  } as t.DecimalLiteral;
+  validateNode(node);
+  return node;
 }
-export function staticBlock(body: Array<t.Statement>): t.StaticBlock {
-  return builder("StaticBlock", ...arguments);
+export function staticBlock(body: Array<t.Statement>) {
+  const node = {
+    type: "StaticBlock",
+    body: body,
+  } as t.StaticBlock;
+  validateNode(node);
+  return node;
 }
-export function moduleExpression(body: t.Program): t.ModuleExpression {
-  return builder("ModuleExpression", ...arguments);
+export function moduleExpression(body: t.Program) {
+  const node = {
+    type: "ModuleExpression",
+    body: body,
+  } as t.ModuleExpression;
+  validateNode(node);
+  return node;
 }
 export function tsParameterProperty(
   parameter: t.Identifier | t.AssignmentPattern,
-): t.TSParameterProperty {
-  return builder("TSParameterProperty", ...arguments);
+) {
+  const node = {
+    type: "TSParameterProperty",
+    parameter: parameter,
+    accessibility: null,
+    readonly: null,
+  } as t.TSParameterProperty;
+  validateNode(node);
+  return node;
 }
 export { tsParameterProperty as tSParameterProperty };
 export function tsDeclareFunction(
@@ -1087,8 +2164,19 @@ export function tsDeclareFunction(
   typeParameters: t.TSTypeParameterDeclaration | t.Noop | null | undefined,
   params: Array<t.Identifier | t.Pattern | t.RestElement>,
   returnType?: t.TSTypeAnnotation | t.Noop | null,
-): t.TSDeclareFunction {
-  return builder("TSDeclareFunction", ...arguments);
+) {
+  const node = {
+    type: "TSDeclareFunction",
+    id: id === undefined ? null : id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    params: params,
+    returnType: returnType === undefined ? null : returnType,
+    async: false,
+    declare: null,
+    generator: false,
+  } as t.TSDeclareFunction;
+  validateNode(node);
+  return node;
 }
 export { tsDeclareFunction as tSDeclareFunction };
 export function tsDeclareMethod(
@@ -1099,39 +2187,85 @@ export function tsDeclareMethod(
     t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
   >,
   returnType?: t.TSTypeAnnotation | t.Noop | null,
-): t.TSDeclareMethod {
-  return builder("TSDeclareMethod", ...arguments);
+) {
+  const node = {
+    type: "TSDeclareMethod",
+    decorators: decorators === undefined ? null : decorators,
+    key: key,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    params: params,
+    returnType: returnType === undefined ? null : returnType,
+    abstract: null,
+    access: null,
+    accessibility: null,
+    async: false,
+    computed: false,
+    generator: false,
+    kind: "method",
+    optional: null,
+    override: false,
+    static: false,
+  } as t.TSDeclareMethod;
+  validateNode(node);
+  return node;
 }
 export { tsDeclareMethod as tSDeclareMethod };
-export function tsQualifiedName(
-  left: t.TSEntityName,
-  right: t.Identifier,
-): t.TSQualifiedName {
-  return builder("TSQualifiedName", ...arguments);
+export function tsQualifiedName(left: t.TSEntityName, right: t.Identifier) {
+  const node = {
+    type: "TSQualifiedName",
+    left: left,
+    right: right,
+  } as t.TSQualifiedName;
+  validateNode(node);
+  return node;
 }
 export { tsQualifiedName as tSQualifiedName };
 export function tsCallSignatureDeclaration(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   parameters: Array<t.Identifier | t.RestElement>,
   typeAnnotation?: t.TSTypeAnnotation | null,
-): t.TSCallSignatureDeclaration {
-  return builder("TSCallSignatureDeclaration", ...arguments);
+) {
+  const node = {
+    type: "TSCallSignatureDeclaration",
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    parameters: parameters,
+    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+  } as t.TSCallSignatureDeclaration;
+  validateNode(node);
+  return node;
 }
 export { tsCallSignatureDeclaration as tSCallSignatureDeclaration };
 export function tsConstructSignatureDeclaration(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   parameters: Array<t.Identifier | t.RestElement>,
   typeAnnotation?: t.TSTypeAnnotation | null,
-): t.TSConstructSignatureDeclaration {
-  return builder("TSConstructSignatureDeclaration", ...arguments);
+) {
+  const node = {
+    type: "TSConstructSignatureDeclaration",
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    parameters: parameters,
+    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+  } as t.TSConstructSignatureDeclaration;
+  validateNode(node);
+  return node;
 }
 export { tsConstructSignatureDeclaration as tSConstructSignatureDeclaration };
 export function tsPropertySignature(
   key: t.Expression,
   typeAnnotation?: t.TSTypeAnnotation | null,
   initializer?: t.Expression | null,
-): t.TSPropertySignature {
-  return builder("TSPropertySignature", ...arguments);
+) {
+  const node = {
+    type: "TSPropertySignature",
+    key: key,
+    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    initializer: initializer === undefined ? null : initializer,
+    computed: null,
+    optional: null,
+    readonly: null,
+  } as t.TSPropertySignature;
+  validateNode(node);
+  return node;
 }
 export { tsPropertySignature as tSPropertySignature };
 export function tsMethodSignature(
@@ -1139,150 +2273,294 @@ export function tsMethodSignature(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   parameters: Array<t.Identifier | t.RestElement>,
   typeAnnotation?: t.TSTypeAnnotation | null,
-): t.TSMethodSignature {
-  return builder("TSMethodSignature", ...arguments);
+) {
+  const node = {
+    type: "TSMethodSignature",
+    key: key,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    parameters: parameters,
+    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    computed: null,
+    kind: null,
+    optional: null,
+  } as t.TSMethodSignature;
+  validateNode(node);
+  return node;
 }
 export { tsMethodSignature as tSMethodSignature };
 export function tsIndexSignature(
   parameters: Array<t.Identifier>,
   typeAnnotation?: t.TSTypeAnnotation | null,
-): t.TSIndexSignature {
-  return builder("TSIndexSignature", ...arguments);
+) {
+  const node = {
+    type: "TSIndexSignature",
+    parameters: parameters,
+    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    readonly: null,
+    static: null,
+  } as t.TSIndexSignature;
+  validateNode(node);
+  return node;
 }
 export { tsIndexSignature as tSIndexSignature };
-export function tsAnyKeyword(): t.TSAnyKeyword {
-  return builder("TSAnyKeyword", ...arguments);
+export function tsAnyKeyword() {
+  const node = {
+    type: "TSAnyKeyword",
+  } as t.TSAnyKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsAnyKeyword as tSAnyKeyword };
-export function tsBooleanKeyword(): t.TSBooleanKeyword {
-  return builder("TSBooleanKeyword", ...arguments);
+export function tsBooleanKeyword() {
+  const node = {
+    type: "TSBooleanKeyword",
+  } as t.TSBooleanKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsBooleanKeyword as tSBooleanKeyword };
-export function tsBigIntKeyword(): t.TSBigIntKeyword {
-  return builder("TSBigIntKeyword", ...arguments);
+export function tsBigIntKeyword() {
+  const node = {
+    type: "TSBigIntKeyword",
+  } as t.TSBigIntKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsBigIntKeyword as tSBigIntKeyword };
-export function tsIntrinsicKeyword(): t.TSIntrinsicKeyword {
-  return builder("TSIntrinsicKeyword", ...arguments);
+export function tsIntrinsicKeyword() {
+  const node = {
+    type: "TSIntrinsicKeyword",
+  } as t.TSIntrinsicKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsIntrinsicKeyword as tSIntrinsicKeyword };
-export function tsNeverKeyword(): t.TSNeverKeyword {
-  return builder("TSNeverKeyword", ...arguments);
+export function tsNeverKeyword() {
+  const node = {
+    type: "TSNeverKeyword",
+  } as t.TSNeverKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsNeverKeyword as tSNeverKeyword };
-export function tsNullKeyword(): t.TSNullKeyword {
-  return builder("TSNullKeyword", ...arguments);
+export function tsNullKeyword() {
+  const node = {
+    type: "TSNullKeyword",
+  } as t.TSNullKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsNullKeyword as tSNullKeyword };
-export function tsNumberKeyword(): t.TSNumberKeyword {
-  return builder("TSNumberKeyword", ...arguments);
+export function tsNumberKeyword() {
+  const node = {
+    type: "TSNumberKeyword",
+  } as t.TSNumberKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsNumberKeyword as tSNumberKeyword };
-export function tsObjectKeyword(): t.TSObjectKeyword {
-  return builder("TSObjectKeyword", ...arguments);
+export function tsObjectKeyword() {
+  const node = {
+    type: "TSObjectKeyword",
+  } as t.TSObjectKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsObjectKeyword as tSObjectKeyword };
-export function tsStringKeyword(): t.TSStringKeyword {
-  return builder("TSStringKeyword", ...arguments);
+export function tsStringKeyword() {
+  const node = {
+    type: "TSStringKeyword",
+  } as t.TSStringKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsStringKeyword as tSStringKeyword };
-export function tsSymbolKeyword(): t.TSSymbolKeyword {
-  return builder("TSSymbolKeyword", ...arguments);
+export function tsSymbolKeyword() {
+  const node = {
+    type: "TSSymbolKeyword",
+  } as t.TSSymbolKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsSymbolKeyword as tSSymbolKeyword };
-export function tsUndefinedKeyword(): t.TSUndefinedKeyword {
-  return builder("TSUndefinedKeyword", ...arguments);
+export function tsUndefinedKeyword() {
+  const node = {
+    type: "TSUndefinedKeyword",
+  } as t.TSUndefinedKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsUndefinedKeyword as tSUndefinedKeyword };
-export function tsUnknownKeyword(): t.TSUnknownKeyword {
-  return builder("TSUnknownKeyword", ...arguments);
+export function tsUnknownKeyword() {
+  const node = {
+    type: "TSUnknownKeyword",
+  } as t.TSUnknownKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsUnknownKeyword as tSUnknownKeyword };
-export function tsVoidKeyword(): t.TSVoidKeyword {
-  return builder("TSVoidKeyword", ...arguments);
+export function tsVoidKeyword() {
+  const node = {
+    type: "TSVoidKeyword",
+  } as t.TSVoidKeyword;
+  validateNode(node);
+  return node;
 }
 export { tsVoidKeyword as tSVoidKeyword };
-export function tsThisType(): t.TSThisType {
-  return builder("TSThisType", ...arguments);
+export function tsThisType() {
+  const node = {
+    type: "TSThisType",
+  } as t.TSThisType;
+  validateNode(node);
+  return node;
 }
 export { tsThisType as tSThisType };
 export function tsFunctionType(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   parameters: Array<t.Identifier | t.RestElement>,
   typeAnnotation?: t.TSTypeAnnotation | null,
-): t.TSFunctionType {
-  return builder("TSFunctionType", ...arguments);
+) {
+  const node = {
+    type: "TSFunctionType",
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    parameters: parameters,
+    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+  } as t.TSFunctionType;
+  validateNode(node);
+  return node;
 }
 export { tsFunctionType as tSFunctionType };
 export function tsConstructorType(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   parameters: Array<t.Identifier | t.RestElement>,
   typeAnnotation?: t.TSTypeAnnotation | null,
-): t.TSConstructorType {
-  return builder("TSConstructorType", ...arguments);
+) {
+  const node = {
+    type: "TSConstructorType",
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    parameters: parameters,
+    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    abstract: null,
+  } as t.TSConstructorType;
+  validateNode(node);
+  return node;
 }
 export { tsConstructorType as tSConstructorType };
 export function tsTypeReference(
   typeName: t.TSEntityName,
   typeParameters?: t.TSTypeParameterInstantiation | null,
-): t.TSTypeReference {
-  return builder("TSTypeReference", ...arguments);
+) {
+  const node = {
+    type: "TSTypeReference",
+    typeName: typeName,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+  } as t.TSTypeReference;
+  validateNode(node);
+  return node;
 }
 export { tsTypeReference as tSTypeReference };
 export function tsTypePredicate(
   parameterName: t.Identifier | t.TSThisType,
   typeAnnotation?: t.TSTypeAnnotation | null,
   asserts?: boolean | null,
-): t.TSTypePredicate {
-  return builder("TSTypePredicate", ...arguments);
+) {
+  const node = {
+    type: "TSTypePredicate",
+    parameterName: parameterName,
+    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    asserts: asserts === undefined ? null : asserts,
+  } as t.TSTypePredicate;
+  validateNode(node);
+  return node;
 }
 export { tsTypePredicate as tSTypePredicate };
-export function tsTypeQuery(
-  exprName: t.TSEntityName | t.TSImportType,
-): t.TSTypeQuery {
-  return builder("TSTypeQuery", ...arguments);
+export function tsTypeQuery(exprName: t.TSEntityName | t.TSImportType) {
+  const node = {
+    type: "TSTypeQuery",
+    exprName: exprName,
+  } as t.TSTypeQuery;
+  validateNode(node);
+  return node;
 }
 export { tsTypeQuery as tSTypeQuery };
-export function tsTypeLiteral(
-  members: Array<t.TSTypeElement>,
-): t.TSTypeLiteral {
-  return builder("TSTypeLiteral", ...arguments);
+export function tsTypeLiteral(members: Array<t.TSTypeElement>) {
+  const node = {
+    type: "TSTypeLiteral",
+    members: members,
+  } as t.TSTypeLiteral;
+  validateNode(node);
+  return node;
 }
 export { tsTypeLiteral as tSTypeLiteral };
-export function tsArrayType(elementType: t.TSType): t.TSArrayType {
-  return builder("TSArrayType", ...arguments);
+export function tsArrayType(elementType: t.TSType) {
+  const node = {
+    type: "TSArrayType",
+    elementType: elementType,
+  } as t.TSArrayType;
+  validateNode(node);
+  return node;
 }
 export { tsArrayType as tSArrayType };
 export function tsTupleType(
   elementTypes: Array<t.TSType | t.TSNamedTupleMember>,
-): t.TSTupleType {
-  return builder("TSTupleType", ...arguments);
+) {
+  const node = {
+    type: "TSTupleType",
+    elementTypes: elementTypes,
+  } as t.TSTupleType;
+  validateNode(node);
+  return node;
 }
 export { tsTupleType as tSTupleType };
-export function tsOptionalType(typeAnnotation: t.TSType): t.TSOptionalType {
-  return builder("TSOptionalType", ...arguments);
+export function tsOptionalType(typeAnnotation: t.TSType) {
+  const node = {
+    type: "TSOptionalType",
+    typeAnnotation: typeAnnotation,
+  } as t.TSOptionalType;
+  validateNode(node);
+  return node;
 }
 export { tsOptionalType as tSOptionalType };
-export function tsRestType(typeAnnotation: t.TSType): t.TSRestType {
-  return builder("TSRestType", ...arguments);
+export function tsRestType(typeAnnotation: t.TSType) {
+  const node = {
+    type: "TSRestType",
+    typeAnnotation: typeAnnotation,
+  } as t.TSRestType;
+  validateNode(node);
+  return node;
 }
 export { tsRestType as tSRestType };
 export function tsNamedTupleMember(
   label: t.Identifier,
   elementType: t.TSType,
   optional?: boolean,
-): t.TSNamedTupleMember {
-  return builder("TSNamedTupleMember", ...arguments);
+) {
+  const node = {
+    type: "TSNamedTupleMember",
+    label: label,
+    elementType: elementType,
+    optional: optional === undefined ? false : optional,
+  } as t.TSNamedTupleMember;
+  validateNode(node);
+  return node;
 }
 export { tsNamedTupleMember as tSNamedTupleMember };
-export function tsUnionType(types: Array<t.TSType>): t.TSUnionType {
-  return builder("TSUnionType", ...arguments);
+export function tsUnionType(types: Array<t.TSType>) {
+  const node = {
+    type: "TSUnionType",
+    types: types,
+  } as t.TSUnionType;
+  validateNode(node);
+  return node;
 }
 export { tsUnionType as tSUnionType };
-export function tsIntersectionType(
-  types: Array<t.TSType>,
-): t.TSIntersectionType {
-  return builder("TSIntersectionType", ...arguments);
+export function tsIntersectionType(types: Array<t.TSType>) {
+  const node = {
+    type: "TSIntersectionType",
+    types: types,
+  } as t.TSIntersectionType;
+  validateNode(node);
+  return node;
 }
 export { tsIntersectionType as tSIntersectionType };
 export function tsConditionalType(
@@ -1290,37 +2568,71 @@ export function tsConditionalType(
   extendsType: t.TSType,
   trueType: t.TSType,
   falseType: t.TSType,
-): t.TSConditionalType {
-  return builder("TSConditionalType", ...arguments);
+) {
+  const node = {
+    type: "TSConditionalType",
+    checkType: checkType,
+    extendsType: extendsType,
+    trueType: trueType,
+    falseType: falseType,
+  } as t.TSConditionalType;
+  validateNode(node);
+  return node;
 }
 export { tsConditionalType as tSConditionalType };
-export function tsInferType(typeParameter: t.TSTypeParameter): t.TSInferType {
-  return builder("TSInferType", ...arguments);
+export function tsInferType(typeParameter: t.TSTypeParameter) {
+  const node = {
+    type: "TSInferType",
+    typeParameter: typeParameter,
+  } as t.TSInferType;
+  validateNode(node);
+  return node;
 }
 export { tsInferType as tSInferType };
-export function tsParenthesizedType(
-  typeAnnotation: t.TSType,
-): t.TSParenthesizedType {
-  return builder("TSParenthesizedType", ...arguments);
+export function tsParenthesizedType(typeAnnotation: t.TSType) {
+  const node = {
+    type: "TSParenthesizedType",
+    typeAnnotation: typeAnnotation,
+  } as t.TSParenthesizedType;
+  validateNode(node);
+  return node;
 }
 export { tsParenthesizedType as tSParenthesizedType };
-export function tsTypeOperator(typeAnnotation: t.TSType): t.TSTypeOperator {
-  return builder("TSTypeOperator", ...arguments);
+export function tsTypeOperator(typeAnnotation: t.TSType) {
+  const node = {
+    type: "TSTypeOperator",
+    typeAnnotation: typeAnnotation,
+    operator: null,
+  } as t.TSTypeOperator;
+  validateNode(node);
+  return node;
 }
 export { tsTypeOperator as tSTypeOperator };
-export function tsIndexedAccessType(
-  objectType: t.TSType,
-  indexType: t.TSType,
-): t.TSIndexedAccessType {
-  return builder("TSIndexedAccessType", ...arguments);
+export function tsIndexedAccessType(objectType: t.TSType, indexType: t.TSType) {
+  const node = {
+    type: "TSIndexedAccessType",
+    objectType: objectType,
+    indexType: indexType,
+  } as t.TSIndexedAccessType;
+  validateNode(node);
+  return node;
 }
 export { tsIndexedAccessType as tSIndexedAccessType };
 export function tsMappedType(
   typeParameter: t.TSTypeParameter,
   typeAnnotation?: t.TSType | null,
   nameType?: t.TSType | null,
-): t.TSMappedType {
-  return builder("TSMappedType", ...arguments);
+) {
+  const node = {
+    type: "TSMappedType",
+    typeParameter: typeParameter,
+    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    nameType: nameType === undefined ? null : nameType,
+    optional: null,
+    readonly: null,
+  } as t.TSMappedType;
+  validateNode(node);
+  return node;
 }
 export { tsMappedType as tSMappedType };
 export function tsLiteralType(
@@ -1329,15 +2641,26 @@ export function tsLiteralType(
     | t.StringLiteral
     | t.BooleanLiteral
     | t.BigIntLiteral,
-): t.TSLiteralType {
-  return builder("TSLiteralType", ...arguments);
+) {
+  const node = {
+    type: "TSLiteralType",
+    literal: literal,
+  } as t.TSLiteralType;
+  validateNode(node);
+  return node;
 }
 export { tsLiteralType as tSLiteralType };
 export function tsExpressionWithTypeArguments(
   expression: t.TSEntityName,
   typeParameters?: t.TSTypeParameterInstantiation | null,
-): t.TSExpressionWithTypeArguments {
-  return builder("TSExpressionWithTypeArguments", ...arguments);
+) {
+  const node = {
+    type: "TSExpressionWithTypeArguments",
+    expression: expression,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+  } as t.TSExpressionWithTypeArguments;
+  validateNode(node);
+  return node;
 }
 export { tsExpressionWithTypeArguments as tSExpressionWithTypeArguments };
 export function tsInterfaceDeclaration(
@@ -1345,124 +2668,228 @@ export function tsInterfaceDeclaration(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   _extends: Array<t.TSExpressionWithTypeArguments> | null | undefined,
   body: t.TSInterfaceBody,
-): t.TSInterfaceDeclaration {
-  return builder("TSInterfaceDeclaration", ...arguments);
+) {
+  const node = {
+    type: "TSInterfaceDeclaration",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    extends: _extends === undefined ? null : _extends,
+    body: body,
+    declare: null,
+  } as t.TSInterfaceDeclaration;
+  validateNode(node);
+  return node;
 }
 export { tsInterfaceDeclaration as tSInterfaceDeclaration };
-export function tsInterfaceBody(
-  body: Array<t.TSTypeElement>,
-): t.TSInterfaceBody {
-  return builder("TSInterfaceBody", ...arguments);
+export function tsInterfaceBody(body: Array<t.TSTypeElement>) {
+  const node = {
+    type: "TSInterfaceBody",
+    body: body,
+  } as t.TSInterfaceBody;
+  validateNode(node);
+  return node;
 }
 export { tsInterfaceBody as tSInterfaceBody };
 export function tsTypeAliasDeclaration(
   id: t.Identifier,
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   typeAnnotation: t.TSType,
-): t.TSTypeAliasDeclaration {
-  return builder("TSTypeAliasDeclaration", ...arguments);
+) {
+  const node = {
+    type: "TSTypeAliasDeclaration",
+    id: id,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeAnnotation: typeAnnotation,
+    declare: null,
+  } as t.TSTypeAliasDeclaration;
+  validateNode(node);
+  return node;
 }
 export { tsTypeAliasDeclaration as tSTypeAliasDeclaration };
 export function tsAsExpression(
   expression: t.Expression,
   typeAnnotation: t.TSType,
-): t.TSAsExpression {
-  return builder("TSAsExpression", ...arguments);
+) {
+  const node = {
+    type: "TSAsExpression",
+    expression: expression,
+    typeAnnotation: typeAnnotation,
+  } as t.TSAsExpression;
+  validateNode(node);
+  return node;
 }
 export { tsAsExpression as tSAsExpression };
 export function tsTypeAssertion(
   typeAnnotation: t.TSType,
   expression: t.Expression,
-): t.TSTypeAssertion {
-  return builder("TSTypeAssertion", ...arguments);
+) {
+  const node = {
+    type: "TSTypeAssertion",
+    typeAnnotation: typeAnnotation,
+    expression: expression,
+  } as t.TSTypeAssertion;
+  validateNode(node);
+  return node;
 }
 export { tsTypeAssertion as tSTypeAssertion };
 export function tsEnumDeclaration(
   id: t.Identifier,
   members: Array<t.TSEnumMember>,
-): t.TSEnumDeclaration {
-  return builder("TSEnumDeclaration", ...arguments);
+) {
+  const node = {
+    type: "TSEnumDeclaration",
+    id: id,
+    members: members,
+    const: null,
+    declare: null,
+    initializer: null,
+  } as t.TSEnumDeclaration;
+  validateNode(node);
+  return node;
 }
 export { tsEnumDeclaration as tSEnumDeclaration };
 export function tsEnumMember(
   id: t.Identifier | t.StringLiteral,
   initializer?: t.Expression | null,
-): t.TSEnumMember {
-  return builder("TSEnumMember", ...arguments);
+) {
+  const node = {
+    type: "TSEnumMember",
+    id: id,
+    initializer: initializer === undefined ? null : initializer,
+  } as t.TSEnumMember;
+  validateNode(node);
+  return node;
 }
 export { tsEnumMember as tSEnumMember };
 export function tsModuleDeclaration(
   id: t.Identifier | t.StringLiteral,
   body: t.TSModuleBlock | t.TSModuleDeclaration,
-): t.TSModuleDeclaration {
-  return builder("TSModuleDeclaration", ...arguments);
+) {
+  const node = {
+    type: "TSModuleDeclaration",
+    id: id,
+    body: body,
+    declare: null,
+    global: null,
+  } as t.TSModuleDeclaration;
+  validateNode(node);
+  return node;
 }
 export { tsModuleDeclaration as tSModuleDeclaration };
-export function tsModuleBlock(body: Array<t.Statement>): t.TSModuleBlock {
-  return builder("TSModuleBlock", ...arguments);
+export function tsModuleBlock(body: Array<t.Statement>) {
+  const node = {
+    type: "TSModuleBlock",
+    body: body,
+  } as t.TSModuleBlock;
+  validateNode(node);
+  return node;
 }
 export { tsModuleBlock as tSModuleBlock };
 export function tsImportType(
   argument: t.StringLiteral,
   qualifier?: t.TSEntityName | null,
   typeParameters?: t.TSTypeParameterInstantiation | null,
-): t.TSImportType {
-  return builder("TSImportType", ...arguments);
+) {
+  const node = {
+    type: "TSImportType",
+    argument: argument,
+    qualifier: qualifier === undefined ? null : qualifier,
+    typeParameters: typeParameters === undefined ? null : typeParameters,
+  } as t.TSImportType;
+  validateNode(node);
+  return node;
 }
 export { tsImportType as tSImportType };
 export function tsImportEqualsDeclaration(
   id: t.Identifier,
   moduleReference: t.TSEntityName | t.TSExternalModuleReference,
-): t.TSImportEqualsDeclaration {
-  return builder("TSImportEqualsDeclaration", ...arguments);
+) {
+  const node = {
+    type: "TSImportEqualsDeclaration",
+    id: id,
+    moduleReference: moduleReference,
+    isExport: null,
+  } as t.TSImportEqualsDeclaration;
+  validateNode(node);
+  return node;
 }
 export { tsImportEqualsDeclaration as tSImportEqualsDeclaration };
-export function tsExternalModuleReference(
-  expression: t.StringLiteral,
-): t.TSExternalModuleReference {
-  return builder("TSExternalModuleReference", ...arguments);
+export function tsExternalModuleReference(expression: t.StringLiteral) {
+  const node = {
+    type: "TSExternalModuleReference",
+    expression: expression,
+  } as t.TSExternalModuleReference;
+  validateNode(node);
+  return node;
 }
 export { tsExternalModuleReference as tSExternalModuleReference };
-export function tsNonNullExpression(
-  expression: t.Expression,
-): t.TSNonNullExpression {
-  return builder("TSNonNullExpression", ...arguments);
+export function tsNonNullExpression(expression: t.Expression) {
+  const node = {
+    type: "TSNonNullExpression",
+    expression: expression,
+  } as t.TSNonNullExpression;
+  validateNode(node);
+  return node;
 }
 export { tsNonNullExpression as tSNonNullExpression };
-export function tsExportAssignment(
-  expression: t.Expression,
-): t.TSExportAssignment {
-  return builder("TSExportAssignment", ...arguments);
+export function tsExportAssignment(expression: t.Expression) {
+  const node = {
+    type: "TSExportAssignment",
+    expression: expression,
+  } as t.TSExportAssignment;
+  validateNode(node);
+  return node;
 }
 export { tsExportAssignment as tSExportAssignment };
-export function tsNamespaceExportDeclaration(
-  id: t.Identifier,
-): t.TSNamespaceExportDeclaration {
-  return builder("TSNamespaceExportDeclaration", ...arguments);
+export function tsNamespaceExportDeclaration(id: t.Identifier) {
+  const node = {
+    type: "TSNamespaceExportDeclaration",
+    id: id,
+  } as t.TSNamespaceExportDeclaration;
+  validateNode(node);
+  return node;
 }
 export { tsNamespaceExportDeclaration as tSNamespaceExportDeclaration };
-export function tsTypeAnnotation(typeAnnotation: t.TSType): t.TSTypeAnnotation {
-  return builder("TSTypeAnnotation", ...arguments);
+export function tsTypeAnnotation(typeAnnotation: t.TSType) {
+  const node = {
+    type: "TSTypeAnnotation",
+    typeAnnotation: typeAnnotation,
+  } as t.TSTypeAnnotation;
+  validateNode(node);
+  return node;
 }
 export { tsTypeAnnotation as tSTypeAnnotation };
-export function tsTypeParameterInstantiation(
-  params: Array<t.TSType>,
-): t.TSTypeParameterInstantiation {
-  return builder("TSTypeParameterInstantiation", ...arguments);
+export function tsTypeParameterInstantiation(params: Array<t.TSType>) {
+  const node = {
+    type: "TSTypeParameterInstantiation",
+    params: params,
+  } as t.TSTypeParameterInstantiation;
+  validateNode(node);
+  return node;
 }
 export { tsTypeParameterInstantiation as tSTypeParameterInstantiation };
-export function tsTypeParameterDeclaration(
-  params: Array<t.TSTypeParameter>,
-): t.TSTypeParameterDeclaration {
-  return builder("TSTypeParameterDeclaration", ...arguments);
+export function tsTypeParameterDeclaration(params: Array<t.TSTypeParameter>) {
+  const node = {
+    type: "TSTypeParameterDeclaration",
+    params: params,
+  } as t.TSTypeParameterDeclaration;
+  validateNode(node);
+  return node;
 }
 export { tsTypeParameterDeclaration as tSTypeParameterDeclaration };
 export function tsTypeParameter(
   constraint: t.TSType | null | undefined,
   _default: t.TSType | null | undefined,
   name: string,
-): t.TSTypeParameter {
-  return builder("TSTypeParameter", ...arguments);
+) {
+  const node = {
+    type: "TSTypeParameter",
+    constraint: constraint === undefined ? null : constraint,
+    default: _default === undefined ? null : _default,
+    name: name,
+  } as t.TSTypeParameter;
+  validateNode(node);
+  return node;
 }
 export { tsTypeParameter as tSTypeParameter };
 /** @deprecated */

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -8,11 +8,11 @@ import type * as t from "../..";
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 export function arrayExpression(
-  elements?: Array<null | t.Expression | t.SpreadElement>,
+  elements: Array<null | t.Expression | t.SpreadElement> = [],
 ) {
   const node = {
     type: "ArrayExpression",
-    elements: elements === undefined ? [] : elements,
+    elements: elements,
   } as t.ArrayExpression;
   validateNode(node);
   return node;
@@ -93,20 +93,20 @@ export function directiveLiteral(value: string) {
 }
 export function blockStatement(
   body: Array<t.Statement>,
-  directives?: Array<t.Directive>,
+  directives: Array<t.Directive> = [],
 ) {
   const node = {
     type: "BlockStatement",
     body: body,
-    directives: directives === undefined ? [] : directives,
+    directives: directives,
   } as t.BlockStatement;
   validateNode(node);
   return node;
 }
-export function breakStatement(label?: t.Identifier | null) {
+export function breakStatement(label: t.Identifier | null = null) {
   const node = {
     type: "BreakStatement",
-    label: label === undefined ? null : label,
+    label: label,
   } as t.BreakStatement;
   validateNode(node);
   return node;
@@ -134,7 +134,7 @@ export function catchClause(
 ) {
   const node = {
     type: "CatchClause",
-    param: param === undefined ? null : param,
+    param: param,
     body: body,
   } as t.CatchClause;
   validateNode(node);
@@ -154,10 +154,10 @@ export function conditionalExpression(
   validateNode(node);
   return node;
 }
-export function continueStatement(label?: t.Identifier | null) {
+export function continueStatement(label: t.Identifier | null = null) {
   const node = {
     type: "ContinueStatement",
-    label: label === undefined ? null : label,
+    label: label,
   } as t.ContinueStatement;
   validateNode(node);
   return node;
@@ -195,14 +195,14 @@ export function expressionStatement(expression: t.Expression) {
 }
 export function file(
   program: t.Program,
-  comments?: Array<t.CommentBlock | t.CommentLine> | null,
-  tokens?: Array<any> | null,
+  comments: Array<t.CommentBlock | t.CommentLine> | null = null,
+  tokens: Array<any> | null = null,
 ) {
   const node = {
     type: "File",
     program: program,
-    comments: comments === undefined ? null : comments,
-    tokens: tokens === undefined ? null : tokens,
+    comments: comments,
+    tokens: tokens,
   } as t.File;
   validateNode(node);
   return node;
@@ -229,9 +229,9 @@ export function forStatement(
 ) {
   const node = {
     type: "ForStatement",
-    init: init === undefined ? null : init,
-    test: test === undefined ? null : test,
-    update: update === undefined ? null : update,
+    init: init,
+    test: test,
+    update: update,
     body: body,
   } as t.ForStatement;
   validateNode(node);
@@ -241,16 +241,16 @@ export function functionDeclaration(
   id: t.Identifier | null | undefined,
   params: Array<t.Identifier | t.Pattern | t.RestElement>,
   body: t.BlockStatement,
-  generator?: boolean,
-  async?: boolean,
+  generator: boolean = false,
+  async: boolean = false,
 ) {
   const node = {
     type: "FunctionDeclaration",
-    id: id === undefined ? null : id,
+    id: id,
     params: params,
     body: body,
-    generator: generator === undefined ? false : generator,
-    async: async === undefined ? false : async,
+    generator: generator,
+    async: async,
     declare: null,
     returnType: null,
     typeParameters: null,
@@ -262,16 +262,16 @@ export function functionExpression(
   id: t.Identifier | null | undefined,
   params: Array<t.Identifier | t.Pattern | t.RestElement>,
   body: t.BlockStatement,
-  generator?: boolean,
-  async?: boolean,
+  generator: boolean = false,
+  async: boolean = false,
 ) {
   const node = {
     type: "FunctionExpression",
-    id: id === undefined ? null : id,
+    id: id,
     params: params,
     body: body,
-    generator: generator === undefined ? false : generator,
-    async: async === undefined ? false : async,
+    generator: generator,
+    async: async,
     returnType: null,
     typeParameters: null,
   } as t.FunctionExpression;
@@ -292,13 +292,13 @@ export function identifier(name: string) {
 export function ifStatement(
   test: t.Expression,
   consequent: t.Statement,
-  alternate?: t.Statement | null,
+  alternate: t.Statement | null = null,
 ) {
   const node = {
     type: "IfStatement",
     test: test,
     consequent: consequent,
-    alternate: alternate === undefined ? null : alternate,
+    alternate: alternate,
   } as t.IfStatement;
   validateNode(node);
   return node;
@@ -343,11 +343,11 @@ export function booleanLiteral(value: boolean) {
   validateNode(node);
   return node;
 }
-export function regExpLiteral(pattern: string, flags?: string) {
+export function regExpLiteral(pattern: string, flags: string = "") {
   const node = {
     type: "RegExpLiteral",
     pattern: pattern,
-    flags: flags === undefined ? "" : flags,
+    flags: flags,
   } as t.RegExpLiteral;
   validateNode(node);
   return node;
@@ -369,15 +369,15 @@ export function logicalExpression(
 export function memberExpression(
   object: t.Expression,
   property: t.Expression | t.Identifier | t.PrivateName,
-  computed?: boolean,
-  optional?: true | false | null,
+  computed: boolean = false,
+  optional: true | false | null = null,
 ) {
   const node = {
     type: "MemberExpression",
     object: object,
     property: property,
-    computed: computed === undefined ? false : computed,
-    optional: optional === undefined ? null : optional,
+    computed: computed,
+    optional: optional,
   } as t.MemberExpression;
   validateNode(node);
   return node;
@@ -401,16 +401,16 @@ export function newExpression(
 }
 export function program(
   body: Array<t.Statement>,
-  directives?: Array<t.Directive>,
-  sourceType?: "script" | "module",
-  interpreter?: t.InterpreterDirective | null,
+  directives: Array<t.Directive> = [],
+  sourceType: "script" | "module" = "script",
+  interpreter: t.InterpreterDirective | null = null,
 ) {
   const node = {
     type: "Program",
     body: body,
-    directives: directives === undefined ? [] : directives,
-    sourceType: sourceType === undefined ? "script" : sourceType,
-    interpreter: interpreter === undefined ? null : interpreter,
+    directives: directives,
+    sourceType: sourceType,
+    interpreter: interpreter,
     sourceFile: null,
   } as t.Program;
   validateNode(node);
@@ -431,19 +431,19 @@ export function objectMethod(
   key: t.Expression | t.Identifier | t.StringLiteral | t.NumericLiteral,
   params: Array<t.Identifier | t.Pattern | t.RestElement>,
   body: t.BlockStatement,
-  computed?: boolean,
-  generator?: boolean,
-  async?: boolean,
+  computed: boolean = false,
+  generator: boolean = false,
+  async: boolean = false,
 ) {
   const node = {
     type: "ObjectMethod",
-    kind: kind === undefined ? "method" : kind,
+    kind: kind,
     key: key,
     params: params,
     body: body,
-    computed: computed === undefined ? false : computed,
-    generator: generator === undefined ? false : generator,
-    async: async === undefined ? false : async,
+    computed: computed,
+    generator: generator,
+    async: async,
     decorators: null,
     returnType: null,
     typeParameters: null,
@@ -454,17 +454,17 @@ export function objectMethod(
 export function objectProperty(
   key: t.Expression | t.Identifier | t.StringLiteral | t.NumericLiteral,
   value: t.Expression | t.PatternLike,
-  computed?: boolean,
-  shorthand?: boolean,
-  decorators?: Array<t.Decorator> | null,
+  computed: boolean = false,
+  shorthand: boolean = false,
+  decorators: Array<t.Decorator> | null = null,
 ) {
   const node = {
     type: "ObjectProperty",
     key: key,
     value: value,
-    computed: computed === undefined ? false : computed,
-    shorthand: shorthand === undefined ? false : shorthand,
-    decorators: decorators === undefined ? null : decorators,
+    computed: computed,
+    shorthand: shorthand,
+    decorators: decorators,
   } as t.ObjectProperty;
   validateNode(node);
   return node;
@@ -479,10 +479,10 @@ export function restElement(argument: t.LVal) {
   validateNode(node);
   return node;
 }
-export function returnStatement(argument?: t.Expression | null) {
+export function returnStatement(argument: t.Expression | null = null) {
   const node = {
     type: "ReturnStatement",
-    argument: argument === undefined ? null : argument,
+    argument: argument,
   } as t.ReturnStatement;
   validateNode(node);
   return node;
@@ -509,7 +509,7 @@ export function switchCase(
 ) {
   const node = {
     type: "SwitchCase",
-    test: test === undefined ? null : test,
+    test: test,
     consequent: consequent,
   } as t.SwitchCase;
   validateNode(node);
@@ -544,14 +544,14 @@ export function throwStatement(argument: t.Expression) {
 }
 export function tryStatement(
   block: t.BlockStatement,
-  handler?: t.CatchClause | null,
-  finalizer?: t.BlockStatement | null,
+  handler: t.CatchClause | null = null,
+  finalizer: t.BlockStatement | null = null,
 ) {
   const node = {
     type: "TryStatement",
     block: block,
-    handler: handler === undefined ? null : handler,
-    finalizer: finalizer === undefined ? null : finalizer,
+    handler: handler,
+    finalizer: finalizer,
   } as t.TryStatement;
   validateNode(node);
   return node;
@@ -559,13 +559,13 @@ export function tryStatement(
 export function unaryExpression(
   operator: "void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof",
   argument: t.Expression,
-  prefix?: boolean,
+  prefix: boolean = true,
 ) {
   const node = {
     type: "UnaryExpression",
     operator: operator,
     argument: argument,
-    prefix: prefix === undefined ? true : prefix,
+    prefix: prefix,
   } as t.UnaryExpression;
   validateNode(node);
   return node;
@@ -573,13 +573,13 @@ export function unaryExpression(
 export function updateExpression(
   operator: "++" | "--",
   argument: t.Expression,
-  prefix?: boolean,
+  prefix: boolean = false,
 ) {
   const node = {
     type: "UpdateExpression",
     operator: operator,
     argument: argument,
-    prefix: prefix === undefined ? false : prefix,
+    prefix: prefix,
   } as t.UpdateExpression;
   validateNode(node);
   return node;
@@ -597,11 +597,14 @@ export function variableDeclaration(
   validateNode(node);
   return node;
 }
-export function variableDeclarator(id: t.LVal, init?: t.Expression | null) {
+export function variableDeclarator(
+  id: t.LVal,
+  init: t.Expression | null = null,
+) {
   const node = {
     type: "VariableDeclarator",
     id: id,
-    init: init === undefined ? null : init,
+    init: init,
     definite: null,
   } as t.VariableDeclarator;
   validateNode(node);
@@ -652,13 +655,13 @@ export function arrayPattern(elements: Array<null | t.PatternLike>) {
 export function arrowFunctionExpression(
   params: Array<t.Identifier | t.Pattern | t.RestElement>,
   body: t.BlockStatement | t.Expression,
-  async?: boolean,
+  async: boolean = false,
 ) {
   const node = {
     type: "ArrowFunctionExpression",
     params: params,
     body: body,
-    async: async === undefined ? false : async,
+    async: async,
     expression: null,
     generator: false,
     returnType: null,
@@ -688,14 +691,14 @@ export function classExpression(
   id: t.Identifier | null | undefined,
   superClass: t.Expression | null | undefined,
   body: t.ClassBody,
-  decorators?: Array<t.Decorator> | null,
+  decorators: Array<t.Decorator> | null = null,
 ) {
   const node = {
     type: "ClassExpression",
-    id: id === undefined ? null : id,
-    superClass: superClass === undefined ? null : superClass,
+    id: id,
+    superClass: superClass,
     body: body,
-    decorators: decorators === undefined ? null : decorators,
+    decorators: decorators,
     implements: null,
     mixins: null,
     superTypeParameters: null,
@@ -708,14 +711,14 @@ export function classDeclaration(
   id: t.Identifier,
   superClass: t.Expression | null | undefined,
   body: t.ClassBody,
-  decorators?: Array<t.Decorator> | null,
+  decorators: Array<t.Decorator> | null = null,
 ) {
   const node = {
     type: "ClassDeclaration",
     id: id,
-    superClass: superClass === undefined ? null : superClass,
+    superClass: superClass,
     body: body,
-    decorators: decorators === undefined ? null : decorators,
+    decorators: decorators,
     abstract: null,
     declare: null,
     implements: null,
@@ -751,17 +754,17 @@ export function exportDefaultDeclaration(
   return node;
 }
 export function exportNamedDeclaration(
-  declaration?: t.Declaration | null,
-  specifiers?: Array<
+  declaration: t.Declaration | null = null,
+  specifiers: Array<
     t.ExportSpecifier | t.ExportDefaultSpecifier | t.ExportNamespaceSpecifier
-  >,
-  source?: t.StringLiteral | null,
+  > = [],
+  source: t.StringLiteral | null = null,
 ) {
   const node = {
     type: "ExportNamedDeclaration",
-    declaration: declaration === undefined ? null : declaration,
-    specifiers: specifiers === undefined ? [] : specifiers,
-    source: source === undefined ? null : source,
+    declaration: declaration,
+    specifiers: specifiers,
+    source: source,
     assertions: null,
     exportKind: null,
   } as t.ExportNamedDeclaration;
@@ -784,14 +787,14 @@ export function forOfStatement(
   left: t.VariableDeclaration | t.LVal,
   right: t.Expression,
   body: t.Statement,
-  _await?: boolean,
+  _await: boolean = false,
 ) {
   const node = {
     type: "ForOfStatement",
     left: left,
     right: right,
     body: body,
-    await: _await === undefined ? false : _await,
+    await: _await,
   } as t.ForOfStatement;
   validateNode(node);
   return node;
@@ -857,21 +860,21 @@ export function classMethod(
     t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
   >,
   body: t.BlockStatement,
-  computed?: boolean,
-  _static?: boolean,
-  generator?: boolean,
-  async?: boolean,
+  computed: boolean = false,
+  _static: boolean = false,
+  generator: boolean = false,
+  async: boolean = false,
 ) {
   const node = {
     type: "ClassMethod",
-    kind: kind === undefined ? "method" : kind,
+    kind: kind,
     key: key,
     params: params,
     body: body,
-    computed: computed === undefined ? false : computed,
-    static: _static === undefined ? false : _static,
-    generator: generator === undefined ? false : generator,
-    async: async === undefined ? false : async,
+    computed: computed,
+    static: _static,
+    generator: generator,
+    async: async,
     abstract: null,
     access: null,
     accessibility: null,
@@ -927,12 +930,12 @@ export function taggedTemplateExpression(
 }
 export function templateElement(
   value: { raw: string; cooked?: string },
-  tail?: boolean,
+  tail: boolean = false,
 ) {
   const node = {
     type: "TemplateElement",
     value: value,
-    tail: tail === undefined ? false : tail,
+    tail: tail,
   } as t.TemplateElement;
   validateNode(node);
   return node;
@@ -950,13 +953,13 @@ export function templateLiteral(
   return node;
 }
 export function yieldExpression(
-  argument?: t.Expression | null,
-  delegate?: boolean,
+  argument: t.Expression | null = null,
+  delegate: boolean = false,
 ) {
   const node = {
     type: "YieldExpression",
-    argument: argument === undefined ? null : argument,
-    delegate: delegate === undefined ? false : delegate,
+    argument: argument,
+    delegate: delegate,
   } as t.YieldExpression;
   validateNode(node);
   return node;
@@ -1003,7 +1006,7 @@ export function optionalMemberExpression(
     type: "OptionalMemberExpression",
     object: object,
     property: property,
-    computed: computed === undefined ? false : computed,
+    computed: computed,
     optional: optional,
   } as t.OptionalMemberExpression;
   validateNode(node);
@@ -1066,12 +1069,12 @@ export function nullLiteralTypeAnnotation() {
 }
 export function classImplements(
   id: t.Identifier,
-  typeParameters?: t.TypeParameterInstantiation | null,
+  typeParameters: t.TypeParameterInstantiation | null = null,
 ) {
   const node = {
     type: "ClassImplements",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
   } as t.ClassImplements;
   validateNode(node);
   return node;
@@ -1085,8 +1088,8 @@ export function declareClass(
   const node = {
     type: "DeclareClass",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
-    extends: _extends === undefined ? null : _extends,
+    typeParameters: typeParameters,
+    extends: _extends,
     body: body,
     implements: null,
     mixins: null,
@@ -1112,8 +1115,8 @@ export function declareInterface(
   const node = {
     type: "DeclareInterface",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
-    extends: _extends === undefined ? null : _extends,
+    typeParameters: typeParameters,
+    extends: _extends,
     body: body,
     implements: null,
     mixins: null,
@@ -1124,13 +1127,13 @@ export function declareInterface(
 export function declareModule(
   id: t.Identifier | t.StringLiteral,
   body: t.BlockStatement,
-  kind?: "CommonJS" | "ES" | null,
+  kind: "CommonJS" | "ES" | null = null,
 ) {
   const node = {
     type: "DeclareModule",
     id: id,
     body: body,
-    kind: kind === undefined ? null : kind,
+    kind: kind,
   } as t.DeclareModule;
   validateNode(node);
   return node;
@@ -1151,7 +1154,7 @@ export function declareTypeAlias(
   const node = {
     type: "DeclareTypeAlias",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
     right: right,
   } as t.DeclareTypeAlias;
   validateNode(node);
@@ -1159,14 +1162,14 @@ export function declareTypeAlias(
 }
 export function declareOpaqueType(
   id: t.Identifier,
-  typeParameters?: t.TypeParameterDeclaration | null,
-  supertype?: t.FlowType | null,
+  typeParameters: t.TypeParameterDeclaration | null = null,
+  supertype: t.FlowType | null = null,
 ) {
   const node = {
     type: "DeclareOpaqueType",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
-    supertype: supertype === undefined ? null : supertype,
+    typeParameters: typeParameters,
+    supertype: supertype,
   } as t.DeclareOpaqueType;
   validateNode(node);
   return node;
@@ -1180,15 +1183,17 @@ export function declareVariable(id: t.Identifier) {
   return node;
 }
 export function declareExportDeclaration(
-  declaration?: t.Flow | null,
-  specifiers?: Array<t.ExportSpecifier | t.ExportNamespaceSpecifier> | null,
-  source?: t.StringLiteral | null,
+  declaration: t.Flow | null = null,
+  specifiers: Array<
+    t.ExportSpecifier | t.ExportNamespaceSpecifier
+  > | null = null,
+  source: t.StringLiteral | null = null,
 ) {
   const node = {
     type: "DeclareExportDeclaration",
-    declaration: declaration === undefined ? null : declaration,
-    specifiers: specifiers === undefined ? null : specifiers,
-    source: source === undefined ? null : source,
+    declaration: declaration,
+    specifiers: specifiers,
+    source: source,
     default: null,
   } as t.DeclareExportDeclaration;
   validateNode(node);
@@ -1226,9 +1231,9 @@ export function functionTypeAnnotation(
 ) {
   const node = {
     type: "FunctionTypeAnnotation",
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
     params: params,
-    rest: rest === undefined ? null : rest,
+    rest: rest,
     returnType: returnType,
     this: null,
   } as t.FunctionTypeAnnotation;
@@ -1241,7 +1246,7 @@ export function functionTypeParam(
 ) {
   const node = {
     type: "FunctionTypeParam",
-    name: name === undefined ? null : name,
+    name: name,
     typeAnnotation: typeAnnotation,
     optional: null,
   } as t.FunctionTypeParam;
@@ -1250,12 +1255,12 @@ export function functionTypeParam(
 }
 export function genericTypeAnnotation(
   id: t.Identifier | t.QualifiedTypeIdentifier,
-  typeParameters?: t.TypeParameterInstantiation | null,
+  typeParameters: t.TypeParameterInstantiation | null = null,
 ) {
   const node = {
     type: "GenericTypeAnnotation",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
   } as t.GenericTypeAnnotation;
   validateNode(node);
   return node;
@@ -1269,12 +1274,12 @@ export function inferredPredicate() {
 }
 export function interfaceExtends(
   id: t.Identifier | t.QualifiedTypeIdentifier,
-  typeParameters?: t.TypeParameterInstantiation | null,
+  typeParameters: t.TypeParameterInstantiation | null = null,
 ) {
   const node = {
     type: "InterfaceExtends",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
   } as t.InterfaceExtends;
   validateNode(node);
   return node;
@@ -1288,8 +1293,8 @@ export function interfaceDeclaration(
   const node = {
     type: "InterfaceDeclaration",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
-    extends: _extends === undefined ? null : _extends,
+    typeParameters: typeParameters,
+    extends: _extends,
     body: body,
     implements: null,
     mixins: null,
@@ -1303,7 +1308,7 @@ export function interfaceTypeAnnotation(
 ) {
   const node = {
     type: "InterfaceTypeAnnotation",
-    extends: _extends === undefined ? null : _extends,
+    extends: _extends,
     body: body,
   } as t.InterfaceTypeAnnotation;
   validateNode(node);
@@ -1356,18 +1361,18 @@ export function numberTypeAnnotation() {
 }
 export function objectTypeAnnotation(
   properties: Array<t.ObjectTypeProperty | t.ObjectTypeSpreadProperty>,
-  indexers?: Array<t.ObjectTypeIndexer> | null,
-  callProperties?: Array<t.ObjectTypeCallProperty> | null,
-  internalSlots?: Array<t.ObjectTypeInternalSlot> | null,
-  exact?: boolean,
+  indexers: Array<t.ObjectTypeIndexer> | null = null,
+  callProperties: Array<t.ObjectTypeCallProperty> | null = null,
+  internalSlots: Array<t.ObjectTypeInternalSlot> | null = null,
+  exact: boolean = false,
 ) {
   const node = {
     type: "ObjectTypeAnnotation",
     properties: properties,
-    indexers: indexers === undefined ? null : indexers,
-    callProperties: callProperties === undefined ? null : callProperties,
-    internalSlots: internalSlots === undefined ? null : internalSlots,
-    exact: exact === undefined ? false : exact,
+    indexers: indexers,
+    callProperties: callProperties,
+    internalSlots: internalSlots,
+    exact: exact,
     inexact: null,
   } as t.ObjectTypeAnnotation;
   validateNode(node);
@@ -1404,14 +1409,14 @@ export function objectTypeIndexer(
   id: t.Identifier | null | undefined,
   key: t.FlowType,
   value: t.FlowType,
-  variance?: t.Variance | null,
+  variance: t.Variance | null = null,
 ) {
   const node = {
     type: "ObjectTypeIndexer",
-    id: id === undefined ? null : id,
+    id: id,
     key: key,
     value: value,
-    variance: variance === undefined ? null : variance,
+    variance: variance,
     static: null,
   } as t.ObjectTypeIndexer;
   validateNode(node);
@@ -1420,13 +1425,13 @@ export function objectTypeIndexer(
 export function objectTypeProperty(
   key: t.Identifier | t.StringLiteral,
   value: t.FlowType,
-  variance?: t.Variance | null,
+  variance: t.Variance | null = null,
 ) {
   const node = {
     type: "ObjectTypeProperty",
     key: key,
     value: value,
-    variance: variance === undefined ? null : variance,
+    variance: variance,
     kind: null,
     method: null,
     optional: null,
@@ -1453,8 +1458,8 @@ export function opaqueType(
   const node = {
     type: "OpaqueType",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
-    supertype: supertype === undefined ? null : supertype,
+    typeParameters: typeParameters,
+    supertype: supertype,
     impltype: impltype,
   } as t.OpaqueType;
   validateNode(node);
@@ -1525,7 +1530,7 @@ export function typeAlias(
   const node = {
     type: "TypeAlias",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
     right: right,
   } as t.TypeAlias;
   validateNode(node);
@@ -1552,15 +1557,15 @@ export function typeCastExpression(
   return node;
 }
 export function typeParameter(
-  bound?: t.TypeAnnotation | null,
-  _default?: t.FlowType | null,
-  variance?: t.Variance | null,
+  bound: t.TypeAnnotation | null = null,
+  _default: t.FlowType | null = null,
+  variance: t.Variance | null = null,
 ) {
   const node = {
     type: "TypeParameter",
-    bound: bound === undefined ? null : bound,
-    default: _default === undefined ? null : _default,
-    variance: variance === undefined ? null : variance,
+    bound: bound,
+    default: _default,
+    variance: variance,
     name: null,
   } as t.TypeParameter;
   validateNode(node);
@@ -1724,17 +1729,17 @@ export function optionalIndexedAccessType(
 }
 export function jsxAttribute(
   name: t.JSXIdentifier | t.JSXNamespacedName,
-  value?:
+  value:
     | t.JSXElement
     | t.JSXFragment
     | t.StringLiteral
     | t.JSXExpressionContainer
-    | null,
+    | null = null,
 ) {
   const node = {
     type: "JSXAttribute",
     name: name,
-    value: value === undefined ? null : value,
+    value: value,
   } as t.JSXAttribute;
   validateNode(node);
   return node;
@@ -1761,14 +1766,14 @@ export function jsxElement(
     | t.JSXElement
     | t.JSXFragment
   >,
-  selfClosing?: boolean | null,
+  selfClosing: boolean | null = null,
 ) {
   const node = {
     type: "JSXElement",
     openingElement: openingElement,
-    closingElement: closingElement === undefined ? null : closingElement,
+    closingElement: closingElement,
     children: children,
-    selfClosing: selfClosing === undefined ? null : selfClosing,
+    selfClosing: selfClosing,
   } as t.JSXElement;
   validateNode(node);
   return node;
@@ -1840,13 +1845,13 @@ export { jsxNamespacedName as jSXNamespacedName };
 export function jsxOpeningElement(
   name: t.JSXIdentifier | t.JSXMemberExpression | t.JSXNamespacedName,
   attributes: Array<t.JSXAttribute | t.JSXSpreadAttribute>,
-  selfClosing?: boolean,
+  selfClosing: boolean = false,
 ) {
   const node = {
     type: "JSXOpeningElement",
     name: name,
     attributes: attributes,
-    selfClosing: selfClosing === undefined ? false : selfClosing,
+    selfClosing: selfClosing,
     typeParameters: null,
   } as t.JSXOpeningElement;
   validateNode(node);
@@ -1961,20 +1966,20 @@ export function bindExpression(object: t.Expression, callee: t.Expression) {
 }
 export function classProperty(
   key: t.Identifier | t.StringLiteral | t.NumericLiteral | t.Expression,
-  value?: t.Expression | null,
-  typeAnnotation?: t.TypeAnnotation | t.TSTypeAnnotation | t.Noop | null,
-  decorators?: Array<t.Decorator> | null,
-  computed?: boolean,
-  _static?: boolean,
+  value: t.Expression | null = null,
+  typeAnnotation: t.TypeAnnotation | t.TSTypeAnnotation | t.Noop | null = null,
+  decorators: Array<t.Decorator> | null = null,
+  computed: boolean = false,
+  _static: boolean = false,
 ) {
   const node = {
     type: "ClassProperty",
     key: key,
-    value: value === undefined ? null : value,
-    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
-    decorators: decorators === undefined ? null : decorators,
-    computed: computed === undefined ? false : computed,
-    static: _static === undefined ? false : _static,
+    value: value,
+    typeAnnotation: typeAnnotation,
+    decorators: decorators,
+    computed: computed,
+    static: _static,
     abstract: null,
     accessibility: null,
     declare: null,
@@ -2018,8 +2023,8 @@ export function classPrivateProperty(
   const node = {
     type: "ClassPrivateProperty",
     key: key,
-    value: value === undefined ? null : value,
-    decorators: decorators === undefined ? null : decorators,
+    value: value,
+    decorators: decorators,
     static: _static,
     typeAnnotation: null,
   } as t.ClassPrivateProperty;
@@ -2033,15 +2038,15 @@ export function classPrivateMethod(
     t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
   >,
   body: t.BlockStatement,
-  _static?: boolean,
+  _static: boolean = false,
 ) {
   const node = {
     type: "ClassPrivateMethod",
-    kind: kind === undefined ? "method" : kind,
+    kind: kind,
     key: key,
     params: params,
     body: body,
-    static: _static === undefined ? false : _static,
+    static: _static,
     abstract: null,
     access: null,
     accessibility: null,
@@ -2077,11 +2082,11 @@ export function decorator(expression: t.Expression) {
   validateNode(node);
   return node;
 }
-export function doExpression(body: t.BlockStatement, async?: boolean) {
+export function doExpression(body: t.BlockStatement, async: boolean = false) {
   const node = {
     type: "DoExpression",
     body: body,
-    async: async === undefined ? false : async,
+    async: async,
   } as t.DoExpression;
   validateNode(node);
   return node;
@@ -2113,11 +2118,11 @@ export function recordExpression(
   return node;
 }
 export function tupleExpression(
-  elements?: Array<t.Expression | t.SpreadElement>,
+  elements: Array<t.Expression | t.SpreadElement> = [],
 ) {
   const node = {
     type: "TupleExpression",
-    elements: elements === undefined ? [] : elements,
+    elements: elements,
   } as t.TupleExpression;
   validateNode(node);
   return node;
@@ -2163,14 +2168,14 @@ export function tsDeclareFunction(
   id: t.Identifier | null | undefined,
   typeParameters: t.TSTypeParameterDeclaration | t.Noop | null | undefined,
   params: Array<t.Identifier | t.Pattern | t.RestElement>,
-  returnType?: t.TSTypeAnnotation | t.Noop | null,
+  returnType: t.TSTypeAnnotation | t.Noop | null = null,
 ) {
   const node = {
     type: "TSDeclareFunction",
-    id: id === undefined ? null : id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    id: id,
+    typeParameters: typeParameters,
     params: params,
-    returnType: returnType === undefined ? null : returnType,
+    returnType: returnType,
     async: false,
     declare: null,
     generator: false,
@@ -2186,15 +2191,15 @@ export function tsDeclareMethod(
   params: Array<
     t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
   >,
-  returnType?: t.TSTypeAnnotation | t.Noop | null,
+  returnType: t.TSTypeAnnotation | t.Noop | null = null,
 ) {
   const node = {
     type: "TSDeclareMethod",
-    decorators: decorators === undefined ? null : decorators,
+    decorators: decorators,
     key: key,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
     params: params,
-    returnType: returnType === undefined ? null : returnType,
+    returnType: returnType,
     abstract: null,
     access: null,
     accessibility: null,
@@ -2223,13 +2228,13 @@ export { tsQualifiedName as tSQualifiedName };
 export function tsCallSignatureDeclaration(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   parameters: Array<t.Identifier | t.RestElement>,
-  typeAnnotation?: t.TSTypeAnnotation | null,
+  typeAnnotation: t.TSTypeAnnotation | null = null,
 ) {
   const node = {
     type: "TSCallSignatureDeclaration",
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
     parameters: parameters,
-    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    typeAnnotation: typeAnnotation,
   } as t.TSCallSignatureDeclaration;
   validateNode(node);
   return node;
@@ -2238,13 +2243,13 @@ export { tsCallSignatureDeclaration as tSCallSignatureDeclaration };
 export function tsConstructSignatureDeclaration(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   parameters: Array<t.Identifier | t.RestElement>,
-  typeAnnotation?: t.TSTypeAnnotation | null,
+  typeAnnotation: t.TSTypeAnnotation | null = null,
 ) {
   const node = {
     type: "TSConstructSignatureDeclaration",
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
     parameters: parameters,
-    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    typeAnnotation: typeAnnotation,
   } as t.TSConstructSignatureDeclaration;
   validateNode(node);
   return node;
@@ -2252,14 +2257,14 @@ export function tsConstructSignatureDeclaration(
 export { tsConstructSignatureDeclaration as tSConstructSignatureDeclaration };
 export function tsPropertySignature(
   key: t.Expression,
-  typeAnnotation?: t.TSTypeAnnotation | null,
-  initializer?: t.Expression | null,
+  typeAnnotation: t.TSTypeAnnotation | null = null,
+  initializer: t.Expression | null = null,
 ) {
   const node = {
     type: "TSPropertySignature",
     key: key,
-    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
-    initializer: initializer === undefined ? null : initializer,
+    typeAnnotation: typeAnnotation,
+    initializer: initializer,
     computed: null,
     optional: null,
     readonly: null,
@@ -2272,14 +2277,14 @@ export function tsMethodSignature(
   key: t.Expression,
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   parameters: Array<t.Identifier | t.RestElement>,
-  typeAnnotation?: t.TSTypeAnnotation | null,
+  typeAnnotation: t.TSTypeAnnotation | null = null,
 ) {
   const node = {
     type: "TSMethodSignature",
     key: key,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
     parameters: parameters,
-    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    typeAnnotation: typeAnnotation,
     computed: null,
     kind: null,
     optional: null,
@@ -2290,12 +2295,12 @@ export function tsMethodSignature(
 export { tsMethodSignature as tSMethodSignature };
 export function tsIndexSignature(
   parameters: Array<t.Identifier>,
-  typeAnnotation?: t.TSTypeAnnotation | null,
+  typeAnnotation: t.TSTypeAnnotation | null = null,
 ) {
   const node = {
     type: "TSIndexSignature",
     parameters: parameters,
-    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    typeAnnotation: typeAnnotation,
     readonly: null,
     static: null,
   } as t.TSIndexSignature;
@@ -2418,13 +2423,13 @@ export { tsThisType as tSThisType };
 export function tsFunctionType(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   parameters: Array<t.Identifier | t.RestElement>,
-  typeAnnotation?: t.TSTypeAnnotation | null,
+  typeAnnotation: t.TSTypeAnnotation | null = null,
 ) {
   const node = {
     type: "TSFunctionType",
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
     parameters: parameters,
-    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    typeAnnotation: typeAnnotation,
   } as t.TSFunctionType;
   validateNode(node);
   return node;
@@ -2433,13 +2438,13 @@ export { tsFunctionType as tSFunctionType };
 export function tsConstructorType(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   parameters: Array<t.Identifier | t.RestElement>,
-  typeAnnotation?: t.TSTypeAnnotation | null,
+  typeAnnotation: t.TSTypeAnnotation | null = null,
 ) {
   const node = {
     type: "TSConstructorType",
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
     parameters: parameters,
-    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
+    typeAnnotation: typeAnnotation,
     abstract: null,
   } as t.TSConstructorType;
   validateNode(node);
@@ -2448,12 +2453,12 @@ export function tsConstructorType(
 export { tsConstructorType as tSConstructorType };
 export function tsTypeReference(
   typeName: t.TSEntityName,
-  typeParameters?: t.TSTypeParameterInstantiation | null,
+  typeParameters: t.TSTypeParameterInstantiation | null = null,
 ) {
   const node = {
     type: "TSTypeReference",
     typeName: typeName,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
   } as t.TSTypeReference;
   validateNode(node);
   return node;
@@ -2461,14 +2466,14 @@ export function tsTypeReference(
 export { tsTypeReference as tSTypeReference };
 export function tsTypePredicate(
   parameterName: t.Identifier | t.TSThisType,
-  typeAnnotation?: t.TSTypeAnnotation | null,
-  asserts?: boolean | null,
+  typeAnnotation: t.TSTypeAnnotation | null = null,
+  asserts: boolean | null = null,
 ) {
   const node = {
     type: "TSTypePredicate",
     parameterName: parameterName,
-    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
-    asserts: asserts === undefined ? null : asserts,
+    typeAnnotation: typeAnnotation,
+    asserts: asserts,
   } as t.TSTypePredicate;
   validateNode(node);
   return node;
@@ -2533,13 +2538,13 @@ export { tsRestType as tSRestType };
 export function tsNamedTupleMember(
   label: t.Identifier,
   elementType: t.TSType,
-  optional?: boolean,
+  optional: boolean = false,
 ) {
   const node = {
     type: "TSNamedTupleMember",
     label: label,
     elementType: elementType,
-    optional: optional === undefined ? false : optional,
+    optional: optional,
   } as t.TSNamedTupleMember;
   validateNode(node);
   return node;
@@ -2620,14 +2625,14 @@ export function tsIndexedAccessType(objectType: t.TSType, indexType: t.TSType) {
 export { tsIndexedAccessType as tSIndexedAccessType };
 export function tsMappedType(
   typeParameter: t.TSTypeParameter,
-  typeAnnotation?: t.TSType | null,
-  nameType?: t.TSType | null,
+  typeAnnotation: t.TSType | null = null,
+  nameType: t.TSType | null = null,
 ) {
   const node = {
     type: "TSMappedType",
     typeParameter: typeParameter,
-    typeAnnotation: typeAnnotation === undefined ? null : typeAnnotation,
-    nameType: nameType === undefined ? null : nameType,
+    typeAnnotation: typeAnnotation,
+    nameType: nameType,
     optional: null,
     readonly: null,
   } as t.TSMappedType;
@@ -2652,12 +2657,12 @@ export function tsLiteralType(
 export { tsLiteralType as tSLiteralType };
 export function tsExpressionWithTypeArguments(
   expression: t.TSEntityName,
-  typeParameters?: t.TSTypeParameterInstantiation | null,
+  typeParameters: t.TSTypeParameterInstantiation | null = null,
 ) {
   const node = {
     type: "TSExpressionWithTypeArguments",
     expression: expression,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
   } as t.TSExpressionWithTypeArguments;
   validateNode(node);
   return node;
@@ -2672,8 +2677,8 @@ export function tsInterfaceDeclaration(
   const node = {
     type: "TSInterfaceDeclaration",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
-    extends: _extends === undefined ? null : _extends,
+    typeParameters: typeParameters,
+    extends: _extends,
     body: body,
     declare: null,
   } as t.TSInterfaceDeclaration;
@@ -2698,7 +2703,7 @@ export function tsTypeAliasDeclaration(
   const node = {
     type: "TSTypeAliasDeclaration",
     id: id,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    typeParameters: typeParameters,
     typeAnnotation: typeAnnotation,
     declare: null,
   } as t.TSTypeAliasDeclaration;
@@ -2750,12 +2755,12 @@ export function tsEnumDeclaration(
 export { tsEnumDeclaration as tSEnumDeclaration };
 export function tsEnumMember(
   id: t.Identifier | t.StringLiteral,
-  initializer?: t.Expression | null,
+  initializer: t.Expression | null = null,
 ) {
   const node = {
     type: "TSEnumMember",
     id: id,
-    initializer: initializer === undefined ? null : initializer,
+    initializer: initializer,
   } as t.TSEnumMember;
   validateNode(node);
   return node;
@@ -2787,14 +2792,14 @@ export function tsModuleBlock(body: Array<t.Statement>) {
 export { tsModuleBlock as tSModuleBlock };
 export function tsImportType(
   argument: t.StringLiteral,
-  qualifier?: t.TSEntityName | null,
-  typeParameters?: t.TSTypeParameterInstantiation | null,
+  qualifier: t.TSEntityName | null = null,
+  typeParameters: t.TSTypeParameterInstantiation | null = null,
 ) {
   const node = {
     type: "TSImportType",
     argument: argument,
-    qualifier: qualifier === undefined ? null : qualifier,
-    typeParameters: typeParameters === undefined ? null : typeParameters,
+    qualifier: qualifier,
+    typeParameters: typeParameters,
   } as t.TSImportType;
   validateNode(node);
   return node;
@@ -2884,8 +2889,8 @@ export function tsTypeParameter(
 ) {
   const node = {
     type: "TSTypeParameter",
-    constraint: constraint === undefined ? null : constraint,
-    default: _default === undefined ? null : _default,
+    constraint: constraint,
+    default: _default,
     name: name,
   } as t.TSTypeParameter;
   validateNode(node);

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -1466,30 +1466,30 @@ export function tsTypeParameter(
 }
 export { tsTypeParameter as tSTypeParameter };
 /** @deprecated */
-function NumberLiteral(...args: Array<any>): any {
+function NumberLiteral(...args: Parameters<typeof numericLiteral>): any {
   console.trace(
     "The node type NumberLiteral has been renamed to NumericLiteral",
   );
-  return builder("NumberLiteral", ...args);
+  return numericLiteral(...args);
 }
 export { NumberLiteral as numberLiteral };
 /** @deprecated */
-function RegexLiteral(...args: Array<any>): any {
+function RegexLiteral(...args: Parameters<typeof regExpLiteral>): any {
   console.trace("The node type RegexLiteral has been renamed to RegExpLiteral");
-  return builder("RegexLiteral", ...args);
+  return regExpLiteral(...args);
 }
 export { RegexLiteral as regexLiteral };
 /** @deprecated */
-function RestProperty(...args: Array<any>): any {
+function RestProperty(...args: Parameters<typeof restElement>): any {
   console.trace("The node type RestProperty has been renamed to RestElement");
-  return builder("RestProperty", ...args);
+  return restElement(...args);
 }
 export { RestProperty as restProperty };
 /** @deprecated */
-function SpreadProperty(...args: Array<any>): any {
+function SpreadProperty(...args: Parameters<typeof spreadElement>): any {
   console.trace(
     "The node type SpreadProperty has been renamed to SpreadElement",
   );
-  return builder("SpreadProperty", ...args);
+  return spreadElement(...args);
 }
 export { SpreadProperty as spreadProperty };

--- a/packages/babel-types/src/builders/validateNode.ts
+++ b/packages/babel-types/src/builders/validateNode.ts
@@ -1,0 +1,11 @@
+import validate from "../validators/validate";
+import type * as t from "..";
+import { BUILDER_KEYS } from "..";
+
+export default function validateNode(node: t.Node) {
+  // todo: because keys not in BUILDER_KEYS are not validated - this actually allows invalid nodes in some cases
+  const keys = BUILDER_KEYS[node.type];
+  for (const key of keys) {
+    validate(node, key, node[key]);
+  }
+}

--- a/packages/babel-types/src/clone/cloneNode.ts
+++ b/packages/babel-types/src/clone/cloneNode.ts
@@ -39,8 +39,11 @@ export default function cloneNode<T extends t.Node>(
   if (isIdentifier(node)) {
     newNode.name = node.name;
 
-    if (has(node, "optional") && typeof node.optional === "boolean") {
+    if (has(node, "optional")) {
       newNode.optional = node.optional;
+    }
+    if (has(node, "decorators")) {
+      newNode.decorators = node.decorators;
     }
 
     if (has(node, "typeAnnotation")) {

--- a/packages/babel-types/test/builders/es2015/__snapshots__/templateElement.js.snap
+++ b/packages/babel-types/test/builders/es2015/__snapshots__/templateElement.js.snap
@@ -92,4 +92,4 @@ Expected 1 quasis but got 2"
 
 exports[`builders es2015 templateLiteral should validate 5`] = `"Property quasis expected type of array but got object"`;
 
-exports[`builders es2015 templateLiteral should validate 6`] = `"Property expressions expected type of array but got null"`;
+exports[`builders es2015 templateLiteral should validate 6`] = `"Property expressions expected type of array but got undefined"`;

--- a/packages/babel-types/test/builders/experimental/__snapshots__/classProperty.js.snap
+++ b/packages/babel-types/test/builders/experimental/__snapshots__/classProperty.js.snap
@@ -2,12 +2,19 @@
 
 exports[`builders experimental classProperty should validate 1`] = `
 Object {
+  "abstract": null,
+  "accessibility": null,
   "computed": false,
+  "declare": null,
   "decorators": null,
+  "definite": null,
   "key": Object {
     "type": "StringLiteral",
     "value": "test",
   },
+  "optional": null,
+  "override": false,
+  "readonly": null,
   "static": false,
   "type": "ClassProperty",
   "typeAnnotation": null,
@@ -20,12 +27,19 @@ Object {
 
 exports[`builders experimental classProperty should validate 2`] = `
 Object {
+  "abstract": null,
+  "accessibility": null,
   "computed": false,
+  "declare": null,
   "decorators": null,
+  "definite": null,
   "key": Object {
     "type": "StringLiteral",
     "value": "test",
   },
+  "optional": null,
+  "override": false,
+  "readonly": null,
   "static": true,
   "type": "ClassProperty",
   "typeAnnotation": null,

--- a/packages/babel-types/test/builders/flow/__snapshots__/createTypeAnnotationBasedOnTypeof.js.snap
+++ b/packages/babel-types/test/builders/flow/__snapshots__/createTypeAnnotationBasedOnTypeof.js.snap
@@ -9,8 +9,11 @@ Object {
 exports[`builders flow createTypeAnnotationBasedOnTypeof function 1`] = `
 Object {
   "id": Object {
+    "decorators": null,
     "name": "Function",
+    "optional": null,
     "type": "Identifier",
+    "typeAnnotation": null,
   },
   "type": "GenericTypeAnnotation",
   "typeParameters": null,
@@ -26,8 +29,11 @@ Object {
 exports[`builders flow createTypeAnnotationBasedOnTypeof object 1`] = `
 Object {
   "id": Object {
+    "decorators": null,
     "name": "Object",
+    "optional": null,
     "type": "Identifier",
+    "typeAnnotation": null,
   },
   "type": "GenericTypeAnnotation",
   "typeParameters": null,
@@ -43,8 +49,11 @@ Object {
 exports[`builders flow createTypeAnnotationBasedOnTypeof symbol 1`] = `
 Object {
   "id": Object {
+    "decorators": null,
     "name": "Symbol",
+    "optional": null,
     "type": "Identifier",
+    "typeAnnotation": null,
   },
   "type": "GenericTypeAnnotation",
   "typeParameters": null,

--- a/packages/babel-types/test/builders/typescript/__snapshots__/tsTypeParameter.js.snap
+++ b/packages/babel-types/test/builders/typescript/__snapshots__/tsTypeParameter.js.snap
@@ -5,16 +5,22 @@ Object {
   "constraint": Object {
     "type": "TSTypeReference",
     "typeName": Object {
+      "decorators": null,
       "name": "bar",
+      "optional": null,
       "type": "Identifier",
+      "typeAnnotation": null,
     },
     "typeParameters": null,
   },
   "default": Object {
     "type": "TSTypeReference",
     "typeName": Object {
+      "decorators": null,
       "name": "baz",
+      "optional": null,
       "type": "Identifier",
+      "typeAnnotation": null,
     },
     "typeParameters": null,
   },

--- a/packages/babel-types/test/builders/typescript/tsTypeParameter.js
+++ b/packages/babel-types/test/builders/typescript/tsTypeParameter.js
@@ -17,7 +17,7 @@ describe("builders", function () {
             t.tsTypeReference(t.identifier("bar")),
             t.tsTypeReference(t.identifier("baz")),
           );
-        }).toThrow("Property name expected type of string but got null");
+        }).toThrow("Property name expected type of string but got undefined");
       });
     });
   });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is experimental try to improve node builders in @babel/types. Feedback and suggestions are welcome.

Goals:

- try generating complete builders instead of dynamically building nodes - having juts one object literal might be faster
- experiment about removing node validation from builders -- idea is that this is probably useful only during development, but if typescript is used - this should be already covered for most cases… so - it sounds like a good candidate to remove/disable in production

Todo:

- come-up with realistic approach to measure how faster it can be if generated and how much overhead there is because of validation -- suggestions and help is welcome

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13369"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

