### PR TITLE
fix(babel-types): accept `UnaryExpression` in `TSLiteralType`

### DIFF
--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -1905,7 +1905,12 @@ export interface TSMappedType extends BaseNode {
 
 export interface TSLiteralType extends BaseNode {
   type: "TSLiteralType";
-  literal: any;
+  literal:
+    | "NumericLiteral"
+    | "StringLiteral"
+    | "BooleanLiteral"
+    | "BigIntLiteral"
+    | "UnaryExpression";
 }
 
 export interface TSExpressionWithTypeArguments extends BaseNode {

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -1906,11 +1906,11 @@ export interface TSMappedType extends BaseNode {
 export interface TSLiteralType extends BaseNode {
   type: "TSLiteralType";
   literal:
-    | "NumericLiteral"
-    | "StringLiteral"
-    | "BooleanLiteral"
-    | "BigIntLiteral"
-    | "UnaryExpression";
+    | NumericLiteral
+    | StringLiteral
+    | BooleanLiteral
+    | BigIntLiteral
+    | UnaryExpression;
 }
 
 export interface TSExpressionWithTypeArguments extends BaseNode {

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -1905,7 +1905,7 @@ export interface TSMappedType extends BaseNode {
 
 export interface TSLiteralType extends BaseNode {
   type: "TSLiteralType";
-  literal: NumericLiteral | StringLiteral | BooleanLiteral | BigIntLiteral;
+  literal: any;
 }
 
 export interface TSExpressionWithTypeArguments extends BaseNode {

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -1325,11 +1325,11 @@ export function tsMappedType(
 export { tsMappedType as tSMappedType };
 export function tsLiteralType(
   literal:
-    | "NumericLiteral"
-    | "StringLiteral"
-    | "BooleanLiteral"
-    | "BigIntLiteral"
-    | "UnaryExpression",
+    | t.NumericLiteral
+    | t.StringLiteral
+    | t.BooleanLiteral
+    | t.BigIntLiteral
+    | t.UnaryExpression,
 ): t.TSLiteralType {
   return builder("TSLiteralType", ...arguments);
 }

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -1323,13 +1323,7 @@ export function tsMappedType(
   return builder("TSMappedType", ...arguments);
 }
 export { tsMappedType as tSMappedType };
-export function tsLiteralType(
-  literal:
-    | t.NumericLiteral
-    | t.StringLiteral
-    | t.BooleanLiteral
-    | t.BigIntLiteral,
-): t.TSLiteralType {
+export function tsLiteralType(literal: any): t.TSLiteralType {
   return builder("TSLiteralType", ...arguments);
 }
 export { tsLiteralType as tSLiteralType };

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -1323,7 +1323,14 @@ export function tsMappedType(
   return builder("TSMappedType", ...arguments);
 }
 export { tsMappedType as tSMappedType };
-export function tsLiteralType(literal: any): t.TSLiteralType {
+export function tsLiteralType(
+  literal:
+    | "NumericLiteral"
+    | "StringLiteral"
+    | "BooleanLiteral"
+    | "BigIntLiteral"
+    | "UnaryExpression",
+): t.TSLiteralType {
   return builder("TSLiteralType", ...arguments);
 }
 export { tsLiteralType as tSLiteralType };

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -15,6 +15,7 @@ import {
   functionDeclarationCommon,
   classMethodOrDeclareMethodCommon,
 } from "./core";
+import is from "../validators/is";
 
 const bool = assertValueType("boolean");
 
@@ -335,12 +336,33 @@ defineType("TSLiteralType", {
   aliases: ["TSType", "TSBaseType"],
   visitor: ["literal"],
   fields: {
-    literal: validateType([
-      "NumericLiteral",
-      "StringLiteral",
-      "BooleanLiteral",
-      "BigIntLiteral",
-    ]),
+    literal: {
+      validate: (function () {
+        const unaryExpression = assertNodeType(
+          "NumericLiteral",
+          "BigIntLiteral",
+        );
+        const unaryOperator = assertOneOf("-");
+
+        const literal = assertNodeType(
+          "NumericLiteral",
+          "StringLiteral",
+          "BooleanLiteral",
+          "BigIntLiteral",
+        );
+        return function validator(parent, key: string, node) {
+          // type A = -1 | 1;
+          if (is("UnaryExpression", node)) {
+            // check operator first
+            unaryOperator(node, "operator", node.operator);
+            unaryExpression(node, "argument", node.argument);
+          } else {
+            // type A = 'foo' | 'bar' | false | 1;
+            literal(parent, key, node);
+          }
+        };
+      })(),
+    },
   },
 });
 

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -362,7 +362,7 @@ defineType("TSLiteralType", {
           }
         }
 
-        validator.oneOf = [
+        validator.oneOfNodeTypes = [
           "NumericLiteral",
           "StringLiteral",
           "BooleanLiteral",

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -350,7 +350,7 @@ defineType("TSLiteralType", {
           "BooleanLiteral",
           "BigIntLiteral",
         );
-        return function validator(parent, key: string, node) {
+        function validator(parent, key: string, node) {
           // type A = -1 | 1;
           if (is("UnaryExpression", node)) {
             // check operator first
@@ -360,7 +360,17 @@ defineType("TSLiteralType", {
             // type A = 'foo' | 'bar' | false | 1;
             literal(parent, key, node);
           }
-        };
+        }
+
+        validator.oneOf = [
+          "NumericLiteral",
+          "StringLiteral",
+          "BooleanLiteral",
+          "BigIntLiteral",
+          "UnaryExpression",
+        ];
+
+        return validator;
       })(),
     },
   },

--- a/packages/babel-types/test/builders/typescript/__snapshots__/tsLiteralType.js.snap
+++ b/packages/babel-types/test/builders/typescript/__snapshots__/tsLiteralType.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builders typescript tsLiteralType accept unary expression 1`] = `
+Object {
+  "literal": Object {
+    "argument": Object {
+      "type": "NumericLiteral",
+      "value": 1,
+    },
+    "operator": "-",
+    "prefix": true,
+    "type": "UnaryExpression",
+  },
+  "type": "TSLiteralType",
+}
+`;
+
+exports[`builders typescript tsLiteralType accept unary expression 2`] = `
+Object {
+  "literal": Object {
+    "argument": Object {
+      "type": "BigIntLiteral",
+      "value": "123456789",
+    },
+    "operator": "-",
+    "prefix": true,
+    "type": "UnaryExpression",
+  },
+  "type": "TSLiteralType",
+}
+`;

--- a/packages/babel-types/test/builders/typescript/tsLiteralType.js
+++ b/packages/babel-types/test/builders/typescript/tsLiteralType.js
@@ -1,0 +1,52 @@
+import * as t from "../../..";
+
+describe("builders", function () {
+  describe("typescript", function () {
+    describe("tsLiteralType", function () {
+      it("accept unary expression", function () {
+        expect(
+          t.tsLiteralType(t.unaryExpression("-", t.numericLiteral(1))),
+        ).toMatchSnapshot();
+        expect(
+          t.tsLiteralType(t.unaryExpression("-", t.bigIntLiteral("123456789"))),
+        ).toMatchSnapshot();
+      });
+      it("throws with non-numeric argument", function () {
+        expect(() => {
+          t.tsLiteralType(t.unaryExpression("-", t.stringLiteral(1)));
+        }).toThrow("Property value expected type of string but got number");
+        expect(() => {
+          t.tsLiteralType(t.unaryExpression("-", t.objectExpression([])));
+        }).toThrow(
+          'Property argument of UnaryExpression expected node to be of a type ["NumericLiteral","BigIntLiteral"] but instead got "ObjectExpression"',
+        );
+      });
+    });
+    it("throws with bad operator", function () {
+      expect(() => {
+        t.tsLiteralType(t.unaryExpression("+", t.numericLiteral(1)));
+      }).toThrow(
+        'Property operator expected value to be one of ["-"] but got "+"',
+      );
+
+      // should check operator first since it appears first
+      expect(() => {
+        t.tsLiteralType(t.unaryExpression("+", t.objectExpression([])));
+      }).toThrow(
+        'Property operator expected value to be one of ["-"] but got "+"',
+      );
+
+      expect(() => {
+        t.tsLiteralType(t.unaryExpression("~", t.numericLiteral(1)));
+      }).toThrow(
+        'Property operator expected value to be one of ["-"] but got "~"',
+      );
+
+      expect(() => {
+        t.tsLiteralType(t.unaryExpression("void", t.numericLiteral(1)));
+      }).toThrow(
+        'Property operator expected value to be one of ["-"] but got "void"',
+      );
+    });
+  });
+});


### PR DESCRIPTION




<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13327 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Add validator for `TSLiteralType` to accept `UnaryExpression`

eg:

```ts
type A = -1 | 1;
```


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13525"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

