### PR TITLE
enhance benchmark output with thousands separators

### DIFF
--- a/packages/babel-helper-validator-identifier/benchmark/util.mjs
+++ b/packages/babel-helper-validator-identifier/benchmark/util.mjs
@@ -1,13 +1,17 @@
 export function report(event) {
   const bench = event.target;
-  const factor = bench.hz < 100 ? 100 : 1;
   const timeMs = bench.stats.mean * 1000;
   const time =
     timeMs < 10
       ? `${Math.round(timeMs * 1000) / 1000}ms`
       : `${Math.round(timeMs)}ms`;
-  const msg = `${bench.name}: ${
-    Math.round(bench.hz * factor) / factor
-  } ops/sec ±${Math.round(bench.stats.rme * 100) / 100}% (${time})`;
+  const msg = `${bench.name}: ${formatNumber(bench.hz)} ops/sec ±${
+    Math.round(bench.stats.rme * 100) / 100
+  }% (${time})`;
   console.log(msg);
+}
+
+function formatNumber(x) {
+  if (x < 100) return `${Math.round(x * 100) / 100}`;
+  return `${Math.round(x)}`.replace(/\d(?=(?:\d{3})+$)/g, "$&_");
 }

--- a/packages/babel-parser/benchmark/util.mjs
+++ b/packages/babel-parser/benchmark/util.mjs
@@ -1,13 +1,17 @@
 export function report(event) {
   const bench = event.target;
-  const factor = bench.hz < 100 ? 100 : 1;
   const timeMs = bench.stats.mean * 1000;
   const time =
     timeMs < 10
       ? `${Math.round(timeMs * 1000) / 1000}ms`
       : `${Math.round(timeMs)}ms`;
-  const msg = `${bench.name}: ${
-    Math.round(bench.hz * factor) / factor
-  } ops/sec ±${Math.round(bench.stats.rme * 100) / 100}% (${time})`;
+  const msg = `${bench.name}: ${formatNumber(bench.hz)} ops/sec ±${
+    Math.round(bench.stats.rme * 100) / 100
+  }% (${time})`;
   console.log(msg);
+}
+
+function formatNumber(x) {
+  if (x < 100) return `${Math.round(x * 100) / 100}`;
+  return `${Math.round(x)}`.replace(/\d(?=(?:\d{3})+$)/g, "$&_");
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Just adding underscores as thousands separators to the two copies of benchmark utils, as suggested in https://github.com/babel/babel/pull/13466#discussion_r651924923


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13512"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

