### PR TITLE
chore: bump test262-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "rollup-plugin-dts": "^2.0.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-terser": "^7.0.2",
-    "test262-stream": "^1.3.0",
+    "test262-stream": "^1.4.0",
     "through2": "^2.0.0",
     "typescript": "~4.2.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5760,7 +5760,7 @@ __metadata:
     rollup-plugin-dts: ^2.0.0
     rollup-plugin-node-polyfills: ^0.2.1
     rollup-plugin-terser: ^7.0.2
-    test262-stream: ^1.3.0
+    test262-stream: ^1.4.0
     through2: ^2.0.0
     typescript: ~4.2.3
   dependenciesMeta:
@@ -14433,13 +14433,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"test262-stream@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "test262-stream@npm:1.3.0"
+"test262-stream@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "test262-stream@npm:1.4.0"
   dependencies:
     js-yaml: ^3.2.1
     klaw: ^2.1.0
-  checksum: 19957e245241f3c843830dee72c49f8b57351fae092b0fdd73f9ef14342cd332ad5c0c7cc113d929bdf45bf782ee431aabc35c1d6a508f5febb2dd31b7f004fe
+  checksum: a60b9da6a0b95a9574c79799f6838a7256a225c3be6f759d02f4c2de2beefec8fe41b3b380c46a03b372132512ec82116d512dedcc42e4d5df509ad9afb0867b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes test262 updating errors. ([CI](https://github.com/babel/babel/runs/3024369305?check_suite_focus=true#step:10:7))
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | bumped `test262-stream`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Bumped `test262-stream` so it can work with test262 5.0.

It could have been created from #13343. For unknown reasons it does not show up on the dashboard.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13543"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

