### PR TITLE
fix: remove traverse trap on `NODE_ENV == "test"`

### DIFF
--- a/packages/babel-traverse/src/context.ts
+++ b/packages/babel-traverse/src/context.ts
@@ -2,8 +2,6 @@ import NodePath from "./path";
 import * as t from "@babel/types";
 import type Scope from "./scope";
 
-const testing = process.env.NODE_ENV === "test";
-
 export default class TraversalContext {
   constructor(scope, opts, state, parentPath) {
     this.parentPath = parentPath;
@@ -18,7 +16,6 @@ export default class TraversalContext {
   declare opts;
   queue: Array<NodePath> | null = null;
   priorityQueue: Array<NodePath> | null = null;
-  declare trap?: boolean;
 
   /**
    * This method does a simple check to determine whether or not we really need to attempt
@@ -57,10 +54,6 @@ export default class TraversalContext {
   }
 
   maybeQueue(path, notPriority?: boolean) {
-    if (this.trap) {
-      throw new Error("Infinite cycle detected");
-    }
-
     if (this.queue) {
       if (notPriority) {
         this.queue.push(path);
@@ -119,10 +112,6 @@ export default class TraversalContext {
 
       // this path no longer belongs to the tree
       if (path.key === null) continue;
-
-      if (testing && queue.length >= 10_000) {
-        this.trap = true;
-      }
 
       // ensure we don't visit the same node twice
       const { node } = path;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Resolves #13471 
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When `NODE_ENV` is `test`, Babel assumes infinite cycle is hit when Babel has a queue length > 10000. However, transforming a big file could result to large queue as in #13471 and #12218. Overall the behaviour is inconsistent in different `NODE_ENV` settings. We should align the behaviour and do not assume 10000 is too much for traverser.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13475"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

