### PR TITLE
refactor(pipeline-operator): DRY when calling buildOptimizedSequenceExpression

### DIFF
--- a/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
@@ -14,7 +14,7 @@ const fsharpVisitor = {
         ? t.awaitExpression(t.cloneNode(placeholder))
         : t.callExpression(right, [t.cloneNode(placeholder)]);
     const sequence = buildOptimizedSequenceExpression({
-      assign: t.assignmentExpression("=", t.cloneNode(placeholder), left),
+      placeholder,
       call,
       path,
     });

--- a/packages/babel-plugin-proposal-pipeline-operator/src/minimalVisitor.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/minimalVisitor.js
@@ -12,7 +12,7 @@ const minimalVisitor = {
     const call = t.callExpression(right, [t.cloneNode(placeholder)]);
     path.replaceWith(
       buildOptimizedSequenceExpression({
-        assign: t.assignmentExpression("=", t.cloneNode(placeholder), left),
+        placeholder,
         call,
         path,
       }),


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | none, minor refactoring
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When adding another pipeline flavour, I found myself repeating the `t.assignmentExpression(...)` boilerplate, which  `buildOptimizedSequenceExpression` requires, and so can just as well construct itself.

Also fixes a typo in comment.

While on the topic of `buildOptimizedSequenceExpression`, I'd like to know why it rewrites `eval`.
Given that:
```js
x |> a.m
// desugars to:
a.m(x)
// and not:
(0, a.m)(x)
```
It seems surprising that:
```js
x |> eval
// desugars to:
(0, eval)(x)
// and not:
eval(x)
```
