### PR TITLE
Faster checkReservedWord

### DIFF
--- a/packages/babel-parser/benchmark/many-identifiers/11-length.bench.mjs
+++ b/packages/babel-parser/benchmark/many-identifiers/11-length.bench.mjs
@@ -1,0 +1,23 @@
+import Benchmark from "benchmark";
+import baseline from "../../lib/index-main.js";
+import current from "../../lib/index.js";
+import { report } from "../util.mjs";
+
+const suite = new Benchmark.Suite();
+function createInput(length) {
+  return "abcde12345z;".repeat(length);
+}
+current.parse("a");
+function benchCases(name, implementation, options) {
+  for (const length of [64, 128, 256, 512]) {
+    const input = createInput(length);
+    suite.add(`${name} ${length} length-11 identifiers`, () => {
+      implementation.parse(input, options);
+    });
+  }
+}
+
+benchCases("baseline", baseline);
+benchCases("current", current);
+
+suite.on("cycle", report).run();

--- a/packages/babel-parser/benchmark/many-identifiers/await.mjs
+++ b/packages/babel-parser/benchmark/many-identifiers/await.mjs
@@ -1,0 +1,23 @@
+import Benchmark from "benchmark";
+import baseline from "../../lib/index-main.js";
+import current from "../../lib/index.js";
+import { report } from "../util.mjs";
+
+const suite = new Benchmark.Suite();
+function createInput(length) {
+  return "await;".repeat(length);
+}
+current.parse("a");
+function benchCases(name, implementation, options) {
+  for (const length of [64, 128, 256, 512]) {
+    const input = createInput(length);
+    suite.add(`${name} ${length} await identifier`, () => {
+      implementation.parse(input, options);
+    });
+  }
+}
+
+benchCases("baseline", baseline);
+benchCases("current", current);
+
+suite.on("cycle", report).run();

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -28,6 +28,7 @@ import {
   isStrictReservedWord,
   isStrictBindReservedWord,
   isIdentifierStart,
+  canBeReservedWord,
 } from "../util/identifier";
 import type { Pos } from "../util/location";
 import { Position } from "../util/location";
