### PR TITLE
[eslint, babel 8] Pass `cwd` to worker

### DIFF
--- a/eslint/babel-eslint-parser/src/configuration.cjs
+++ b/eslint/babel-eslint-parser/src/configuration.cjs
@@ -10,7 +10,7 @@ exports.normalizeESLintConfig = function (options) {
   } = options;
 
   return {
-    babelOptions,
+    babelOptions: { cwd: process.cwd(), ...babelOptions },
     ecmaVersion,
     sourceType,
     allowImportExportEverywhere,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This fixes a failure in the vue e2e test for Babel 8. For some reason the status is reported as green, but you can see that it's failing on `main`: https://app.circleci.com/pipelines/github/babel/babel/7475/workflows/43b7d304-3b9e-4745-9d0d-9ab7cef0ba5f/jobs/47269/parallel-runs/0/steps/0-104

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13526"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

