### PR TITLE
Add back `index.js` to `@babel/eslint-parser`

### DIFF
--- a/eslint/babel-eslint-parser/src/index.js
+++ b/eslint/babel-eslint-parser/src/index.js
@@ -1,0 +1,7 @@
+// This file is needed for backward compat, since previous versions
+// of @babel/eslint-parser has an index.js entry point
+
+// TODO: Remove in Babel 8
+
+// eslint-disable-next-line no-restricted-globals
+module.exports = require("./index.cjs");

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import { createRequire } from "module";
 import { parseForESLint } from "../lib/index.cjs";
 
+const require = createRequire(import.meta.url);
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const BABEL_OPTIONS = {
@@ -78,8 +79,6 @@ describe("Babel and Espree", () => {
   }
 
   beforeAll(() => {
-    const require = createRequire(import.meta.url);
-
     // Use the version of Espree that is a dependency of
     // the version of ESLint we are testing against.
     const espreePath = require.resolve("espree", {
@@ -630,4 +629,14 @@ describe("Babel and Espree", () => {
       `);
     });
   });
+});
+
+describe("regressions", () => {
+  (process.env.BABEL_8_BREAKING ? it.skip : it)(
+    "has a ./lib/index.js entry point",
+    () => {
+      expect(() => require("../lib")).not.toThrow();
+      expect(() => require("../lib/index.js")).not.toThrow();
+    },
+  );
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/discussions/13391
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I don't understand why, but it seems like ESLint sometimes expects the file to be named `index.js`. I'm adding back that file for backward compatiblity.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13397"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

