### PR TITLE
Makefile: invoke yarn consistently via $(YARN)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ endif
 	$(MAKE) clean
 
 bootstrap-only: clean-all
-	yarn install
+	$(YARN) install
 
 bootstrap: bootstrap-only
 	$(MAKE) generate-tsconfig build


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | ø
| Patch: Bug Fix?          | not really
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | none
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Replaces one forgotten invocation of `yarn` not using the variable `$(YARN)` like all other places in the Makefile.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13415"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

