### PR TITLE
Fix `_step.value` access in `for await`

### DIFF
--- a/packages/babel-plugin-proposal-async-generator-functions/src/for-await.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/src/for-await.js
@@ -2,14 +2,14 @@ import { types as t, template } from "@babel/core";
 
 const buildForAwait = template(`
   async function wrapper() {
-    var ITERATOR_COMPLETION = true;
+    var ITERATOR_ABRUPT_COMPLETION = false;
     var ITERATOR_HAD_ERROR_KEY = false;
     var ITERATOR_ERROR_KEY;
     try {
       for (
         var ITERATOR_KEY = GET_ITERATOR(OBJECT), STEP_KEY;
-        !(ITERATOR_COMPLETION = (STEP_KEY = await ITERATOR_KEY.next()).done);
-        ITERATOR_COMPLETION = true
+        ITERATOR_ABRUPT_COMPLETION = !(STEP_KEY = await ITERATOR_KEY.next()).done;
+        ITERATOR_ABRUPT_COMPLETION = false
       ) {
       }
     } catch (err) {
@@ -17,7 +17,7 @@ const buildForAwait = template(`
       ITERATOR_ERROR_KEY = err;
     } finally {
       try {
-        if (!ITERATOR_COMPLETION && ITERATOR_KEY.return != null) {
+        if (ITERATOR_ABRUPT_COMPLETION && ITERATOR_KEY.return != null) {
           await ITERATOR_KEY.return();
         }
       } finally {
@@ -50,8 +50,8 @@ export default function (path, { getAsyncIterator }) {
   }
   let template = buildForAwait({
     ITERATOR_HAD_ERROR_KEY: scope.generateUidIdentifier("didIteratorError"),
-    ITERATOR_COMPLETION: scope.generateUidIdentifier(
-      "iteratorNormalCompletion",
+    ITERATOR_ABRUPT_COMPLETION: scope.generateUidIdentifier(
+      "iteratorAbruptCompletion",
     ),
     ITERATOR_ERROR_KEY: scope.generateUidIdentifier("iteratorError"),
     ITERATOR_KEY: scope.generateUidIdentifier("iterator"),

--- a/packages/babel-plugin-proposal-async-generator-functions/src/for-await.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/src/for-await.js
@@ -7,14 +7,10 @@ const buildForAwait = template(`
     var ITERATOR_ERROR_KEY;
     try {
       for (
-        var ITERATOR_KEY = GET_ITERATOR(OBJECT), STEP_KEY, STEP_VALUE;
-        (
-          STEP_KEY = await ITERATOR_KEY.next(),
-          ITERATOR_COMPLETION = STEP_KEY.done,
-          STEP_VALUE = await STEP_KEY.value,
-          !ITERATOR_COMPLETION
-        );
-        ITERATOR_COMPLETION = true) {
+        var ITERATOR_KEY = GET_ITERATOR(OBJECT), STEP_KEY;
+        !(ITERATOR_COMPLETION = (STEP_KEY = await ITERATOR_KEY.next()).done);
+        ITERATOR_COMPLETION = true
+      ) {
       }
     } catch (err) {
       ITERATOR_HAD_ERROR_KEY = true;
@@ -37,7 +33,7 @@ export default function (path, { getAsyncIterator }) {
   const { node, scope, parent } = path;
 
   const stepKey = scope.generateUidIdentifier("step");
-  const stepValue = scope.generateUidIdentifier("value");
+  const stepValue = t.memberExpression(stepKey, t.identifier("value"));
   const left = node.left;
   let declar;
 
@@ -61,8 +57,7 @@ export default function (path, { getAsyncIterator }) {
     ITERATOR_KEY: scope.generateUidIdentifier("iterator"),
     GET_ITERATOR: getAsyncIterator,
     OBJECT: node.right,
-    STEP_VALUE: t.cloneNode(stepValue),
-    STEP_KEY: stepKey,
+    STEP_KEY: t.cloneNode(stepKey),
   });
 
   // remove async function wrapper

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-arrow/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-arrow/output.js
@@ -1,12 +1,12 @@
 /*#__PURE__*/
 babelHelpers.asyncToGenerator(function* () {
-  var _iteratorNormalCompletion = true;
+  var _iteratorAbruptCompletion = false;
   var _didIteratorError = false;
 
   var _iteratorError;
 
   try {
-    for (var _iterator = babelHelpers.asyncIterator(y), _step; !(_iteratorNormalCompletion = (_step = yield _iterator.next()).done); _iteratorNormalCompletion = true) {
+    for (var _iterator = babelHelpers.asyncIterator(y), _step; _iteratorAbruptCompletion = !(_step = yield _iterator.next()).done; _iteratorAbruptCompletion = false) {
       let x = _step.value;
       f(x);
     }
@@ -15,7 +15,7 @@ babelHelpers.asyncToGenerator(function* () {
     _iteratorError = err;
   } finally {
     try {
-      if (!_iteratorNormalCompletion && _iterator.return != null) {
+      if (_iteratorAbruptCompletion && _iterator.return != null) {
         yield _iterator.return();
       }
     } finally {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-arrow/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-arrow/output.js
@@ -6,8 +6,8 @@ babelHelpers.asyncToGenerator(function* () {
   var _iteratorError;
 
   try {
-    for (var _iterator = babelHelpers.asyncIterator(y), _step, _value; _step = yield _iterator.next(), _iteratorNormalCompletion = _step.done, _value = yield _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
-      let x = _value;
+    for (var _iterator = babelHelpers.asyncIterator(y), _step; !(_iteratorNormalCompletion = (_step = yield _iterator.next()).done); _iteratorNormalCompletion = true) {
+      let x = _step.value;
       f(x);
     }
   } catch (err) {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function-no-transform/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function-no-transform/output.js
@@ -1,11 +1,11 @@
 async function foo() {
-  var _iteratorNormalCompletion = true;
+  var _iteratorAbruptCompletion = false;
   var _didIteratorError = false;
 
   var _iteratorError;
 
   try {
-    for (var _iterator = babelHelpers.asyncIterator(y), _step; !(_iteratorNormalCompletion = (_step = await _iterator.next()).done); _iteratorNormalCompletion = true) {
+    for (var _iterator = babelHelpers.asyncIterator(y), _step; _iteratorAbruptCompletion = !(_step = await _iterator.next()).done; _iteratorAbruptCompletion = false) {
       const x = _step.value;
     }
   } catch (err) {
@@ -13,7 +13,7 @@ async function foo() {
     _iteratorError = err;
   } finally {
     try {
-      if (!_iteratorNormalCompletion && _iterator.return != null) {
+      if (_iteratorAbruptCompletion && _iterator.return != null) {
         await _iterator.return();
       }
     } finally {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function-no-transform/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function-no-transform/output.js
@@ -5,8 +5,8 @@ async function foo() {
   var _iteratorError;
 
   try {
-    for (var _iterator = babelHelpers.asyncIterator(y), _step, _value; _step = await _iterator.next(), _iteratorNormalCompletion = _step.done, _value = await _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
-      const x = _value;
+    for (var _iterator = babelHelpers.asyncIterator(y), _step; !(_iteratorNormalCompletion = (_step = await _iterator.next()).done); _iteratorNormalCompletion = true) {
+      const x = _step.value;
     }
   } catch (err) {
     _didIteratorError = true;

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function/output.js
@@ -4,13 +4,13 @@ function f() {
 
 function _f() {
   _f = babelHelpers.asyncToGenerator(function* () {
-    var _iteratorNormalCompletion = true;
+    var _iteratorAbruptCompletion = false;
     var _didIteratorError = false;
 
     var _iteratorError;
 
     try {
-      for (var _iterator = babelHelpers.asyncIterator(y), _step; !(_iteratorNormalCompletion = (_step = yield _iterator.next()).done); _iteratorNormalCompletion = true) {
+      for (var _iterator = babelHelpers.asyncIterator(y), _step; _iteratorAbruptCompletion = !(_step = yield _iterator.next()).done; _iteratorAbruptCompletion = false) {
         let x = _step.value;
         g(x);
       }
@@ -19,7 +19,7 @@ function _f() {
       _iteratorError = err;
     } finally {
       try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
+        if (_iteratorAbruptCompletion && _iterator.return != null) {
           yield _iterator.return();
         }
       } finally {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function/output.js
@@ -10,8 +10,8 @@ function _f() {
     var _iteratorError;
 
     try {
-      for (var _iterator = babelHelpers.asyncIterator(y), _step, _value; _step = yield _iterator.next(), _iteratorNormalCompletion = _step.done, _value = yield _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
-        let x = _value;
+      for (var _iterator = babelHelpers.asyncIterator(y), _step; !(_iteratorNormalCompletion = (_step = yield _iterator.next()).done); _iteratorNormalCompletion = true) {
+        let x = _step.value;
         g(x);
       }
     } catch (err) {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-generator/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-generator/output.js
@@ -4,13 +4,13 @@ function g() {
 
 function _g() {
   _g = babelHelpers.wrapAsyncGenerator(function* () {
-    var _iteratorNormalCompletion = true;
+    var _iteratorAbruptCompletion = false;
     var _didIteratorError = false;
 
     var _iteratorError;
 
     try {
-      for (var _iterator = babelHelpers.asyncIterator(y), _step; !(_iteratorNormalCompletion = (_step = yield babelHelpers.awaitAsyncGenerator(_iterator.next())).done); _iteratorNormalCompletion = true) {
+      for (var _iterator = babelHelpers.asyncIterator(y), _step; _iteratorAbruptCompletion = !(_step = yield babelHelpers.awaitAsyncGenerator(_iterator.next())).done; _iteratorAbruptCompletion = false) {
         let x = _step.value;
         f(x);
       }
@@ -19,7 +19,7 @@ function _g() {
       _iteratorError = err;
     } finally {
       try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
+        if (_iteratorAbruptCompletion && _iterator.return != null) {
           yield babelHelpers.awaitAsyncGenerator(_iterator.return());
         }
       } finally {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-generator/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-generator/output.js
@@ -10,8 +10,8 @@ function _g() {
     var _iteratorError;
 
     try {
-      for (var _iterator = babelHelpers.asyncIterator(y), _step, _value; _step = yield babelHelpers.awaitAsyncGenerator(_iterator.next()), _iteratorNormalCompletion = _step.done, _value = yield babelHelpers.awaitAsyncGenerator(_step.value), !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
-        let x = _value;
+      for (var _iterator = babelHelpers.asyncIterator(y), _step; !(_iteratorNormalCompletion = (_step = yield babelHelpers.awaitAsyncGenerator(_iterator.next())).done); _iteratorNormalCompletion = true) {
+        let x = _step.value;
         f(x);
       }
     } catch (err) {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/destructuring/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/destructuring/output.js
@@ -10,11 +10,11 @@ function _f() {
     var _iteratorError;
 
     try {
-      for (var _iterator = babelHelpers.asyncIterator(a), _step, _value; _step = yield _iterator.next(), _iteratorNormalCompletion = _step.done, _value = yield _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
+      for (var _iterator = babelHelpers.asyncIterator(a), _step; !(_iteratorNormalCompletion = (_step = yield _iterator.next()).done); _iteratorNormalCompletion = true) {
         let {
           x,
           y: [z]
-        } = _value;
+        } = _step.value;
         g(x, z);
       }
     } catch (err) {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/destructuring/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/destructuring/output.js
@@ -4,13 +4,13 @@ function f() {
 
 function _f() {
   _f = babelHelpers.asyncToGenerator(function* () {
-    var _iteratorNormalCompletion = true;
+    var _iteratorAbruptCompletion = false;
     var _didIteratorError = false;
 
     var _iteratorError;
 
     try {
-      for (var _iterator = babelHelpers.asyncIterator(a), _step; !(_iteratorNormalCompletion = (_step = yield _iterator.next()).done); _iteratorNormalCompletion = true) {
+      for (var _iterator = babelHelpers.asyncIterator(a), _step; _iteratorAbruptCompletion = !(_step = yield _iterator.next()).done; _iteratorAbruptCompletion = false) {
         let {
           x,
           y: [z]
@@ -22,7 +22,7 @@ function _f() {
       _iteratorError = err;
     } finally {
       try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
+        if (_iteratorAbruptCompletion && _iterator.return != null) {
           yield _iterator.return();
         }
       } finally {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/exec.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/exec.js
@@ -1,0 +1,6 @@
+return async function () {
+  let obj = {};
+  for await (obj.x of [1, 2]);
+
+  expect(obj.x).toBe(2);
+}();

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/input.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/input.js
@@ -1,0 +1,3 @@
+(async function () {
+  for await (obj.x of y) {}
+})();

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/options.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/options.json
@@ -1,6 +1,5 @@
 {
   "parserOpts": {
     "allowReturnOutsideFunction": true
-  },
-  "plugins": ["proposal-async-generator-functions"]
+  }
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/options.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/options.json
@@ -1,0 +1,6 @@
+{
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  },
+  "plugins": ["proposal-async-generator-functions"]
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/output.js
@@ -1,11 +1,11 @@
-(async function () {
+babelHelpers.asyncToGenerator(function* () {
   var _iteratorAbruptCompletion = false;
   var _didIteratorError = false;
 
   var _iteratorError;
 
   try {
-    for (var _iterator = babelHelpers.asyncIterator(y), _step; _iteratorAbruptCompletion = !(_step = await _iterator.next()).done; _iteratorAbruptCompletion = false) {
+    for (var _iterator = babelHelpers.asyncIterator(y), _step; _iteratorAbruptCompletion = !(_step = yield _iterator.next()).done; _iteratorAbruptCompletion = false) {
       obj.x = _step.value;
     }
   } catch (err) {
@@ -14,7 +14,7 @@
   } finally {
     try {
       if (_iteratorAbruptCompletion && _iterator.return != null) {
-        await _iterator.return();
+        yield _iterator.return();
       }
     } finally {
       if (_didIteratorError) {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/output.js
@@ -1,11 +1,11 @@
 (async function () {
-  var _iteratorNormalCompletion = true;
+  var _iteratorAbruptCompletion = false;
   var _didIteratorError = false;
 
   var _iteratorError;
 
   try {
-    for (var _iterator = babelHelpers.asyncIterator(y), _step; !(_iteratorNormalCompletion = (_step = await _iterator.next()).done); _iteratorNormalCompletion = true) {
+    for (var _iterator = babelHelpers.asyncIterator(y), _step; _iteratorAbruptCompletion = !(_step = await _iterator.next()).done; _iteratorAbruptCompletion = false) {
       obj.x = _step.value;
     }
   } catch (err) {
@@ -13,7 +13,7 @@
     _iteratorError = err;
   } finally {
     try {
-      if (!_iteratorNormalCompletion && _iterator.return != null) {
+      if (_iteratorAbruptCompletion && _iterator.return != null) {
         await _iterator.return();
       }
     } finally {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/lhs-member-expression/output.js
@@ -1,0 +1,25 @@
+(async function () {
+  var _iteratorNormalCompletion = true;
+  var _didIteratorError = false;
+
+  var _iteratorError;
+
+  try {
+    for (var _iterator = babelHelpers.asyncIterator(y), _step; !(_iteratorNormalCompletion = (_step = await _iterator.next()).done); _iteratorNormalCompletion = true) {
+      obj.x = _step.value;
+    }
+  } catch (err) {
+    _didIteratorError = true;
+    _iteratorError = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion && _iterator.return != null) {
+        await _iterator.return();
+      }
+    } finally {
+      if (_didIteratorError) {
+        throw _iteratorError;
+      }
+    }
+  }
+})();

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-single-tick/exec.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-single-tick/exec.js
@@ -1,7 +1,7 @@
 let resolve;
 let promise = new Promise((r) => (resolve = r));
 let iterable = {
-  [Symbol.asyncIterator]() {
+  [Symbol.asyncIterator || "@@asyncIterator"]() {
     return {
       next: () => promise,
     };

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-single-tick/exec.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-single-tick/exec.js
@@ -1,0 +1,31 @@
+let resolve;
+let promise = new Promise((r) => (resolve = r));
+let iterable = {
+  [Symbol.asyncIterator]() {
+    return {
+      next: () => promise,
+    };
+  },
+};
+
+let values = [];
+
+return Promise.all([
+  async function () {
+    for await (let value of iterable) {
+      values.push(value);
+    }
+  }(),
+  async function () {
+    resolve({ value: 0, done: false });
+    promise = new Promise((r) => (resolve = r));
+
+    await null;
+    resolve({ value: 1, done: false });
+    promise = new Promise((r) => (resolve = r));
+
+    resolve({ value: undefined, done: true });
+  }(),
+]).then(() => {
+  expect(values).toEqual([0, 1]);
+});

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-single-tick/options.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-single-tick/options.json
@@ -1,6 +1,5 @@
 {
   "parserOpts": {
     "allowReturnOutsideFunction": true
-  },
-  "plugins": ["proposal-async-generator-functions"]
+  }
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-single-tick/options.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-single-tick/options.json
@@ -1,0 +1,6 @@
+{
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  },
+  "plugins": ["proposal-async-generator-functions"]
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-is-promise/exec.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-is-promise/exec.js
@@ -1,0 +1,22 @@
+let steps = [
+  { done: false, value: Promise.resolve(1) },
+  { done: true, value: undefined }
+];
+
+let iterable = {
+  [Symbol.asyncIterator]() {
+    return {
+      next: () => steps.shift(),
+    };
+  },
+};
+
+let values = [];
+
+return async function () {
+  let value;
+  for await (value of iterable);
+
+  expect(value).toBeInstanceOf(Promise);
+  await expect(value).resolves.toBe(1);
+}();

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-is-promise/exec.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-is-promise/exec.js
@@ -4,7 +4,7 @@ let steps = [
 ];
 
 let iterable = {
-  [Symbol.asyncIterator]() {
+  [Symbol.asyncIterator || "@@asyncIterator"]() {
     return {
       next: () => steps.shift(),
     };

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-is-promise/options.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-is-promise/options.json
@@ -1,6 +1,5 @@
 {
   "parserOpts": {
     "allowReturnOutsideFunction": true
-  },
-  "plugins": ["proposal-async-generator-functions"]
+  }
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-is-promise/options.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-is-promise/options.json
@@ -1,0 +1,6 @@
+{
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  },
+  "plugins": ["proposal-async-generator-functions"]
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-not-accessed-when-done/exec.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-not-accessed-when-done/exec.js
@@ -1,0 +1,18 @@
+let gotValue = false;
+
+let iterable = {
+  [Symbol.asyncIterator]() {
+    return {
+      next: () => Promise.resolve({
+        get value() { gotValue = true },
+        done: true
+      })
+    };
+  },
+};
+
+return async function () {
+  for await (let value of iterable) {}
+
+  expect(gotValue).toBe(false);
+}();

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-not-accessed-when-done/exec.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-not-accessed-when-done/exec.js
@@ -1,7 +1,7 @@
 let gotValue = false;
 
 let iterable = {
-  [Symbol.asyncIterator]() {
+  [Symbol.asyncIterator || "@@asyncIterator"]() {
     return {
       next: () => Promise.resolve({
         get value() { gotValue = true },

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-not-accessed-when-done/options.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-not-accessed-when-done/options.json
@@ -1,6 +1,5 @@
 {
   "parserOpts": {
     "allowReturnOutsideFunction": true
-  },
-  "plugins": ["proposal-async-generator-functions"]
+  }
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-not-accessed-when-done/options.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/step-value-not-accessed-when-done/options.json
@@ -1,0 +1,6 @@
+{
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  },
+  "plugins": ["proposal-async-generator-functions"]
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/regression/5880/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/regression/5880/output.js
@@ -1,11 +1,11 @@
 (async () => {
-  var _iteratorNormalCompletion = true;
+  var _iteratorAbruptCompletion = false;
   var _didIteratorError = false;
 
   var _iteratorError;
 
   try {
-    for (var _iterator = babelHelpers.asyncIterator(iterable), _step; !(_iteratorNormalCompletion = (_step = await _iterator.next()).done); _iteratorNormalCompletion = true) {
+    for (var _iterator = babelHelpers.asyncIterator(iterable), _step; _iteratorAbruptCompletion = !(_step = await _iterator.next()).done; _iteratorAbruptCompletion = false) {
       const _step$value = babelHelpers.slicedToArray(_step.value, 1),
             value = _step$value[0];
     }
@@ -14,7 +14,7 @@
     _iteratorError = err;
   } finally {
     try {
-      if (!_iteratorNormalCompletion && _iterator.return != null) {
+      if (_iteratorAbruptCompletion && _iterator.return != null) {
         await _iterator.return();
       }
     } finally {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/regression/5880/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/regression/5880/output.js
@@ -5,10 +5,9 @@
   var _iteratorError;
 
   try {
-    for (var _iterator = babelHelpers.asyncIterator(iterable), _step, _value; _step = await _iterator.next(), _iteratorNormalCompletion = _step.done, _value = await _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
-      const _value2 = _value,
-            _value3 = babelHelpers.slicedToArray(_value2, 1),
-            value = _value3[0];
+    for (var _iterator = babelHelpers.asyncIterator(iterable), _step; !(_iteratorNormalCompletion = (_step = await _iterator.next()).done); _iteratorNormalCompletion = true) {
+      const _step$value = babelHelpers.slicedToArray(_step.value, 1),
+            value = _step$value[0];
     }
   } catch (err) {
     _didIteratorError = true;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/13490
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The relevant spec steps are 6.d-6.f of [`14.7.5.7 ForIn/OfBodyEvaluation`](https://tc39.es/ecma262/#sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13491"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

