### PR TITLE
Fix  parser `strictMode` option

### DIFF
--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -33,7 +33,11 @@ export default class State {
 
   init(options: Options): void {
     this.strict =
-      options.strictMode === false ? false : options.sourceType === "module";
+      options.strictMode === false
+        ? false
+        : options.strictMode === true
+        ? true
+        : options.sourceType === "module";
 
     this.curLine = options.startLine;
     this.startLoc = this.endLoc = this.curPosition();

--- a/packages/babel-parser/test/options.js
+++ b/packages/babel-parser/test/options.js
@@ -1,0 +1,59 @@
+import { parse } from "../lib";
+
+describe("options", () => {
+  describe("strictMode", () => {
+    const CODE = "function f(x, x) {}";
+
+    function expectToSucceed(opts) {
+      expect(parse(CODE, opts).program.body[0]).toMatchObject({
+        type: "FunctionDeclaration",
+        id: { type: "Identifier", name: "f" },
+        generator: false,
+        async: false,
+        params: [
+          { type: "Identifier", name: "x" },
+          { type: "Identifier", name: "x" },
+        ],
+        body: {
+          type: "BlockStatement",
+          body: [],
+          directives: [],
+        },
+      });
+    }
+
+    function expectToFail(opts) {
+      expect(() => parse(CODE, opts)).toThrow(
+        new SyntaxError("Argument name clash. (1:14)"),
+      );
+    }
+
+    describe("sourceType module", () => {
+      it("default parses as strict mode", () => {
+        expectToFail({ sourceType: "module" });
+      });
+
+      it("false parses as sloppy mode", () => {
+        expectToSucceed({ sourceType: "module", strictMode: false });
+      });
+
+      it("true parses as strict mode", () => {
+        expectToFail({ sourceType: "module", strictMode: true });
+      });
+    });
+
+    describe("sourceType script", () => {
+      it("default parses as sloppy mode", () => {
+        expectToSucceed({ sourceType: "script" });
+      });
+
+      it("false parses as sloppy mode", () => {
+        expectToSucceed({ sourceType: "script", strictMode: false });
+      });
+
+      it("true parses as strict mode", () => {
+        expectToFail({ sourceType: "script", strictMode: true });
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No issue
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | n/a
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The `strictMode` option to `parse()` does not behave as described in the docs.

[The docs](https://babeljs.io/docs/en/babel-parser#options) say:

> strictMode: By default, ECMAScript code is parsed as strict only if a `"use strict"`; directive is present or if the parsed file is an ECMAScript module. Set this option to `true` to always parse files in strict mode.

The [actual behavior](https://github.com/overlookmotel/babel/blob/main/packages/babel-parser/src/tokenizer/state.js#L35) is `strict = options.strictMode === false ? false : options.sourceType === "module";`

Setting the option to `true` has no effect - contradicting what it says in docs.

This PR fixes this so the option behaves as documented, while also preserving the current (undocumented) behavior of allowing `strictMode: false` to override `sourceType: 'module'`.

I have opted to check for `true` and `false` explicitly and ignore any other values for the option, rather than accepting other truthy/falsy values. This is intended to make this change less likely to cause unexpected breakage for incorrect configurations e.g. `strictMode: "sloppy"`. But I think anyone who has explicitly said `strictMode: true` clearly wants that!

By the way, this option *is* useful in some cases. I ran into it because was trying to parse code that was being run in an `eval()` which is nested within strict mode code. So it should be parsed as strict mode, but not as a module as there's no `import` inside `eval()`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13548"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

