### PR TITLE
Faster readRegexp

### DIFF
--- a/packages/babel-parser/benchmark/large-regexp/bench.mjs
+++ b/packages/babel-parser/benchmark/large-regexp/bench.mjs
@@ -1,0 +1,22 @@
+import Benchmark from "benchmark";
+import baseline from "@babel-baseline/parser";
+import current from "../../lib/index.js";
+import { report } from "../util.mjs";
+
+const suite = new Benchmark.Suite();
+function createInput(length) {
+  return "const a = /" + "[/\\\\]".repeat(length / 4) + "/igsudm";
+}
+function benchCases(name, implementation, options) {
+  for (const length of [256, 512, 1024, 2048]) {
+    const input = createInput(length);
+    suite.add(`${name} ${length}-size RegExp literal `, () => {
+      implementation.parse(input, options);
+    });
+  }
+}
+
+benchCases("baseline", baseline);
+benchCases("current", current);
+
+suite.on("cycle", report).run();

--- a/packages/babel-parser/benchmark/many-small-all-flags-regexp/bench.mjs
+++ b/packages/babel-parser/benchmark/many-small-all-flags-regexp/bench.mjs
@@ -1,0 +1,22 @@
+import Benchmark from "benchmark";
+import baseline from "../../lib/index-v2.js";
+import current from "../../lib/index.js";
+import { report } from "../util.mjs";
+
+const suite = new Benchmark.Suite();
+function createInput(length) {
+  return "/x/dgimsuy;".repeat(length);
+}
+function benchCases(name, implementation, options) {
+  for (const length of [256, 512, 1024, 2048]) {
+    const input = createInput(length);
+    suite.add(`${name} ${length} small regexp literal with all flags`, () => {
+      implementation.parse(input, options);
+    });
+  }
+}
+
+benchCases("baseline", baseline);
+benchCases("current", current);
+
+suite.on("cycle", report).run();

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -33,7 +33,7 @@
     "node": ">=6.0.0"
   },
   "devDependencies": {
-    "@babel-baseline/parser": "npm:@babel/parser@^7.14.4",
+    "@babel-baseline/parser": "npm:@babel/parser@^7.14.5",
     "@babel/code-frame": "workspace:*",
     "@babel/helper-fixtures": "workspace:*",
     "@babel/helper-validator-identifier": "workspace:*",

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -975,11 +975,12 @@ export default class Tokenizer extends ParserErrors {
   readRegexp(): void {
     const start = this.state.start + 1;
     let escaped, inClass;
-    for (;;) {
-      if (this.state.pos >= this.length) {
+    let { pos } = this.state;
+    for (; ; ++pos) {
+      if (pos >= this.length) {
         throw this.raise(start, Errors.UnterminatedRegExp);
       }
-      const ch = this.input.charCodeAt(this.state.pos);
+      const ch = this.input.charCodeAt(pos);
       if (isNewLine(ch)) {
         throw this.raise(start, Errors.UnterminatedRegExp);
       }
@@ -995,33 +996,33 @@ export default class Tokenizer extends ParserErrors {
         }
         escaped = ch === charCodes.backslash;
       }
-      ++this.state.pos;
     }
-    const content = this.input.slice(start, this.state.pos);
-    ++this.state.pos;
+    const content = this.input.slice(start, pos);
+    ++pos;
 
     let mods = "";
 
-    while (this.state.pos < this.length) {
-      const char = this.input[this.state.pos];
-      const charCode = this.codePointAtPos(this.state.pos);
+    while (pos < this.length) {
+      const char = this.input[pos];
+      const charCode = this.codePointAtPos(pos);
 
       if (VALID_REGEX_FLAGS.has(char)) {
         if (mods.indexOf(char) > -1) {
-          this.raise(this.state.pos + 1, Errors.DuplicateRegExpFlags);
+          this.raise(pos + 1, Errors.DuplicateRegExpFlags);
         }
       } else if (
         isIdentifierChar(charCode) ||
         charCode === charCodes.backslash
       ) {
-        this.raise(this.state.pos + 1, Errors.MalformedRegExpFlags);
+        this.raise(pos + 1, Errors.MalformedRegExpFlags);
       } else {
         break;
       }
 
-      ++this.state.pos;
+      ++pos;
       mods += char;
     }
+    this.state.pos = pos;
 
     this.finishToken(tt.regexp, {
       pattern: content,

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -20,7 +20,15 @@ import {
 import State from "./state";
 import type { LookaheadState } from "./state";
 
-const VALID_REGEX_FLAGS = new Set(["g", "m", "s", "i", "y", "u", "d"]);
+const VALID_REGEX_FLAGS = new Set([
+  charCodes.lowercaseG,
+  charCodes.lowercaseM,
+  charCodes.lowercaseS,
+  charCodes.lowercaseI,
+  charCodes.lowercaseY,
+  charCodes.lowercaseU,
+  charCodes.lowercaseD,
+]);
 
 // The following character codes are forbidden from being
 // an immediate sibling of NumericLiteralSeparator _
@@ -1003,17 +1011,15 @@ export default class Tokenizer extends ParserErrors {
     let mods = "";
 
     while (pos < this.length) {
-      const char = this.input[pos];
-      const charCode = this.codePointAtPos(pos);
+      const cp = this.codePointAtPos(pos);
+      // It doesn't matter if cp > 0xffff, the loop will either throw or break because we check on cp
+      const char = String.fromCharCode(cp);
 
-      if (VALID_REGEX_FLAGS.has(char)) {
-        if (mods.indexOf(char) > -1) {
+      if (VALID_REGEX_FLAGS.has(cp)) {
+        if (mods.includes(char)) {
           this.raise(pos + 1, Errors.DuplicateRegExpFlags);
         }
-      } else if (
-        isIdentifierChar(charCode) ||
-        charCode === charCodes.backslash
-      ) {
+      } else if (isIdentifierChar(cp) || cp === charCodes.backslash) {
         this.raise(pos + 1, Errors.MalformedRegExpFlags);
       } else {
         break;

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -12,7 +12,6 @@ import { type TokContext, types as ct } from "./context";
 import ParserErrors, { Errors, type ErrorTemplate } from "../parser/error";
 import { SourceLocation } from "../util/location";
 import {
-  lineBreak,
   lineBreakG,
   isNewLine,
   isWhitespace,
@@ -980,21 +979,21 @@ export default class Tokenizer extends ParserErrors {
       if (this.state.pos >= this.length) {
         throw this.raise(start, Errors.UnterminatedRegExp);
       }
-      const ch = this.input.charAt(this.state.pos);
-      if (lineBreak.test(ch)) {
+      const ch = this.input.charCodeAt(this.state.pos);
+      if (isNewLine(ch)) {
         throw this.raise(start, Errors.UnterminatedRegExp);
       }
       if (escaped) {
         escaped = false;
       } else {
-        if (ch === "[") {
+        if (ch === charCodes.leftSquareBracket) {
           inClass = true;
-        } else if (ch === "]" && inClass) {
+        } else if (ch === charCodes.rightSquareBracket && inClass) {
           inClass = false;
-        } else if (ch === "/" && !inClass) {
+        } else if (ch === charCodes.slash && !inClass) {
           break;
         }
-        escaped = ch === "\\";
+        escaped = ch === charCodes.backslash;
       }
       ++this.state.pos;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,12 +5,12 @@ __metadata:
   version: 4
   cacheKey: 7
 
-"@babel-baseline/parser@npm:@babel/parser@^7.14.4":
-  version: 7.14.4
-  resolution: "@babel/parser@npm:7.14.4"
+"@babel-baseline/parser@npm:@babel/parser@^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/parser@npm:7.14.5"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 3bc067c1ee0e0178d365e1b2988ea1a0d6d37af37870ea1a7e80729b3bdc40acda083cac44ce72f63a5b31a489e35120f617bd41f312dec4c86cf814cff8e64a
+  checksum: 55c14793888cb7d54275811e7f13136875df1ee4fc368f3f10cff46ebdf95b6a072e706a0486be0ac5686a597cbfb82f33b5f66aa6ba80ff50b73bca945035c6
   languageName: node
   linkType: hard
 
@@ -658,6 +658,7 @@ __metadata:
   resolution: "@babel/helper-module-transforms@condition:BABEL_8_BREAKING?:workspace:^7.14.5#2510a1"
   dependencies:
     "@babel/helper-module-transforms-BABEL_8_BREAKING-false": "npm:@babel/helper-module-transforms@workspace:^7.14.5"
+  checksum: eb4895913562bf398b8bf7e6c68a0380f153f52f2715b3685f9d07e376725227678c2f920dfe0772012dfed655e037534619de86bb9f3284b92555f8bf9d0f42
   languageName: node
   linkType: hard
 
@@ -972,7 +973,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/parser@workspace:packages/babel-parser"
   dependencies:
-    "@babel-baseline/parser": "npm:@babel/parser@^7.14.4"
+    "@babel-baseline/parser": "npm:@babel/parser@^7.14.5"
     "@babel/code-frame": "workspace:*"
     "@babel/helper-fixtures": "workspace:*"
     "@babel/helper-validator-identifier": "workspace:*"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Scanning Regexp is now 200% faster for large regexp, 15% faster for a small regexp with all available flags.

The following improvements are implemented:
1) avoid single-byte string comparison
2) avoid codepoint => string conversion by replacing `charAt` to `charCodeAt`
3) avoid update `pos` to parser state until we have to
4) avoid reading string twice (String#charCodeAt, String#charAt).

For benchmark results, please check commit messages below.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13453"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

