### PR TITLE
fix: sync default_extensions to babel-cli usage

### DIFF
--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 
 import commander from "commander";
-import { version } from "@babel/core";
+import { version, DEFAULT_EXTENSIONS } from "@babel/core";
 import glob from "glob";
 
 // Standard Babel input configs.
@@ -113,7 +113,9 @@ if (!process.env.BABEL_8_BREAKING) {
 // "babel" command specific arguments that are not passed to @babel/core.
 commander.option(
   "-x, --extensions [extensions]",
-  "List of extensions to compile when a directory has been the input. [.es6,.js,.es,.jsx,.mjs]",
+  "List of extensions to compile when a directory has been the input. [" +
+    DEFAULT_EXTENSIONS.join() +
+    "]",
   collect,
 );
 commander.option(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Found this issue when searching docs about the `--extension` option. The updated usage in this PR, as of `@babel/core` 7.14, is
```
  -x, --extensions [extensions]               List of extensions to compile when a directory has been the input.
                                              [.js,.jsx,.es6,.es,.mjs,.cjs]
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13508"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

