### PR TITLE
minor improvement to gulp generate-runtime-helpers error message

### DIFF
--- a/packages/babel-helpers/scripts/generate-helpers.js
+++ b/packages/babel-helpers/scripts/generate-helpers.js
@@ -22,13 +22,15 @@ import template from "@babel/template";
     const isValidId = isValidBindingIdentifier(helperName);
     const varName = isValidId ? helperName : `_${helperName}`;
 
-    const fileContents = await fs.promises.readFile(
-      join(fileURLToPath(HELPERS_FOLDER), file),
-      "utf8"
-    );
-    const { minVersion } = fileContents.match(
+    const filePath = join(fileURLToPath(HELPERS_FOLDER), file);
+    const fileContents = await fs.promises.readFile(filePath, "utf8");
+    const minVersionMatch = fileContents.match(
       /^\s*\/\*\s*@minVersion\s+(?<minVersion>\S+)\s*\*\/\s*$/m
-    ).groups;
+    );
+    if (!minVersionMatch) {
+      throw new Error(`@minVersion number missing in ${filePath}`);
+    }
+    const { minVersion } = minVersionMatch.groups;
 
     // TODO: We can minify the helpers in production
     const source = fileContents

--- a/packages/babel-helpers/scripts/generate-helpers.js
+++ b/packages/babel-helpers/scripts/generate-helpers.js
@@ -17,6 +17,7 @@ import template from "@babel/template";
 
   for (const file of (await fs.promises.readdir(HELPERS_FOLDER)).sort()) {
     if (IGNORED_FILES.has(file)) continue;
+    if (file.startsWith(".")) continue; // ignore e.g. vim swap files
 
     const [helperName] = file.split(".");
     const isValidId = isValidBindingIdentifier(helperName);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | none added
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`generate-helpers.js` failed with an unhelpful `TypeError` if it couldn't find a `minVersion` in some file under `src/helpers/`. I had some (hidden) vim swap files in there and it was quite baffling. So after adding a more informative message I also made it ignore dotfiles.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13522"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

