### PR TITLE
Simplify token context

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -19,7 +19,6 @@
 // [opp]: http://en.wikipedia.org/wiki/Operator-precedence_parser
 
 import { types as tt, type TokenType } from "../tokenizer/types";
-import { types as ct } from "../tokenizer/context";
 import * as N from "../types";
 import LValParser from "./lval";
 import {
@@ -2338,19 +2337,6 @@ export default class ExpressionParser extends LValParser {
       name = this.state.value;
     } else if (type.keyword) {
       name = type.keyword;
-
-      // `class` and `function` keywords push function-type token context into this.context.
-      // But there is no chance to pop the context if the keyword is consumed
-      // as an identifier such as a property name.
-      if (type === tt._class || type === tt._function) {
-        const curContext = this.curContext();
-        if (
-          curContext === ct.functionStatement ||
-          curContext === ct.functionExpression
-        ) {
-          this.state.context.pop();
-        }
-      }
     } else {
       throw this.unexpected();
     }

--- a/packages/babel-parser/src/plugins/flow/index.js
+++ b/packages/babel-parser/src/plugins/flow/index.js
@@ -2849,9 +2849,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         // by parsing `jsxTagStart` to stop the JSX plugin from
         // messing with the tokens
         const { context } = this.state;
-        if (context[context.length - 1] === tc.j_oTag) {
+        const curContext = context[context.length - 1];
+        if (curContext === tc.j_oTag) {
           context.length -= 2;
-        } else if (context[context.length - 1] === tc.j_expr) {
+        } else if (curContext === tc.j_expr) {
           context.length -= 1;
         }
       }

--- a/packages/babel-parser/src/plugins/jsx/index.js
+++ b/packages/babel-parser/src/plugins/jsx/index.js
@@ -616,15 +616,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     updateContext(prevType: TokenType): void {
       super.updateContext(prevType);
       const { context, type } = this.state;
-      if (type === tt.braceL) {
-        const curContext = context[context.length - 1];
-        if (curContext === tc.j_oTag) {
-          context.push(tc.brace);
-        } else if (curContext === tc.j_expr) {
-          context.push(tc.templateQuasi);
-        }
-        this.state.exprAllowed = true;
-      } else if (type === tt.slash && prevType === tt.jsxTagStart) {
+      if (type === tt.slash && prevType === tt.jsxTagStart) {
         context.length -= 2; // do not consider JSX expr -> JSX open tag -> ... anymore
         context.push(tc.j_cTag); // reconsider as closing tag context
         this.state.exprAllowed = false;

--- a/packages/babel-parser/src/plugins/jsx/index.js
+++ b/packages/babel-parser/src/plugins/jsx/index.js
@@ -55,8 +55,10 @@ tt.jsxTagStart = new TokenType("jsxTagStart", { startsExpr: true });
 tt.jsxTagEnd = new TokenType("jsxTagEnd");
 
 tt.jsxTagStart.updateContext = context => {
-  context.push(tc.j_expr); // treat as beginning of JSX expression
-  context.push(tc.j_oTag); // start opening tag context
+  context.push(
+    tc.j_expr, // treat as beginning of JSX expression
+    tc.j_oTag, // start opening tag context
+  );
 };
 
 function isFragment(object: ?N.JSXElement): boolean {
@@ -617,8 +619,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       super.updateContext(prevType);
       const { context, type } = this.state;
       if (type === tt.slash && prevType === tt.jsxTagStart) {
-        context.length -= 2; // do not consider JSX expr -> JSX open tag -> ... anymore
-        context.push(tc.j_cTag); // reconsider as closing tag context
+        // do not consider JSX expr -> JSX open tag -> ... anymore
+        // reconsider as closing tag context
+        context.splice(-2, 2, tc.j_cTag);
         this.state.exprAllowed = false;
       } else if (type === tt.jsxTagEnd) {
         const out = context.pop();

--- a/packages/babel-parser/src/tokenizer/context.js
+++ b/packages/babel-parser/src/tokenizer/context.js
@@ -1,8 +1,7 @@
 // @flow
 
-// The token context is used to track whether `}` matches
-// a template quasi `${` or other tokens containing `{`:
-// namely tt.braceL `{` and tt.braceHashL `#{`
+// The token context is used to track whether the apostrophe "`"
+// starts or ends a string template
 
 import { types as tt } from "./types";
 
@@ -20,7 +19,6 @@ export const types: {
   [key: string]: TokContext,
 } = {
   brace: new TokContext("{"),
-  templateQuasi: new TokContext("${"),
   template: new TokContext("`", true),
 };
 
@@ -35,19 +33,22 @@ export const types: {
 // `this.prodParam` still has `[Yield]` production because it is not yet updated
 
 tt.braceR.updateContext = context => {
-  if (context.length > 1) {
-    context.pop();
-  }
+  context.pop();
 };
 
 // we don't need to update context for tt.braceBarL because we do not pop context for tt.braceBarR
-tt.braceL.updateContext = tt.braceHashL.updateContext = context => {
-  context.push(types.brace);
-};
-
-tt.dollarBraceL.updateContext = context => {
-  context.push(types.templateQuasi);
-};
+// ideally only dollarBraceL "${" needs a non-template context
+// in order to indicate that the last "`" in `${`" starts a new string template
+// inside a template element within outer string template.
+// but when we popped such context in `}`, we lost track of whether this
+// `}` matches a `${` or other tokens matching `}`, so we have to push
+// such context in every token that `}` will match.
+tt.braceL.updateContext =
+  tt.braceHashL.updateContext =
+  tt.dollarBraceL.updateContext =
+    context => {
+      context.push(types.brace);
+    };
 
 tt.backQuote.updateContext = context => {
   if (context[context.length - 1] === types.template) {

--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -127,10 +127,10 @@ export default class State {
   lastTokStart: number = 0;
   lastTokEnd: number = 0;
 
-  // The context stack is used to superficially track syntactic
-  // context to predict whether a regular expression is allowed in a
-  // given position.
+  // The context stack is used to track whether the apostrophe "`" starts
+  // or ends a string template
   context: Array<TokContext> = [ct.brace];
+  // Used to track whether a JSX element is allowed to form
   exprAllowed: boolean = true;
 
   // Used to signal to callers of `readWord1` whether the word


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR continues efforts on #13431. When I am working on https://github.com/babel/babel/pull/13449 I realize that `tc.brace` and `tc.templateQuasi` are unifiable, they were separated before when we have `braceIsBlock` logic on `tc.brace` but not the other. Now that parsing RegExp no longer depends on `state.exprAllowed` and `braceIsBlock` is removed, we can further simplify the token context by unifying these two contexts into one context.

The other commits are cleanup and micro-optimizations.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13450"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

