### PR TITLE
Fix broken e2e test

### DIFF
--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -566,7 +566,7 @@ defineType("TSTypeParameter", {
   visitor: ["constraint", "default"],
   fields: {
     name: {
-      validate: !process.env.BABEL_TYPES_8_BREAKING
+      validate: !process.env.BABEL_8_BREAKING
         ? assertValueType("string")
         : assertNodeType("Identifier"),
     },

--- a/packages/babel-types/test/builders/typescript/tsTypeParameter.js
+++ b/packages/babel-types/test/builders/typescript/tsTypeParameter.js
@@ -7,7 +7,7 @@ describe("builders", function () {
         const tsTypeParameter = t.tsTypeParameter(
           t.tsTypeReference(t.identifier("bar")),
           t.tsTypeReference(t.identifier("baz")),
-          !process.env.BABEL_TYPES_8_BREAKING ? "foo" : t.identifier("foo"),
+          !process.env.BABEL_8_BREAKING ? "foo" : t.identifier("foo"),
         );
         expect(tsTypeParameter).toMatchSnapshot({
           name: expect.anything(),
@@ -15,7 +15,7 @@ describe("builders", function () {
         // TODO(babel-8): move this check to the snapshot
         expect(tsTypeParameter).toEqual(
           expect.objectContaining({
-            name: !process.env.BABEL_TYPES_8_BREAKING
+            name: !process.env.BABEL_8_BREAKING
               ? "foo"
               : expect.objectContaining({
                   name: "foo",
@@ -31,7 +31,7 @@ describe("builders", function () {
             t.tsTypeReference(t.identifier("baz")),
           );
         }).toThrow(
-          !process.env.BABEL_TYPES_8_BREAKING
+          !process.env.BABEL_8_BREAKING
             ? "Property name expected type of string but got null"
             : 'Property name of TSTypeParameter expected node to be of a type ["Identifier"] but instead got undefined',
         );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes failing main https://app.circleci.com/pipelines/github/babel/babel/7433/workflows/3c5a3b2f-5501-46f2-8e48-3161d2ab1c5c/jobs/47170
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
CI is failing since #12829 because current breaking-e2e test does take `BABEL_TYPES_8_BREAKING` into account. I think `BABEL_TYPES_8_BREAKING` should default to `BABEL_8_BREAKING`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13538"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

