### PR TITLE
[Babel 8] Remove `optional` field from `MemberExpression`

### DIFF
--- a/packages/babel-plugin-proposal-partial-application/src/index.js
+++ b/packages/babel-plugin-proposal-partial-application/src/index.js
@@ -99,8 +99,6 @@ export default declare(api => {
               t.memberExpression(
                 t.cloneNode(receiverLVal),
                 node.callee.property,
-                false,
-                false,
               ),
             ),
             ...argsInitializers,
@@ -114,8 +112,6 @@ export default declare(api => {
                       t.memberExpression(
                         t.cloneNode(functionLVal),
                         t.identifier("call"),
-                        false,
-                        false,
                       ),
                       [t.cloneNode(receiverLVal), ...args],
                     ),

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -641,7 +641,12 @@ defineType("LogicalExpression", {
 });
 
 defineType("MemberExpression", {
-  builder: ["object", "property", "computed", "optional"],
+  builder: [
+    "object",
+    "property",
+    "computed",
+    ...(!process.env.BABEL_TYPES_8_BREAKING ? ["optional"] : []),
+  ],
   visitor: ["object", "property"],
   aliases: ["Expression", "LVal"],
   fields: {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | behind flag
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

The validation is already removed behind the flag, but the field should also be removed from the builder then. 

It was added in #5813 before the optional-chaining was moved into its own AST node in #7288

I noticed this in v7 because I tried to compare AST nodes generated from the parser `foo.bar` to a manual generated node `types.memberExpression(types.identifier("foo"), types.identifier("bar"))` and they did not match, because the builder always adds the `optional` field (set to null).

edit: Ok need to figure out the test problems first.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13407"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

