### PR TITLE
Setup Renovate to update third-party parser tests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,50 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "dependencyDashboardApproval": true,
-  "labels": ["PR: Dependency ⬆️", "repo automation 🤖" ],
+  "labels": ["PR: Dependency ⬆️", "repo automation 🤖"],
   "postUpdateOptions": ["yarnDedupeHighest"],
+  "regexManagers": [
+    {
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": ["TEST262_COMMIT = (?<currentDigest>.*)\\n"],
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "tests-test262",
+      "lookupNameTemplate": "https://github.com/tc39/test262.git",
+      "currentValueTemplate": "main"
+    },
+    {
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": ["FLOW_COMMIT = (?<currentDigest>.*)\\n"],
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "tests-flow",
+      "lookupNameTemplate": "https://github.com/facebook/flow.git",
+      "currentValueTemplate": "master"
+    },
+    {
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": ["TYPESCRIPT_COMMIT = (?<currentDigest>.*)\\n"],
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "tests-typescript",
+      "lookupNameTemplate": "https://github.com/Microsoft/TypeScript.git",
+      "currentValueTemplate": "main"
+    },
+    {
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": ["COMPAT_TABLE_COMMIT=(?<currentDigest>.*)\\n"],
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "compat-table",
+      "lookupNameTemplate": "https://github.com/kangax/compat-table.git",
+      "currentValueTemplate": "gh-pages"
+    }
+  ],
   "packageRules": [
     {
       "matchDepTypes": ["dependencies", "devDependencies"],
       "rangeStrategy": "replace",
-      "ignoreDeps": ["@babel/core-7.12", "@babel/helper-validator-identifier-baseline"]
+      "ignoreDeps": [
+        "@babel/core-7.12",
+        "@babel/helper-validator-identifier-baseline"
+      ]
     },
     {
       "matchPackagePatterns": ["^eslint"],
@@ -22,6 +57,22 @@
     {
       "matchPackagePatterns": ["^gulp"],
       "groupName": "gulp packages"
+    },
+    {
+      "matchPackageNames": ["tests-test262", "tests-flow", "tests-typescript"],
+      "groupName": "third-party parser tests",
+      "schedule": ["before 00:05 am on Friday"],
+      "postUpgradeTasks": {
+        "commands": [
+          "yarn install --immutable --skip-builds",
+          "yarn gulp build-rollup",
+          "make test-test262-update-allowlist",
+          "make test-flow-update-allowlist",
+          "make test-typescript-update-allowlist"
+        ],
+        "fileFilters": ["scripts/parser-tests/*/allowlist.txt"],
+        "executionMode": "branch"
+      }
     }
   ]
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is based on https://github.com/renovatebot/renovate/discussions/10381#discussioncomment-855411 (thanks @rarkins!). If it works, we can avoid maintaining the custom action to udpate test262 tests.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13454"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

