### PR TITLE
add 12 missing NODE_FIELDS

### DIFF
--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -547,12 +547,10 @@ export function OpaqueType(
     this.print(node.supertype, node);
   }
 
-  // @ts-expect-error todo(flow->ts) `.impltype` does not exist on t.DeclareOpaqueType
   if (node.impltype) {
     this.space();
     this.token("=");
     this.space();
-    // @ts-expect-error todo(flow->ts) `.impltype` does not exist on t.DeclareOpaqueType
     this.print(node.impltype, node);
   }
   this.semicolon();

--- a/packages/babel-traverse/src/path/lib/virtual-types.ts
+++ b/packages/babel-traverse/src/path/lib/virtual-types.ts
@@ -116,7 +116,6 @@ export const Flow = {
     } else if (t.isImportDeclaration(node)) {
       return node.importKind === "type" || node.importKind === "typeof";
     } else if (t.isExportDeclaration(node)) {
-      // @ts-expect-error todo(flow->ts) `exportKind` does not exist on ExportAllDeclaration
       return node.exportKind === "type";
     } else if (t.isImportSpecifier(node)) {
       return node.importKind === "type" || node.importKind === "typeof";

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -31,7 +31,6 @@
     "@babel/generator": "workspace:*",
     "@babel/parser": "workspace:*",
     "chalk": "^4.1.0",
-    "fs-extra": "^10.0.0",
     "glob": "^7.1.7"
   },
   "engines": {

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -30,7 +30,9 @@
   "devDependencies": {
     "@babel/generator": "workspace:*",
     "@babel/parser": "workspace:*",
-    "chalk": "^4.1.0"
+    "chalk": "^4.1.0",
+    "fs-extra": "^10.0.0",
+    "glob": "^7.1.7"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -643,6 +643,7 @@ export interface RestElement extends BaseNode {
   type: "RestElement";
   argument: LVal;
   decorators?: Array<Decorator> | null;
+  optional?: boolean | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
 }
 
@@ -653,6 +654,7 @@ export interface RestProperty extends BaseNode {
   type: "RestProperty";
   argument: LVal;
   decorators?: Array<Decorator> | null;
+  optional?: boolean | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
 }
 
@@ -751,6 +753,7 @@ export interface ArrayPattern extends BaseNode {
   type: "ArrayPattern";
   elements: Array<null | PatternLike>;
   decorators?: Array<Decorator> | null;
+  optional?: boolean | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
 }
 
@@ -835,6 +838,7 @@ export interface ExportDefaultDeclaration extends BaseNode {
     | TSDeclareFunction
     | ClassDeclaration
     | Expression;
+  exportKind?: "value" | null;
 }
 
 export interface ExportNamedDeclaration extends BaseNode {
@@ -1024,6 +1028,7 @@ export interface ClassProperty extends BaseNode {
   optional?: boolean | null;
   override?: boolean;
   readonly?: boolean | null;
+  variance?: Variance | null;
 }
 
 export interface ClassPrivateProperty extends BaseNode {
@@ -1032,7 +1037,10 @@ export interface ClassPrivateProperty extends BaseNode {
   value?: Expression | null;
   decorators?: Array<Decorator> | null;
   static: any;
+  definite?: boolean | null;
+  readonly?: boolean | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
+  variance?: Variance | null;
 }
 
 export interface ClassPrivateMethod extends BaseNode {
@@ -1142,6 +1150,7 @@ export interface DeclareOpaqueType extends BaseNode {
   id: Identifier;
   typeParameters?: TypeParameterDeclaration | null;
   supertype?: FlowType | null;
+  impltype?: FlowType | null;
 }
 
 export interface DeclareVariable extends BaseNode {
@@ -1651,6 +1660,8 @@ export interface TSParameterProperty extends BaseNode {
   type: "TSParameterProperty";
   parameter: Identifier | AssignmentPattern;
   accessibility?: "public" | "private" | "protected" | null;
+  decorators?: Array<Decorator> | null;
+  override?: boolean | null;
   readonly?: boolean | null;
 }
 
@@ -1710,6 +1721,7 @@ export interface TSPropertySignature extends BaseNode {
   typeAnnotation?: TSTypeAnnotation | null;
   initializer?: Expression | null;
   computed?: boolean | null;
+  kind: "get" | "set";
   optional?: boolean | null;
   readonly?: boolean | null;
 }
@@ -1992,6 +2004,7 @@ export interface TSImportEqualsDeclaration extends BaseNode {
   type: "TSImportEqualsDeclaration";
   id: Identifier;
   moduleReference: TSEntityName | TSExternalModuleReference;
+  importKind?: "type" | "value" | null;
   isExport: boolean;
 }
 

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -900,6 +900,11 @@ defineType("RestElement", {
         ? assertNodeType("LVal")
         : assertNodeType("Identifier", "Pattern", "MemberExpression"),
     },
+    // For Flow
+    optional: {
+      validate: assertValueType("boolean"),
+      optional: true,
+    },
   },
   validate(parent, key) {
     if (!process.env.BABEL_TYPES_8_BREAKING) return;
@@ -1206,6 +1211,10 @@ defineType("ArrayPattern", {
       ),
       optional: true,
     },
+    optional: {
+      validate: assertValueType("boolean"),
+      optional: true,
+    },
   },
 });
 
@@ -1440,6 +1449,7 @@ defineType("ExportDefaultDeclaration", {
         "Expression",
       ),
     },
+    exportKind: validateOptional(assertOneOf("value")),
   },
 });
 
@@ -2095,6 +2105,10 @@ defineType("ClassProperty", {
       validate: assertValueType("boolean"),
       optional: true,
     },
+    variance: {
+      validate: assertNodeType("Variance"),
+      optional: true,
+    },
   },
 });
 
