### PR TITLE
Back parser state `exportedIdentifiers` by set

### DIFF
--- a/packages/babel-parser/benchmark/many-named-export/1-length.bench.mjs
+++ b/packages/babel-parser/benchmark/many-named-export/1-length.bench.mjs
@@ -1,0 +1,34 @@
+import Benchmark from "benchmark";
+import baseline from "@babel-baseline/parser";
+import current from "../../lib/index.js";
+import { report } from "../util.mjs";
+
+const suite = new Benchmark.Suite();
+// All codepoints in [0x4e00, 0x9ffc] are valid identifier name per Unicode 13
+function createInput(length) {
+  if (length > 0x9ffc - 0x4e00) {
+    throw new Error(
+      `Length greater than ${
+        0x9ffc - 0x4e00
+      } is not supported! Consider modify the \`createInput\`.`
+    );
+  }
+  let source = "export { ";
+  for (let i = 0; i < length; i++) {
+    source += String.fromCharCode(0x4e00 + i) + ",";
+  }
+  return source + " } from './foo'";
+}
+function benchCases(name, implementation, options) {
+  for (const length of [256, 512, 1024, 2048]) {
+    const input = createInput(length);
+    suite.add(`${name} ${length} length-1 named export`, () => {
+      implementation.parse(input, options);
+    });
+  }
+}
+
+benchCases("baseline", baseline, { sourceType: "module" });
+benchCases("current", current, { sourceType: "module" });
+
+suite.on("cycle", report).run();

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -33,7 +33,7 @@
     "node": ">=6.0.0"
   },
   "devDependencies": {
-    "@babel-baseline/parser": "npm:@babel/parser@^7.14.0",
+    "@babel-baseline/parser": "npm:@babel/parser@^7.14.4",
     "@babel/code-frame": "workspace:*",
     "@babel/helper-fixtures": "workspace:*",
     "@babel/helper-validator-identifier": "workspace:*",

--- a/packages/babel-parser/src/parser/base.js
+++ b/packages/babel-parser/src/parser/base.js
@@ -18,6 +18,9 @@ export default class BaseParser {
   declare expressionScope: ExpressionScopeHandler;
   declare plugins: PluginsMap;
   declare filename: ?string;
+  // Names of exports store. `default` is stored as a name for both
+  // `export default foo;` and `export { foo as default };`.
+  declare exportedIdentifiers: Set<string>;
   sawUnambiguousESM: boolean = false;
   ambiguousScriptDifferentAst: boolean = false;
 

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -2114,7 +2114,7 @@ export default class StatementParser extends ExpressionParser {
       | N.ExportDefaultSpecifier,
     name: string,
   ): void {
-    if (this.state.exportedIdentifiers.indexOf(name) > -1) {
+    if (this.exportedIdentifiers.has(name)) {
       this.raise(
         node.start,
         name === "default"
@@ -2123,7 +2123,7 @@ export default class StatementParser extends ExpressionParser {
         name,
       );
     }
-    this.state.exportedIdentifiers.push(name);
+    this.exportedIdentifiers.add(name);
   }
 
   // Parses a comma-separated list of module exports.

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -349,8 +349,8 @@ export default class UtilParser extends Tokenizer {
     const oldLabels = this.state.labels;
     this.state.labels = [];
 
-    const oldExportedIdentifiers = this.state.exportedIdentifiers;
-    this.state.exportedIdentifiers = [];
+    const oldExportedIdentifiers = this.exportedIdentifiers;
+    this.exportedIdentifiers = new Set();
 
     // initialize scopes
     const oldInModule = this.inModule;
@@ -372,7 +372,7 @@ export default class UtilParser extends Tokenizer {
     return () => {
       // Revert state
       this.state.labels = oldLabels;
-      this.state.exportedIdentifiers = oldExportedIdentifiers;
+      this.exportedIdentifiers = oldExportedIdentifiers;
 
       // Revert scopes
       this.inModule = oldInModule;

--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -148,10 +148,6 @@ export default class State {
   // after a non-directive is parsed
   strictErrors: Map<number, ErrorTemplate> = new Map();
 
-  // Names of exports store. `default` is stored as a name for both
-  // `export default foo;` and `export { foo as default };`.
-  exportedIdentifiers: Array<string> = [];
-
   // Tokens length in token store
   tokensLength: number = 0;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,12 +5,12 @@ __metadata:
   version: 4
   cacheKey: 7
 
-"@babel-baseline/parser@npm:@babel/parser@^7.14.0, npm-babel-parser@npm:@babel/parser@^7.14.0":
-  version: 7.14.0
-  resolution: "@babel/parser@npm:7.14.0"
+"@babel-baseline/parser@npm:@babel/parser@^7.14.4":
+  version: 7.14.4
+  resolution: "@babel/parser@npm:7.14.4"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: ef6165f3038b9f8761a02768ab14034f4935baf2e050a2924aa093f54e3164732bce7fee81b3c8ff3be03048091e4ea208a72b23a3715debf7fd06b79495c9e9
+  checksum: 3bc067c1ee0e0178d365e1b2988ea1a0d6d37af37870ea1a7e80729b3bdc40acda083cac44ce72f63a5b31a489e35120f617bd41f312dec4c86cf814cff8e64a
   languageName: node
   linkType: hard
 
@@ -963,7 +963,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/parser@workspace:packages/babel-parser"
   dependencies:
-    "@babel-baseline/parser": "npm:@babel/parser@^7.14.0"
+    "@babel-baseline/parser": "npm:@babel/parser@^7.14.4"
     "@babel/code-frame": "workspace:*"
     "@babel/helper-fixtures": "workspace:*"
     "@babel/helper-validator-identifier": "workspace:*"
@@ -11638,6 +11638,15 @@ fsevents@^1.2.7:
   dependencies:
     once: ^1.3.2
   checksum: c3130e565f3ac4b8d3b6b329d2f8a8391c844a7c8718bc4747b77d1b431fa5259be92d8e88ba1dd0f79963539146dae735f46d48540e079367a917a9adad7488
+  languageName: node
+  linkType: hard
+
+"npm-babel-parser@npm:@babel/parser@^7.14.0":
+  version: 7.14.0
+  resolution: "@babel/parser@npm:7.14.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: ef6165f3038b9f8761a02768ab14034f4935baf2e050a2924aa093f54e3164732bce7fee81b3c8ff3be03048091e4ea208a72b23a3715debf7fd06b79495c9e9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Parsing named exports costs O(n^2) time
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR changes the data structure of `exportedIdentifiers` to a set to avoid O(n^2) time when checking duplicate exports. This PR also moves `exportedIdentifiers` to the root state so it won't be cloned in `state.clone`.

Benchmark result:
<details>
  <summary>Length-1 named exports</summary>

```
$ node --predictable ./many-named-export/1-length.bench.mjs

baseline 256 length-1 named export: 2060 ops/sec ±20.93% (0.485ms)
baseline 512 length-1 named export: 875 ops/sec ±1.16% (1.143ms)
baseline 1024 length-1 named export: 273 ops/sec ±1.3% (3.669ms)
baseline 2048 length-1 named export: 73.69 ops/sec ±2.17% (14ms)

current 256 length-1 named export: 2862 ops/sec ±34.06% (0.349ms)
current 512 length-1 named export: 1747 ops/sec ±1.39% (0.572ms)
current 1024 length-1 named export: 814 ops/sec ±0.63% (1.228ms)
current 2048 length-1 named export: 392 ops/sec ±0.45% (2.549ms)
```
</details>

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13406"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

