### PR TITLE
feat(ts): raise error for abstract property with initializer

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2619,7 +2619,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         this.raise(
           this.state.start,
           TSErrors.AbstractPropertyHasInitializer,
-          key.type === "Identifier"
+          !node.computed
             ? key.name
             : `[${this.input.slice(key.start, key.end)}]`,
         );
@@ -3213,7 +3213,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           this.raise(
             method.start,
             TSErrors.AbstractMethodHasImplementation,
-            key.type === "Identifier"
+            !method.computed
               ? key.name
               : `[${this.input.slice(key.start, key.end)}]`,
           );

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -70,6 +70,8 @@ const TSErrors = makeErrorTemplates(
   {
     AbstractMethodHasImplementation:
       "Method '%0' cannot have an implementation because it is marked abstract.",
+    AbstractPropertyHasInitializer:
+      "Property '%0' cannot have a initializer because it is marked abstract.",
     AccesorCannotDeclareThisParameter:
       "'get' and 'set' accessors cannot declare 'this' parameters.",
     AccesorCannotHaveTypeParameters: "An accessor cannot have type parameters.",
@@ -2611,6 +2613,16 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
       if (this.state.isAmbientContext && this.match(tt.eq)) {
         this.raise(this.state.start, TSErrors.DeclareClassFieldHasInitializer);
+      }
+      if (node.abstract && this.match(tt.eq)) {
+        const { key } = node;
+        this.raise(
+          this.state.start,
+          TSErrors.AbstractPropertyHasInitializer,
+          key.type === "Identifier"
+            ? key.name
+            : `[${this.input.slice(key.start, key.end)}]`,
+        );
       }
 
       return super.parseClassProperty(node);

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -71,7 +71,7 @@ const TSErrors = makeErrorTemplates(
     AbstractMethodHasImplementation:
       "Method '%0' cannot have an implementation because it is marked abstract.",
     AbstractPropertyHasInitializer:
-      "Property '%0' cannot have a initializer because it is marked abstract.",
+      "Property '%0' cannot have an initializer because it is marked abstract.",
     AccesorCannotDeclareThisParameter:
       "'get' and 'set' accessors cannot declare 'this' parameters.",
     AccesorCannotHaveTypeParameters: "An accessor cannot have type parameters.",

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2619,7 +2619,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         this.raise(
           this.state.start,
           TSErrors.AbstractPropertyHasInitializer,
-          !node.computed
+          key.type === "Identifier" && !node.computed
             ? key.name
             : `[${this.input.slice(key.start, key.end)}]`,
         );
@@ -3213,7 +3213,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           this.raise(
             method.start,
             TSErrors.AbstractMethodHasImplementation,
-            !method.computed
+            key.type === "Identifier" && !method.computed
               ? key.name
               : `[${this.input.slice(key.start, key.end)}]`,
           );

--- a/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/input.ts
@@ -1,0 +1,3 @@
+abstract class Foo {
+  abstract prop = 1
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/input.ts
@@ -1,4 +1,5 @@
 abstract class Foo {
   abstract prop = 1
   abstract [Bar.foo] = 2
+  abstract [Bar] = 3
 }

--- a/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/input.ts
@@ -1,3 +1,4 @@
 abstract class Foo {
   abstract prop = 1
+  abstract [Bar.foo] = 2
 }

--- a/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/input.ts
@@ -2,4 +2,6 @@ abstract class Foo {
   abstract prop = 1
   abstract [Bar.foo] = 2
   abstract [Bar] = 3
+  abstract 2 = 4
+  abstract "c" = 5
 }

--- a/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/output.json
@@ -1,18 +1,19 @@
 {
   "type": "File",
-  "start":0,"end":42,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "start":0,"end":67,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
   "errors": [
-    "SyntaxError: Property 'prop' cannot have a initializer because it is marked abstract. (2:16)"
+    "SyntaxError: Property 'prop' cannot have a initializer because it is marked abstract. (2:16)",
+    "SyntaxError: Property '[Bar.foo]' cannot have a initializer because it is marked abstract. (3:21)"
   ],
   "program": {
     "type": "Program",
-    "start":0,"end":42,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "start":0,"end":67,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
-        "start":0,"end":42,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "start":0,"end":67,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
         "abstract": true,
         "id": {
           "type": "Identifier",
@@ -22,7 +23,7 @@
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start":19,"end":42,"loc":{"start":{"line":1,"column":19},"end":{"line":3,"column":1}},
+          "start":19,"end":67,"loc":{"start":{"line":1,"column":19},"end":{"line":4,"column":1}},
           "body": [
             {
               "type": "ClassProperty",
@@ -43,6 +44,37 @@
                   "raw": "1"
                 },
                 "value": 1
+              }
+            },
+            {
+              "type": "ClassProperty",
+              "start":43,"end":65,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":24}},
+              "abstract": true,
+              "static": false,
+              "computed": true,
+              "key": {
+                "type": "MemberExpression",
+                "start":53,"end":60,"loc":{"start":{"line":3,"column":12},"end":{"line":3,"column":19}},
+                "object": {
+                  "type": "Identifier",
+                  "start":53,"end":56,"loc":{"start":{"line":3,"column":12},"end":{"line":3,"column":15},"identifierName":"Bar"},
+                  "name": "Bar"
+                },
+                "computed": false,
+                "property": {
+                  "type": "Identifier",
+                  "start":57,"end":60,"loc":{"start":{"line":3,"column":16},"end":{"line":3,"column":19},"identifierName":"foo"},
+                  "name": "foo"
+                }
+              },
+              "value": {
+                "type": "NumericLiteral",
+                "start":64,"end":65,"loc":{"start":{"line":3,"column":23},"end":{"line":3,"column":24}},
+                "extra": {
+                  "rawValue": 2,
+                  "raw": "2"
+                },
+                "value": 2
               }
             }
           ]

--- a/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/output.json
@@ -1,19 +1,20 @@
 {
   "type": "File",
-  "start":0,"end":67,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "start":0,"end":88,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
   "errors": [
     "SyntaxError: Property 'prop' cannot have a initializer because it is marked abstract. (2:16)",
-    "SyntaxError: Property '[Bar.foo]' cannot have a initializer because it is marked abstract. (3:21)"
+    "SyntaxError: Property '[Bar.foo]' cannot have a initializer because it is marked abstract. (3:21)",
+    "SyntaxError: Property '[Bar]' cannot have a initializer because it is marked abstract. (4:17)"
   ],
   "program": {
     "type": "Program",
-    "start":0,"end":67,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "start":0,"end":88,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
-        "start":0,"end":67,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "start":0,"end":88,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
         "abstract": true,
         "id": {
           "type": "Identifier",
@@ -23,7 +24,7 @@
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start":19,"end":67,"loc":{"start":{"line":1,"column":19},"end":{"line":4,"column":1}},
+          "start":19,"end":88,"loc":{"start":{"line":1,"column":19},"end":{"line":5,"column":1}},
           "body": [
             {
               "type": "ClassProperty",
@@ -75,6 +76,27 @@
                   "raw": "2"
                 },
                 "value": 2
+              }
+            },
+            {
+              "type": "ClassProperty",
+              "start":68,"end":86,"loc":{"start":{"line":4,"column":2},"end":{"line":4,"column":20}},
+              "abstract": true,
+              "static": false,
+              "computed": true,
+              "key": {
+                "type": "Identifier",
+                "start":78,"end":81,"loc":{"start":{"line":4,"column":12},"end":{"line":4,"column":15},"identifierName":"Bar"},
+                "name": "Bar"
+              },
+              "value": {
+                "type": "NumericLiteral",
+                "start":85,"end":86,"loc":{"start":{"line":4,"column":19},"end":{"line":4,"column":20}},
+                "extra": {
+                  "rawValue": 3,
+                  "raw": "3"
+                },
+                "value": 3
               }
             }
           ]

--- a/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/output.json
@@ -1,0 +1,54 @@
+{
+  "type": "File",
+  "start":0,"end":42,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: Property 'prop' cannot have a initializer because it is marked abstract. (2:16)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":42,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":42,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "abstract": true,
+        "id": {
+          "type": "Identifier",
+          "start":15,"end":18,"loc":{"start":{"line":1,"column":15},"end":{"line":1,"column":18},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":19,"end":42,"loc":{"start":{"line":1,"column":19},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":23,"end":40,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":19}},
+              "abstract": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":32,"end":36,"loc":{"start":{"line":2,"column":11},"end":{"line":2,"column":15},"identifierName":"prop"},
+                "name": "prop"
+              },
+              "computed": false,
+              "value": {
+                "type": "NumericLiteral",
+                "start":39,"end":40,"loc":{"start":{"line":2,"column":18},"end":{"line":2,"column":19}},
+                "extra": {
+                  "rawValue": 1,
+                  "raw": "1"
+                },
+                "value": 1
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/output.json
@@ -2,11 +2,11 @@
   "type": "File",
   "start":0,"end":124,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
   "errors": [
-    "SyntaxError: Property 'prop' cannot have a initializer because it is marked abstract. (2:16)",
-    "SyntaxError: Property '[Bar.foo]' cannot have a initializer because it is marked abstract. (3:21)",
-    "SyntaxError: Property '[Bar]' cannot have a initializer because it is marked abstract. (4:17)",
-    "SyntaxError: Property '[2]' cannot have a initializer because it is marked abstract. (5:13)",
-    "SyntaxError: Property '[\"c\"]' cannot have a initializer because it is marked abstract. (6:15)"
+    "SyntaxError: Property 'prop' cannot have an initializer because it is marked abstract. (2:16)",
+    "SyntaxError: Property '[Bar.foo]' cannot have an initializer because it is marked abstract. (3:21)",
+    "SyntaxError: Property '[Bar]' cannot have an initializer because it is marked abstract. (4:17)",
+    "SyntaxError: Property '[2]' cannot have an initializer because it is marked abstract. (5:13)",
+    "SyntaxError: Property '[\"c\"]' cannot have an initializer because it is marked abstract. (6:15)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/abstract-property-initializer/output.json
@@ -1,20 +1,22 @@
 {
   "type": "File",
-  "start":0,"end":88,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+  "start":0,"end":124,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
   "errors": [
     "SyntaxError: Property 'prop' cannot have a initializer because it is marked abstract. (2:16)",
     "SyntaxError: Property '[Bar.foo]' cannot have a initializer because it is marked abstract. (3:21)",
-    "SyntaxError: Property '[Bar]' cannot have a initializer because it is marked abstract. (4:17)"
+    "SyntaxError: Property '[Bar]' cannot have a initializer because it is marked abstract. (4:17)",
+    "SyntaxError: Property '[2]' cannot have a initializer because it is marked abstract. (5:13)",
+    "SyntaxError: Property '[\"c\"]' cannot have a initializer because it is marked abstract. (6:15)"
   ],
   "program": {
     "type": "Program",
-    "start":0,"end":88,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+    "start":0,"end":124,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
-        "start":0,"end":88,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+        "start":0,"end":124,"loc":{"start":{"line":1,"column":0},"end":{"line":7,"column":1}},
         "abstract": true,
         "id": {
           "type": "Identifier",
@@ -24,7 +26,7 @@
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start":19,"end":88,"loc":{"start":{"line":1,"column":19},"end":{"line":5,"column":1}},
+          "start":19,"end":124,"loc":{"start":{"line":1,"column":19},"end":{"line":7,"column":1}},
           "body": [
             {
               "type": "ClassProperty",
@@ -97,6 +99,56 @@
                   "raw": "3"
                 },
                 "value": 3
+              }
+            },
+            {
+              "type": "ClassProperty",
+              "start":89,"end":103,"loc":{"start":{"line":5,"column":2},"end":{"line":5,"column":16}},
+              "abstract": true,
+              "static": false,
+              "key": {
+                "type": "NumericLiteral",
+                "start":98,"end":99,"loc":{"start":{"line":5,"column":11},"end":{"line":5,"column":12}},
+                "extra": {
+                  "rawValue": 2,
+                  "raw": "2"
+                },
+                "value": 2
+              },
+              "computed": false,
+              "value": {
+                "type": "NumericLiteral",
+                "start":102,"end":103,"loc":{"start":{"line":5,"column":15},"end":{"line":5,"column":16}},
+                "extra": {
+                  "rawValue": 4,
+                  "raw": "4"
+                },
+                "value": 4
+              }
+            },
+            {
+              "type": "ClassProperty",
+              "start":106,"end":122,"loc":{"start":{"line":6,"column":2},"end":{"line":6,"column":18}},
+              "abstract": true,
+              "static": false,
+              "key": {
+                "type": "StringLiteral",
+                "start":115,"end":118,"loc":{"start":{"line":6,"column":11},"end":{"line":6,"column":14}},
+                "extra": {
+                  "rawValue": "c",
+                  "raw": "\"c\""
+                },
+                "value": "c"
+              },
+              "computed": false,
+              "value": {
+                "type": "NumericLiteral",
+                "start":121,"end":122,"loc":{"start":{"line":6,"column":17},"end":{"line":6,"column":18}},
+                "extra": {
+                  "rawValue": 5,
+                  "raw": "5"
+                },
+                "value": 5
               }
             }
           ]


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Raise an error for class abstract properties with initializer as specified in [TS 4.4 beta](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-beta/#abstract-properties-do-not-allow-initializers) announcement.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13523"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

