### PR TITLE
Fix config validation message typo

### DIFF
--- a/packages/babel-core/src/config/full.ts
+++ b/packages/babel-core/src/config/full.ts
@@ -124,7 +124,7 @@ export default gensync<(inputOpts: unknown) => ResolvedConfig | null>(
               }
             } catch (e) {
               if (e.code === "BABEL_UNKNOWN_OPTION") {
-                checkNoUnwrappedItemOptionPairs(rawPresets, i, "presets", e);
+                checkNoUnwrappedItemOptionPairs(rawPresets, i, "preset", e);
               }
               throw e;
             }
@@ -187,7 +187,7 @@ export default gensync<(inputOpts: unknown) => ResolvedConfig | null>(
             } catch (e) {
               if (e.code === "BABEL_UNKNOWN_PLUGIN_PROPERTY") {
                 // print special message for `plugins: ["@babel/foo", { foo: "option" }]`
-                checkNoUnwrappedItemOptionPairs(descs, i, "plugins", e);
+                checkNoUnwrappedItemOptionPairs(descs, i, "plugin", e);
               }
               throw e;
             }

--- a/packages/babel-core/src/config/full.ts
+++ b/packages/babel-core/src/config/full.ts
@@ -124,7 +124,7 @@ export default gensync<(inputOpts: unknown) => ResolvedConfig | null>(
               }
             } catch (e) {
               if (e.code === "BABEL_UNKNOWN_OPTION") {
-                checkNoUnwrappedItemOptionPairs(rawPresets, i, "preset", e);
+                checkNoUnwrappedItemOptionPairs(rawPresets, i, "presets", e);
               }
               throw e;
             }
@@ -187,7 +187,7 @@ export default gensync<(inputOpts: unknown) => ResolvedConfig | null>(
             } catch (e) {
               if (e.code === "BABEL_UNKNOWN_PLUGIN_PROPERTY") {
                 // print special message for `plugins: ["@babel/foo", { foo: "option" }]`
-                checkNoUnwrappedItemOptionPairs(descs, i, "plugin", e);
+                checkNoUnwrappedItemOptionPairs(descs, i, "plugins", e);
               }
               throw e;
             }

--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -440,7 +440,7 @@ function assertOverridesList(
 export function checkNoUnwrappedItemOptionPairs(
   items: Array<UnloadedDescriptor>,
   index: number,
-  type: "plugins" | "presets",
+  type: "plugin" | "preset",
   e: Error,
 ): void {
   if (index === 0) return;
@@ -455,7 +455,7 @@ export function checkNoUnwrappedItemOptionPairs(
   ) {
     e.message +=
       `\n- Maybe you meant to use\n` +
-      `"${type}": [\n  ["${lastItem.file.request}", ${JSON.stringify(
+      `"${type}s": [\n  ["${lastItem.file.request}", ${JSON.stringify(
         thisItem.value,
         undefined,
         2,

--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -440,7 +440,7 @@ function assertOverridesList(
 export function checkNoUnwrappedItemOptionPairs(
   items: Array<UnloadedDescriptor>,
   index: number,
-  type: "plugin" | "preset",
+  type: "plugins" | "presets",
   e: Error,
 ): void {
   if (index === 0) return;

--- a/packages/babel-core/test/__snapshots__/option-manager.js.snap
+++ b/packages/babel-core/test/__snapshots__/option-manager.js.snap
@@ -3,32 +3,32 @@
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is following a preset 1`] = `
 "[BABEL] unknown: Unknown option: .useSpread. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
 - Maybe you meant to use
-\\"preset\\": [
+\\"presets\\": [
   [\\"./fixtures/option-manager/babel-preset-bar\\", {
   \\"useSpread\\": true
 }]
 ]
-To be a valid preset, its name and options should be wrapped in a pair of brackets"
+To be a valid presets, its name and options should be wrapped in a pair of brackets"
 `;
 
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a plugin 1`] = `
 "[BABEL] unknown: .useSpread is not a valid Plugin property
 - Maybe you meant to use
-\\"plugin\\": [
+\\"plugins\\": [
   [\\"./fixtures/option-manager/babel-plugin-foo\\", {
   \\"useSpread\\": true
 }]
 ]
-To be a valid plugin, its name and options should be wrapped in a pair of brackets"
+To be a valid plugins, its name and options should be wrapped in a pair of brackets"
 `;
 
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a preset 1`] = `
 "[BABEL] unknown: Unknown option: .useBuiltIns. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
 - Maybe you meant to use
-\\"preset\\": [
+\\"presets\\": [
   [\\"./fixtures/option-manager/babel-preset-bar\\", {
   \\"useBuiltIns\\": \\"entry\\"
 }]
 ]
-To be a valid preset, its name and options should be wrapped in a pair of brackets"
+To be a valid presets, its name and options should be wrapped in a pair of brackets"
 `;

--- a/packages/babel-core/test/__snapshots__/option-manager.js.snap
+++ b/packages/babel-core/test/__snapshots__/option-manager.js.snap
@@ -8,7 +8,7 @@ exports[`option-manager config plugin/preset flattening and overriding should th
   \\"useSpread\\": true
 }]
 ]
-To be a valid presets, its name and options should be wrapped in a pair of brackets"
+To be a valid preset, its name and options should be wrapped in a pair of brackets"
 `;
 
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a plugin 1`] = `
@@ -19,7 +19,7 @@ exports[`option-manager config plugin/preset flattening and overriding should th
   \\"useSpread\\": true
 }]
 ]
-To be a valid plugins, its name and options should be wrapped in a pair of brackets"
+To be a valid plugin, its name and options should be wrapped in a pair of brackets"
 `;
 
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a preset 1`] = `
@@ -30,5 +30,5 @@ exports[`option-manager config plugin/preset flattening and overriding should th
   \\"useBuiltIns\\": \\"entry\\"
 }]
 ]
-To be a valid presets, its name and options should be wrapped in a pair of brackets"
+To be a valid preset, its name and options should be wrapped in a pair of brackets"
 `;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Fixed config option names in validation message `preset`/`plugin` -> `presets`/`plugins`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13515"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

