### PR TITLE
Add typings to `create-class-features-plugin` helper

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1,21 +1,26 @@
 import { types as t, template } from "@babel/core";
+import type { File } from "@babel/core";
+import type { NodePath } from "@babel/traverse";
 import ReplaceSupers from "@babel/helper-replace-supers";
 import nameFunction from "@babel/helper-function-name";
 
-export function hasOwnDecorators(node) {
+type Decoratable = Extract<t.Node, { decorators?: t.Decorator[] | null }>;
+
+export function hasOwnDecorators(node: t.Node) {
+  // @ts-expect-error(flow->ts) TODO: maybe we could add t.isDecoratable to make ts happy
   return !!(node.decorators && node.decorators.length);
 }
 
-export function hasDecorators(node) {
+export function hasDecorators(node: t.Class) {
   return hasOwnDecorators(node) || node.body.body.some(hasOwnDecorators);
 }
 
-function prop(key, value) {
+function prop(key: string, value?: t.Expression) {
   if (!value) return null;
   return t.objectProperty(t.identifier(key), value);
 }
 
-function method(key, body) {
+function method(key: string, body: t.Statement[]) {
   return t.objectMethod(
     "method",
     t.identifier(key),
@@ -24,8 +29,8 @@ function method(key, body) {
   );
 }
 
-function takeDecorators(node) {
-  let result;
+function takeDecorators(node: Decoratable) {
+  let result: t.ArrayExpression | undefined;
   if (node.decorators && node.decorators.length > 0) {
     result = t.arrayExpression(
       node.decorators.map(decorator => decorator.expression),
@@ -47,9 +52,15 @@ function getKey(node) {
 
 // NOTE: This function can be easily bound as .bind(file, classRef, superRef)
 //       to make it easier to use it in a loop.
-function extractElementDescriptor(/* this: File, */ classRef, superRef, path) {
+function extractElementDescriptor(
+  /* this: File, */
+  classRef: t.Identifier,
+  superRef: t.Identifier,
+  path: ClassElementPath,
+) {
   const { node, scope } = path;
   const isMethod = path.isClassMethod();
+  const isMethodNode = (node: t.Node): node is t.ClassMethod => isMethod;
 
   if (path.isPrivate()) {
     throw path.buildCodeFrameError(
@@ -68,17 +79,17 @@ function extractElementDescriptor(/* this: File, */ classRef, superRef, path) {
   }).replace();
 
   const properties: t.ObjectExpression["properties"] = [
-    prop("kind", t.stringLiteral(isMethod ? node.kind : "field")),
-    prop("decorators", takeDecorators(node)),
+    prop("kind", t.stringLiteral(isMethodNode(node) ? node.kind : "field")),
+    prop("decorators", takeDecorators(node as Decoratable)),
     prop("static", node.static && t.booleanLiteral(true)),
     prop("key", getKey(node)),
   ].filter(Boolean);
 
-  if (isMethod) {
+  if (isMethodNode(node)) {
     const id = node.computed ? null : node.key;
     t.toExpression(node);
     properties.push(prop("value", nameFunction({ node, id, scope }) || node));
-  } else if (node.value) {
+  } else if (t.isClassProperty(node) && node.value) {
     properties.push(
       method("value", template.statements.ast`return ${node.value}`),
     );
@@ -91,7 +102,7 @@ function extractElementDescriptor(/* this: File, */ classRef, superRef, path) {
   return t.objectExpression(properties);
 }
 
-function addDecorateHelper(file) {
+function addDecorateHelper(file: File) {
   try {
     return file.addHelper("decorate");
   } catch (err) {
@@ -105,7 +116,15 @@ function addDecorateHelper(file) {
   }
 }
 
-export function buildDecoratedClass(ref, path, elements, file) {
+type ClassElement = t.Class["body"]["body"][number];
+type ClassElementPath = NodePath<ClassElement>;
+
+export function buildDecoratedClass(
+  ref: t.Identifier,
+  path: NodePath<t.Class>,
+  elements: ClassElementPath[],
+  file: File,
+) {
   const { node, scope } = path;
   const initializeId = scope.generateUidIdentifier("initialize");
   const isDeclaration = node.id && path.isDeclaration();
@@ -115,7 +134,7 @@ export function buildDecoratedClass(ref, path, elements, file) {
   node.type = "ClassDeclaration";
   if (!node.id) node.id = t.cloneNode(ref);
 
-  let superId;
+  let superId: t.Identifier;
   if (superClass) {
     superId = scope.generateUidIdentifierBasedOnNode(node.superClass, "super");
     node.superClass = superId;
@@ -124,7 +143,7 @@ export function buildDecoratedClass(ref, path, elements, file) {
   const classDecorators = takeDecorators(node);
   const definitions = t.arrayExpression(
     elements
-      // Ignore TypeScript's abstract methods (see #10514)
+      // @ts-expect-error Ignore TypeScript's abstract methods (see #10514)
       .filter(element => !element.node.abstract)
       .map(extractElementDescriptor.bind(file, node.id, superId)),
   );
@@ -155,9 +174,9 @@ export function buildDecoratedClass(ref, path, elements, file) {
 
   return {
     instanceNodes: [template.statement.ast`${t.cloneNode(initializeId)}(this)`],
-    wrapClass(path) {
+    wrapClass(path: NodePath<t.Class>) {
       path.replaceWith(replacement);
-      return path.get(classPathDesc);
+      return path.get(classPathDesc) as NodePath;
     },
   };
 }

--- a/packages/babel-helper-create-class-features-plugin/src/features.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/features.ts
@@ -66,8 +66,8 @@ export function enableFeature(file: File, feature: number, loose: boolean) {
     }
   }
 
-  let resolvedLoose: boolean;
-  let higherPriorityPluginName: string;
+  let resolvedLoose: boolean | undefined;
+  let higherPriorityPluginName: string | undefined;
 
   for (const [mask, name] of featuresSameLoose) {
     if (!hasFeature(file, mask)) continue;
@@ -149,7 +149,7 @@ export function verifyUsedFeatures(path: NodePath, file: File) {
     }
   }
 
-  // NOTE: path.isPrivateMethod() it isn't supported in <7.2.0
+  // NOTE: path.isClassPrivateMethod() it isn't supported in <7.2.0
   if (path.isClassPrivateMethod?.()) {
     if (!hasFeature(file, FEATURES.privateMethods)) {
       throw path.buildCodeFrameError("Class private methods are not enabled.");

--- a/packages/babel-helper-create-class-features-plugin/src/features.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/features.ts
@@ -1,3 +1,5 @@
+import type { File } from "@babel/core";
+import type { NodePath } from "@babel/traverse";
 import { hasOwnDecorators } from "./decorators";
 
 export const FEATURES = Object.freeze({
@@ -36,7 +38,7 @@ const looseKey = "@babel/plugin-class-features/looseKey";
 const looseLowPriorityKey =
   "@babel/plugin-class-features/looseLowPriorityKey/#__internal__@babel/preset-env__please-overwrite-loose-instead-of-throwing";
 
-export function enableFeature(file, feature, loose) {
+export function enableFeature(file: File, feature: number, loose: boolean) {
   // We can't blindly enable the feature because, if it was already set,
   // "loose" can't be changed, so that
   //   @babel/plugin-class-properties { loose: true }
@@ -46,12 +48,14 @@ export function enableFeature(file, feature, loose) {
   if (!hasFeature(file, feature) || canIgnoreLoose(file, feature)) {
     file.set(featuresKey, file.get(featuresKey) | feature);
     if (
+      // @ts-expect-error
       loose ===
       "#__internal__@babel/preset-env__prefer-true-but-false-is-ok-if-it-prevents-an-error"
     ) {
       setLoose(file, feature, true);
       file.set(looseLowPriorityKey, file.get(looseLowPriorityKey) | feature);
     } else if (
+      // @ts-expect-error
       loose ===
       "#__internal__@babel/preset-env__prefer-false-but-true-is-ok-if-it-prevents-an-error"
     ) {
@@ -62,8 +66,8 @@ export function enableFeature(file, feature, loose) {
     }
   }
 
-  let resolvedLoose: void | true | false;
-  let higherPriorityPluginName: void | string;
+  let resolvedLoose: boolean;
+  let higherPriorityPluginName: string;
 
   for (const [mask, name] of featuresSameLoose) {
     if (!hasFeature(file, mask)) continue;
@@ -103,26 +107,26 @@ export function enableFeature(file, feature, loose) {
   }
 }
 
-function hasFeature(file, feature) {
+function hasFeature(file: File, feature: number) {
   return !!(file.get(featuresKey) & feature);
 }
 
-export function isLoose(file, feature) {
+export function isLoose(file: File, feature: number) {
   return !!(file.get(looseKey) & feature);
 }
 
-function setLoose(file, feature, loose) {
+function setLoose(file: File, feature: number, loose: boolean) {
   if (loose) file.set(looseKey, file.get(looseKey) | feature);
   else file.set(looseKey, file.get(looseKey) & ~feature);
 
   file.set(looseLowPriorityKey, file.get(looseLowPriorityKey) & ~feature);
 }
 
-function canIgnoreLoose(file, feature) {
+function canIgnoreLoose(file: File, feature: number) {
   return !!(file.get(looseLowPriorityKey) & feature);
 }
 
-export function verifyUsedFeatures(path, file) {
+export function verifyUsedFeatures(path: NodePath, file: File) {
   if (hasOwnDecorators(path.node)) {
     if (!hasFeature(file, FEATURES.decorators)) {
       throw path.buildCodeFrameError(
@@ -146,7 +150,7 @@ export function verifyUsedFeatures(path, file) {
   }
 
   // NOTE: path.isPrivateMethod() it isn't supported in <7.2.0
-  if (path.isPrivateMethod?.()) {
+  if (path.isClassPrivateMethod?.()) {
     if (!hasFeature(file, FEATURES.privateMethods)) {
       throw path.buildCodeFrameError("Class private methods are not enabled.");
     }

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -111,8 +111,7 @@ function privateNameVisitorFactory<S>(
     Class(path) {
       const { privateNamesMap } = this;
       // not using body.body since it will loose typing
-      const classBody = path.get("body");
-      const body = classBody.get("body");
+      const body = path.get("body").get("body");
 
       const visiblePrivateNames = new Map(privateNamesMap);
       const redeclared = [];

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -3,7 +3,8 @@ import type { NodePath, Visitor } from "@babel/traverse";
 import ReplaceSupers, {
   environmentVisitor,
 } from "@babel/helper-replace-supers";
-import memberExpressionToFunctions, {
+import memberExpressionToFunctions from "@babel/helper-member-expression-to-functions";
+import type {
   Handler,
   HandlerState,
 } from "@babel/helper-member-expression-to-functions";

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -1,4 +1,5 @@
 import { template, traverse, types as t } from "@babel/core";
+import type { File } from "@babel/core";
 import type { NodePath, Visitor } from "@babel/traverse";
 import ReplaceSupers, {
   environmentVisitor,
@@ -163,7 +164,7 @@ function privateNameVisitorFactory<S>(
 interface PrivateNameState {
   privateNamesMap: PrivateNamesMap;
   classRef: t.Identifier;
-  file: any;
+  file: File;
   noDocumentAll: boolean;
 }
 
@@ -190,7 +191,7 @@ const privateNameVisitor = privateNameVisitorFactory<
 
 const privateInVisitor = privateNameVisitorFactory<{
   classRef: t.Identifier;
-  file: unknown;
+  file: File;
 }>({
   BinaryExpression(path) {
     const { operator, left, right } = path.node;
@@ -784,7 +785,7 @@ function replaceThisContext(
   path: PropPath,
   ref: t.Identifier,
   getSuperRef: () => t.Identifier,
-  file,
+  file: File,
   isStaticBlock: boolean,
   constantSuper: boolean,
   innerBindingRef: t.Identifier,

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -113,8 +113,7 @@ function privateNameVisitorFactory<S>(
 
     Class(path) {
       const { privateNamesMap } = this;
-      // not using body.body since it will loose typing
-      const body = path.get("body").get("body");
+      const body = path.get("body.body");
 
       const visiblePrivateNames = new Map(privateNamesMap);
       const redeclared = [];

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -880,7 +880,7 @@ export function buildFieldsInitNodes(
     // TODO(ts): there are so many `ts-expect-error` inside cases since
     // ts can not infer type from pre-computed values (or a case test)
     // even change `isStaticBlock` to `t.isStaticBlock(prop)` will not make prop
-    // a `NodePath<t.StaticBlock`
+    // a `NodePath<t.StaticBlock>`
     // this maybe a bug for ts
     switch (true) {
       case isStaticBlock:

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -7,8 +7,8 @@ import {
   buildPrivateNamesMap,
   transformPrivateNamesUsage,
   buildFieldsInitNodes,
-  PropPath,
 } from "./fields";
+import type { PropPath } from "./fields";
 import {
   hasOwnDecorators,
   buildDecoratedClass,

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -107,14 +107,18 @@ export function createClassFeaturePlugin({
         let isDecorated = hasOwnDecorators(path.node);
         const props: PropPath[] = [];
         const elements = [];
-        const computedPaths: NodePath<t.ClassProperty>[] = [];
+        const computedPaths: NodePath<t.ClassProperty | t.ClassMethod>[] = [];
         const privateNames = new Set<string>();
         const body = path.get("body");
 
         for (const path of body.get("body")) {
           verifyUsedFeatures(path, this.file);
 
-          if (path.isClassProperty() && path.node.computed) {
+          if (
+            // check path.node.computed is enough, but ts will complain
+            (path.isClassProperty() || path.isClassMethod()) &&
+            path.node.computed
+          ) {
             computedPaths.push(path);
           }
 
@@ -245,7 +249,7 @@ export function createClassFeaturePlugin({
             (referenceVisitor, state) => {
               if (isDecorated) return;
               for (const prop of props) {
-                if (prop.isStatic()) continue;
+                if (prop.node.static) continue;
                 prop.traverse(referenceVisitor, state);
               }
             },

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -102,7 +102,7 @@ export function createClassFeaturePlugin({
         const props = [];
         const elements = [];
         const computedPaths = [];
-        const privateNames = new Set();
+        const privateNames = new Set<string>();
         const body = path.get("body");
 
         for (const path of body.get("body")) {
@@ -169,7 +169,7 @@ export function createClassFeaturePlugin({
         if (!props.length && !isDecorated) return;
 
         const innerBinding = path.node.id;
-        let ref;
+        let ref: t.Identifier;
         if (!innerBinding || path.isClassExpression()) {
           nameFunction(path);
           ref = path.scope.generateUidIdentifier("class");

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -123,27 +123,24 @@ export function createClassFeaturePlugin({
             const getName = `get ${name}`;
             const setName = `set ${name}`;
 
-            if (path.isClassPrivateMethod() && path.node.kind === "get") {
-              if (
-                privateNames.has(getName) ||
-                (privateNames.has(name) && !privateNames.has(setName))
-              ) {
-                throw path.buildCodeFrameError("Duplicate private field");
+            if (path.isClassPrivateMethod()) {
+              if (path.node.kind === "get") {
+                if (
+                  privateNames.has(getName) ||
+                  (privateNames.has(name) && !privateNames.has(setName))
+                ) {
+                  throw path.buildCodeFrameError("Duplicate private field");
+                }
+                privateNames.add(getName).add(name);
+              } else if (path.node.kind === "set") {
+                if (
+                  privateNames.has(setName) ||
+                  (privateNames.has(name) && !privateNames.has(getName))
+                ) {
+                  throw path.buildCodeFrameError("Duplicate private field");
+                }
+                privateNames.add(setName).add(name);
               }
-
-              privateNames.add(getName).add(name);
-            } else if (
-              path.isClassPrivateMethod() &&
-              path.node.kind === "set"
-            ) {
-              if (
-                privateNames.has(setName) ||
-                (privateNames.has(name) && !privateNames.has(getName))
-              ) {
-                throw path.buildCodeFrameError("Duplicate private field");
-              }
-
-              privateNames.add(setName).add(name);
             } else {
               if (
                 (privateNames.has(name) &&

--- a/packages/babel-helper-create-class-features-plugin/src/misc.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/misc.ts
@@ -1,4 +1,5 @@
 import { template, traverse, types as t } from "@babel/core";
+import type { File } from "@babel/core";
 import type { NodePath, Scope, Visitor, Binding } from "@babel/traverse";
 import { environmentVisitor } from "@babel/helper-replace-supers";
 
@@ -30,7 +31,7 @@ function handleClassTDZ(
   path: NodePath<t.Identifier>,
   state: {
     classBinding: Binding;
-    file;
+    file: File;
   },
 ) {
   if (
@@ -108,7 +109,7 @@ export function extractComputedKeys(
   ref: t.Identifier,
   path: NodePath<t.Class>,
   computedPaths: NodePath<t.ClassProperty | t.ClassMethod>[],
-  file,
+  file: File,
 ) {
   const declarations: t.Statement[] = [];
   const state = {

--- a/packages/babel-helper-create-class-features-plugin/src/misc.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/misc.ts
@@ -118,7 +118,6 @@ export function extractComputedKeys(
   for (const computedPath of computedPaths) {
     const computedKey = computedPath.get("key");
     if (computedKey.isReferencedIdentifier()) {
-      // @ts-expect-error TODO: make isReferencedIdentifier return path is Identifier
       handleClassTDZ(computedKey, state);
     } else {
       computedKey.traverse(classFieldDefinitionEvaluationTDZVisitor, state);

--- a/packages/babel-helper-create-class-features-plugin/src/misc.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/misc.ts
@@ -107,7 +107,7 @@ export function injectInitialization(
 export function extractComputedKeys(
   ref: t.Identifier,
   path: NodePath<t.Class>,
-  computedPaths: NodePath<t.ClassProperty>[],
+  computedPaths: NodePath<t.ClassProperty | t.ClassMethod>[],
   file,
 ) {
   const declarations: t.Statement[] = [];

--- a/packages/babel-helper-member-expression-to-functions/src/index.ts
+++ b/packages/babel-helper-member-expression-to-functions/src/index.ts
@@ -222,10 +222,7 @@ const handle = {
       let regular: t.Expression = member.node;
       for (let current: NodePath = member; current !== endPath; ) {
         const { parentPath } = current;
-        if (!parentPath.isExpression()) {
-          // should not happen, just for type check
-          break;
-        }
+        parentPath.assertExpression();
         // skip transforming `Foo.#BAR?.call(FOO)`
         if (
           parentPath === endPath &&

--- a/packages/babel-helper-member-expression-to-functions/src/index.ts
+++ b/packages/babel-helper-member-expression-to-functions/src/index.ts
@@ -200,6 +200,7 @@ const handle = {
       });
       // here we use a function to wrap `parentIsOptionalCall` to get type
       // for parent, do not use it anywhere else
+      // See https://github.com/microsoft/TypeScript/issues/10421
       const isOptionalCall = (
         parent: t.Node,
       ): parent is t.OptionalCallExpression => parentIsOptionalCall;
@@ -221,7 +222,9 @@ const handle = {
 
       let regular: t.Expression = member.node;
       for (let current: NodePath = member; current !== endPath; ) {
-        const { parentPath } = current;
+        // Assertions require every name in the call target
+        // to be declared with an explicit type annotation
+        const parentPath: NodePath = current.parentPath;
         parentPath.assertExpression();
         // skip transforming `Foo.#BAR?.call(FOO)`
         if (

--- a/packages/babel-helper-member-expression-to-functions/src/index.ts
+++ b/packages/babel-helper-member-expression-to-functions/src/index.ts
@@ -1,17 +1,18 @@
+import type { NodePath, Visitor } from "@babel/traverse";
 import * as t from "@babel/types";
 import { willPathCastToBoolean } from "./util";
 
 class AssignmentMemoiser {
-  private _map: WeakMap<object, any>;
+  private _map: WeakMap<t.Expression, { count: number; value: t.LVal }>;
   constructor() {
     this._map = new WeakMap();
   }
 
-  has(key) {
+  has(key: t.Expression) {
     return this._map.has(key);
   }
 
-  get(key) {
+  get(key: t.Expression) {
     if (!this.has(key)) return;
 
     const record = this._map.get(key);
@@ -26,15 +27,17 @@ class AssignmentMemoiser {
     return value;
   }
 
-  set(key, value, count) {
+  set(key: t.Expression, value: t.LVal, count: number) {
     return this._map.set(key, { count, value });
   }
 }
 
-function toNonOptional(path, base) {
-  const { node } = path;
+function toNonOptional(
+  path: NodePath<t.Expression>,
+  base: t.Expression,
+): t.Expression {
   if (path.isOptionalMemberExpression()) {
-    return t.memberExpression(base, node.property, node.computed);
+    return t.memberExpression(base, path.node.property, path.node.computed);
   }
 
   if (path.isOptionalCallExpression()) {
@@ -44,15 +47,15 @@ function toNonOptional(path, base) {
       const context = path.scope.maybeGenerateMemoised(object) || object;
       callee
         .get("object")
-        .replaceWith(t.assignmentExpression("=", context, object));
+        .replaceWith(t.assignmentExpression("=", context as t.LVal, object));
 
       return t.callExpression(t.memberExpression(base, t.identifier("call")), [
         context,
-        ...node.arguments,
+        ...path.node.arguments,
       ]);
     }
 
-    return t.callExpression(base, node.arguments);
+    return t.callExpression(base, path.node.arguments);
   }
 
   return path.node;
@@ -62,7 +65,7 @@ function toNonOptional(path, base) {
 // we are iterating on a path, and replace an ancestor with a new node. Babel
 // doesn't always stop traversing the old node tree, and that can cause
 // inconsistencies.
-function isInDetachedTree(path) {
+function isInDetachedTree(path: NodePath) {
   while (path) {
     if (path.isProgram()) break;
 
@@ -80,13 +83,15 @@ function isInDetachedTree(path) {
   return false;
 }
 
+type Member = NodePath<t.OptionalMemberExpression | t.MemberExpression>;
+
 const handle = {
   memoise() {
     // noop.
   },
 
   // todo(flow->ts) member:NodePath<t.Expression>, refactor function body to avoid too many typecasts
-  handle(member: any, noDocumentAll: boolean) {
+  handle(this: HandlerState, member: Member, noDocumentAll: boolean) {
     const { node, parent, parentPath, scope } = member;
 
     if (member.isOptionalMemberExpression()) {
@@ -102,14 +107,14 @@ const handle = {
       // Everything up to it could be skipped if it `FOO` were nullish. But
       // actually, we can consider the `baz` access to be the end. So we're
       // looking for the nearest optional chain that is `optional: true`.
-      const endPath = member.find(({ node, parent, parentPath }) => {
-        if (parentPath.isOptionalMemberExpression()) {
+      const endPath = member.find(({ node, parent }) => {
+        if (t.isOptionalMemberExpression(parent)) {
           // We need to check `parent.object` since we could be inside the
           // computed expression of a `bad?.[FOO?.BAR]`. In this case, the
           // endPath is the `FOO?.BAR` member itself.
           return parent.optional || parent.object !== node;
         }
-        if (parentPath.isOptionalCallExpression()) {
+        if (t.isOptionalCallExpression(parent)) {
           // Checking `parent.callee` since we could be in the arguments, eg
           // `bad?.(FOO?.BAR)`.
           // Also skip `FOO?.BAR` in `FOO?.BAR?.()` since we need to transform the optional call to ensure proper this
@@ -119,7 +124,7 @@ const handle = {
           );
         }
         return true;
-      });
+      }) as NodePath<t.OptionalMemberExpression>;
 
       // Replace `function (a, x = a.b?.#c) {}` to `function (a, x = (() => a.b?.#c)() ){}`
       // so the temporary variable can be injected in correct scope
@@ -164,7 +169,7 @@ const handle = {
       // But actually, we can consider the `bar` access to be the start. So
       // we're looking for the nearest optional chain that is `optional: true`,
       // which is guaranteed to be somewhere in the object/callee tree.
-      let startingOptional = member;
+      let startingOptional: NodePath<t.Expression> = member;
       for (;;) {
         if (startingOptional.isOptionalMemberExpression()) {
           if (startingOptional.node.optional) break;
@@ -193,10 +198,15 @@ const handle = {
       const parentIsOptionalCall = parentPath.isOptionalCallExpression({
         callee: node,
       });
+      // here we use a function to wrap `parentIsOptionalCall` to get type
+      // for parent, do not use it anywhere else
+      const isOptionalCall = (
+        parent: t.Node,
+      ): parent is t.OptionalCallExpression => parentIsOptionalCall;
       // if parentIsCall is true, it implies that node.extra.parenthesized is always true
       const parentIsCall = parentPath.isCallExpression({ callee: node });
       startingOptional.replaceWith(toNonOptional(startingOptional, baseRef));
-      if (parentIsOptionalCall) {
+      if (isOptionalCall(parent)) {
         if (parent.optional) {
           parentPath.replaceWith(this.optionalCall(member, parent.arguments));
         } else {
@@ -209,11 +219,19 @@ const handle = {
         member.replaceWith(this.get(member));
       }
 
-      let regular = member.node;
-      for (let current = member; current !== endPath; ) {
+      let regular: t.Expression = member.node;
+      for (let current: NodePath = member; current !== endPath; ) {
         const { parentPath } = current;
+        if (!parentPath.isExpression()) {
+          // should not happen, just for type check
+          break;
+        }
         // skip transforming `Foo.#BAR?.call(FOO)`
-        if (parentPath === endPath && parentIsOptionalCall && parent.optional) {
+        if (
+          parentPath === endPath &&
+          isOptionalCall(parent) &&
+          parent.optional
+        ) {
           regular = parentPath.node;
           break;
         }
@@ -221,8 +239,8 @@ const handle = {
         current = parentPath;
       }
 
-      let context;
-      const endParentPath = endPath.parentPath;
+      let context: t.Identifier;
+      const endParentPath = endPath.parentPath as NodePath<t.Expression>;
       if (
         t.isMemberExpression(regular) &&
         endParentPath.isOptionalCallExpression({
@@ -237,7 +255,7 @@ const handle = {
         }
       }
 
-      let replacementPath = endPath;
+      let replacementPath: NodePath = endPath;
       if (isDeleteOperation) {
         replacementPath = endParentPath;
         regular = endParentPath.node;
@@ -306,7 +324,7 @@ const handle = {
 
       // context and isDeleteOperation can not be both truthy
       if (context) {
-        const endParent = endParentPath.node;
+        const endParent = endParentPath.node as t.OptionalCallExpression;
         endParentPath.replaceWith(
           t.optionalCallExpression(
             t.optionalMemberExpression(
@@ -332,7 +350,7 @@ const handle = {
         return;
       }
 
-      const { operator, prefix } = parent;
+      const { operator, prefix } = parentPath.node;
 
       // Give the state handler a chance to memoise the member, since we'll
       // reference it twice. The second access (the set) should do the memo
@@ -340,7 +358,7 @@ const handle = {
       this.memoise(member, 2);
 
       const value = t.binaryExpression(
-        operator[0],
+        operator[0] as "+" | "-",
         t.unaryExpression("+", this.get(member)),
         t.numericLiteral(1),
       );
@@ -375,7 +393,7 @@ const handle = {
         return;
       }
 
-      const { operator, right: value } = parent;
+      const { operator, right: value } = parentPath.node;
 
       if (operator === "=") {
         parentPath.replaceWith(this.set(member, value));
@@ -388,7 +406,7 @@ const handle = {
           this.memoise(member, 1);
           parentPath.replaceWith(
             t.logicalExpression(
-              operatorTrunc,
+              operatorTrunc as t.LogicalExpression["operator"],
               this.get(member),
               this.set(member, value),
             ),
@@ -399,7 +417,11 @@ const handle = {
           parentPath.replaceWith(
             this.set(
               member,
-              t.binaryExpression(operatorTrunc, this.get(member), value),
+              t.binaryExpression(
+                operatorTrunc as t.BinaryExpression["operator"],
+                this.get(member),
+                value,
+              ),
             ),
           );
         }
@@ -409,7 +431,7 @@ const handle = {
 
     // MEMBER(ARGS) -> _call(MEMBER, ARGS)
     if (parentPath.isCallExpression({ callee: node })) {
-      parentPath.replaceWith(this.call(member, parent.arguments));
+      parentPath.replaceWith(this.call(member, parentPath.node.arguments));
       return;
     }
 
@@ -425,7 +447,9 @@ const handle = {
         );
         return;
       }
-      parentPath.replaceWith(this.optionalCall(member, parent.arguments));
+      parentPath.replaceWith(
+        this.optionalCall(member, parentPath.node.arguments),
+      );
       return;
     }
 
@@ -472,6 +496,45 @@ const handle = {
   },
 };
 
+export interface Handler<State> {
+  memoise?(
+    this: HandlerState<State> & State,
+    member: Member,
+    count: number,
+  ): void;
+  destructureSet(
+    this: HandlerState<State> & State,
+    member: Member,
+  ): t.Expression;
+  boundGet(this: HandlerState<State> & State, member: Member): t.Expression;
+  simpleSet?(this: HandlerState<State> & State, member: Member): t.Expression;
+  get(this: HandlerState<State> & State, member: Member): t.Expression;
+  set(
+    this: HandlerState<State> & State,
+    member: Member,
+    value: t.Expression,
+  ): t.Expression;
+  call(
+    this: HandlerState<State> & State,
+    member: Member,
+    args: t.CallExpression["arguments"],
+  ): t.Expression;
+  optionalCall(
+    this: HandlerState<State> & State,
+    member: Member,
+    args: t.OptionalCallExpression["arguments"],
+  ): t.Expression;
+}
+
+export interface HandlerState<State = {}> extends Handler<State> {
+  handle(
+    this: HandlerState<State> & State,
+    member: Member,
+    noDocumentAll: boolean,
+  ): void;
+  memoiser: AssignmentMemoiser;
+}
+
 // We do not provide a default traversal visitor
 // Instead, caller passes one, and must call `state.handle` on the members
 // it wishes to be transformed.
@@ -479,7 +542,11 @@ const handle = {
 // get, set, and call methods.
 // Optionally, a memoise method may be defined on the state, which will be
 // called when the member is a self-referential update.
-export default function memberExpressionToFunctions(path, visitor, state) {
+export default function memberExpressionToFunctions<CustomState = {}>(
+  path: NodePath,
+  visitor: Visitor<HandlerState<CustomState>>,
+  state: Handler<CustomState> & CustomState,
+) {
   path.traverse(visitor, {
     ...handle,
     ...state,

--- a/packages/babel-helper-member-expression-to-functions/src/index.ts
+++ b/packages/babel-helper-member-expression-to-functions/src/index.ts
@@ -91,7 +91,6 @@ const handle = {
     // noop.
   },
 
-  // todo(flow->ts) member:NodePath<t.Expression>, refactor function body to avoid too many typecasts
   handle(this: HandlerState, member: Member, noDocumentAll: boolean) {
     const { node, parent, parentPath, scope } = member;
 

--- a/packages/babel-helper-replace-supers/src/index.ts
+++ b/packages/babel-helper-replace-supers/src/index.ts
@@ -1,4 +1,4 @@
-import type { HubInterface, NodePath } from "@babel/traverse";
+import type { HubInterface, NodePath, Scope } from "@babel/traverse";
 import traverse from "@babel/traverse";
 import memberExpressionToFunctions from "@babel/helper-member-expression-to-functions";
 import optimiseCall from "@babel/helper-optimise-call-expression";
@@ -271,6 +271,16 @@ type ReplaceSupersOptions = ReplaceSupersOptionsBase &
     | { superRef: t.Node; getSuperRef?: undefined }
   );
 
+interface ReplaceState {
+  file: unknown;
+  scope: Scope;
+  isDerivedConstructor: boolean;
+  isStatic: boolean;
+  isPrivateMethod: boolean;
+  getObjectRef: ReplaceSupers["getObjectRef"];
+  getSuperRef: ReplaceSupers["getSuperRef"];
+}
+
 export default class ReplaceSupers {
   constructor(opts: ReplaceSupersOptions) {
     const path = opts.methodPath;
@@ -317,7 +327,7 @@ export default class ReplaceSupers {
 
     const handler = this.constantSuper ? looseHandlers : specHandlers;
 
-    memberExpressionToFunctions(this.methodPath, visitor, {
+    memberExpressionToFunctions<ReplaceState>(this.methodPath, visitor, {
       file: this.file,
       scope: this.methodPath.scope,
       isDerivedConstructor: this.isDerivedConstructor,
@@ -325,6 +335,11 @@ export default class ReplaceSupers {
       isPrivateMethod: this.isPrivateMethod,
       getObjectRef: this.getObjectRef.bind(this),
       getSuperRef: this.getSuperRef.bind(this),
+      boundGet() {
+        // noop
+        // we dont need boundGet here, but memberExpressionToFunctions handler needs it.
+        throw new Error("");
+      },
       ...handler,
     });
   }

--- a/packages/babel-helper-replace-supers/src/index.ts
+++ b/packages/babel-helper-replace-supers/src/index.ts
@@ -335,11 +335,8 @@ export default class ReplaceSupers {
       isPrivateMethod: this.isPrivateMethod,
       getObjectRef: this.getObjectRef.bind(this),
       getSuperRef: this.getSuperRef.bind(this),
-      boundGet() {
-        // noop
-        // we dont need boundGet here, but memberExpressionToFunctions handler needs it.
-        throw new Error("");
-      },
+      // we dont need boundGet here, but memberExpressionToFunctions handler needs it.
+      boundGet: handler.get,
       ...handler,
     });
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-self-method/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-self-method/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["proposal-class-properties", "transform-block-scoping"]
+  "plugins": ["proposal-class-properties", "proposal-private-methods", "transform-block-scoping"]
 }

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -3,10 +3,10 @@ import * as visitors from "./visitors";
 import * as t from "@babel/types";
 import * as cache from "./cache";
 import type NodePath from "./path";
-import type Scope from "./scope";
+import type { default as Scope, Binding } from "./scope";
 import type { Visitor } from "./types";
 
-export type { Visitor };
+export type { Visitor, Binding };
 export { default as NodePath } from "./path";
 export { default as Scope } from "./scope";
 export { default as Hub } from "./hub";

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -317,6 +317,8 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
 
 let uid = 0;
 
+export type { Binding };
+
 export default class Scope {
   uid;
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      |
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

I was trying to read codes in `babel-helper-create-class-features-plugin`, then I found that most of its code are written without typings. So I tried to add the correct typings to it, hopefully it can help others to read the code easier.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13570"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

