### PR TITLE
Fix `make generate-standalone` -> `make build-standalone`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,7 +341,7 @@ Note that the code shown in Chrome DevTools is compiled code and therefore diffe
   - [ ] Add `@babel/syntax-new-syntax` package. You can copy `packages/babel-plugin-syntax-decimal` and replace `decimal` to `new-syntax`.
   - [ ] Add `@babel/syntax-new-syntax` to `@babel/standalone`.
     - [ ] Add `@babel/syntax-new-syntax` to `package.json`
-    - [ ] Add `@babel/syntax-new-syntax` to [`pluginsConfig.json`](https://github.com/babel/babel/blob/master/packages/babel-standalone/scripts/pluginConfig.json), run `make generate-standalone`.
+    - [ ] Add `@babel/syntax-new-syntax` to [`pluginsConfig.json`](https://github.com/babel/babel/blob/master/packages/babel-standalone/scripts/pluginConfig.json), run `make build-standalone`.
     - [ ] Add `@babel/syntax-new-syntax` to `src/preset-stage-x`.
   - [ ] Add `"newSyntax"` to parser [typings](https://github.com/babel/babel/blob/master/packages/babel-parser/typings/babel-parser.d.ts)
 - [ ] Implement generator support in `packages/babel-generator/src/generators`. The generator converts AST to source code.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Y
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Fix `make generate-standalone` -> `make build-standalone` in CONTRIBUTING.md. In now `make generate-standalone` command does not exist.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13562"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

