### PR TITLE
Move Yarn validation CI checks to a separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
     needs: prepare-yarn-cache
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Use Node.js latest
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: "*"
       - name: 'Check for unmet constraints (fix w/ "yarn constraints --fix")'
         run: |
           yarn constraints

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,18 @@ jobs:
           key: yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             yarn-
+      - name: 'Check or update Yarn cache (fix w/ "yarn install")'
+        env:
+          YARN_ENABLE_SCRIPTS: false # disable post-install scripts
+          YARN_NODE_LINKER: pnp # use pnp linker for better linking performance: it's meant to update yarn cache only
+        run: |
+          yarn install --immutable --skip-builds
+
+  yarn-validate:
+    name: Validate Yarn dependencies and constraints
+    needs: prepare-yarn-cache
+    runs-on: ubuntu-latest
+    steps:
       - name: 'Check for unmet constraints (fix w/ "yarn constraints --fix")'
         run: |
           yarn constraints
@@ -30,12 +42,6 @@ jobs:
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: |
           yarn dedupe --check
-      - name: 'Check or update Yarn cache (fix w/ "yarn install")'
-        env:
-          YARN_ENABLE_SCRIPTS: false # disable post-install scripts
-          YARN_NODE_LINKER: pnp # use pnp linker for better linking performance: it's meant to update yarn cache only
-        run: |
-          yarn install --immutable --skip-builds
       - name: Check for dependency cycles
         run: |
           yarn release-tool check-cycles


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

It's annoying that whenever someone forgets to run `yarn dedupe` CI doesn't run any test.
Moving the Yarn checks to a separate jobs lets the test to run even if `yarn dedupe`, `yarn constraints` or `yarn release-tool check-cycles` fails.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13443"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

