### PR TITLE
Hoist omitted keys from object spread operator

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -182,7 +182,7 @@ export default declare((api, opts) => {
       if (!t.isProgram(path.scope.block)) {
         // Hoist definition of excluded keys, so that it's not created each time.
         const program = path.findParent(path => path.isProgram());
-        const id = path.scope.generateUidIdentifier("exclude");
+        const id = path.scope.generateUidIdentifier("excluded");
 
         program.scope.push({
           id,

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -178,19 +178,20 @@ export default declare((api, opts) => {
       );
     } else {
       keyExpression = t.arrayExpression(keys);
-    }
 
-    // Hoist definition of excluded keys, so that it's not created each time.
-    if (!t.isProgram(path.scope.block)) {
-      const id = path.scope.generateUidIdentifier();
+      if (!t.isProgram(path.scope.block)) {
+        // Hoist definition of excluded keys, so that it's not created each time.
+        const program = path.findParent(path => path.isProgram());
+        const id = path.scope.generateUidIdentifier("exclude");
 
-      file.path.scope.push({
-        id,
-        init: keyExpression,
-        kind: "const",
-      });
+        program.scope.push({
+          id,
+          init: keyExpression,
+          kind: "const",
+        });
 
-      keyExpression = t.cloneNode(id);
+        keyExpression = t.cloneNode(id);
+      }
     }
 
     return [

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -180,6 +180,19 @@ export default declare((api, opts) => {
       keyExpression = t.arrayExpression(keys);
     }
 
+    // Hoist definition of excluded keys, so that it's not created each time.
+    if (!t.isProgram(path.scope.block)) {
+      const id = path.scope.generateUidIdentifier();
+
+      file.path.scope.push({
+        id,
+        init: keyExpression,
+        kind: "const",
+      });
+
+      keyExpression = t.cloneNode(id);
+    }
+
     return [
       impureComputedPropertyDeclarators,
       restElement.argument,

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/assumption-pureGetters/rest-remove-unused-excluded-keys/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/assumption-pureGetters/rest-remove-unused-excluded-keys/output.js
@@ -1,5 +1,5 @@
-const _temp = ["excluded", "excluded2", "used", "used2"],
-      _temp2 = ["unused"];
+const _exclude = ["excluded", "excluded2", "used", "used2"],
+      _exclude2 = ["unused"];
 // should not remove when destructuring into existing bindings
 var _c = c2;
 ({
@@ -14,12 +14,12 @@ function render() {
     used,
     used2: usedRenamed
   } = _this$props,
-        props = babelHelpers.objectWithoutProperties(_this$props, _temp);
+        props = babelHelpers.objectWithoutProperties(_this$props, _exclude);
   console.log(used, usedRenamed);
   return React.createElement("input", props);
 }
 
 function smth(_ref) {
-  let rest = babelHelpers.objectWithoutProperties(_ref, _temp2);
+  let rest = babelHelpers.objectWithoutProperties(_ref, _exclude2);
   call(rest);
 }

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/assumption-pureGetters/rest-remove-unused-excluded-keys/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/assumption-pureGetters/rest-remove-unused-excluded-keys/output.js
@@ -1,5 +1,5 @@
-const _exclude = ["excluded", "excluded2", "used", "used2"],
-      _exclude2 = ["unused"];
+const _excluded = ["excluded", "excluded2", "used", "used2"],
+      _excluded2 = ["unused"];
 // should not remove when destructuring into existing bindings
 var _c = c2;
 ({
@@ -14,12 +14,12 @@ function render() {
     used,
     used2: usedRenamed
   } = _this$props,
-        props = babelHelpers.objectWithoutProperties(_this$props, _exclude);
+        props = babelHelpers.objectWithoutProperties(_this$props, _excluded);
   console.log(used, usedRenamed);
   return React.createElement("input", props);
 }
 
 function smth(_ref) {
-  let rest = babelHelpers.objectWithoutProperties(_ref, _exclude2);
+  let rest = babelHelpers.objectWithoutProperties(_ref, _excluded2);
   call(rest);
 }

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/assumption-pureGetters/rest-remove-unused-excluded-keys/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/assumption-pureGetters/rest-remove-unused-excluded-keys/output.js
@@ -1,3 +1,5 @@
+const _temp = ["excluded", "excluded2", "used", "used2"],
+      _temp2 = ["unused"];
 // should not remove when destructuring into existing bindings
 var _c = c2;
 ({
@@ -12,12 +14,12 @@ function render() {
     used,
     used2: usedRenamed
   } = _this$props,
-        props = babelHelpers.objectWithoutProperties(_this$props, ["excluded", "excluded2", "used", "used2"]);
+        props = babelHelpers.objectWithoutProperties(_this$props, _temp);
   console.log(used, usedRenamed);
   return React.createElement("input", props);
 }
 
 function smth(_ref) {
-  let rest = babelHelpers.objectWithoutProperties(_ref, ["unused"]);
+  let rest = babelHelpers.objectWithoutProperties(_ref, _temp2);
   call(rest);
 }

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/catch-clause/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/catch-clause/output.js
@@ -1,6 +1,6 @@
-const _exclude = ["a1"],
-      _exclude2 = ["a2", "b2"],
-      _exclude3 = ["c3"];
+const _excluded = ["a1"],
+      _excluded2 = ["a2", "b2"],
+      _excluded3 = ["c3"];
 
 try {} catch (_ref) {
   let a34 = babelHelpers.extends({}, _ref);
@@ -10,7 +10,7 @@ try {} catch (_ref2) {
   let {
     a1
   } = _ref2,
-      b1 = babelHelpers.objectWithoutProperties(_ref2, _exclude);
+      b1 = babelHelpers.objectWithoutProperties(_ref2, _excluded);
 }
 
 try {} catch (_ref3) {
@@ -18,7 +18,7 @@ try {} catch (_ref3) {
     a2,
     b2
   } = _ref3,
-      c2 = babelHelpers.objectWithoutProperties(_ref3, _exclude2);
+      c2 = babelHelpers.objectWithoutProperties(_ref3, _excluded2);
 }
 
 try {} catch (_ref4) {
@@ -29,7 +29,7 @@ try {} catch (_ref4) {
       c3
     }
   } = _ref4,
-      c4 = babelHelpers.objectWithoutProperties(_ref4.c2, _exclude3);
+      c4 = babelHelpers.objectWithoutProperties(_ref4.c2, _excluded3);
 } // Unchanged
 
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/catch-clause/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/catch-clause/output.js
@@ -1,3 +1,7 @@
+const _temp = ["a1"],
+      _temp2 = ["a2", "b2"],
+      _temp3 = ["c3"];
+
 try {} catch (_ref) {
   let a34 = babelHelpers.extends({}, _ref);
 }
@@ -6,7 +10,7 @@ try {} catch (_ref2) {
   let {
     a1
   } = _ref2,
-      b1 = babelHelpers.objectWithoutProperties(_ref2, ["a1"]);
+      b1 = babelHelpers.objectWithoutProperties(_ref2, _temp);
 }
 
 try {} catch (_ref3) {
@@ -14,7 +18,7 @@ try {} catch (_ref3) {
     a2,
     b2
   } = _ref3,
-      c2 = babelHelpers.objectWithoutProperties(_ref3, ["a2", "b2"]);
+      c2 = babelHelpers.objectWithoutProperties(_ref3, _temp2);
 }
 
 try {} catch (_ref4) {
@@ -25,7 +29,7 @@ try {} catch (_ref4) {
       c3
     }
   } = _ref4,
-      c4 = babelHelpers.objectWithoutProperties(_ref4.c2, ["c3"]);
+      c4 = babelHelpers.objectWithoutProperties(_ref4.c2, _temp3);
 } // Unchanged
 
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/catch-clause/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/catch-clause/output.js
@@ -1,6 +1,6 @@
-const _temp = ["a1"],
-      _temp2 = ["a2", "b2"],
-      _temp3 = ["c3"];
+const _exclude = ["a1"],
+      _exclude2 = ["a2", "b2"],
+      _exclude3 = ["c3"];
 
 try {} catch (_ref) {
   let a34 = babelHelpers.extends({}, _ref);
@@ -10,7 +10,7 @@ try {} catch (_ref2) {
   let {
     a1
   } = _ref2,
-      b1 = babelHelpers.objectWithoutProperties(_ref2, _temp);
+      b1 = babelHelpers.objectWithoutProperties(_ref2, _exclude);
 }
 
 try {} catch (_ref3) {
@@ -18,7 +18,7 @@ try {} catch (_ref3) {
     a2,
     b2
   } = _ref3,
-      c2 = babelHelpers.objectWithoutProperties(_ref3, _temp2);
+      c2 = babelHelpers.objectWithoutProperties(_ref3, _exclude2);
 }
 
 try {} catch (_ref4) {
@@ -29,7 +29,7 @@ try {} catch (_ref4) {
       c3
     }
   } = _ref4,
-      c4 = babelHelpers.objectWithoutProperties(_ref4.c2, _temp3);
+      c4 = babelHelpers.objectWithoutProperties(_ref4.c2, _exclude3);
 } // Unchanged
 
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/output.js
@@ -1,6 +1,6 @@
-const _exclude = ["a"],
-      _exclude2 = ["a"],
-      _exclude3 = ["a"];
+const _excluded = ["a"],
+      _excluded2 = ["a"],
+      _excluded3 = ["a"];
 
 // ForXStatement
 for (const _ref of []) {
@@ -8,7 +8,7 @@ for (const _ref of []) {
   const {
     a
   } = _ref2,
-        b = babelHelpers.objectWithoutProperties(_ref2, _exclude);
+        b = babelHelpers.objectWithoutProperties(_ref2, _excluded);
 }
 
 for (var _ref3 of []) {
@@ -16,7 +16,7 @@ for (var _ref3 of []) {
   var {
     a
   } = _ref4,
-      b = babelHelpers.objectWithoutProperties(_ref4, _exclude2);
+      b = babelHelpers.objectWithoutProperties(_ref4, _excluded2);
 }
 
 async function a() {
@@ -25,7 +25,7 @@ async function a() {
     var {
       a
     } = _ref6,
-        b = babelHelpers.objectWithoutProperties(_ref6, _exclude3);
+        b = babelHelpers.objectWithoutProperties(_ref6, _excluded3);
   }
 } // skip
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/output.js
@@ -1,6 +1,6 @@
-const _temp = ["a"],
-      _temp2 = ["a"],
-      _temp3 = ["a"];
+const _exclude = ["a"],
+      _exclude2 = ["a"],
+      _exclude3 = ["a"];
 
 // ForXStatement
 for (const _ref of []) {
@@ -8,7 +8,7 @@ for (const _ref of []) {
   const {
     a
   } = _ref2,
-        b = babelHelpers.objectWithoutProperties(_ref2, _temp);
+        b = babelHelpers.objectWithoutProperties(_ref2, _exclude);
 }
 
 for (var _ref3 of []) {
@@ -16,7 +16,7 @@ for (var _ref3 of []) {
   var {
     a
   } = _ref4,
-      b = babelHelpers.objectWithoutProperties(_ref4, _temp2);
+      b = babelHelpers.objectWithoutProperties(_ref4, _exclude2);
 }
 
 async function a() {
@@ -25,7 +25,7 @@ async function a() {
     var {
       a
     } = _ref6,
-        b = babelHelpers.objectWithoutProperties(_ref6, _temp3);
+        b = babelHelpers.objectWithoutProperties(_ref6, _exclude3);
   }
 } // skip
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/output.js
@@ -1,10 +1,14 @@
+const _temp = ["a"],
+      _temp2 = ["a"],
+      _temp3 = ["a"];
+
 // ForXStatement
 for (const _ref of []) {
   const [_ref2] = _ref;
   const {
     a
   } = _ref2,
-        b = babelHelpers.objectWithoutProperties(_ref2, ["a"]);
+        b = babelHelpers.objectWithoutProperties(_ref2, _temp);
 }
 
 for (var _ref3 of []) {
@@ -12,7 +16,7 @@ for (var _ref3 of []) {
   var {
     a
   } = _ref4,
-      b = babelHelpers.objectWithoutProperties(_ref4, ["a"]);
+      b = babelHelpers.objectWithoutProperties(_ref4, _temp2);
 }
 
 async function a() {
@@ -21,7 +25,7 @@ async function a() {
     var {
       a
     } = _ref6,
-        b = babelHelpers.objectWithoutProperties(_ref6, ["a"]);
+        b = babelHelpers.objectWithoutProperties(_ref6, _temp3);
   }
 } // skip
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-completion-record/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-completion-record/output.js
@@ -1,11 +1,11 @@
-const _temp = ["a"];
+const _exclude = ["a"];
 
 for (var _ref of []) {
   var _ref2 = _ref;
   ({
     a
   } = _ref2);
-  b = babelHelpers.objectWithoutProperties(_ref2, _temp);
+  b = babelHelpers.objectWithoutProperties(_ref2, _exclude);
   _ref2;
   void 0;
 }

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-completion-record/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-completion-record/output.js
@@ -1,9 +1,11 @@
+const _temp = ["a"];
+
 for (var _ref of []) {
   var _ref2 = _ref;
   ({
     a
   } = _ref2);
-  b = babelHelpers.objectWithoutProperties(_ref2, ["a"]);
+  b = babelHelpers.objectWithoutProperties(_ref2, _temp);
   _ref2;
   void 0;
 }

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-completion-record/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x-completion-record/output.js
@@ -1,11 +1,11 @@
-const _exclude = ["a"];
+const _excluded = ["a"];
 
 for (var _ref of []) {
   var _ref2 = _ref;
   ({
     a
   } = _ref2);
-  b = babelHelpers.objectWithoutProperties(_ref2, _exclude);
+  b = babelHelpers.objectWithoutProperties(_ref2, _excluded);
   _ref2;
   void 0;
 }

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x/output.js
@@ -1,13 +1,13 @@
-const _exclude = ["a"],
-      _exclude2 = ["a"],
-      _exclude3 = ["a"];
+const _excluded = ["a"],
+      _excluded2 = ["a"],
+      _excluded3 = ["a"];
 
 // ForXStatement
 for (var _ref of []) {
   var {
     a
   } = _ref,
-      b = babelHelpers.objectWithoutProperties(_ref, _exclude);
+      b = babelHelpers.objectWithoutProperties(_ref, _excluded);
 }
 
 for (var _ref2 of []) {
@@ -15,7 +15,7 @@ for (var _ref2 of []) {
   ({
     a
   } = _ref3);
-  b = babelHelpers.objectWithoutProperties(_ref3, _exclude2);
+  b = babelHelpers.objectWithoutProperties(_ref3, _excluded2);
   _ref3;
 }
 
@@ -25,7 +25,7 @@ async function a() {
     ({
       a
     } = _ref5);
-    b = babelHelpers.objectWithoutProperties(_ref5, _exclude3);
+    b = babelHelpers.objectWithoutProperties(_ref5, _excluded3);
     _ref5;
   }
 } // skip

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x/output.js
@@ -1,9 +1,13 @@
+const _temp = ["a"],
+      _temp2 = ["a"],
+      _temp3 = ["a"];
+
 // ForXStatement
 for (var _ref of []) {
   var {
     a
   } = _ref,
-      b = babelHelpers.objectWithoutProperties(_ref, ["a"]);
+      b = babelHelpers.objectWithoutProperties(_ref, _temp);
 }
 
 for (var _ref2 of []) {
@@ -11,7 +15,7 @@ for (var _ref2 of []) {
   ({
     a
   } = _ref3);
-  b = babelHelpers.objectWithoutProperties(_ref3, ["a"]);
+  b = babelHelpers.objectWithoutProperties(_ref3, _temp2);
   _ref3;
 }
 
@@ -21,7 +25,7 @@ async function a() {
     ({
       a
     } = _ref5);
-    b = babelHelpers.objectWithoutProperties(_ref5, ["a"]);
+    b = babelHelpers.objectWithoutProperties(_ref5, _temp3);
     _ref5;
   }
 } // skip

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/for-x/output.js
@@ -1,13 +1,13 @@
-const _temp = ["a"],
-      _temp2 = ["a"],
-      _temp3 = ["a"];
+const _exclude = ["a"],
+      _exclude2 = ["a"],
+      _exclude3 = ["a"];
 
 // ForXStatement
 for (var _ref of []) {
   var {
     a
   } = _ref,
-      b = babelHelpers.objectWithoutProperties(_ref, _temp);
+      b = babelHelpers.objectWithoutProperties(_ref, _exclude);
 }
 
 for (var _ref2 of []) {
@@ -15,7 +15,7 @@ for (var _ref2 of []) {
   ({
     a
   } = _ref3);
-  b = babelHelpers.objectWithoutProperties(_ref3, _temp2);
+  b = babelHelpers.objectWithoutProperties(_ref3, _exclude2);
   _ref3;
 }
 
@@ -25,7 +25,7 @@ async function a() {
     ({
       a
     } = _ref5);
-    b = babelHelpers.objectWithoutProperties(_ref5, _temp3);
+    b = babelHelpers.objectWithoutProperties(_ref5, _exclude3);
     _ref5;
   }
 } // skip

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters-object-rest-used-in-default/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters-object-rest-used-in-default/output.js
@@ -1,4 +1,4 @@
-const _temp = ["X"];
+const _exclude = ["X"];
 
 _ref => {
   let R = babelHelpers.extends({}, _ref);
@@ -9,7 +9,7 @@ _ref => {
   let {
     X: Y
   } = _ref2,
-      R = babelHelpers.objectWithoutProperties(_ref2, _temp);
+      R = babelHelpers.objectWithoutProperties(_ref2, _exclude);
   let {
     a = {
       Y

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters-object-rest-used-in-default/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters-object-rest-used-in-default/output.js
@@ -1,3 +1,5 @@
+const _temp = ["X"];
+
 _ref => {
   let R = babelHelpers.extends({}, _ref);
   let a = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : R;
@@ -7,7 +9,7 @@ _ref => {
   let {
     X: Y
   } = _ref2,
-      R = babelHelpers.objectWithoutProperties(_ref2, ["X"]);
+      R = babelHelpers.objectWithoutProperties(_ref2, _temp);
   let {
     a = {
       Y

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters-object-rest-used-in-default/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters-object-rest-used-in-default/output.js
@@ -1,4 +1,4 @@
-const _exclude = ["X"];
+const _excluded = ["X"];
 
 _ref => {
   let R = babelHelpers.extends({}, _ref);
@@ -9,7 +9,7 @@ _ref => {
   let {
     X: Y
   } = _ref2,
-      R = babelHelpers.objectWithoutProperties(_ref2, _exclude);
+      R = babelHelpers.objectWithoutProperties(_ref2, _excluded);
   let {
     a = {
       Y

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters/output.js
@@ -1,3 +1,13 @@
+const _temp = ["a1"],
+      _temp2 = ["a2", "b2"],
+      _temp3 = ["a5"],
+      _temp4 = ["a3"],
+      _temp5 = ["ba1"],
+      _temp6 = ["a3", "b2"],
+      _temp7 = ["ba1"],
+      _temp8 = ["a1"],
+      _temp9 = ["a1"];
+
 function a(_ref) {
   let a34 = babelHelpers.extends({}, _ref);
 }
@@ -6,7 +16,7 @@ function a2(_ref2) {
   let {
     a1
   } = _ref2,
-      b1 = babelHelpers.objectWithoutProperties(_ref2, ["a1"]);
+      b1 = babelHelpers.objectWithoutProperties(_ref2, _temp);
 }
 
 function a3(_ref3) {
@@ -14,18 +24,18 @@ function a3(_ref3) {
     a2,
     b2
   } = _ref3,
-      c2 = babelHelpers.objectWithoutProperties(_ref3, ["a2", "b2"]);
+      c2 = babelHelpers.objectWithoutProperties(_ref3, _temp2);
 }
 
 function a4(_ref4, _ref5) {
   let {
     a5
   } = _ref5,
-      c5 = babelHelpers.objectWithoutProperties(_ref5, ["a5"]);
+      c5 = babelHelpers.objectWithoutProperties(_ref5, _temp3);
   let {
     a3
   } = _ref4,
-      c3 = babelHelpers.objectWithoutProperties(_ref4, ["a3"]);
+      c3 = babelHelpers.objectWithoutProperties(_ref4, _temp4);
 }
 
 function a5(_ref6) {
@@ -35,8 +45,8 @@ function a5(_ref6) {
       ba1
     }
   } = _ref6,
-      ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, ["ba1"]),
-      c3 = babelHelpers.objectWithoutProperties(_ref6, ["a3", "b2"]);
+      ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, _temp5),
+      c3 = babelHelpers.objectWithoutProperties(_ref6, _temp6);
 }
 
 function a6(_ref7) {
@@ -46,14 +56,14 @@ function a6(_ref7) {
       ba1
     }
   } = _ref7,
-      ba2 = babelHelpers.objectWithoutProperties(_ref7.b2, ["ba1"]);
+      ba2 = babelHelpers.objectWithoutProperties(_ref7.b2, _temp7);
 }
 
 function a7(_ref8 = {}) {
   let {
     a1 = 1
   } = _ref8,
-      b1 = babelHelpers.objectWithoutProperties(_ref8, ["a1"]);
+      b1 = babelHelpers.objectWithoutProperties(_ref8, _temp8);
 }
 
 function a8([_ref9]) {
@@ -64,7 +74,7 @@ function a9([_ref10]) {
   let {
     a1
   } = _ref10,
-      a2 = babelHelpers.objectWithoutProperties(_ref10, ["a1"]);
+      a2 = babelHelpers.objectWithoutProperties(_ref10, _temp9);
 }
 
 function a10([a1, _ref11]) {

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters/output.js
@@ -1,12 +1,12 @@
-const _exclude = ["a1"],
-      _exclude2 = ["a2", "b2"],
-      _exclude3 = ["a5"],
-      _exclude4 = ["a3"],
-      _exclude5 = ["ba1"],
-      _exclude6 = ["a3", "b2"],
-      _exclude7 = ["ba1"],
-      _exclude8 = ["a1"],
-      _exclude9 = ["a1"];
+const _excluded = ["a1"],
+      _excluded2 = ["a2", "b2"],
+      _excluded3 = ["a5"],
+      _excluded4 = ["a3"],
+      _excluded5 = ["ba1"],
+      _excluded6 = ["a3", "b2"],
+      _excluded7 = ["ba1"],
+      _excluded8 = ["a1"],
+      _excluded9 = ["a1"];
 
 function a(_ref) {
   let a34 = babelHelpers.extends({}, _ref);
@@ -16,7 +16,7 @@ function a2(_ref2) {
   let {
     a1
   } = _ref2,
-      b1 = babelHelpers.objectWithoutProperties(_ref2, _exclude);
+      b1 = babelHelpers.objectWithoutProperties(_ref2, _excluded);
 }
 
 function a3(_ref3) {
@@ -24,18 +24,18 @@ function a3(_ref3) {
     a2,
     b2
   } = _ref3,
-      c2 = babelHelpers.objectWithoutProperties(_ref3, _exclude2);
+      c2 = babelHelpers.objectWithoutProperties(_ref3, _excluded2);
 }
 
 function a4(_ref4, _ref5) {
   let {
     a5
   } = _ref5,
-      c5 = babelHelpers.objectWithoutProperties(_ref5, _exclude3);
+      c5 = babelHelpers.objectWithoutProperties(_ref5, _excluded3);
   let {
     a3
   } = _ref4,
-      c3 = babelHelpers.objectWithoutProperties(_ref4, _exclude4);
+      c3 = babelHelpers.objectWithoutProperties(_ref4, _excluded4);
 }
 
 function a5(_ref6) {
@@ -45,8 +45,8 @@ function a5(_ref6) {
       ba1
     }
   } = _ref6,
-      ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, _exclude5),
-      c3 = babelHelpers.objectWithoutProperties(_ref6, _exclude6);
+      ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, _excluded5),
+      c3 = babelHelpers.objectWithoutProperties(_ref6, _excluded6);
 }
 
 function a6(_ref7) {
@@ -56,14 +56,14 @@ function a6(_ref7) {
       ba1
     }
   } = _ref7,
-      ba2 = babelHelpers.objectWithoutProperties(_ref7.b2, _exclude7);
+      ba2 = babelHelpers.objectWithoutProperties(_ref7.b2, _excluded7);
 }
 
 function a7(_ref8 = {}) {
   let {
     a1 = 1
   } = _ref8,
-      b1 = babelHelpers.objectWithoutProperties(_ref8, _exclude8);
+      b1 = babelHelpers.objectWithoutProperties(_ref8, _excluded8);
 }
 
 function a8([_ref9]) {
@@ -74,7 +74,7 @@ function a9([_ref10]) {
   let {
     a1
   } = _ref10,
-      a2 = babelHelpers.objectWithoutProperties(_ref10, _exclude9);
+      a2 = babelHelpers.objectWithoutProperties(_ref10, _excluded9);
 }
 
 function a10([a1, _ref11]) {

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters/output.js
@@ -1,12 +1,12 @@
-const _temp = ["a1"],
-      _temp2 = ["a2", "b2"],
-      _temp3 = ["a5"],
-      _temp4 = ["a3"],
-      _temp5 = ["ba1"],
-      _temp6 = ["a3", "b2"],
-      _temp7 = ["ba1"],
-      _temp8 = ["a1"],
-      _temp9 = ["a1"];
+const _exclude = ["a1"],
+      _exclude2 = ["a2", "b2"],
+      _exclude3 = ["a5"],
+      _exclude4 = ["a3"],
+      _exclude5 = ["ba1"],
+      _exclude6 = ["a3", "b2"],
+      _exclude7 = ["ba1"],
+      _exclude8 = ["a1"],
+      _exclude9 = ["a1"];
 
 function a(_ref) {
   let a34 = babelHelpers.extends({}, _ref);
@@ -16,7 +16,7 @@ function a2(_ref2) {
   let {
     a1
   } = _ref2,
-      b1 = babelHelpers.objectWithoutProperties(_ref2, _temp);
+      b1 = babelHelpers.objectWithoutProperties(_ref2, _exclude);
 }
 
 function a3(_ref3) {
@@ -24,18 +24,18 @@ function a3(_ref3) {
     a2,
     b2
   } = _ref3,
-      c2 = babelHelpers.objectWithoutProperties(_ref3, _temp2);
+      c2 = babelHelpers.objectWithoutProperties(_ref3, _exclude2);
 }
 
 function a4(_ref4, _ref5) {
   let {
     a5
   } = _ref5,
-      c5 = babelHelpers.objectWithoutProperties(_ref5, _temp3);
+      c5 = babelHelpers.objectWithoutProperties(_ref5, _exclude3);
   let {
     a3
   } = _ref4,
-      c3 = babelHelpers.objectWithoutProperties(_ref4, _temp4);
+      c3 = babelHelpers.objectWithoutProperties(_ref4, _exclude4);
 }
 
 function a5(_ref6) {
@@ -45,8 +45,8 @@ function a5(_ref6) {
       ba1
     }
   } = _ref6,
-      ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, _temp5),
-      c3 = babelHelpers.objectWithoutProperties(_ref6, _temp6);
+      ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, _exclude5),
+      c3 = babelHelpers.objectWithoutProperties(_ref6, _exclude6);
 }
 
 function a6(_ref7) {
@@ -56,14 +56,14 @@ function a6(_ref7) {
       ba1
     }
   } = _ref7,
-      ba2 = babelHelpers.objectWithoutProperties(_ref7.b2, _temp7);
+      ba2 = babelHelpers.objectWithoutProperties(_ref7.b2, _exclude7);
 }
 
 function a7(_ref8 = {}) {
   let {
     a1 = 1
   } = _ref8,
-      b1 = babelHelpers.objectWithoutProperties(_ref8, _temp8);
+      b1 = babelHelpers.objectWithoutProperties(_ref8, _exclude8);
 }
 
 function a8([_ref9]) {
@@ -74,7 +74,7 @@ function a9([_ref10]) {
   let {
     a1
   } = _ref10,
-      a2 = babelHelpers.objectWithoutProperties(_ref10, _temp9);
+      a2 = babelHelpers.objectWithoutProperties(_ref10, _exclude9);
 }
 
 function a10([a1, _ref11]) {

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/output.js
@@ -1,5 +1,5 @@
-const _exclude = ["excluded", "excluded2", "used", "used2"],
-      _exclude2 = ["unused"];
+const _excluded = ["excluded", "excluded2", "used", "used2"],
+      _excluded2 = ["unused"];
 // should not remove when destructuring into existing bindings
 var _c = c2;
 ({
@@ -15,7 +15,7 @@ class Comp extends React.Component {
       used,
       used2: usedRenamed
     } = _this$props,
-          props = babelHelpers.objectWithoutPropertiesLoose(_this$props, _exclude);
+          props = babelHelpers.objectWithoutPropertiesLoose(_this$props, _excluded);
     console.log(used, usedRenamed);
     return React.createElement("input", props);
   }
@@ -23,6 +23,6 @@ class Comp extends React.Component {
 }
 
 function smth(_ref) {
-  let rest = babelHelpers.objectWithoutPropertiesLoose(_ref, _exclude2);
+  let rest = babelHelpers.objectWithoutPropertiesLoose(_ref, _excluded2);
   call(rest);
 }

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/output.js
@@ -1,3 +1,5 @@
+const _temp = ["excluded", "excluded2", "used", "used2"],
+      _temp2 = ["unused"];
 // should not remove when destructuring into existing bindings
 var _c = c2;
 ({
@@ -13,7 +15,7 @@ class Comp extends React.Component {
       used,
       used2: usedRenamed
     } = _this$props,
-          props = babelHelpers.objectWithoutPropertiesLoose(_this$props, ["excluded", "excluded2", "used", "used2"]);
+          props = babelHelpers.objectWithoutPropertiesLoose(_this$props, _temp);
     console.log(used, usedRenamed);
     return React.createElement("input", props);
   }
@@ -21,6 +23,6 @@ class Comp extends React.Component {
 }
 
 function smth(_ref) {
-  let rest = babelHelpers.objectWithoutPropertiesLoose(_ref, ["unused"]);
+  let rest = babelHelpers.objectWithoutPropertiesLoose(_ref, _temp2);
   call(rest);
 }

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/output.js
@@ -1,5 +1,5 @@
-const _temp = ["excluded", "excluded2", "used", "used2"],
-      _temp2 = ["unused"];
+const _exclude = ["excluded", "excluded2", "used", "used2"],
+      _exclude2 = ["unused"];
 // should not remove when destructuring into existing bindings
 var _c = c2;
 ({
@@ -15,7 +15,7 @@ class Comp extends React.Component {
       used,
       used2: usedRenamed
     } = _this$props,
-          props = babelHelpers.objectWithoutPropertiesLoose(_this$props, _temp);
+          props = babelHelpers.objectWithoutPropertiesLoose(_this$props, _exclude);
     console.log(used, usedRenamed);
     return React.createElement("input", props);
   }
@@ -23,6 +23,6 @@ class Comp extends React.Component {
 }
 
 function smth(_ref) {
-  let rest = babelHelpers.objectWithoutPropertiesLoose(_ref, _temp2);
+  let rest = babelHelpers.objectWithoutPropertiesLoose(_ref, _exclude2);
   call(rest);
 }

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-4904/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-4904/output.js
@@ -1,4 +1,4 @@
-const _temp = ["b"];
+const _exclude = ["b"];
 
 const _foo = foo(),
       {
@@ -21,6 +21,6 @@ const {
   let {
     b
   } = _ref,
-      c = babelHelpers.objectWithoutProperties(_ref, _temp);
+      c = babelHelpers.objectWithoutProperties(_ref, _exclude);
   console.log(b, c);
 });

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-4904/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-4904/output.js
@@ -1,4 +1,4 @@
-const _exclude = ["b"];
+const _excluded = ["b"];
 
 const _foo = foo(),
       {
@@ -21,6 +21,6 @@ const {
   let {
     b
   } = _ref,
-      c = babelHelpers.objectWithoutProperties(_ref, _exclude);
+      c = babelHelpers.objectWithoutProperties(_ref, _excluded);
   console.log(b, c);
 });

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-4904/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-4904/output.js
@@ -1,3 +1,5 @@
+const _temp = ["b"];
+
 const _foo = foo(),
       {
   s
@@ -19,6 +21,6 @@ const {
   let {
     b
   } = _ref,
-      c = babelHelpers.objectWithoutProperties(_ref, ["b"]);
+      c = babelHelpers.objectWithoutProperties(_ref, _temp);
   console.log(b, c);
 });

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-7388/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-7388/output.js
@@ -1,4 +1,4 @@
-const _temp = ["a"];
+const _exclude = ["a"];
 
 function fn0(obj0) {
   const {
@@ -8,7 +8,7 @@ function fn0(obj0) {
           const {
             a
           } = obj2,
-                rest = babelHelpers.objectWithoutProperties(obj2, _temp);
+                rest = babelHelpers.objectWithoutProperties(obj2, _exclude);
           console.log(rest);
         }
       } = obj1;

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-7388/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-7388/output.js
@@ -1,4 +1,4 @@
-const _exclude = ["a"];
+const _excluded = ["a"];
 
 function fn0(obj0) {
   const {
@@ -8,7 +8,7 @@ function fn0(obj0) {
           const {
             a
           } = obj2,
-                rest = babelHelpers.objectWithoutProperties(obj2, _exclude);
+                rest = babelHelpers.objectWithoutProperties(obj2, _excluded);
           console.log(rest);
         }
       } = obj1;

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-7388/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-7388/output.js
@@ -1,3 +1,5 @@
+const _temp = ["a"];
+
 function fn0(obj0) {
   const {
     fn1 = (obj1 = {}) => {
@@ -6,7 +8,7 @@ function fn0(obj0) {
           const {
             a
           } = obj2,
-                rest = babelHelpers.objectWithoutProperties(obj2, ["a"]);
+                rest = babelHelpers.objectWithoutProperties(obj2, _temp);
           console.log(rest);
         }
       } = obj1;

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-8323/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-8323/output.js
@@ -1,3 +1,5 @@
+const _temp = ["a", "b", "c"];
+
 const get = () => {
   fireTheMissiles();
   return 3;
@@ -8,6 +10,6 @@ const f = _ref => {
     a = get(),
     b
   } = _ref,
-      z = babelHelpers.objectWithoutPropertiesLoose(_ref, ["a", "b", "c"]);
+      z = babelHelpers.objectWithoutPropertiesLoose(_ref, _temp);
   const v = b + 3;
 };

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-8323/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-8323/output.js
@@ -1,4 +1,4 @@
-const _temp = ["a", "b", "c"];
+const _exclude = ["a", "b", "c"];
 
 const get = () => {
   fireTheMissiles();
@@ -10,6 +10,6 @@ const f = _ref => {
     a = get(),
     b
   } = _ref,
-      z = babelHelpers.objectWithoutPropertiesLoose(_ref, _temp);
+      z = babelHelpers.objectWithoutPropertiesLoose(_ref, _exclude);
   const v = b + 3;
 };

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-8323/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-8323/output.js
@@ -1,4 +1,4 @@
-const _exclude = ["a", "b", "c"];
+const _excluded = ["a", "b", "c"];
 
 const get = () => {
   fireTheMissiles();
@@ -10,6 +10,6 @@ const f = _ref => {
     a = get(),
     b
   } = _ref,
-      z = babelHelpers.objectWithoutPropertiesLoose(_ref, _exclude);
+      z = babelHelpers.objectWithoutPropertiesLoose(_ref, _excluded);
   const v = b + 3;
 };

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/output.js
@@ -1,3 +1,5 @@
+var _exclude = ["foo"];
+
 var _loop = function (foo, bar) {
   () => foo;
 
@@ -12,7 +14,7 @@ for (var _ref of {}) {
   var {
     foo
   } = _ref,
-      bar = babelHelpers.objectWithoutPropertiesLoose(_ref, ["foo"]);
+      bar = babelHelpers.objectWithoutPropertiesLoose(_ref, _exclude);
 
   _loop(foo, bar);
 }

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/output.js
@@ -1,4 +1,4 @@
-var _exclude = ["foo"];
+var _excluded = ["foo"];
 
 var _loop = function (foo, bar) {
   () => foo;
@@ -14,7 +14,7 @@ for (var _ref of {}) {
   var {
     foo
   } = _ref,
-      bar = babelHelpers.objectWithoutPropertiesLoose(_ref, _exclude);
+      bar = babelHelpers.objectWithoutPropertiesLoose(_ref, _excluded);
 
   _loop(foo, bar);
 }

--- a/packages/babel-plugin-transform-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-destructuring/src/index.js
@@ -228,6 +228,18 @@ export default declare((api, options) => {
             t.memberExpression(keyExpression, t.identifier("map")),
             [this.addHelper("toPropertyKey")],
           );
+        } else if (!t.isProgram(this.scope.block)) {
+          // Hoist definition of excluded keys, so that it's not created each time.
+          const program = this.scope.path.findParent(path => path.isProgram());
+          const id = this.scope.generateUidIdentifier("excluded");
+
+          program.scope.push({
+            id,
+            init: keyExpression,
+            kind: "const",
+          });
+
+          keyExpression = t.cloneNode(id);
         }
 
         value = t.callExpression(

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/output.js
@@ -1,3 +1,4 @@
+var _excluded = ["x"];
 var z = {};
 var _z = z,
     x = Object.assign({}, _z);
@@ -10,7 +11,7 @@ var _z3 = z,
 
 (function (_ref) {
   var x = _ref.x,
-      y = babelHelpers.objectWithoutProperties(_ref, ["x"]);
+      y = babelHelpers.objectWithoutProperties(_ref, _excluded);
 });
 
 var _o = o;

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-loose/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-loose/output.js
@@ -1,3 +1,4 @@
+const _excluded = ["x"];
 var z = {};
 var _z = z,
     x = babelHelpers.extends({}, _z);
@@ -10,7 +11,7 @@ var _z3 = z,
 
 (function (_ref) {
   let x = _ref.x,
-      y = babelHelpers.objectWithoutPropertiesLoose(_ref, ["x"]);
+      y = babelHelpers.objectWithoutPropertiesLoose(_ref, _excluded);
 });
 
 var _o = o;

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest/output.js
@@ -1,3 +1,4 @@
+var _excluded = ["x"];
 var z = {};
 var _z = z,
     x = babelHelpers.extends({}, _z);
@@ -10,7 +11,7 @@ var _z3 = z,
 
 (function (_ref) {
   var x = _ref.x,
-      y = babelHelpers.objectWithoutProperties(_ref, ["x"]);
+      y = babelHelpers.objectWithoutProperties(_ref, _excluded);
 });
 
 var _o = o;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/output.js
@@ -1,10 +1,12 @@
+const _excluded = ["text", "className", "id"];
+
 function render(_ref) {
   var _Component;
 
   let text = _ref.text,
       className = _ref.className,
       id = _ref.id,
-      props = babelHelpers.objectWithoutProperties(_ref, ["text", "className", "id"]);
+      props = babelHelpers.objectWithoutProperties(_ref, _excluded);
   // intentionally ignoring props
   return () => _Component || (_Component = <Component text={text} className={className} id={id} />);
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-spread-deopt/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-spread-deopt/output.js
@@ -1,7 +1,9 @@
+const _excluded = ["text", "className", "id"];
+
 function render(_ref) {
   let text = _ref.text,
       className = _ref.className,
       id = _ref.id,
-      props = babelHelpers.objectWithoutProperties(_ref, ["text", "className", "id"]);
+      props = babelHelpers.objectWithoutProperties(_ref, _excluded);
   return () => <Component text={text} className={className} id={id} {...props} />;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/integration/issue-12303/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/integration/issue-12303/output.mjs
@@ -1,9 +1,11 @@
+const _exclude = ["outsetArrows"];
+
 function Foo(_ref) {
   var _div;
 
   let {
     outsetArrows
   } = _ref,
-      rest = babelHelpers.objectWithoutProperties(_ref, ["outsetArrows"]);
+      rest = babelHelpers.objectWithoutProperties(_ref, _exclude);
   return useMemo(() => _div || (_div = <div outsetArrows={outsetArrows} />), [outsetArrows]);
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/integration/issue-12303/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/integration/issue-12303/output.mjs
@@ -1,4 +1,4 @@
-const _exclude = ["outsetArrows"];
+const _excluded = ["outsetArrows"];
 
 function Foo(_ref) {
   var _div;
@@ -6,6 +6,6 @@ function Foo(_ref) {
   let {
     outsetArrows
   } = _ref,
-      rest = babelHelpers.objectWithoutProperties(_ref, _exclude);
+      rest = babelHelpers.objectWithoutProperties(_ref, _excluded);
   return useMemo(() => _div || (_div = <div outsetArrows={outsetArrows} />), [outsetArrows]);
 }

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-11278/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-11278/output.js
@@ -1,7 +1,9 @@
 "use strict";
 
+var _excluded = ["a"];
+
 function F(_ref) {
   var a = _ref.a,
-      O = babelHelpers.objectWithoutProperties(_ref, ["a"]);
+      O = babelHelpers.objectWithoutProperties(_ref, _excluded);
   var b = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : O;
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

The object `...spread` operator will create a call to the `objectWithoutProperties` helper. The second argument for this helper is a list of omitted keys:

```js
const { a, b, ...rest } = foo;
```

```js
const { a, b } = foo;
const rest = babelHelpers.objectWithoutProperties(foo, ["a", "b"]);
```

When the destructuring statement for `...rest` is inside a function, it's inneficient to create the array each time.

This is a common pattern in functional components, like on React:

```js
function Component({ a, ...rest }) {}
```

```js
function Component(_arg) {
  const { a } = _arg;
  const rest = babelHelpers.objectWithoutProperties(foo, ["a", "b"]);
}
```

**Now hoisted to the module scope:**

```js
const _temp = ["a", "b"];

function Component(_arg) {
  const { a } = _arg;
  const rest = babelHelpers.objectWithoutProperties(foo, _temp);
}
```



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13384"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

