### PR TITLE
disallow surrogate in the end of contextual name

### DIFF
--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -71,11 +71,17 @@ export default class UtilParser extends Tokenizer {
 
   isUnparsedContextual(nameStart: number, name: string): boolean {
     const nameEnd = nameStart + name.length;
-    return (
-      this.input.slice(nameStart, nameEnd) === name &&
-      (nameEnd === this.input.length ||
-        !isIdentifierChar(this.input.charCodeAt(nameEnd)))
-    );
+    if (this.input.slice(nameStart, nameEnd) === name) {
+      const nextCh = this.input.charCodeAt(nameEnd);
+      return !(
+        isIdentifierChar(nextCh) ||
+        // check if `nextCh is between 0xd800 - 0xdbff,
+        // if `nextCh` is NaN, `NaN & 0xfc00` is 0, the function
+        // returns true
+        (nextCh & 0xfc00) === 0xd800
+      );
+    }
+    return false;
   }
 
   isLookaheadContextual(name: string): boolean {

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/async-function-and-non-bmp-character/input.js
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/async-function-and-non-bmp-character/input.js
@@ -1,0 +1,1 @@
+async function𝐬 f() {}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/async-function-and-non-bmp-character/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/async-function-and-non-bmp-character/output.json
@@ -1,0 +1,56 @@
+{
+  "type": "File",
+  "start":0,"end":23,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":23}},
+  "errors": [
+    "SyntaxError: Missing semicolon. (1:5)",
+    "SyntaxError: Missing semicolon. (1:16)",
+    "SyntaxError: Missing semicolon. (1:20)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":23,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":23}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":5,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":5}},
+        "expression": {
+          "type": "Identifier",
+          "start":0,"end":5,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":5},"identifierName":"async"},
+          "name": "async"
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start":6,"end":16,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":16}},
+        "expression": {
+          "type": "Identifier",
+          "start":6,"end":16,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":16},"identifierName":"function𝐬"},
+          "name": "function𝐬"
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start":17,"end":20,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":20}},
+        "expression": {
+          "type": "CallExpression",
+          "start":17,"end":20,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":20}},
+          "callee": {
+            "type": "Identifier",
+            "start":17,"end":18,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":18},"identifierName":"f"},
+            "name": "f"
+          },
+          "arguments": []
+        }
+      },
+      {
+        "type": "BlockStatement",
+        "start":21,"end":23,"loc":{"start":{"line":1,"column":21},"end":{"line":1,"column":23}},
+        "body": [],
+        "directives": []
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13339
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we disallow any surrogate start in the end of a contextual name token. It is sufficient to check surrogate start only, if it turns out it is _not_ an identifier char, it will be thrown later when we create a name token, since the starting character must be an identifier start.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13377"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

