### PR TITLE
Fix `%==` parsing in hack pipes

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1219,7 +1219,8 @@ export default class ExpressionParser extends LValParser {
           this.getPluginOption("pipelineOperator", "proposal") === "hack" &&
           this.getPluginOption("pipelineOperator", "topicToken") === "%"
         ) {
-          // If we find %= in an expression position, and % could be a topic token,
+          // If we find %= in an expression position, and the Hack-pipes proposal is active,
+          // then the % could be the topic token (e.g., in x |> %==y or x |> %===y), and so we
           // reparse it as %.
           // The next readToken() call will start parsing from =.
 

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1214,6 +1214,26 @@ export default class ExpressionParser extends LValParser {
         return node;
       }
 
+      case tt.assign:
+        if (
+          this.state.value === "%=" &&
+          this.getPluginOption("pipelineOperator", "proposal") === "hack" &&
+          this.getPluginOption("pipelineOperator", "topicToken") === "%"
+        ) {
+          // If we find %= in an expression position, and % could be a topic token,
+          // repase it as %.
+          // The next readToken() call will start parsing from =.
+
+          this.state.value = "%";
+          this.state.type = tt.modulo;
+          this.state.pos--;
+          this.state.end--;
+          this.state.endLoc.column--;
+        } else {
+          throw this.unexpected();
+        }
+
+      // falls through
       case tt.modulo:
       case tt.hash: {
         const pipeProposal = this.getPluginOption(

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1214,9 +1214,8 @@ export default class ExpressionParser extends LValParser {
         return node;
       }
 
-      case tt.assign:
+      case tt.moduloAssign:
         if (
-          this.state.value === "%=" &&
           this.getPluginOption("pipelineOperator", "proposal") === "hack" &&
           this.getPluginOption("pipelineOperator", "topicToken") === "%"
         ) {

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1220,7 +1220,7 @@ export default class ExpressionParser extends LValParser {
           this.getPluginOption("pipelineOperator", "topicToken") === "%"
         ) {
           // If we find %= in an expression position, and % could be a topic token,
-          // repase it as %.
+          // reparse it as %.
           // The next readToken() call will start parsing from =.
 
           this.state.value = "%";

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -574,7 +574,7 @@ export default class Tokenizer extends ParserErrors {
 
     if (next === charCodes.equalsTo && !this.state.inType) {
       width++;
-      type = tt.assign;
+      type = code === charCodes.percentSign ? tt.moduloAssign : tt.assign;
     }
 
     this.finishOp(type, width);

--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -140,6 +140,9 @@ export const types: { [name: string]: TokenType } = {
   eq: new TokenType("=", { beforeExpr, isAssign }),
   assign: new TokenType("_=", { beforeExpr, isAssign }),
   slashAssign: new TokenType("_=", { beforeExpr, isAssign }),
+  // This is only needed to support % as a pipe topic token. If the proosal
+  // ends up choosing a different token, it can be merged with tt.assign.
+  moduloAssign: new TokenType("_=", { beforeExpr, isAssign }),
   incDec: new TokenType("++/--", { prefix, postfix, startsExpr }),
   bang: new TokenType("!", { beforeExpr, prefix, startsExpr }),
   tilde: new TokenType("~", { beforeExpr, prefix, startsExpr }),

--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -140,7 +140,7 @@ export const types: { [name: string]: TokenType } = {
   eq: new TokenType("=", { beforeExpr, isAssign }),
   assign: new TokenType("_=", { beforeExpr, isAssign }),
   slashAssign: new TokenType("_=", { beforeExpr, isAssign }),
-  // This is only needed to support % as a pipe topic token. If the proosal
+  // This is only needed to support % as a Hack-pipe topic token. If the proposal
   // ends up choosing a different token, it can be merged with tt.assign.
   moduloAssign: new TokenType("_=", { beforeExpr, isAssign }),
   incDec: new TokenType("++/--", { prefix, postfix, startsExpr }),


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes failing CI in https://github.com/babel/babel/pull/13413
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

https://github.com/babel/babel/commit/b9c1884a58ee847220b08e896b11cbf6e160c83a removed `exprAllowed` usage from the main parser. However, it was used by the %` followed by a token starting with `=`. This PR modify the parser to re-interpret `%=` as `%` when parsing it in an expression position if hack pipes are enabled. 

cc @js-choi (please review!)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13536"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