@@ -2121,6 +2135,18 @@ defineType("ClassPrivateProperty", {
         assertValueType("array"),
         assertEach(assertNodeType("Decorator")),
       ),
+      optional: true,
+    },
+    readonly: {
+      validate: assertValueType("boolean"),
+      optional: true,
+    },
+    definite: {
+      validate: assertValueType("boolean"),
+      optional: true,
+    },
+    variance: {
+      validate: assertNodeType("Variance"),
       optional: true,
     },
   },

--- a/packages/babel-types/src/definitions/flow.ts
+++ b/packages/babel-types/src/definitions/flow.ts
@@ -121,6 +121,7 @@ defineType("DeclareOpaqueType", {
     id: validateType("Identifier"),
     typeParameters: validateOptionalType("TypeParameterDeclaration"),
     supertype: validateOptionalType("FlowType"),
+    impltype: validateOptionalType("FlowType"),
   },
 });
 

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -49,6 +49,17 @@ defineType("TSParameterProperty", {
     parameter: {
       validate: assertNodeType("Identifier", "AssignmentPattern"),
     },
+    override: {
+      validate: assertValueType("boolean"),
+      optional: true,
+    },
+    decorators: {
+      validate: chain(
+        assertValueType("array"),
+        assertEach(assertNodeType("Decorator")),
+      ),
+      optional: true,
+    },
   },
 });
 
@@ -110,6 +121,9 @@ defineType("TSPropertySignature", {
     readonly: validateOptional(bool),
     typeAnnotation: validateOptionalType("TSTypeAnnotation"),
     initializer: validateOptionalType("Expression"),
+    kind: {
+      validate: assertOneOf("get", "set"),
+    },
   },
 });
 
@@ -494,6 +508,10 @@ defineType("TSImportEqualsDeclaration", {
       "TSEntityName",
       "TSExternalModuleReference",
     ]),
+    importKind: {
+      validate: assertOneOf("type", "value"),
+      optional: true,
+    },
   },
 });
 

--- a/packages/babel-types/test/fields.js
+++ b/packages/babel-types/test/fields.js
@@ -2,10 +2,19 @@ import * as t from "../lib";
 import glob from "glob";
 import path from "path";
 import fs from "fs";
-import { promisify, inspect } from "util";
+import { inspect } from "util";
 
 // eslint-disable-next-line no-restricted-globals
 const packages = path.resolve(__dirname, "..", "..");
