### PR TITLE
Add record and tuple tokens to eslint parser

### DIFF
--- a/eslint/babel-eslint-parser/src/convert/convertTokens.cjs
+++ b/eslint/babel-eslint-parser/src/convert/convertTokens.cjs
@@ -135,6 +135,12 @@ function convertToken(token, source, tl) {
     label === tl.doubleColon ||
     label === tl.hash ||
     label === tl.questionDot ||
+    label === tl.braceHashL ||
+    label === tl.braceBarL ||
+    label === tl.braceBarR ||
+    label === tl.bracketHashL ||
+    label === tl.bracketBarL ||
+    label === tl.bracketBarR ||
     type.isAssign
   ) {
     token.type = "Punctuator";

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -332,6 +332,54 @@ describe("Babel and Espree", () => {
     expect(babylonAST.tokens[1].type).toEqual("Punctuator");
   });
 
+  it("brace and bracket hash operator (token)", () => {
+    const code = "#[]; #{}";
+    const babylonAST = parseForESLint(code, {
+      eslintVisitorKeys: true,
+      eslintScopeManager: true,
+      babelOptions: {
+        filename: "test.js",
+        parserOpts: {
+          plugins: [["recordAndTuple", { syntaxType: "hash" }]],
+          tokens: true,
+        },
+      },
+    }).ast;
+    expect(babylonAST.tokens[0]).toEqual(
+      expect.objectContaining({ type: "Punctuator", value: "#[" }),
+    );
+    expect(babylonAST.tokens[3]).toEqual(
+      expect.objectContaining({ type: "Punctuator", value: "#{" }),
+    );
+  });
+
+  it("brace and bracket bar operator (token)", () => {
+    const code = "{||}; [||]";
+    const babylonAST = parseForESLint(code, {
+      eslintVisitorKeys: true,
+      eslintScopeManager: true,
+      babelOptions: {
+        filename: "test.js",
+        parserOpts: {
+          plugins: [["recordAndTuple", { syntaxType: "bar" }]],
+          tokens: true,
+        },
+      },
+    }).ast;
+    expect(babylonAST.tokens[0]).toEqual(
+      expect.objectContaining({ type: "Punctuator", value: "{|" }),
+    );
+    expect(babylonAST.tokens[1]).toEqual(
+      expect.objectContaining({ type: "Punctuator", value: "|}" }),
+    );
+    expect(babylonAST.tokens[3]).toEqual(
+      expect.objectContaining({ type: "Punctuator", value: "[|" }),
+    );
+    expect(babylonAST.tokens[4]).toEqual(
+      expect.objectContaining({ type: "Punctuator", value: "|]" }),
+    );
+  });
+
   if (process.env.BABEL_8_BREAKING) {
     it("hash (token)", () => {
       const code = "class A { #x }";


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes  #13465
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Correctly transforms the tokens in record and tuple as Punctuators (`#{`, `#[`, `{|`, `|}`, `[|` `|]`).

I went ahead with `expect.objectContaining` since I grouped some of the tests, but you prefer I can revert back to an individual comparison.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13477"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

