### PR TITLE
feat: support hack pipeline in `@babel/standalone`

### DIFF
--- a/packages/babel-standalone/src/preset-stage-0.ts
+++ b/packages/babel-standalone/src/preset-stage-0.ts
@@ -7,7 +7,8 @@ export default (_: any, opts: any = {}) => {
     useBuiltIns = false,
     decoratorsLegacy = false,
     decoratorsBeforeExport,
-    pipelineProposal = "minimal",
+    pipelineProposal,
+    pipelineTopicToken,
     importAssertionsVersion = "september-2020",
   } = opts;
 
@@ -21,6 +22,7 @@ export default (_: any, opts: any = {}) => {
           decoratorsLegacy,
           decoratorsBeforeExport,
           pipelineProposal,
+          pipelineTopicToken,
           importAssertionsVersion,
         },
       ],

--- a/packages/babel-standalone/src/preset-stage-1.ts
+++ b/packages/babel-standalone/src/preset-stage-1.ts
@@ -23,7 +23,10 @@ export default (_: any, opts: any = {}) => {
       [babelPlugins.syntaxRecordAndTuple, { syntaxType: recordAndTupleSyntax }],
       babelPlugins.syntaxModuleBlocks,
       babelPlugins.proposalExportDefaultFrom,
-      [babelPlugins.proposalPipelineOperator, { proposal: pipelineProposal }],
+      [
+        babelPlugins.proposalPipelineOperator,
+        { proposal: pipelineProposal, topicToken: "%" },
+      ],
       babelPlugins.proposalDoExpressions,
     ],
   };

--- a/packages/babel-standalone/src/preset-stage-1.ts
+++ b/packages/babel-standalone/src/preset-stage-1.ts
@@ -8,6 +8,7 @@ export default (_: any, opts: any = {}) => {
     decoratorsLegacy = false,
     decoratorsBeforeExport,
     pipelineProposal = "minimal",
+    pipelineTopicToken = "%",
     recordAndTupleSyntax: recordAndTupleSyntax = "hash",
   } = opts;
 
@@ -25,7 +26,7 @@ export default (_: any, opts: any = {}) => {
       babelPlugins.proposalExportDefaultFrom,
       [
         babelPlugins.proposalPipelineOperator,
-        { proposal: pipelineProposal, topicToken: "%" },
+        { proposal: pipelineProposal, topicToken: pipelineTopicToken },
       ],
       babelPlugins.proposalDoExpressions,
     ],

--- a/packages/babel-standalone/test/preset-stage-1.test.js
+++ b/packages/babel-standalone/test/preset-stage-1.test.js
@@ -15,5 +15,24 @@ const require = createRequire(import.meta.url);
       }).code;
       expect(output).toBe("0.3m;");
     });
+
+    it("should support hack pipeline", () => {
+      const output = Babel.transform("x |> %", {
+        presets: [
+          [
+            "stage-1",
+            {
+              pipelineProposal: "hack",
+              decoratorsBeforeExport: true,
+            },
+          ],
+        ],
+      }).code;
+      expect(output).toMatchInlineSnapshot(`
+"var _ref;
+
+_ref = x, _ref;"
+`);
+    });
   },
 );

--- a/packages/babel-standalone/test/preset-stage-1.test.js
+++ b/packages/babel-standalone/test/preset-stage-1.test.js
@@ -34,5 +34,26 @@ const require = createRequire(import.meta.url);
 _ref = x, _ref;"
 `);
     });
+
+    it("should support hack pipeline with `#` topic token", () => {
+      const output = Babel.transform("x |> #", {
+        presets: [
+          [
+            "stage-1",
+            {
+              pipelineProposal: "hack",
+              pipelineTopicToken: "#",
+              recordAndTupleSyntax: "bar",
+              decoratorsBeforeExport: true,
+            },
+          ],
+        ],
+      }).code;
+      expect(output).toMatchInlineSnapshot(`
+"var _ref;
+
+_ref = x, _ref;"
+`);
+    });
   },
 );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Support `hack` pipeline proposal in standalone
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
<s>Due to conflict with record and tuple. Only `%` topic token is currently supported.</s>

Supports hack pipeline and topic token. The topic token defaults to `%` since recordAndTupleSyntax defaults to `hash`.

[REPL Preview](https://deploy-preview-2553--babel.netlify.app/repl/build/47434)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13555"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

