### PR TITLE
Prepare for compiling Babel to native ESM

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -54,7 +54,7 @@ module.exports = {
         "guard-for-in": "error",
         "import/extensions": ["error", { json: "always", cjs: "always" }],
       },
-      globals: { PACKAGE_JSON: "readonly" },
+      globals: { PACKAGE_JSON: "readonly", USE_ESM: "readonly" },
     },
     {
       files: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,30 @@ jobs:
       - name: Upload coverage report
         uses: codecov/codecov-action@v1
 
+  test-esm:
+    name: Test ESM version
+    needs: prepare-yarn-cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Use Node.js latest
+        uses: actions/setup-node@v3
+        with:
+          node-version: "*"
+          cache: "yarn"
+      - name: Use ESM and build
+        run: make use-esm
+        env:
+          USE_ESM: true
+      - name: Test
+        # Hack: --color has supports-color@5 returned true for GitHub CI
+        # Remove once `chalk` is bumped to 4.0.
+        run: yarn jest --ci --color
+        env:
+          BABEL_ENV: test
+          USE_ESM: true
+
   build:
     name: Build Babel Artifacts
     needs: prepare-yarn-cache

--- a/.github/workflows/e2e-tests-esm.yml
+++ b/.github/workflows/e2e-tests-esm.yml
@@ -1,0 +1,82 @@
+name: E2E tests (esm)
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-publish:
+    name: Publish to local Verdaccio registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Use Node.js latest
+        uses: actions/setup-node@v3
+        with:
+          node-version: "*"
+          cache: "yarn"
+      - name: Use ESM
+        run: make use-esm
+      - name: Publish
+        run: ./scripts/integration-tests/publish-local.sh
+        env:
+          USE_ESM: true
+      - uses: actions/upload-artifact@v3
+        with:
+          name: verdaccio-workspace
+          path: /tmp/verdaccio-workspace
+
+  e2e-tests:
+    name: Test
+    needs: e2e-publish
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - create-react-app
+    steps:
+      - name: Get yarn1 cache directory path
+        id: yarn1-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Use Node.js latest
+        uses: actions/setup-node@v3
+        with:
+          node-version: "*"
+      - name: Get yarn3 cache directory path
+        id: yarn3-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - name: Use yarn1 cache
+        uses: actions/cache@v3
+        id: yarn1-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn1-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn1-e2e-breaking-${{ matrix.project }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn1-e2e-breaking-${{ matrix.project }}-
+      - name: Use yarn3 cache
+        uses: actions/cache@v3
+        id: yarn3-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn3-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn3-e2e-breaking-${{ matrix.project }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn3-e2e-breaking-${{ matrix.project }}-
+      - name: Clean babel cache
+        run: |
+          rm -rf ${{ steps.yarn1-cache-dir-path.outputs.dir }}/*babel*
+          rm -rf ${{ steps.yarn3-cache-dir-path.outputs.dir }}/*babel*
+      - uses: actions/download-artifact@v3
+        with:
+          name: verdaccio-workspace
+          path: /tmp/verdaccio-workspace
+      - name: Test
+        run: ./scripts/integration-tests/e2e-${{ matrix.project }}.sh
+        env:
+          USE_ESM: true

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ packages/babel-standalone/babel.min.js
 
 /test/runtime-integration/*/output.js
 /test/runtime-integration/*/absolute-output.js
+
+.module-type

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,8 @@ make use-cjs
 
 Note that they need to recompile the whole monorepo, so please make sure to stop any running `make watch` process before running them.
 
+If you never run a `make use-*` (or if you delete the `.module-type` file that they generate), our build process defaults to CJS.
+
 ### Running linting/tests
 
 #### Lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,19 @@ If you wish to build a copy of Babel for distribution, then run:
 $ make build-dist
 ```
 
+## Develop compiling to CommonJS or to ECMAScript modules
+
+Babel can currently be compiled both to CJS and to ESM. You can toggle between those two
+modes by running one of the following commands:
+```sh
+make use-esm
+```
+```sh
+make use-cjs
+```
+
+Note that they need to recompile the whole monorepo, so please make sure to stop any running `make watch` process before running them.
+
 ### Running linting/tests
 
 #### Lint
@@ -121,16 +134,17 @@ $ TEST_ONLY=babel-cli make test
   <summary>More options</summary>
   <code>TEST_ONLY</code> will also match substrings of the package name:
 
-  ```sh
-  # Run tests for the @babel/plugin-transform-classes package.
-  $ TEST_ONLY=babel-plugin-transform-classes make test
-  ```
+```sh
+# Run tests for the @babel/plugin-transform-classes package.
+$ TEST_ONLY=babel-plugin-transform-classes make test
+```
 
-  Or you can use Yarn: 
+Or you can use Yarn:
 
-  ```sh
-  $ yarn jest babel-cli
-  ```
+```sh
+$ yarn jest babel-cli
+```
+
 </details>
 <br>
 
@@ -145,16 +159,19 @@ $ TEST_GREP=transformation make test
 Substitute spaces for hyphens and forward slashes when targeting specific test names:
 
 For example, for the following path:
+
 ```sh
 packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/destructuring-parameters
 ```
 
 You can use:
+
 ```sh
 $ TEST_GREP="arrow functions destructuring parameters" make test
 ```
 
 Or you can directly use Yarn:
+
 ```sh
 $ yarn jest -t "arrow functions destructuring parameters"
 ```

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -596,7 +596,11 @@ ${fs.readFileSync(path.join(path.dirname(input), "license"), "utf8")}*/
 
 gulp.task("build-cjs-bundles", () => {
   if (!USE_ESM) {
-    fancyLog(chalk.yellow("Skipping CJS-compat bundles for ESM-based builds, because not compiling to ESM"));
+    fancyLog(
+      chalk.yellow(
+        "Skipping CJS-compat bundles for ESM-based builds, because not compiling to ESM"
+      )
+    );
     return Promise.resolve();
   }
   return Promise.all(

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -596,7 +596,7 @@ ${fs.readFileSync(path.join(path.dirname(input), "license"), "utf8")}*/
 
 gulp.task("build-cjs-bundles", () => {
   if (!USE_ESM) {
-    fancyLog(chalk.yellow("Skipping CJS bundles because not compiling to ESM"));
+    fancyLog(chalk.yellow("Skipping CJS-compat bundles for ESM-based builds, because not compiling to ESM"));
     return Promise.resolve();
   }
   return Promise.all(

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -25,6 +25,14 @@ import { resolve as importMetaResolve } from "import-meta-resolve";
 import rollupBabelSource from "./scripts/rollup-plugin-babel-source.js";
 import formatCode from "./scripts/utils/formatCode.js";
 
+let USE_ESM = false;
+try {
+  const type = fs
+    .readFileSync(new URL(".module-type", import.meta.url), "utf-8")
+    .trim();
+  USE_ESM = type === "module";
+} catch {}
+
 const require = createRequire(import.meta.url);
 const monorepoRoot = path.dirname(fileURLToPath(import.meta.url));
 
@@ -480,9 +488,14 @@ const libBundles = [
   "packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression",
 ].map(src => ({
   src,
-  format: "cjs",
+  format: USE_ESM ? "esm" : "cjs",
   dest: "lib",
 }));
+
+const cjsBundles = [
+  // This is used by Prettier, @babel/register and @babel/eslint-parser
+  { src: "packages/babel-parser" },
+];
 
 const dtsBundles = ["packages/babel-types"];
 
@@ -581,6 +594,41 @@ ${fs.readFileSync(path.join(path.dirname(input), "license"), "utf8")}*/
   );
 });
 
+gulp.task("build-cjs-bundles", () => {
+  if (!USE_ESM) {
+    fancyLog(chalk.yellow("Skipping CJS bundles because not compiling to ESM"));
+    return Promise.resolve();
+  }
+  return Promise.all(
+    cjsBundles.map(async ({ src, external = [] }) => {
+      const input = `./${src}/lib/index.js`;
+      const output = `./${src}/lib/index.cjs`;
+
+      const bundle = await rollup({
+        input,
+        external,
+        onwarn(warning, warn) {
+          if (warning.code === "CIRCULAR_DEPENDENCY") return;
+          warn(warning);
+        },
+        plugins: [
+          rollupCommonJs({ defaultIsModuleExports: true }),
+          rollupNodeResolve({
+            extensions: [".js", ".mjs", ".cjs", ".json"],
+            preferBuiltins: true,
+          }),
+        ],
+      });
+
+      await bundle.write({
+        file: output,
+        format: "cjs",
+        sourcemap: false,
+      });
+    })
+  );
+});
+
 gulp.task(
   "build",
   gulp.series(
@@ -590,7 +638,7 @@ gulp.task(
     // rebuild @babel/types and @babel/helpers since
     // type-helpers and generated helpers may be changed
     "build-babel",
-    "generate-standalone"
+    gulp.parallel("generate-standalone", "build-cjs-bundles")
   )
 );
 
@@ -612,7 +660,8 @@ gulp.task(
       gulp.series(
         "generate-type-helpers",
         // rebuild @babel/types since type-helpers may be changed
-        "build-no-bundle"
+        "build-no-bundle",
+        "build-cjs-bundles"
       )
     )
   )
@@ -631,5 +680,11 @@ gulp.task(
       "./packages/babel-helpers/src/helpers/*.js",
       gulp.task("generate-runtime-helpers")
     );
+    if (USE_ESM) {
+      gulp.watch(
+        cjsBundles.map(({ src }) => `./${src}/lib/**.js`),
+        gulp.task("build-cjs-bundles")
+      );
+    }
   })
 );

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ifneq ("$(BABEL_COVERAGE)", "true")
 endif
 
 build-bundle: clean clean-lib
-	$(NODE) ./scripts/set-module-type.js
+	./scripts/set-module-type.js
 	$(YARN) gulp build
 	$(MAKE) build-flow-typings
 	$(MAKE) build-dist
@@ -35,7 +35,7 @@ build-no-bundle-ci: bootstrap-only
 	$(MAKE) build-dist
 
 build-no-bundle: clean clean-lib
-	$(NODE) ./scripts/set-module-type.js
+	./scripts/set-module-type.js
 	BABEL_ENV=development $(YARN) gulp build-dev
 	$(MAKE) build-flow-typings
 	$(MAKE) build-dist

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ YARN := yarn
 NODE := $(YARN) node
 
 
-.PHONY: build build-dist watch lint fix clean test-clean test-only test test-ci publish bootstrap
+.PHONY: build build-dist watch lint fix clean test-clean test-only test test-ci publish bootstrap use-esm use-cjs
 
 build: build-no-bundle
 ifneq ("$(BABEL_COVERAGE)", "true")
@@ -24,6 +24,7 @@ ifneq ("$(BABEL_COVERAGE)", "true")
 endif
 
 build-bundle: clean clean-lib
+	$(NODE) ./scripts/set-module-type.js
 	$(YARN) gulp build
 	$(MAKE) build-flow-typings
 	$(MAKE) build-dist
@@ -34,6 +35,7 @@ build-no-bundle-ci: bootstrap-only
 	$(MAKE) build-dist
 
 build-no-bundle: clean clean-lib
+	$(NODE) ./scripts/set-module-type.js
 	BABEL_ENV=development $(YARN) gulp build-dev
 	$(MAKE) build-flow-typings
 	$(MAKE) build-dist
@@ -186,6 +188,7 @@ prepublish:
 	$(MAKE) bootstrap-only
 	$(MAKE) prepublish-build
 	IS_PUBLISH=true $(MAKE) test
+	./scripts/set-module-type.js clean
 
 new-version-checklist:
 	# @echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
@@ -221,6 +224,7 @@ ifneq ("$(I_AM_USING_VERDACCIO)", "I_AM_SURE")
 endif
 	$(YARN) release-tool version $(VERSION) --all --yes --tag-version-prefix="version-e2e-test-"
 	$(MAKE) prepublish-build
+	./scripts/set-module-type.js clean
 	YARN_NPM_PUBLISH_REGISTRY=http://localhost:4873 $(YARN) release-tool publish --yes --tag-version-prefix="version-e2e-test-"
 	$(MAKE) clean
 
@@ -229,6 +233,14 @@ bootstrap-only: clean-all
 
 bootstrap: bootstrap-only
 	$(MAKE) generate-tsconfig build
+
+use-cjs:
+	./scripts/set-module-type.js script
+	$(MAKE) bootstrap
+
+use-esm:
+	./scripts/set-module-type.js module
+	$(MAKE) bootstrap
 
 clean-lib:
 	$(foreach source, $(SOURCES), \

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ifneq ("$(BABEL_COVERAGE)", "true")
 endif
 
 build-bundle: clean clean-lib
-	./scripts/set-module-type.js
+	node ./scripts/set-module-type.js
 	$(YARN) gulp build
 	$(MAKE) build-flow-typings
 	$(MAKE) build-dist
@@ -35,7 +35,7 @@ build-no-bundle-ci: bootstrap-only
 	$(MAKE) build-dist
 
 build-no-bundle: clean clean-lib
-	./scripts/set-module-type.js
+	node ./scripts/set-module-type.js
 	BABEL_ENV=development $(YARN) gulp build-dev
 	$(MAKE) build-flow-typings
 	$(MAKE) build-dist
@@ -188,7 +188,7 @@ prepublish:
 	$(MAKE) bootstrap-only
 	$(MAKE) prepublish-build
 	IS_PUBLISH=true $(MAKE) test
-	./scripts/set-module-type.js clean
+	node ./scripts/set-module-type.js clean
 
 new-version-checklist:
 	# @echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
@@ -224,7 +224,7 @@ ifneq ("$(I_AM_USING_VERDACCIO)", "I_AM_SURE")
 endif
 	$(YARN) release-tool version $(VERSION) --all --yes --tag-version-prefix="version-e2e-test-"
 	$(MAKE) prepublish-build
-	./scripts/set-module-type.js clean
+	node ./scripts/set-module-type.js clean
 	YARN_NPM_PUBLISH_REGISTRY=http://localhost:4873 $(YARN) release-tool publish --yes --tag-version-prefix="version-e2e-test-"
 	$(MAKE) clean
 
@@ -235,11 +235,11 @@ bootstrap: bootstrap-only
 	$(MAKE) generate-tsconfig build
 
 use-cjs:
-	./scripts/set-module-type.js script
+	node ./scripts/set-module-type.js script
 	$(MAKE) bootstrap
 
 use-esm:
-	./scripts/set-module-type.js module
+	node ./scripts/set-module-type.js module
 	$(MAKE) bootstrap
 
 clean-lib:

--- a/babel.config.js
+++ b/babel.config.js
@@ -11,6 +11,14 @@ function normalize(src) {
 module.exports = function (api) {
   const env = api.env();
 
+  const outputType = api.cache.invalidate(() => {
+    try {
+      return fs.readFileSync(__dirname + "/.module-type", "utf-8").trim();
+    } catch (_) {
+      return "script";
+    }
+  });
+
   const sources = ["packages/*/src", "codemods/*/src", "eslint/*/src"];
 
   const includeCoverage = process.env.BABEL_COVERAGE === "true";
@@ -54,7 +62,8 @@ module.exports = function (api) {
   };
 
   let targets = {};
-  let convertESM = true;
+  let convertESM = outputType === "script";
+  let addImportExtension = !convertESM;
   let ignoreLib = true;
   let includeRegeneratorRuntime = false;
   let needsPolyfillsForOldNode = false;
@@ -84,6 +93,7 @@ module.exports = function (api) {
     case "standalone":
       includeRegeneratorRuntime = true;
       convertESM = false;
+      addImportExtension = false;
       ignoreLib = false;
       // rollup-commonjs will converts node_modules to ESM
       unambiguousSources.push(
@@ -95,6 +105,7 @@ module.exports = function (api) {
       break;
     case "rollup":
       convertESM = false;
+      addImportExtension = false;
       ignoreLib = false;
       // rollup-commonjs will converts node_modules to ESM
       unambiguousSources.push(
@@ -216,7 +227,10 @@ module.exports = function (api) {
       {
         test: sources.map(normalize),
         assumptions: sourceAssumptions,
-        plugins: [transformNamedBabelTypesImportToDestructuring],
+        plugins: [
+          transformNamedBabelTypesImportToDestructuring,
+          addImportExtension ? pluginAddImportExtension : null,
+        ].filter(Boolean),
       },
       convertESM && {
         test: lazyRequireSources.map(normalize),
@@ -653,6 +667,56 @@ function pluginImportMetaUrl({ types: t, template }) {
             }
           },
         });
+      },
+    },
+  };
+}
+
+function pluginAddImportExtension() {
+  return {
+    visitor: {
+      "ImportDeclaration|ExportDeclaration"({ node }) {
+        const { source } = node;
+        if (!source) return;
+
+        if (source.value.startsWith(".") && !/\.[a-z]+$/.test(source.value)) {
+          const dir = pathUtils.dirname(this.filename);
+
+          try {
+            const pkg = JSON.parse(
+              fs.readFileSync(
+                pathUtils.join(dir, `${source.value}/package.json`)
+              ),
+              "utf8"
+            );
+
+            if (pkg.main) source.value = pathUtils.join(source.value, pkg.main);
+          } catch (_) {}
+
+          try {
+            if (fs.statSync(pathUtils.join(dir, source.value)).isFile()) return;
+          } catch (_) {}
+
+          for (const [src, lib = src] of [["ts", "js"], ["js"], ["cjs"]]) {
+            try {
+              fs.statSync(pathUtils.join(dir, `${source.value}.${src}`));
+              source.value += `.${lib}`;
+              return;
+            } catch (_) {}
+          }
+
+          source.value += "/index.js";
+        }
+        if (
+          source.value.startsWith("lodash/") ||
+          source.value.startsWith("core-js-compat/") ||
+          source.value === "babel-plugin-dynamic-import-node/utils"
+        ) {
+          source.value += ".js";
+        }
+        if (source.value.startsWith("@babel/preset-modules/")) {
+          source.value += "/index.js";
+        }
       },
     },
   };

--- a/constraints.pro
+++ b/constraints.pro
@@ -81,8 +81,9 @@ gen_enforced_field(WorkspaceCwd, 'exports', '{ ".": "./lib/index.js", "./package
   % Exclude packages with more complex `exports`
   workspace_ident(WorkspaceCwd, WorkspaceIdent),
   WorkspaceIdent \= '@babel/compat-data',
-  WorkspaceIdent \= '@babel/plugin-transform-react-jsx', % TODO: Remove in Babel 8
   WorkspaceIdent \= '@babel/helper-plugin-test-runner', % TODO: Remove in Babel 8
+  WorkspaceIdent \= '@babel/parser',
+  WorkspaceIdent \= '@babel/plugin-transform-react-jsx', % TODO: Remove in Babel 8
   WorkspaceIdent \= '@babel/standalone',
   \+ atom_concat('@babel/eslint-', _, WorkspaceIdent),
   \+ atom_concat('@babel/runtime', _, WorkspaceIdent).

--- a/eslint/babel-eslint-parser/src/client.cjs
+++ b/eslint/babel-eslint-parser/src/client.cjs
@@ -90,7 +90,7 @@ exports.WorkerClient = class WorkerClient extends Client {
   }
 };
 
-if (!process.env.BABEL_8_BREAKING) {
+if (!USE_ESM) {
   exports.LocalClient = class LocalClient extends Client {
     static #handleMessage;
 

--- a/eslint/babel-eslint-parser/src/index.cjs
+++ b/eslint/babel-eslint-parser/src/index.cjs
@@ -3,9 +3,7 @@ const analyzeScope = require("./analyze-scope.cjs");
 const baseParse = require("./parse.cjs");
 
 const { LocalClient, WorkerClient } = require("./client.cjs");
-const client = new (
-  process.env.BABEL_8_BREAKING ? WorkerClient : LocalClient
-)();
+const client = new (USE_ESM ? WorkerClient : LocalClient)();
 
 exports.parse = function (code, options = {}) {
   return baseParse(code, normalizeESLintConfig(options), client);

--- a/eslint/babel-eslint-parser/src/worker/babel-core.cjs
+++ b/eslint/babel-eslint-parser/src/worker/babel-core.cjs
@@ -10,8 +10,8 @@ function initialize(babel) {
   exports.createConfigItem = babel.createConfigItem;
 }
 
-if (process.env.BABEL_8_BREAKING) {
-  exports.init = import("@babel/core").then(ns => initialize(ns.default));
+if (USE_ESM) {
+  exports.init = import("@babel/core").then(initialize);
 } else {
   initialize(require("@babel/core"));
 }

--- a/eslint/babel-eslint-parser/src/worker/handle-message.cjs
+++ b/eslint/babel-eslint-parser/src/worker/handle-message.cjs
@@ -24,7 +24,7 @@ module.exports = function handleMessage(action, payload) {
         maybeParse(payload.code, options),
       );
     case "MAYBE_PARSE_SYNC":
-      if (!process.env.BABEL_8_BREAKING) {
+      if (!USE_ESM) {
         return maybeParse(
           payload.code,
           normalizeBabelParseConfigSync(payload.options),

--- a/eslint/babel-eslint-tests/test/integration/config-files.js
+++ b/eslint/babel-eslint-tests/test/integration/config-files.js
@@ -1,11 +1,22 @@
 import eslint from "eslint";
 import path from "path";
 import { fileURLToPath } from "url";
+import fs from "fs";
+
+let USE_ESM = false;
+try {
+  const type = fs
+    .readFileSync(new URL("../../../../.module-type", import.meta.url), "utf-8")
+    .trim();
+  USE_ESM = type === "module";
+} catch {}
 
 describe("Babel config files", () => {
-  const babel8 = process.env.BABEL_8_BREAKING ? it : it.skip;
+  const itESM = USE_ESM ? it : it.skip;
+  const itNode12upNoESM =
+    USE_ESM || parseInt(process.versions.node) < 12 ? it.skip : it;
 
-  babel8("works with babel.config.mjs", () => {
+  itESM("works with babel.config.mjs", () => {
     const engine = new eslint.CLIEngine({ ignore: false });
     expect(
       engine.executeOnFiles([
@@ -17,12 +28,7 @@ describe("Babel config files", () => {
     ).toMatchObject({ errorCount: 0 });
   });
 
-  const babel7node12 =
-    process.env.BABEL_8_BREAKING || parseInt(process.versions.node) < 12
-      ? it.skip
-      : it;
-
-  babel7node12("experimental worker works with babel.config.mjs", () => {
+  itNode12upNoESM("experimental worker works with babel.config.mjs", () => {
     const engine = new eslint.CLIEngine({ ignore: false });
     expect(
       engine.executeOnFiles([

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const semver = require("semver");
 const nodeVersion = process.versions.node;
 const supportsESMAndJestLightRunner = semver.satisfies(
@@ -7,6 +8,12 @@ const supportsESMAndJestLightRunner = semver.satisfies(
   "^12.22 || ^13.7 || >=14.17"
 );
 const isPublishBundle = process.env.IS_PUBLISH;
+
+let LIB_USE_ESM = false;
+try {
+  const type = fs.readFileSync(`${__dirname}/.module-type`, "utf-8").trim();
+  LIB_USE_ESM = type === "module";
+} catch (_) {}
 
 module.exports = {
   runner: supportsESMAndJestLightRunner ? "jest-light-runner" : "jest-runner",
@@ -36,6 +43,9 @@ module.exports = {
     // Some tests require internal files of bundled packages, which are not available
     // in production builds. They are marked using the .skip-bundled.js extension.
     ...(isPublishBundle ? ["\\.skip-bundled\\.js$"] : []),
+    ...(LIB_USE_ESM
+      ? ["/babel-node/", "/babel-register/", "/babel-helpers/"]
+      : []),
   ],
   testEnvironment: "node",
   transformIgnorePatterns: [

--- a/packages/babel-core/cjs-proxy.cjs
+++ b/packages/babel-core/cjs-proxy.cjs
@@ -1,0 +1,29 @@
+"use strict";
+
+const babelP = import("./lib/index.js");
+
+const functionNames = [
+  "createConfigItem",
+  "loadPartialConfig",
+  "loadOptions",
+  "transform",
+  "transformFile",
+  "transformFromAst",
+  "parse",
+];
+
+for (const name of functionNames) {
+  exports[`${name}Sync`] = function () {
+    throw new Error(
+      `"${name}Sync" is not supported when loading @babel/core using require()`
+    );
+  };
+  exports[name] = function (...args) {
+    babelP.then(babel => {
+      babel[name](...args);
+    });
+  };
+  exports[`${name}Async`] = function (...args) {
+    return babelP.then(babel => babel[`${name}Async`](...args));
+  };
+}

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -84,7 +84,14 @@
     ],
     "USE_ESM": [
       {
-        "type": "module"
+        "type": "module",
+        "exports": {
+          ".": {
+            "require": "./cjs-proxy.cjs",
+            "default": "./lib/index.js"
+          },
+          "./package.json": "./package.json"
+        }
       },
       null
     ]

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -50,7 +50,7 @@
     "@babel/code-frame": "workspace:^",
     "@babel/generator": "workspace:^",
     "@babel/helper-compilation-targets": "workspace:^",
-    "@babel/helper-module-transforms": "condition:BABEL_8_BREAKING ? : workspace:^7.18.6",
+    "@babel/helper-module-transforms": "workspace:^",
     "@babel/helpers": "workspace:^",
     "@babel/parser": "workspace:^",
     "@babel/template": "workspace:^",

--- a/packages/babel-core/src/config/files/import-meta-resolve.ts
+++ b/packages/babel-core/src/config/files/import-meta-resolve.ts
@@ -6,7 +6,7 @@ const require = createRequire(import.meta.url);
 let import_;
 try {
   // Node < 13.3 doesn't support import() syntax.
-  import_ = require("./import").default;
+  import_ = require("./import.cjs");
 } catch {}
 
 // import.meta.resolve is only available in ESM, but this file is compiled to CJS.

--- a/packages/babel-core/src/config/files/import.cjs
+++ b/packages/babel-core/src/config/files/import.cjs
@@ -2,6 +2,6 @@
 // import() isn't supported, we can try/catch around the require() call
 // when loading this file.
 
-export default function import_(filepath: string) {
+module.exports = function import_(filepath: string) {
   return import(filepath);
-}
+};

--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -10,7 +10,7 @@ const require = createRequire(import.meta.url);
 let import_: ((specifier: string | URL) => any) | undefined;
 try {
   // Old Node.js versions don't support import() syntax.
-  import_ = require("./import").default;
+  import_ = require("./import.cjs");
 } catch {}
 
 export const supportsESM = semver.satisfies(

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -20,6 +20,7 @@
     "@babel/types": "workspace:^"
   },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/babel-helpers/scripts/generate-regenerator-runtime.js
+++ b/packages/babel-helpers/scripts/generate-regenerator-runtime.js
@@ -5,7 +5,7 @@ import { createRequire } from "module";
 
 const [parse, generate] = await Promise.all([
   import("@babel/parser").then(ns => ns.parse),
-  import("@babel/generator").then(ns => ns.default.default),
+  import("@babel/generator").then(ns => ns.default.default || ns.default),
 ]).catch(error =>
   Promise.reject(
     new Error(

--- a/packages/babel-parser/index.cjs
+++ b/packages/babel-parser/index.cjs
@@ -1,0 +1,5 @@
+try {
+  module.exports = require("./lib/index.cjs");
+} catch {
+  module.exports = require("./lib/index.js");
+}

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -27,7 +27,8 @@
   "files": [
     "bin",
     "lib",
-    "typings"
+    "typings",
+    "index.cjs"
   ],
   "engines": {
     "node": ">=6.0.0"
@@ -49,13 +50,23 @@
     ],
     "USE_ESM": [
       {
-        "type": "module"
+        "type": "module",
+        "exports": {
+          ".": {
+            "require": "./lib/index.cjs",
+            "default": "./lib/index.js"
+          },
+          "./package.json": "./package.json"
+        }
       },
       null
     ]
   },
   "exports": {
-    ".": "./lib/index.js",
+    ".": {
+      "require": "./index.cjs",
+      "default": "./lib/index.js"
+    },
     "./package.json": "./package.json"
   },
   "type": "commonjs"

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/exec.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/exec.js
@@ -15,7 +15,7 @@ let functionPath;
 return transformAsync(code, {
   configFile: false,
   plugins: [
-    __dirname + "/../../../../lib",
+    __dirname + "/../../../../lib/index.js",
     {
       post({ path }) {
         programPath = path;

--- a/packages/babel-preset-env/test/index.spec.js
+++ b/packages/babel-preset-env/test/index.spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/extensions
 import compatData from "@babel/compat-data/plugins";
 
-import babelPresetEnv from "../lib/index.js";
+import * as babelPresetEnv from "../lib/index.js";
 
 import _removeRegeneratorEntryPlugin from "../lib/polyfills/regenerator.js";
 import _pluginLegacyBabelPolyfill from "../lib/polyfills/babel-polyfill.js";
@@ -14,12 +14,25 @@ const pluginLegacyBabelPolyfill =
 const transformations = _transformations.default || _transformations;
 const availablePlugins = _availablePlugins.default || _availablePlugins;
 
+// We need to load the correct plugins version (ESM or CJS),
+// because our tests rely on function identity.
+let pluginCoreJS2, pluginCoreJS3, pluginRegenerator;
+import _pluginCoreJS2_esm from "babel-plugin-polyfill-corejs2";
+import _pluginCoreJS3_esm from "babel-plugin-polyfill-corejs3";
+import _pluginRegenerator_esm from "babel-plugin-polyfill-regenerator";
 import { createRequire } from "module";
-const require = createRequire(import.meta.url);
+// eslint-disable-next-line @babel/development-internal/require-default-import-fallback
+if (/* commonjs */ _transformations.default) {
+  const require = createRequire(import.meta.url);
 
-const pluginCoreJS2 = require("babel-plugin-polyfill-corejs2").default;
-const pluginCoreJS3 = require("babel-plugin-polyfill-corejs3").default;
-const pluginRegenerator = require("babel-plugin-polyfill-regenerator").default;
+  pluginCoreJS2 = require("babel-plugin-polyfill-corejs2").default;
+  pluginCoreJS3 = require("babel-plugin-polyfill-corejs3").default;
+  pluginRegenerator = require("babel-plugin-polyfill-regenerator").default;
+} else {
+  pluginCoreJS2 = _pluginCoreJS2_esm;
+  pluginCoreJS3 = _pluginCoreJS3_esm;
+  pluginRegenerator = _pluginRegenerator_esm;
+}
 
 describe("babel-preset-env", () => {
   describe("transformIncludesAndExcludes", () => {

--- a/scripts/set-module-type.js
+++ b/scripts/set-module-type.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+
+const root = rel => new URL(`../${rel}`, import.meta.url).pathname;
+
+// prettier-ignore
+let moduleType;
+if (process.argv.length >= 3) {
+  moduleType = process.argv[2];
+} else if (fs.existsSync(root(".module-type"))) {
+  moduleType = fs.readFileSync(root(".module-type"), "utf-8").trim();
+} else {
+  moduleType = "script";
+}
+
+if (moduleType === "clean") {
+  try {
+    fs.unlinkSync(root(".module-type"));
+  } catch {}
+} else if (moduleType === "module" || moduleType === "script") {
+  fs.writeFileSync(root(".module-type"), moduleType);
+} else {
+  throw new Error(`Unknown module type: ${moduleType}`);
+}
+
+["eslint", "codemods", "packages"]
+  .flatMap(dir => fs.readdirSync(root(dir)).map(file => root(`${dir}/${file}`)))
+  .filter(
+    dir =>
+      fs.statSync(dir).isDirectory() && fs.existsSync(`${dir}/package.json`)
+  )
+  .forEach(dir => {
+    if (moduleType === "clean") {
+      try {
+        fs.unlinkSync(`${dir}/lib/package.json`);
+      } catch {}
+    } else {
+      fs.mkdirSync(`${dir}/lib`, { recursive: true });
+      fs.writeFileSync(
+        `${dir}/lib/package.json`,
+        `{ "type": "${moduleType}" }`
+      );
+    }
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,6 +835,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-remap-async-to-generator@workspace:packages/babel-helper-remap-async-to-generator"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-annotate-as-pure": "workspace:^"
     "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-wrap-function": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,7 +327,7 @@ __metadata:
     "@babel/code-frame": "workspace:^"
     "@babel/generator": "workspace:^"
     "@babel/helper-compilation-targets": "workspace:^"
-    "@babel/helper-module-transforms": "condition:BABEL_8_BREAKING ? : workspace:^7.18.6"
+    "@babel/helper-module-transforms": "workspace:^"
     "@babel/helper-transform-fixture-test-runner": "workspace:^"
     "@babel/helpers": "workspace:^"
     "@babel/parser": "workspace:^"
@@ -749,30 +749,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/helper-module-transforms-BABEL_8_BREAKING-false@npm:@babel/helper-module-transforms@workspace:^7.18.6, @babel/helper-module-transforms@workspace:^, @babel/helper-module-transforms@workspace:packages/babel-helper-module-transforms":
-  version: 0.0.0-use.local
-  resolution: "@babel/helper-module-transforms@workspace:packages/babel-helper-module-transforms"
-  dependencies:
-    "@babel/helper-environment-visitor": "workspace:^"
-    "@babel/helper-module-imports": "workspace:^"
-    "@babel/helper-simple-access": "workspace:^"
-    "@babel/helper-split-export-declaration": "workspace:^"
-    "@babel/helper-validator-identifier": "workspace:^"
-    "@babel/template": "workspace:^"
-    "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
-  languageName: unknown
-  linkType: soft
-
-"@babel/helper-module-transforms@condition:BABEL_8_BREAKING ? : workspace:^7.18.6":
-  version: 0.0.0-condition-893c47
-  resolution: "@babel/helper-module-transforms@condition:BABEL_8_BREAKING?:workspace:^7.18.6#893c47"
-  dependencies:
-    "@babel/helper-module-transforms-BABEL_8_BREAKING-false": "npm:@babel/helper-module-transforms@workspace:^7.18.6"
-  checksum: 7d7ccf481c03d5ba93f2c2fd3d736c67ad544fe53dddd5175790b1b5e0de4130b70566514c073fb51ec56a2ace0fdaa9102ac3cdd0790cc5ac5321142407321c
-  languageName: node
-  linkType: hard
-
 "@babel/helper-module-transforms@npm:^7.12.1, @babel/helper-module-transforms@npm:^7.18.0":
   version: 7.18.0
   resolution: "@babel/helper-module-transforms@npm:7.18.0"
@@ -788,6 +764,21 @@ __metadata:
   checksum: 824c3967c08d75bb36adc18c31dcafebcd495b75b723e2e17c6185e88daf5c6db62a6a75d9f791b5f38618a349e7cb32503e715a1b9a4e8bad4d0f43e3e6b523
   languageName: node
   linkType: hard
+
+"@babel/helper-module-transforms@workspace:^, @babel/helper-module-transforms@workspace:packages/babel-helper-module-transforms":
+  version: 0.0.0-use.local
+  resolution: "@babel/helper-module-transforms@workspace:packages/babel-helper-module-transforms"
+  dependencies:
+    "@babel/helper-environment-visitor": "workspace:^"
+    "@babel/helper-module-imports": "workspace:^"
+    "@babel/helper-simple-access": "workspace:^"
+    "@babel/helper-split-export-declaration": "workspace:^"
+    "@babel/helper-validator-identifier": "workspace:^"
+    "@babel/template": "workspace:^"
+    "@babel/traverse": "workspace:^"
+    "@babel/types": "workspace:^"
+  languageName: unknown
+  linkType: soft
 
 "@babel/helper-optimise-call-expression@npm:^7.16.7":
   version: 7.16.7


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/11701
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Having a dual "compiled to CJS"-"compiled to ESM" codebase is not as easy as having a dual "Babel 7"-"Babel 8" codebase, because it must be determined at compile time and cannot rely on a potentially-runtime flag. This PR adds two new commands, `make use-esm` and `make use-cjs`, to toggle between the two modes: the current mode is stored in the `.module-type` file, and it affects both the output type and the compile-time removal of a new `USE_ESM` flag.

This PR also adds two new GitHub action tests: a "Test ESM" CI job that runs `yarn jest` on the ESM build, and an ESM e2e test (only with React Native, which is the only one working so far) to make sure that the publishing process works.

The ESM migration is not finished yet, but I have updated the "To Do" column in https://github.com/babel/babel/projects/16 to track the next steps that I'll do. This PR can be merged, and I suggest reviewing it commit-by-commit since I tried to keep them as much self-contained as possible.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13414"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