@@ -2358,13 +2359,14 @@ export default class ExpressionParser extends LValParser {
       // `class` and `function` keywords push function-type token context into this.context.
       // But there is no chance to pop the context if the keyword is consumed
       // as an identifier such as a property name.
-      const curContext = this.curContext();
-      if (
-        (type === tt._class || type === tt._function) &&
-        (curContext === ct.functionStatement ||
-          curContext === ct.functionExpression)
-      ) {
-        this.state.context.pop();
+      if (type === tt._class || type === tt._function) {
+        const curContext = this.curContext();
+        if (
+          curContext === ct.functionStatement ||
+          curContext === ct.functionExpression
+        ) {
+          this.state.context.pop();
+        }
       }
     } else {
       throw this.unexpected();
@@ -2393,12 +2395,18 @@ export default class ExpressionParser extends LValParser {
     if (word.length > 10) {
       return;
     }
-    if (this.prodParam.hasYield && word === "yield") {
-      this.raise(startLoc, Errors.YieldBindingIdentifier);
+    // Most identifiers are not reservedWord-like, they don't need special
+    // treatments afterward, which very likely ends up throwing errors
+    if (!canBeReservedWord(word)) {
       return;
     }
 
-    if (word === "await") {
+    if (word === "yield") {
+      if (this.prodParam.hasYield) {
+        this.raise(startLoc, Errors.YieldBindingIdentifier);
+        return;
+      }
+    } else if (word === "await") {
       if (this.prodParam.hasAwait) {
         this.raise(startLoc, Errors.AwaitBindingIdentifier);
         return;
@@ -2411,16 +2419,13 @@ export default class ExpressionParser extends LValParser {
           Errors.AwaitBindingIdentifier,
         );
       }
+    } else if (word === "arguments") {
+      if (this.scope.inClassAndNotInNonArrowFunction) {
+        this.raise(startLoc, Errors.ArgumentsInClass);
+        return;
+      }
     }
 
-    if (
-      this.scope.inClass &&
-      !this.scope.inNonArrowFunction &&
-      word === "arguments"
-    ) {
-      this.raise(startLoc, Errors.ArgumentsInClass);
-      return;
-    }
     if (checkKeywords && isKeyword(word)) {
       this.raise(startLoc, Errors.UnexpectedKeyword, word);
       return;

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -2389,6 +2389,10 @@ export default class ExpressionParser extends LValParser {
     checkKeywords: boolean,
     isBinding: boolean,
   ): void {
+    // All JavaScript reserved words are not longer than 10 characters.
+    if (word.length > 10) {
+      return;
+    }
     if (this.prodParam.hasYield && word === "yield") {
       this.raise(startLoc, Errors.YieldBindingIdentifier);
       return;

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -2391,7 +2391,7 @@ export default class ExpressionParser extends LValParser {
     checkKeywords: boolean,
     isBinding: boolean,
   ): void {
-    // All JavaScript reserved words are not longer than 10 characters.
+    // Every JavaScript reserved word is 10 characters or less.
     if (word.length > 10) {
       return;
     }

--- a/packages/babel-parser/src/util/identifier.js
+++ b/packages/babel-parser/src/util/identifier.js
@@ -21,3 +21,66 @@ export const keywordRelationalOperator = /^in(stanceof)?$/;
 export function isIteratorStart(current: number, next: number): boolean {
   return current === charCodes.atSign && next === charCodes.atSign;
 }
+
+// This is the comprehensive set of JavaScript reserved words
+// If a word is in this set, it could be a reserved word,
+// depending on sourceType/strictMode/binding info. In other words
+// if a word is not in this set, it is not a reserved word under
+// any circumstance.
+const reservedWordLikeSet = new Set([
+  "break",
+  "case",
+  "catch",
+  "continue",
+  "debugger",
+  "default",
+  "do",
+  "else",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "return",
+  "switch",
+  "throw",
+  "try",
+  "var",
+  "const",
+  "while",
+  "with",
+  "new",
+  "this",
+  "super",
+  "class",
+  "extends",
+  "export",
+  "import",
+  "null",
+  "true",
+  "false",
+  "in",
+  "instanceof",
+  "typeof",
+  "void",
+  "delete",
+  // strict
+  "implements",
+  "interface",
+  "let",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "static",
+  "yield",
+  // strictBind
+  "eval",
+  "arguments",
+  // reservedWorkLike
+  "enum",
+  "await",
+]);
+
+export function canBeReservedWord(word: string): boolean {
+  return reservedWordLikeSet.has(word);
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR aims for improving the performance of `checkReservedWord` in _common_ scenarios. It is based on the assumption that even words like `enum`, `protected` _could_ be a valid identifier name, such usage is rare. So in order to improve performance, we offer fast path for common names, and fallback to the slow path when it will be likely to throw an error.

This PR also improves the parse scope utility functions: They are computationally equivalent and reflect my early work on tackling this issue.

## Benchmark results
The baseline is c6bebfe653f862dc4886ace1c7777bea6c4044ca, current is this PR.

<details>
  <summary>Length-11 identifiers</summary>

```
baseline 64 length-11 identifiers: 28849 ops/sec ±1.09% (0.035ms)
baseline 128 length-11 identifiers: 14846 ops/sec ±1.06% (0.067ms)
baseline 256 length-11 identifiers: 7567 ops/sec ±0.5% (0.132ms)
baseline 512 length-11 identifiers: 3772 ops/sec ±1.01% (0.265ms)
current 64 length-11 identifiers: 30111 ops/sec ±0.38% (0.033ms)
current 128 length-11 identifiers: 15391 ops/sec ±0.58% (0.065ms)
current 256 length-11 identifiers: 7544 ops/sec ±2.2% (0.133ms)
current 512 length-11 identifiers: 3883 ops/sec ±0.43% (0.258ms)
```
</details>
<details>
  <summary>Length-2 identifiers</summary>

```
baseline 64 length-2 identifiers: 30858 ops/sec ±0.94% (0.032ms)
baseline 128 length-2 identifiers: 16131 ops/sec ±0.23% (0.062ms)
baseline 256 length-2 identifiers: 8097 ops/sec ±0.16% (0.124ms)
baseline 512 length-2 identifiers: 3673 ops/sec ±2.19% (0.272ms)
baseline 1024 length-2 identifiers: 1952 ops/sec ±1.26% (0.512ms)
current 64 length-2 identifiers: 33006 ops/sec ±0.92% (0.03ms)
current 128 length-2 identifiers: 17058 ops/sec ±1% (0.059ms)
current 256 length-2 identifiers: 8522 ops/sec ±1.42% (0.117ms)
current 512 length-2 identifiers: 4301 ops/sec ±1.04% (0.232ms)
current 1024 length-2 identifiers: 2182 ops/sec ±0.26% (0.458ms)
```
</details>
<details>
  <summary>Length-1 identifiers</summary>

```
baseline 64 length-1 identifiers: 34244 ops/sec ±0.72% (0.029ms)
baseline 128 length-1 identifiers: 16767 ops/sec ±1.99% (0.06ms)
baseline 256 length-1 identifiers: 7606 ops/sec ±2.63% (0.131ms)
baseline 512 length-1 identifiers: 4467 ops/sec ±0.53% (0.224ms)
baseline 1024 length-1 identifiers: 2183 ops/sec ±1.12% (0.458ms)
current 64 length-1 identifiers: 35132 ops/sec ±1.19% (0.028ms)
current 128 length-1 identifiers: 18390 ops/sec ±0.69% (0.054ms)
current 256 length-1 identifiers: 9260 ops/sec ±0.81% (0.108ms)
current 512 length-1 identifiers: 4500 ops/sec ±1.46% (0.222ms)
current 1024 length-1 identifiers: 2304 ops/sec ±0.83% (0.434ms)
```
</details>

<details>
  <summary>await as identifier</summary>

```
baseline 64 await identifier: 26803 ops/sec ±1.36% (0.037ms)
baseline 128 await identifier: 14133 ops/sec ±0.9% (0.071ms)
baseline 256 await identifier: 7061 ops/sec ±1.09% (0.142ms)
baseline 512 await identifier: 3491 ops/sec ±2.81% (0.286ms)
current 64 await identifier: 26729 ops/sec ±0.74% (0.037ms)
current 128 await identifier: 13539 ops/sec ±1.15% (0.074ms)
current 256 await identifier: 6819 ops/sec ±1.2% (0.147ms)
current 512 await identifier: 3470 ops/sec ±0.49% (0.288ms)
```

As is expected, current is slower than the baseline when parsing valid `await` as identifier, because of the extra code path.
</details>



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13386"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

