### PR TITLE
parser: Fix Hack/smart-pipe error positions

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1278,7 +1278,7 @@ export default class ExpressionParser extends LValParser {
     if (pipeProposal) {
       // A pipe-operator proposal is active.
 
-      const tokenType = this.state.type;
+      const { type: tokenType, start } = this.state;
 
       if (this.testTopicReferenceConfiguration(pipeProposal, tokenType)) {
         // The token matches the plugin’s configuration.
@@ -1309,10 +1309,10 @@ export default class ExpressionParser extends LValParser {
           // it is outside of a pipe body.
           // Raise recoverable errors.
           if (pipeProposal === "smart") {
-            this.raise(this.state.start, Errors.PrimaryTopicNotAllowed);
+            this.raise(start, Errors.PrimaryTopicNotAllowed);
           } else {
             // In this case, `pipeProposal === "hack"` is true.
-            this.raise(this.state.start, Errors.PipeTopicUnbound);
+            this.raise(start, Errors.PipeTopicUnbound);
           }
         }
 
@@ -1320,7 +1320,7 @@ export default class ExpressionParser extends LValParser {
       } else {
         // The token does not match the plugin’s configuration.
         throw this.raise(
-          this.state.start,
+          start,
           Errors.PipeTopicUnconfiguredToken,
           tokenType.label,
         );

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-hash-proposal-unbound-topic/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-hash-proposal-unbound-topic/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":5,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":5}},
   "errors": [
-    "SyntaxError: Topic reference is unbound; it must be inside a pipe body. (1:5)"
+    "SyntaxError: Topic reference is unbound; it must be inside a pipe body. (1:4)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-class-expression-with-decorators/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-class-expression-with-decorators/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":130,"loc":{"start":{"line":1,"column":0},"end":{"line":9,"column":2}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (6:15)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (6:13)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (1:9)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-class-expression-with-private-property/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-class-expression-with-private-property/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":94,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":3}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (5:13)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (5:11)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (1:9)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-class-expression-without-private-property/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-class-expression-without-private-property/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":45,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":45}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:40)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:39)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (1:5)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-do-while-loop-and-topic-in-loop-body/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-do-while-loop-and-topic-in-loop-body/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":42,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":42}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:23)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:22)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (1:9)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-for-await-of-loop-and-topic-in-loop-body/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-for-await-of-loop-and-topic-in-loop-body/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":77,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (2:49)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (2:48)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (2:11)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-for-classic-loop-and-topic-in-loop-body/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-for-classic-loop-and-topic-in-loop-body/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":49,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":49}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:46)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:45)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (1:9)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-for-in-loop-and-topic-in-loop-body/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-for-in-loop-and-topic-in-loop-body/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":36}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:33)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:32)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (1:9)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-for-of-loop-and-topic-in-loop-body/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-for-of-loop-and-topic-in-loop-body/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":38,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":38}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:35)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:34)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (1:9)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-try-catch-finally-statements-and-topic-in-catch-clause/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-try-catch-finally-statements-and-topic-in-catch-clause/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":78,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (3:33)"
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (3:32)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-while-loop-topic-in-loop-body/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-while-loop-topic-in-loop-body/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":38,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":38}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:35)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:34)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (1:9)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-with-block-topic-in-body/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-do-transform-with-block-topic-in-body/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":28,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":28}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:25)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:24)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (1:9)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-function-definition-with-another-pipe-in-function-body/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-function-definition-with-another-pipe-in-function-body/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":27,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":27}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:21)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:19)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (1:5)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-function-definition-with-topic-in-function-body/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-function-definition-with-topic-in-function-body/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":22,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":22}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:21)",
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:19)",
     "SyntaxError: Pipeline is in topic style but does not use topic reference. (1:5)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-unbound-topic/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-unbound-topic/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":5,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":5}},
   "errors": [
-    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:5)"
+    "SyntaxError: Topic reference was used in a lexical context without topic binding. (1:4)"
   ],
   "program": {
     "type": "Program",


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | None
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | babel/website#2541
| Any Dependency Changes?  | No
| License                  | MIT

This pull request is for the Hack-pipes proposal (and the deprecated smart-mix pipes proposal). It is a continuation of #13191. It fixes errors raised for invalid topic references, such that the errors point to the topic tokens themselves, rather than immediately after them.

(This therefore also reverts a breaking change to smart-mix pipe error positions made in #13191 that I had not noticed before, in which the positions of such errors were inadvertently incremented by one.)

I made this pull request separately from #13416 because it is a relatively minor change that nevertheless changes several test fixtures that are unrelated to #13416. It should probably be merged before #13416.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13426"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

