### PR TITLE
Add display name after create context

### DIFF
--- a/packages/babel-plugin-transform-react-display-name/src/index.js
+++ b/packages/babel-plugin-transform-react-display-name/src/index.js
@@ -91,10 +91,12 @@ function addDisplayNameAfterCreateContext(
     parentPath.insertAfter(buildDisplayNameAssignment(ref, id));
   } else {
     // (ref = React.createContext(), ref.displayName = "id", ref)
-    const ref = path.scope.generateUidIdentifier("ref");
+    const { scope } = path;
+    const ref = scope.generateUidIdentifier("ref");
+    scope.push({ id: ref });
     path.replaceWith(
       t.sequenceExpression([
-        t.assignmentExpression("=", ref, path.node),
+        t.assignmentExpression("=", t.cloneNode(ref), path.node),
         buildDisplayNameAssignment(ref, id),
         t.cloneNode(ref),
       ]),

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/assignment-expression-and-display-name/input.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/assignment-expression-and-display-name/input.js
@@ -1,0 +1,2 @@
+ThemeContext = React.createContext("light");
+ThemeContext.displayName = "CustomThemeContext";

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/assignment-expression-and-display-name/output.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/assignment-expression-and-display-name/output.js
@@ -1,0 +1,3 @@
+ThemeContext = React.createContext("light");
+ThemeContext.displayName = "ThemeContext";
+ThemeContext.displayName = "CustomThemeContext";

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/assignment-expression/input.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/assignment-expression/input.js
@@ -1,0 +1,1 @@
+ThemeContext = React.createContext("light");

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/assignment-expression/output.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/assignment-expression/output.js
@@ -1,0 +1,2 @@
+ThemeContext = React.createContext("light");
+ThemeContext.displayName = "ThemeContext";

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/nested/input.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/nested/input.js
@@ -1,0 +1,1 @@
+var enhancedContext = qux(React.createContext("light"));

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/nested/output.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/nested/output.js
@@ -1,0 +1,1 @@
+var enhancedContext = qux((_ref = React.createContext("light"), _ref.displayName = "enhancedContext", _ref));

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/nested/output.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/nested/output.js
@@ -1,1 +1,3 @@
+var _ref;
+
 var enhancedContext = qux((_ref = React.createContext("light"), _ref.displayName = "enhancedContext", _ref));

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/object-property/input.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/object-property/input.js
@@ -1,0 +1,3 @@
+({
+  ThemeContext: React.createContext("light")
+});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/object-property/output.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/object-property/output.js
@@ -1,3 +1,5 @@
+var _ref;
+
 ({
   ThemeContext: (_ref = React.createContext("light"), _ref.displayName = "ThemeContext", _ref)
 });

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/object-property/output.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/object-property/output.js
@@ -1,0 +1,3 @@
+({
+  ThemeContext: (_ref = React.createContext("light"), _ref.displayName = "ThemeContext", _ref)
+});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/options.json
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-react-display-name"]
+}

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/variable-declarator/input.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/variable-declarator/input.js
@@ -1,0 +1,1 @@
+var ThemeContext = React.createContext("light");

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/variable-declarator/output.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name-context/variable-declarator/output.js
@@ -1,0 +1,2 @@
+var ThemeContext = React.createContext("light");
+ThemeContext.displayName = "ThemeContext"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11241 (28👍)
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The PR inserts `context.displayName = "context"` assignments after `React.createContext()` call. For common cases like variable declarations and assignment, we reuse the context binding when building assignments. Then we fallback to the sequence expression approach, where `React.createContext()` is transformed into `(ref = React.createContext(), ref.displayName = "myContext", ref)`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13501"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

