### PR TITLE
Fix object destructuring with ...rest using keys twice (plugin-transform-destructuring)

### DIFF
--- a/packages/babel-plugin-transform-destructuring/test/fixtures/assumption-objectRestNoSymbols/rest-computed/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/assumption-objectRestNoSymbols/rest-computed/output.js
@@ -1,4 +1,4 @@
 let _obj = obj,
-    _a = a,
+    _a = babelHelpers.toPropertyKey(a),
     b = _obj[_a],
-    c = babelHelpers.objectWithoutPropertiesLoose(_obj, [_a].map(babelHelpers.toPropertyKey));
+    c = babelHelpers.objectWithoutPropertiesLoose(_obj, [_a]);

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/check-no-hoisting-when-using-template-strings/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/check-no-hoisting-when-using-template-strings/output.js
@@ -1,5 +1,6 @@
 var example = obj => {
   var foo = 'foo';
-  var _ = obj[`prefix_${foo}`],
-      rest = babelHelpers.objectWithoutProperties(obj, [`prefix_${foo}`]);
+  var _ref = `prefix_${foo}`,
+      _ = obj[_ref],
+      rest = babelHelpers.objectWithoutProperties(obj, [_ref]);
 };

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/output.js
@@ -5,9 +5,11 @@ var _z = z,
 var _z2 = z,
     x = _z2.x,
     y = babelHelpers.objectWithoutProperties(_z2, ["x"]);
+
 var _z3 = z,
-    x = _z3[x],
-    y = babelHelpers.objectWithoutProperties(_z3, [x].map(babelHelpers.toPropertyKey));
+    _x = babelHelpers.toPropertyKey(x),
+    x = _z3[_x],
+    y = babelHelpers.objectWithoutProperties(_z3, [_x]);
 
 (function (_ref) {
   var x = _ref.x,

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-loose/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-loose/output.js
@@ -5,9 +5,11 @@ var _z = z,
 var _z2 = z,
     x = _z2.x,
     y = babelHelpers.objectWithoutPropertiesLoose(_z2, ["x"]);
+
 var _z3 = z,
-    x = _z3[x],
-    y = babelHelpers.objectWithoutPropertiesLoose(_z3, [x].map(babelHelpers.toPropertyKey));
+    _x = babelHelpers.toPropertyKey(x),
+    x = _z3[_x],
+    y = babelHelpers.objectWithoutPropertiesLoose(_z3, [_x]);
 
 (function (_ref) {
   let x = _ref.x,

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest/exec.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest/exec.js
@@ -1,0 +1,6 @@
+function foo(x, obj) {
+  var { [x]: x, ...rest } = obj;
+  return x + '|' + Object.keys(rest);
+}
+
+expect(foo("b", { a:'b', b:'c', c:'a' })).toBe("c|a,c");

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest/output.js
@@ -5,9 +5,11 @@ var _z = z,
 var _z2 = z,
     x = _z2.x,
     y = babelHelpers.objectWithoutProperties(_z2, ["x"]);
+
 var _z3 = z,
-    x = _z3[x],
-    y = babelHelpers.objectWithoutProperties(_z3, [x].map(babelHelpers.toPropertyKey));
+    _x = babelHelpers.toPropertyKey(x),
+    x = _z3[_x],
+    y = babelHelpers.objectWithoutProperties(_z3, [_x]);
 
 (function (_ref) {
   var x = _ref.x,

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/issue-9834/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/issue-9834/output.js
@@ -7,4 +7,4 @@ var _ref = prefix + 'state',
     country = input[`country`],
     state = input[_ref],
     consents = input[_ref2],
-    rest = babelHelpers.objectWithoutProperties(input, ["given_name", "last_name", `country`, _ref, _ref2].map(babelHelpers.toPropertyKey));
+    rest = babelHelpers.objectWithoutProperties(input, ["given_name", "last_name", `country`, _ref, _ref2]);

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/object-rest-impure-computed-keys/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/object-rest-impure-computed-keys/output.js
@@ -1,4 +1,4 @@
 var _z = z,
-    _fn = fn(),
+    _fn = babelHelpers.toPropertyKey(fn()),
     x = _z[_fn],
-    y = babelHelpers.objectWithoutProperties(_z, [_fn].map(babelHelpers.toPropertyKey));
+    y = babelHelpers.objectWithoutProperties(_z, [_fn]);

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/object-rest-strigify-keys-once/exec.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/object-rest-strigify-keys-once/exec.js
@@ -1,0 +1,16 @@
+
+function stringifyKeyOnce(obj) {
+  const key = { i: 0, toString() { return String(this.i++); } };
+  const { [key]: value, ...rest } = obj;
+  return rest[1] + value;
+};
+
+expect(stringifyKeyOnce([" value", "correct"])).toBe("correct value");
+
+function stringifyTemplateOnce(obj) {
+  const key = { i: 0, toString() { return String(this.i++); } };
+  const { [`${key}`]: value, ...rest } = obj;
+  return rest[1] + value;
+};
+
+expect(stringifyTemplateOnce([" value", "correct"])).toBe("correct value");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | couldn't find a matching issue
| Patch: Bug Fix?          | :heavy_check_mark: 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This fixes two issues with `...rest` in `@babel/plugin-transform-destructuring`.

#### 1. computed key stringified twice

```js
const { [key]: target, ...rest } = obj;
// key.toString() should not be called twice
```

#### 2. different variable used to exclude keys

There was actually a test for this already in `fixtures/destructuring/es7-object-rest/input.js`:
```js
var { [x]: x, ...y } = z;
```
but the expected output was wrong:
```js
var _z3 = z,
    x = _z3[x],
    y = babelHelpers.objectWithoutProperties(_z3, [x].map(babelHelpers.toPropertyKey));
```
the `x` in `_z3[x]` is from outer scope, whereas the `x` in `objectWithoutProperties` is the local variable assigned by destructuring
