### PR TITLE
feat(typescript): implement namespace alias

### DIFF
--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "`import =` is not supported by @babel/plugin-transform-typescript\nPlease consider using `import <moduleName> from '<moduleName>';` alongside Typescript's --allowSyntheticDefaultImports option."
+  "throws": "`import lib = require('lib')` is not supported by @babel/plugin-transform-typescript\nPlease consider using `import lib from 'lib';` alongside Typescript's --allowSyntheticDefaultImports option."
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/alias/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/alias/input.ts
@@ -1,0 +1,22 @@
+declare module LongNameModule {
+  export type SomeType = number;
+  export const foo: number;
+  module Inner {
+    export type T = string;
+    export const bar: boolean;
+  }
+}
+
+import * as babel from '@babel/core';
+
+/** type only */
+import b = babel;
+import AliasModule = LongNameModule;
+
+const some: AliasModule.SomeType = 3;
+const bar = AliasModule.foo;
+const baz = AliasModule.Inner.bar;
+let str: LongNameModule.Inner.T;
+let node: b.OptionManager;
+
+console.log(some);

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/alias/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/alias/output.mjs
@@ -1,0 +1,11 @@
+import * as babel from '@babel/core';
+/** type only */
+
+var b = babel;
+var AliasModule = LongNameModule;
+const some = 3;
+const bar = AliasModule.foo;
+const baz = AliasModule.Inner.bar;
+let str;
+let node;
+console.log(some);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12345 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Maybe
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | 👍
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Support `import alias = Namespace`, reject `import alias = require('foo')`

Implementation is quite simple. Just replace `moduleReference` with `Expression | MemberExpression`.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13528"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

