### PR TITLE
Skip `flow/typecasts/3` test on Node.js 6

### DIFF
--- a/packages/babel-parser/test/fixtures/flow/typecasts/3/options.json
+++ b/packages/babel-parser/test/fixtures/flow/typecasts/3/options.json
@@ -1,0 +1,3 @@
+{
+  "minNodeVersion": "8.0.0"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes #13374
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Node.js 6 has a bug which causes some booleans to be flipped when V8 5.1 compiles the code with TurboFan (the optimizing compiler).

This is very unlikely to affect our users, since no one parses as many files as we do in our parser tests, and it only affects Node.js 6. Let's just skip the test for now so that CI stops failing.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13382"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

