### PR TITLE
Enable ergonomic brand checks (`#priv in`) by default

### DIFF
--- a/packages/babel-compat-data/scripts/data/plugin-features.js
+++ b/packages/babel-compat-data/scripts/data/plugin-features.js
@@ -134,8 +134,7 @@ const es2021 = {
   "proposal-logical-assignment-operators": "Logical Assignment",
 };
 
-const shippedProposal = {
-  "proposal-class-static-block": "Class static initialization blocks",
+const es2022 = {
   "proposal-private-property-in-object":
     "Ergonomic brand checks for private fields",
   "proposal-class-properties": {
@@ -149,10 +148,15 @@ const shippedProposal = {
   "proposal-private-methods": "private class methods",
 };
 
+const shippedProposal = {
+  "proposal-class-static-block": "Class static initialization blocks",
+};
+
 // Run plugins for modern features first
 module.exports = Object.assign(
   {},
   shippedProposal,
+  es2022,
   es2021,
   es2020,
   es2019,

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1153,16 +1153,12 @@ export default class ExpressionParser extends LValParser {
         // https://tc39.es/proposal-private-fields-in-in
         // RelationalExpression [In, Yield, Await]
         //   [+In] PrivateIdentifier in ShiftExpression[?Yield, ?Await]
-        const start = this.state.start;
         const value = this.state.value;
         node = this.parsePrivateName();
         if (this.match(tt._in)) {
-          this.expectPlugin("privateIn");
           this.classScope.usePrivateName(value, node.start);
-        } else if (this.hasPlugin("privateIn")) {
-          this.raise(this.state.start, Errors.PrivateInExpectedIn, value);
         } else {
-          throw this.unexpected(start);
+          this.raise(this.state.start, Errors.PrivateInExpectedIn, value);
         }
         return node;
       }

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1153,12 +1153,12 @@ export default class ExpressionParser extends LValParser {
         // https://tc39.es/proposal-private-fields-in-in
         // RelationalExpression [In, Yield, Await]
         //   [+In] PrivateIdentifier in ShiftExpression[?Yield, ?Await]
-        const value = this.state.value;
+        const { value, start } = this.state;
         node = this.parsePrivateName();
         if (this.match(tt._in)) {
-          this.classScope.usePrivateName(value, node.start);
+          this.classScope.usePrivateName(value, start);
         } else {
-          this.raise(this.state.start, Errors.PrivateInExpectedIn, value);
+          this.raise(start, Errors.PrivateInExpectedIn, value);
         }
         return node;
       }

--- a/packages/babel-parser/test/fixtures/es2022/class-private-methods/asi-failure-generator/options.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-private-methods/asi-failure-generator/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (3:3)"
+  "throws": "Unexpected token (3:9)"
 }

--- a/packages/babel-parser/test/fixtures/es2022/class-private-properties/failure-shorthand/options.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-private-properties/failure-shorthand/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (4:11)"
-}

--- a/packages/babel-parser/test/fixtures/es2022/class-private-properties/failure-shorthand/output.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-private-properties/failure-shorthand/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":56,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
   "errors": [
-    "SyntaxError: Private names are only allowed in property accesses (`obj.#x`) or in `in` expressions (`#x in obj`). (4:13)"
+    "SyntaxError: Private names are only allowed in property accesses (`obj.#x`) or in `in` expressions (`#x in obj`). (4:11)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2022/class-private-properties/failure-shorthand/output.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-private-properties/failure-shorthand/output.json
@@ -1,0 +1,89 @@
+{
+  "type": "File",
+  "start":0,"end":56,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
+  "errors": [
+    "SyntaxError: Private names are only allowed in property accesses (`obj.#x`) or in `in` expressions (`#x in obj`). (4:13)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":56,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":56,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":56,"loc":{"start":{"line":1,"column":10},"end":{"line":6,"column":1}},
+          "body": [
+            {
+              "type": "ClassPrivateProperty",
+              "start":14,"end":17,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":5}},
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start":14,"end":16,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":4}},
+                "id": {
+                  "type": "Identifier",
+                  "start":15,"end":16,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":4},"identifierName":"x"},
+                  "name": "x"
+                }
+              },
+              "value": null
+            },
+            {
+              "type": "ClassMethod",
+              "start":20,"end":54,"loc":{"start":{"line":3,"column":2},"end":{"line":5,"column":3}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":20,"end":31,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":13},"identifierName":"constructor"},
+                "name": "constructor"
+              },
+              "computed": false,
+              "kind": "constructor",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":34,"end":54,"loc":{"start":{"line":3,"column":16},"end":{"line":5,"column":3}},
+                "body": [
+                  {
+                    "type": "ExpressionStatement",
+                    "start":40,"end":50,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":14}},
+                    "expression": {
+                      "type": "UnaryExpression",
+                      "start":40,"end":49,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":13}},
+                      "operator": "delete",
+                      "prefix": true,
+                      "argument": {
+                        "type": "PrivateName",
+                        "start":47,"end":49,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":13}},
+                        "id": {
+                          "type": "Identifier",
+                          "start":48,"end":49,"loc":{"start":{"line":4,"column":12},"end":{"line":4,"column":13},"identifierName":"x"},
+                          "name": "x"
+                        }
+                      }
+                    }
+                  }
+                ],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/estree/private-in/basic/options.json
+++ b/packages/babel-parser/test/fixtures/estree/private-in/basic/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["estree", "privateIn"]
+  "plugins": ["estree"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/private-in/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/private-in/input.js
@@ -1,7 +1,0 @@
-class Point {
-  #x = 1;
-  #y = 2;
-  static isPoint(obj) {
-    return #x in obj && #y in obj;
-  }
-}

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/private-in/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/private-in/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "This experimental syntax requires enabling the parser plugin: 'privateIn' (5:14)"
-}

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-binary-expression-left/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-binary-expression-left/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["privateIn"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-binary-expression-left/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-binary-expression-left/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":50,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
   "errors": [
-    "SyntaxError: Private names are only allowed in property accesses (`obj.#x`) or in `in` expressions (`#x in obj`). (4:7)"
+    "SyntaxError: Private names are only allowed in property accesses (`obj.#x`) or in `in` expressions (`#x in obj`). (4:4)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-binary-expression-right/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-binary-expression-right/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["privateIn"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-binary-expression-right/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-binary-expression-right/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":50,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
   "errors": [
-    "SyntaxError: Private names are only allowed in property accesses (`obj.#x`) or in `in` expressions (`#x in obj`). (4:10)"
+    "SyntaxError: Private names are only allowed in property accesses (`obj.#x`) or in `in` expressions (`#x in obj`). (4:8)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-expression/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-expression/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["privateIn"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-expression/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-expression/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":46,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
   "errors": [
-    "SyntaxError: Private names are only allowed in property accesses (`obj.#x`) or in `in` expressions (`#x in obj`). (4:6)"
+    "SyntaxError: Private names are only allowed in property accesses (`obj.#x`) or in `in` expressions (`#x in obj`). (4:4)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-in-class-heritage/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-in-class-heritage/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["privateIn"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-in-escaped-sequence/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-in-escaped-sequence/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["privateIn"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-in-parenthesized/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-in-parenthesized/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["privateIn"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-in-parenthesized/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-in-parenthesized/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":54,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
   "errors": [
-    "SyntaxError: Private names are only allowed in property accesses (`obj.#x`) or in `in` expressions (`#x in obj`). (4:7)"
+    "SyntaxError: Private names are only allowed in property accesses (`obj.#x`) or in `in` expressions (`#x in obj`). (4:5)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-in-without-field/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-in-without-field/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["privateIn"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/private-in/private-in/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/private-in/private-in/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["privateIn"]
-}

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -140,7 +140,7 @@ export type ParserPlugin =
   | "partialApplication"
   | "pipelineOperator"
   | "placeholders"
-  | "privateIn"
+  | "privateIn" // Enabled by default
   | "throwExpressions"
   | "topLevelAwait"
   | "typescript"

--- a/packages/babel-preset-env/data/shipped-proposals.js
+++ b/packages/babel-preset-env/data/shipped-proposals.js
@@ -4,7 +4,6 @@
 
 const proposalPlugins = new Set([
   "proposal-class-static-block",
-  "proposal-private-property-in-object",
 ]);
 
 // use intermediary object to enforce alphabetical key order

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ios, node, opera, safari, samsung }
   proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ios, node, opera, safari, samsung }
   proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { edge }
   proposal-class-properties { edge < 84 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { edge }
   proposal-class-properties { edge < 84 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { edge }
   proposal-class-properties { edge < 84 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { edge }
   proposal-class-properties { edge < 84 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { edge }
   proposal-class-properties { edge < 84 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { edge }
   proposal-class-properties { edge < 84 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { edge }
   proposal-class-properties { edge < 84 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { edge }
   proposal-class-properties { edge < 84 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { safari }
   proposal-class-properties { safari < 15 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { safari }
   proposal-class-properties { safari < 15 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { safari }
   proposal-class-properties { safari < 15 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { safari }
   proposal-class-properties { safari < 15 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   syntax-class-properties
   syntax-numeric-separator
   syntax-nullish-coalescing-operator

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   syntax-class-properties
   syntax-numeric-separator
   syntax-nullish-coalescing-operator

--- a/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ios, node, opera, safari, samsung }
   proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ios, node, opera, safari, samsung }
   proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ios, node, opera, safari, samsung }
   proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ios, node, opera, safari, samsung }
   proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios, node < 14.6, opera < 70, safari < 15, samsung }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslist-env/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslist-env/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { ie }
   proposal-class-properties { ie }
   proposal-private-methods { ie }
   proposal-numeric-separator { ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-android-3/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android }
   proposal-class-properties { android }
   proposal-private-methods { android }
   proposal-numeric-separator { android }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
@@ -15,6 +15,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ios, opera, safari, samsung }
   proposal-class-properties { firefox < 90, ios, safari < 15, samsung }
   proposal-private-methods { firefox < 90, ios, safari < 15, samsung }
   syntax-numeric-separator

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ie, ios, opera, safari, samsung }
   proposal-class-properties { firefox < 90, ie, ios, safari < 15, samsung }
   proposal-private-methods { firefox < 90, ie, ios, safari < 15, samsung }
   proposal-numeric-separator { ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
@@ -15,6 +15,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ios, opera, safari, samsung }
   proposal-class-properties { firefox < 90, ios, safari < 15, samsung }
   proposal-private-methods { firefox < 90, ios, safari < 15, samsung }
   syntax-numeric-separator

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/corejs-without-usebuiltins/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { ie }
   proposal-class-properties { ie }
   proposal-private-methods { ie }
   proposal-numeric-separator { ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-android/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android }
   proposal-class-properties { android }
   proposal-private-methods { android }
   proposal-numeric-separator { android }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { electron < 13.0 }
   proposal-class-properties { electron < 10.0 }
   proposal-private-methods { electron < 10.0 }
   proposal-numeric-separator { electron < 6.0 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { node }
   proposal-class-properties { node < 14.6 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { ie }
   proposal-class-properties { ie }
   proposal-private-methods { ie }
   proposal-numeric-separator { ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
@@ -13,6 +13,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, edge, firefox < 90, ie, ios, safari }
   proposal-class-properties { chrome < 84, edge < 84, firefox < 90, ie, ios, safari < 15 }
   proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios, safari < 15 }
   proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
@@ -11,6 +11,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node }
   proposal-class-properties { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-android/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android }
   proposal-class-properties { android }
   proposal-private-methods { android }
   proposal-numeric-separator { android }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { electron < 13.0 }
   proposal-class-properties { electron < 10.0 }
   proposal-private-methods { electron < 10.0 }
   proposal-numeric-separator { electron < 6.0 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { node }
   proposal-class-properties { node < 14.6 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { ie }
   proposal-class-properties { ie }
   proposal-private-methods { ie }
   proposal-numeric-separator { ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
@@ -13,6 +13,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, edge, firefox < 90, ie, ios, safari }
   proposal-class-properties { chrome < 84, edge < 84, firefox < 90, ie, ios, safari < 15 }
   proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios, safari < 15 }
   proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
@@ -11,6 +11,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node }
   proposal-class-properties { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { node }
   proposal-class-properties { node < 14.6 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
@@ -9,6 +9,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { firefox < 90, node }
   proposal-class-properties { firefox < 90, node < 14.6 }
   proposal-private-methods { firefox < 90, node < 14.6 }
   proposal-numeric-separator { firefox < 70, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   syntax-numeric-separator

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { ie }
   proposal-class-properties { ie }
   proposal-private-methods { ie }
   proposal-numeric-separator { ie }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android }
   proposal-class-properties { android }
   proposal-private-methods { android }
   proposal-numeric-separator { android }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -15,6 +15,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ios, opera, safari, samsung }
   proposal-class-properties { firefox < 90, ios, safari < 15, samsung }
   proposal-private-methods { firefox < 90, ios, safari < 15, samsung }
   syntax-numeric-separator

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -16,6 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ie, ios, opera, safari, samsung }
   proposal-class-properties { firefox < 90, ie, ios, safari < 15, samsung }
   proposal-private-methods { firefox < 90, ie, ios, safari < 15, samsung }
   proposal-numeric-separator { ie }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -15,6 +15,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android, chrome < 91, edge, firefox < 90, ios, opera, safari, samsung }
   proposal-class-properties { firefox < 90, ios, safari < 15, samsung }
   proposal-private-methods { firefox < 90, ios, safari < 15, samsung }
   syntax-numeric-separator

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { ie }
   proposal-class-properties { ie }
   proposal-private-methods { ie }
   proposal-numeric-separator { ie }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android }
   proposal-class-properties { android }
   proposal-private-methods { android }
   proposal-numeric-separator { android }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { electron < 13.0 }
   proposal-class-properties { electron < 10.0 }
   proposal-private-methods { electron < 10.0 }
   proposal-numeric-separator { electron < 6.0 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { node }
   proposal-class-properties { node < 14.6 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { ie }
   proposal-class-properties { ie }
   proposal-private-methods { ie }
   proposal-numeric-separator { ie }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -13,6 +13,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, edge, firefox < 90, ie, ios, safari }
   proposal-class-properties { chrome < 84, edge < 84, firefox < 90, ie, ios, safari < 15 }
   proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios, safari < 15 }
   proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -11,6 +11,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node }
   proposal-class-properties { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { android }
   proposal-class-properties { android }
   proposal-private-methods { android }
   proposal-numeric-separator { android }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { electron < 13.0 }
   proposal-class-properties { electron < 10.0 }
   proposal-private-methods { electron < 10.0 }
   proposal-numeric-separator { electron < 6.0 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { node }
   proposal-class-properties { node < 14.6 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { ie }
   proposal-class-properties { ie }
   proposal-private-methods { ie }
   proposal-numeric-separator { ie }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
@@ -13,6 +13,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, edge, firefox < 90, ie, ios, safari }
   proposal-class-properties { chrome < 84, edge < 84, firefox < 90, ie, ios, safari < 15 }
   proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios, safari < 15 }
   proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -11,6 +11,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node }
   proposal-class-properties { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { node }
   proposal-class-properties { node < 14.6 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, ie, node }
   proposal-class-properties { chrome < 84, ie, node < 14.6 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
@@ -9,6 +9,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { firefox < 90, node }
   proposal-class-properties { firefox < 90, node < 14.6 }
   proposal-private-methods { firefox < 90, node < 14.6 }
   proposal-numeric-separator { firefox < 70, node < 12.5 }

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   syntax-numeric-separator

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91 }
   proposal-class-properties { chrome < 84 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
@@ -10,6 +10,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
   proposal-class-properties { chrome < 84, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/methods-loose-preset-not-loose/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/methods-loose-preset-not-loose/stderr.txt
@@ -1,4 +1,8 @@
-Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-class-properties since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-methods.
+Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-methods.
+The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
+	["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
+to the "plugins" section of your Babel config.
+Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-class-properties since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-property-in-object.
 The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
 	["@babel/plugin-proposal-class-properties", { "loose": true }]
 to the "plugins" section of your Babel config.

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-loose-preset-not-loose/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-loose-preset-not-loose/stderr.txt
@@ -1,1 +1,4 @@
-
+Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-methods.
+The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
+	["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
+to the "plugins" section of your Babel config.

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-not-loose-preset-loose/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-and-methods-not-loose-preset-loose/stderr.txt
@@ -1,1 +1,4 @@
-
+Though the "loose" option was set to "true" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "false" for @babel/plugin-proposal-private-methods.
+The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
+	["@babel/plugin-proposal-private-property-in-object", { "loose": false }]
+to the "plugins" section of your Babel config.

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-loose-preset-not-loose/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-loose-preset-not-loose/stderr.txt
@@ -1,4 +1,8 @@
-Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
+Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
+The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
+	["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
+to the "plugins" section of your Babel config.
+Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-property-in-object.
 The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
 	["@babel/plugin-proposal-private-methods", { "loose": true }]
 to the "plugins" section of your Babel config.

--- a/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-not-loose-preset-loose/stderr.txt
+++ b/packages/babel-preset-env/test/fixtures/loose-class-features-precedence/properties-not-loose-preset-loose/stderr.txt
@@ -1,4 +1,8 @@
-Though the "loose" option was set to "true" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "false" for @babel/plugin-proposal-class-properties.
+Though the "loose" option was set to "true" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "false" for @babel/plugin-proposal-class-properties.
+The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
+	["@babel/plugin-proposal-private-property-in-object", { "loose": false }]
+to the "plugins" section of your Babel config.
+Though the "loose" option was set to "true" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "false" for @babel/plugin-proposal-private-property-in-object.
 The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
 	["@babel/plugin-proposal-private-methods", { "loose": false }]
 to the "plugins" section of your Babel config.

--- a/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { safari }
   proposal-class-properties { safari < 15 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-private-property-in-object { safari }
   proposal-class-properties { safari < 15 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }

--- a/scripts/parser-tests/test262/index.js
+++ b/scripts/parser-tests/test262/index.js
@@ -152,7 +152,6 @@ const ignoredFeatures = [
 const ignoredTests = ["built-ins/RegExp/", "language/literals/regexp/"];
 
 const featuresToPlugins = {
-  "class-fields-private-in": "privateIn",
   "class-static-block": "classStaticBlock",
   "top-level-await": "topLevelAwait",
   "import-assertions": "importAssertions",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2556
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

@ljharb is going to ask for Stage 4 at this week's meeting ([agenda](https://github.com/tc39/agendas/blob/master/2021/07.md)).

We were already planning 7.15.0, but it would be very nice to get this PR in (if the feature gets Stage 4).

**EDIT:** Stage 4 confirmed :tada:

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13554"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