+
+function readJson(file) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(file, "utf8", (err, data) => {
+      if (err) reject(err);
+      else resolve(JSON.parse(data));
+    });
+  });
+}
 
 function traverse(thing, visitor) {
   if (Array.isArray(thing)) {
@@ -52,9 +61,7 @@ function isEmpty(obj) {
 describe("NODE_FIELDS contains all fields in", function () {
   files.forEach(file =>
     it(`${file}`, async function () {
-      const ast = await JSON.parse(
-        await promisify(fs.readFile)(path.resolve(packages, file), "utf8"),
-      );
+      const ast = await readJson(path.resolve(packages, file));
       if (ast.type === "File" && ast.errors && ast.errors.length) return;
       t[`assert${ast.type}`](ast);
       const missingFields = {};

--- a/packages/babel-types/test/fields.js
+++ b/packages/babel-types/test/fields.js
@@ -1,8 +1,8 @@
 import * as t from "../lib";
 import glob from "glob";
 import path from "path";
-import fs from "fs-extra";
-import { inspect } from "util";
+import fs from "fs";
+import { promisify, inspect } from "util";
 
 // eslint-disable-next-line no-restricted-globals
 const packages = path.resolve(__dirname, "..", "..");
@@ -52,7 +52,11 @@ function isEmpty(obj) {
 describe("NODE_FIELDS contains all fields in", function () {
   files.forEach(file =>
     it(`${file}`, async function () {
-      const ast = await fs.readJson(path.resolve(packages, file));
+      const ast = await JSON.parse(
+        await promisify(cb =>
+          fs.readFile(path.resolve(packages, file), "utf8", cb),
+        )(),
+      );
       if (ast.type === "File" && ast.errors && ast.errors.length) return;
       t[`assert${ast.type}`](ast);
       const missingFields = {};

--- a/packages/babel-types/test/fields.js
+++ b/packages/babel-types/test/fields.js
@@ -1,52 +1,107 @@
 import * as t from "../lib";
 import glob from "glob";
 import path from "path";
-import fs from "fs";
-import traverse from "@babel/traverse";
+import fs from "fs-extra";
+import { inspect } from "util";
 
+// eslint-disable-next-line no-restricted-globals
 const packages = path.resolve(__dirname, "..", "..");
 
-describe("NODE_FIELDS", function () {
-  describe("includes all fields output by @babel/parser tests", function () {
-    const files = glob.sync(
-      path.join("babel-parser", "test", "**", "output.json"),
-      {
-        cwd: packages,
-      },
-    );
-    files.forEach(file => {
-      it(file, function () {
-        const ast = JSON.parse(
-          fs.readFileSync(path.resolve(packages, file), "utf8"),
-        );
-        traverse(ast, {
-          Node({ node }) {
-            const { type } = node;
-            const fields = t.NODE_FIELDS[type];
-            if (!fields) {
-              throw new Error(`missing NODE_FIELDS[${JSON.stringify(type)}]`);
+function traverse(thing, visitor) {
+  if (Array.isArray(thing)) {
+    thing.forEach(elem => traverse(elem, visitor));
+  } else if (thing instanceof Object && typeof thing.type === "string") {
+    visitor(thing);
+    for (const key in thing) {
+      const value = thing[key];
+      if (value instanceof Object) traverse(value, visitor);
+    }
+  }
+}
+
+const files = glob.sync(
+  path.join("babel-parser", "test", "**", "output.json"),
+  {
+    cwd: packages,
+    ignore: [
+      path.join("**", "estree*", "**"),
+      path.join("**", "is-expression-babel-parser", "**"),
+    ],
+  },
+);
+
+const ignoredFields = {
+  ArrowFunctionExpression: { id: true, predicate: true },
+  ClassMethod: { id: true, predicate: true },
+  ClassPrivateMethod: { id: true, predicate: true },
+  ClassPrivateProperty: { declare: true, optional: true },
+  FunctionDeclaration: { predicate: true },
+  FunctionExpression: { predicate: true },
+  ImportDeclaration: { attributes: true },
+  ObjectProperty: { method: true },
+  ObjectMethod: { method: true, id: true, predicate: true },
+  StaticBlock: { static: true },
+  TSDeclareMethod: { id: true },
+};
+
+function isEmpty(obj) {
+  for (const key in obj) return false;
+  return true;
+}
+
+describe("NODE_FIELDS contains all fields in", function () {
+  files.forEach(file =>
+    it(`${file}`, async function () {
+      const ast = await fs.readJson(path.resolve(packages, file));
+      if (ast.type === "File" && ast.errors && ast.errors.length) return;
+      t[`assert${ast.type}`](ast);
+      const missingFields = {};
+      traverse(ast, node => {
+        const { type } = node;
+        switch (type) {
+          case "File":
+          case "CommentBlock":
+          case "CommentLine":
+            return;
+        }
+        if (ignoredFields[type] === true) return;
+        const fields = t.NODE_FIELDS[type];
+        if (!fields) {
+          if (!missingFields[type]) {
+            missingFields[type] = {
+              MISSING_TYPE: true,
+            };
+          }
+          return;
+        }
+        for (const field in node) {
+          switch (field) {
+            case "type":
+            case "start":
+            case "end":
+            case "loc":
+            case "range":
+            case "leadingComments":
+            case "innerComments":
+            case "trailingComments":
+            case "comments":
+            case "extra":
+              continue;
+          }
+          if (!fields[field]) {
+            if (ignoredFields[type] && ignoredFields[type][field]) continue;
+            if (!missingFields[type]) missingFields[type] = {};
+            if (!missingFields[type][field]) {
+              missingFields[type][field] = true;
             }
-            for (const field in node) {
-              switch (field) {
-                case "type":
-                case "start":
-                case "end":
-                case "loc":
-                  continue;
-              }
-              if (!fields[field]) {
-                throw new Error(
-                  `missing NODE_FIELDS[${JSON.stringify(
-                    type,
-                  )}][${JSON.stringify(
-                    field,
-                  )}], which was found in node: ${JSON.stringify(node)}`,
-                );
-              }
-            }
-          },
-        });
+          }
+        }
       });
-    });
-  });
+      if (!isEmpty(missingFields)) {
+        throw new Error(
+          `the following NODE_FIELDS were missing: ${inspect(missingFields)}`,
+        );
+      }
+    }),
+  );
 });

--- a/packages/babel-types/test/fields.js
+++ b/packages/babel-types/test/fields.js
@@ -53,9 +53,7 @@ describe("NODE_FIELDS contains all fields in", function () {
   files.forEach(file =>
     it(`${file}`, async function () {
       const ast = await JSON.parse(
-        await promisify(cb =>
-          fs.readFile(path.resolve(packages, file), "utf8", cb),
-        )(),
+        await promisify(fs.readFile)(path.resolve(packages, file), "utf8"),
       );
       if (ast.type === "File" && ast.errors && ast.errors.length) return;
       t[`assert${ast.type}`](ast);

--- a/packages/babel-types/test/fields.js
+++ b/packages/babel-types/test/fields.js
@@ -1,0 +1,52 @@
+import * as t from "../lib";
+import glob from "glob";
+import path from "path";
+import fs from "fs";
+import traverse from "@babel/traverse";
+
+const packages = path.resolve(__dirname, "..", "..");
+
+describe("NODE_FIELDS", function () {
+  describe("includes all fields output by @babel/parser tests", function () {
+    const files = glob.sync(
+      path.join("babel-parser", "test", "**", "output.json"),
+      {
+        cwd: packages,
+      },
+    );
+    files.forEach(file => {
+      it(file, function () {
+        const ast = JSON.parse(
+          fs.readFileSync(path.resolve(packages, file), "utf8"),
+        );
+        traverse(ast, {
+          Node({ node }) {
+            const { type } = node;
+            const fields = t.NODE_FIELDS[type];
+            if (!fields) {
+              throw new Error(`missing NODE_FIELDS[${JSON.stringify(type)}]`);
+            }
+            for (const field in node) {
+              switch (field) {
+                case "type":
+                case "start":
+                case "end":
+                case "loc":
+                  continue;
+              }
+              if (!fields[field]) {
+                throw new Error(
+                  `missing NODE_FIELDS[${JSON.stringify(
+                    type,
+                  )}][${JSON.stringify(
+                    field,
+                  )}], which was found in node: ${JSON.stringify(node)}`,
+                );
+              }
+            }
+          },
+        });
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3603,6 +3603,8 @@ __metadata:
     "@babel/helper-validator-identifier": "workspace:^7.14.5"
     "@babel/parser": "workspace:*"
     chalk: ^4.1.0
+    fs-extra: ^10.0.0
+    glob: ^7.1.7
     to-fast-properties: ^2.0.0
   languageName: unknown
   linkType: soft
@@ -8536,6 +8538,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "fs-extra@npm:10.0.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: 84632d143fe3125b8c3c2b1fedbbdfcfb84fc3e087522b4e138cc07edf574619925713a6609f6d5e53ede2e31ab319c7d528ea4a4a770ba6622a16bf4447cd8b
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
@@ -8937,7 +8950,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.0.0, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4":
+"graceful-fs@npm:^4.0.0, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4":
   version: 4.2.6
   resolution: "graceful-fs@npm:4.2.6"
   checksum: 84d39c7756892553da990a9db7e45f844b3309b37b5a00174cbb4748476f2250c54f24594d4d252f64f085c65c2fdac7c809419bf6d55f0e6e42eb07ac0f5bf2
@@ -10712,6 +10725,19 @@ fsevents@^1.2.7:
   bin:
     json5: lib/cli.js
   checksum: 957e4937106cf59975aa0281e68911534d65c8a25be5b4d3559aa55eba351ccab516a943a60ba33e461e4b8af749939986e311de910cbcfd197410b57d971741
+  languageName: node
+  linkType: hard
+
+"jsonfile@npm:^6.0.1":
+  version: 6.1.0
+  resolution: "jsonfile@npm:6.1.0"
+  dependencies:
+    graceful-fs: ^4.1.6
+    universalify: ^2.0.0
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 9419c886abc6f8a5088cbb222b7bc17c76e8ee9f6c0e5c38781a4e09488166084f25247bc0b58e025b08c43064c82ae860ad89a992e35fc8cfae639323b7edbc
   languageName: node
   linkType: hard
 
@@ -14961,6 +14987,13 @@ typescript@~4.2.3:
   version: 0.1.2
   resolution: "universalify@npm:0.1.2"
   checksum: 420fc6547357782c700d53e9a92506a8e95345b13e97684c8f9ab75237912ec2ebb6af8ac10d4f7406b7b6bd21c58f6c5c0811414fb0b4091b78b4743fa6806e
+  languageName: node
+  linkType: hard
+
+"universalify@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "universalify@npm:2.0.0"
+  checksum: 36bfbdc97bd4b483596e66ea65e20663f5ab9ec3650157d99b075b7f97afcdefe46bbb23f89171dd75595d398cea3769a5b6d7130f5c66cae2a0f00904780f62
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3603,7 +3603,6 @@ __metadata:
     "@babel/helper-validator-identifier": "workspace:^7.14.5"
     "@babel/parser": "workspace:*"
     chalk: ^4.1.0
-    fs-extra: ^10.0.0
     glob: ^7.1.7
     to-fast-properties: ^2.0.0
   languageName: unknown
@@ -8538,17 +8537,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "fs-extra@npm:10.0.0"
-  dependencies:
-    graceful-fs: ^4.2.0
-    jsonfile: ^6.0.1
-    universalify: ^2.0.0
-  checksum: 84632d143fe3125b8c3c2b1fedbbdfcfb84fc3e087522b4e138cc07edf574619925713a6609f6d5e53ede2e31ab319c7d528ea4a4a770ba6622a16bf4447cd8b
-  languageName: node
-  linkType: hard
-
 "fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
@@ -8950,7 +8938,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.0.0, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4":
+"graceful-fs@npm:^4.0.0, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4":
   version: 4.2.6
   resolution: "graceful-fs@npm:4.2.6"
   checksum: 84d39c7756892553da990a9db7e45f844b3309b37b5a00174cbb4748476f2250c54f24594d4d252f64f085c65c2fdac7c809419bf6d55f0e6e42eb07ac0f5bf2
@@ -10725,19 +10713,6 @@ fsevents@^1.2.7:
   bin:
     json5: lib/cli.js
   checksum: 957e4937106cf59975aa0281e68911534d65c8a25be5b4d3559aa55eba351ccab516a943a60ba33e461e4b8af749939986e311de910cbcfd197410b57d971741
-  languageName: node
-  linkType: hard
-
-"jsonfile@npm:^6.0.1":
-  version: 6.1.0
-  resolution: "jsonfile@npm:6.1.0"
-  dependencies:
-    graceful-fs: ^4.1.6
-    universalify: ^2.0.0
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 9419c886abc6f8a5088cbb222b7bc17c76e8ee9f6c0e5c38781a4e09488166084f25247bc0b58e025b08c43064c82ae860ad89a992e35fc8cfae639323b7edbc
   languageName: node
   linkType: hard
 
@@ -14987,13 +14962,6 @@ typescript@~4.2.3:
   version: 0.1.2
   resolution: "universalify@npm:0.1.2"
   checksum: 420fc6547357782c700d53e9a92506a8e95345b13e97684c8f9ab75237912ec2ebb6af8ac10d4f7406b7b6bd21c58f6c5c0811414fb0b4091b78b4743fa6806e
-  languageName: node
-  linkType: hard
-
-"universalify@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "universalify@npm:2.0.0"
-  checksum: 36bfbdc97bd4b483596e66ea65e20663f5ab9ec3650157d99b075b7f97afcdefe46bbb23f89171dd75595d398cea3769a5b6d7130f5c66cae2a0f00904780f62
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

fix #13558
fix #13563

QUESTION: Can `ExportDefaultDeclaration.exportKind` be anything other than `"value"`?  I looked through the parser code and tried to come up with Flow or TS example that would result in `exportKind: "type"`, but couldn't find any.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes 
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Added `glob` and `fs-extra` to `devDependencies` of `@babel/types`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13577"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

