### PR TITLE
fix generate-helpers failing in URL-encoded path

### DIFF
--- a/packages/babel-helpers/scripts/generate-helpers.js
+++ b/packages/babel-helpers/scripts/generate-helpers.js
@@ -1,6 +1,6 @@
 import fs from "fs";
 import { join } from "path";
-import { URL } from "url";
+import { URL, fileURLToPath } from "url";
 
 const HELPERS_FOLDER = new URL("../src/helpers", import.meta.url);
 const IGNORED_FILES = new Set(["package.json"]);
@@ -23,7 +23,7 @@ import template from "@babel/template";
     const varName = isValidId ? helperName : `_${helperName}`;
 
     const fileContents = await fs.promises.readFile(
-      join(HELPERS_FOLDER.pathname, file),
+      join(fileURLToPath(HELPERS_FOLDER), file),
       "utf8"
     );
     const { minVersion } = fileContents.match(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | ø
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | ø
| Documentation PR Link    | n/a
| Any Dependency Changes?  | ø
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`make build` fails if your working tree is inside a directory with some non-ASCII characters along the path (or spaces, or certain reserved characters, like `%` or `#`). Example output:
```
...
[19:50:34] Generating @babel/helpers runtime helpers
loading /home/foss%E2%9D%A4/nodejs/babel/packages/babel-helpers/src/helpers jsx.js
[19:50:34] 'generate-runtime-helpers' errored after 357 ms
[19:50:34] Error: ENOENT: no such file or directory, open '/home/foss%E2%9D%A4/nodejs/babel/packages/babel-helpers/src/helpers/jsx.js'
[19:50:34] 'build' errored after 360 ms
make: *** [Makefile:27: build-bundle] Error 1
```

This PR decodes the URL-encoded pathname before passing it to `readFile`.
I don't know how I would write a test for this, because the bug doesn't manifest unless you have the repository checked out under a path containing spaces, for example.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13404"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

