### PR TITLE
feat(traverse): specific return type for virtual types' validators

### DIFF
--- a/packages/babel-traverse/scripts/generators/validators.js
+++ b/packages/babel-traverse/scripts/generators/validators.js
@@ -1,5 +1,6 @@
 import t from "@babel/types";
 import virtualTypes from "../../lib/path/lib/virtual-types.js";
+import definitions from "@babel/types/lib/definitions/index.js";
 
 export default function generateValidators() {
   let output = `/*
@@ -18,8 +19,20 @@ export interface NodePathValidators {
   }
 
   for (const type of Object.keys(virtualTypes)) {
+    const { types } = virtualTypes[type];
     if (type[0] === "_") continue;
-    output += `is${type}(opts?: object): this is NodePath<VirtualTypeAliases["${type}"]>;`;
+    if (definitions.NODE_FIELDS[type] || definitions.FLIPPED_ALIAS_KEYS[type]) {
+      output += `is${type}(opts?: object): this is NodePath<t.${type}>;`;
+    } else if (!types) {
+      // if it don't have types, then VirtualTypeAliases[type] is t.Node
+      // which TS marked as always true
+      // eg. if (path.isBlockScope()) return;
+      //     path resolved to `never` here
+      // so we have to return boolean instead of this is NodePath<t.Node> here
+      output += `is${type}(opts?: object): boolean;`;
+    } else {
+      output += `is${type}(opts?: object): this is NodePath<VirtualTypeAliases["${type}"]>;`;
+    }
   }
 
   output += `

--- a/packages/babel-traverse/scripts/generators/validators.js
+++ b/packages/babel-traverse/scripts/generators/validators.js
@@ -9,7 +9,7 @@ export default function generateValidators() {
  */
 import * as t from "@babel/types";
 import NodePath from "../index";
-import { VirtualTypeAliases } from "./virtual-types";
+import type { VirtualTypeAliases } from "./virtual-types";
 
 export interface NodePathValidators {
 `;
@@ -23,15 +23,15 @@ export interface NodePathValidators {
     if (type[0] === "_") continue;
     if (definitions.NODE_FIELDS[type] || definitions.FLIPPED_ALIAS_KEYS[type]) {
       output += `is${type}(opts?: object): this is NodePath<t.${type}>;`;
-    } else if (!types) {
+    } else if (types /* in VirtualTypeAliases */) {
+      output += `is${type}(opts?: object): this is NodePath<VirtualTypeAliases["${type}"]>;`;
+    } else {
       // if it don't have types, then VirtualTypeAliases[type] is t.Node
       // which TS marked as always true
       // eg. if (path.isBlockScope()) return;
       //     path resolved to `never` here
       // so we have to return boolean instead of this is NodePath<t.Node> here
       output += `is${type}(opts?: object): boolean;`;
-    } else {
-      output += `is${type}(opts?: object): this is NodePath<VirtualTypeAliases["${type}"]>;`;
     }
   }
 

--- a/packages/babel-traverse/scripts/generators/validators.js
+++ b/packages/babel-traverse/scripts/generators/validators.js
@@ -1,6 +1,5 @@
 import t from "@babel/types";
 import virtualTypes from "../../lib/path/lib/virtual-types.js";
-import definitions from "@babel/types/lib/definitions/index.js";
 
 export default function generateValidators() {
   let output = `/*
@@ -9,6 +8,7 @@ export default function generateValidators() {
  */
 import * as t from "@babel/types";
 import NodePath from "../index";
+import { VirtualTypeAliases } from "./virtual-types";
 
 export interface NodePathValidators {
 `;
@@ -18,15 +18,8 @@ export interface NodePathValidators {
   }
 
   for (const type of Object.keys(virtualTypes)) {
-    const { types = [] } = virtualTypes[type];
     if (type[0] === "_") continue;
-    if (definitions.NODE_FIELDS[type] || definitions.FLIPPED_ALIAS_KEYS[type]) {
-      output += `is${type}(opts?: object): this is NodePath<t.${type}>;`;
-    } else if (types.length > 0) {
-      output += `is${type}(opts?: object): this is NodePath<t.${types[0]}>;`;
-    } else {
-      output += `is${type}(opts?: object): boolean;`;
-    }
+    output += `is${type}(opts?: object): this is NodePath<VirtualTypeAliases["${type}"]>;`;
   }
 
   output += `

--- a/packages/babel-traverse/scripts/generators/validators.js
+++ b/packages/babel-traverse/scripts/generators/validators.js
@@ -18,9 +18,12 @@ export interface NodePathValidators {
   }
 
   for (const type of Object.keys(virtualTypes)) {
+    const { types = [] } = virtualTypes[type];
     if (type[0] === "_") continue;
     if (definitions.NODE_FIELDS[type] || definitions.FLIPPED_ALIAS_KEYS[type]) {
       output += `is${type}(opts?: object): this is NodePath<t.${type}>;`;
+    } else if (types.length > 0) {
+      output += `is${type}(opts?: object): this is NodePath<t.${types[0]}>;`;
     } else {
       output += `is${type}(opts?: object): boolean;`;
     }

--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -153,7 +153,6 @@ function _evaluate(path: NodePath, state) {
   }
 
   if (path.isReferencedIdentifier()) {
-    // @ts-expect-error todo(flow->ts): consider separating type refinement and check for reference
     const binding = path.scope.getBinding(path.node.name);
 
     if (binding && binding.constantViolations.length > 0) {
@@ -167,13 +166,10 @@ function _evaluate(path: NodePath, state) {
     if (binding?.hasValue) {
       return binding.value;
     } else {
-      // @ts-expect-error todo(flow->ts): consider separating type refinement and check for reference
       if (path.node.name === "undefined") {
         return binding ? deopt(binding.path, state) : undefined;
-        // @ts-expect-error todo(flow->ts): consider separating type refinement and check for reference
       } else if (path.node.name === "Infinity") {
         return binding ? deopt(binding.path, state) : Infinity;
-        // @ts-expect-error todo(flow->ts): consider separating type refinement and check for reference
       } else if (path.node.name === "NaN") {
         return binding ? deopt(binding.path, state) : NaN;
       }

--- a/packages/babel-traverse/src/path/generated/validators.ts
+++ b/packages/babel-traverse/src/path/generated/validators.ts
@@ -426,22 +426,16 @@ export interface NodePathValidators {
   isBindingIdentifier(
     opts?: object,
   ): this is NodePath<VirtualTypeAliases["BindingIdentifier"]>;
-  isStatement(opts?: object): this is NodePath<VirtualTypeAliases["Statement"]>;
-  isExpression(
-    opts?: object,
-  ): this is NodePath<VirtualTypeAliases["Expression"]>;
+  isStatement(opts?: object): this is NodePath<t.Statement>;
+  isExpression(opts?: object): this is NodePath<t.Expression>;
   isScope(opts?: object): this is NodePath<VirtualTypeAliases["Scope"]>;
-  isReferenced(
-    opts?: object,
-  ): this is NodePath<VirtualTypeAliases["Referenced"]>;
-  isBlockScoped(
-    opts?: object,
-  ): this is NodePath<VirtualTypeAliases["BlockScoped"]>;
+  isReferenced(opts?: object): boolean;
+  isBlockScoped(opts?: object): boolean;
   isVar(opts?: object): this is NodePath<VirtualTypeAliases["Var"]>;
-  isUser(opts?: object): this is NodePath<VirtualTypeAliases["User"]>;
-  isGenerated(opts?: object): this is NodePath<VirtualTypeAliases["Generated"]>;
-  isPure(opts?: object): this is NodePath<VirtualTypeAliases["Pure"]>;
-  isFlow(opts?: object): this is NodePath<VirtualTypeAliases["Flow"]>;
+  isUser(opts?: object): boolean;
+  isGenerated(opts?: object): boolean;
+  isPure(opts?: object): boolean;
+  isFlow(opts?: object): this is NodePath<t.Flow>;
   isRestProperty(
     opts?: object,
   ): this is NodePath<VirtualTypeAliases["RestProperty"]>;

--- a/packages/babel-traverse/src/path/generated/validators.ts
+++ b/packages/babel-traverse/src/path/generated/validators.ts
@@ -4,7 +4,7 @@
  */
 import * as t from "@babel/types";
 import NodePath from "../index";
-import { VirtualTypeAliases } from "./virtual-types";
+import type { VirtualTypeAliases } from "./virtual-types";
 
 export interface NodePathValidators {
   isAnyTypeAnnotation(opts?: object): this is NodePath<t.AnyTypeAnnotation>;

--- a/packages/babel-traverse/src/path/generated/validators.ts
+++ b/packages/babel-traverse/src/path/generated/validators.ts
@@ -4,6 +4,7 @@
  */
 import * as t from "@babel/types";
 import NodePath from "../index";
+import { VirtualTypeAliases } from "./virtual-types";
 
 export interface NodePathValidators {
   isAnyTypeAnnotation(opts?: object): this is NodePath<t.AnyTypeAnnotation>;
@@ -416,28 +417,44 @@ export interface NodePathValidators {
   isWhileStatement(opts?: object): this is NodePath<t.WhileStatement>;
   isWithStatement(opts?: object): this is NodePath<t.WithStatement>;
   isYieldExpression(opts?: object): this is NodePath<t.YieldExpression>;
-  isReferencedIdentifier(opts?: object): this is NodePath<t.Identifier>;
+  isReferencedIdentifier(
+    opts?: object,
+  ): this is NodePath<VirtualTypeAliases["ReferencedIdentifier"]>;
   isReferencedMemberExpression(
     opts?: object,
-  ): this is NodePath<t.MemberExpression>;
-  isBindingIdentifier(opts?: object): this is NodePath<t.Identifier>;
-  isStatement(opts?: object): this is NodePath<t.Statement>;
-  isExpression(opts?: object): this is NodePath<t.Expression>;
-  isScope(opts?: object): this is NodePath<t.Scopable>;
-  isReferenced(opts?: object): boolean;
-  isBlockScoped(opts?: object): boolean;
-  isVar(opts?: object): this is NodePath<t.VariableDeclaration>;
-  isUser(opts?: object): boolean;
-  isGenerated(opts?: object): boolean;
-  isPure(opts?: object): boolean;
-  isFlow(opts?: object): this is NodePath<t.Flow>;
-  isRestProperty(opts?: object): this is NodePath<t.RestElement>;
-  isSpreadProperty(opts?: object): this is NodePath<t.RestElement>;
+  ): this is NodePath<VirtualTypeAliases["ReferencedMemberExpression"]>;
+  isBindingIdentifier(
+    opts?: object,
+  ): this is NodePath<VirtualTypeAliases["BindingIdentifier"]>;
+  isStatement(opts?: object): this is NodePath<VirtualTypeAliases["Statement"]>;
+  isExpression(
+    opts?: object,
+  ): this is NodePath<VirtualTypeAliases["Expression"]>;
+  isScope(opts?: object): this is NodePath<VirtualTypeAliases["Scope"]>;
+  isReferenced(
+    opts?: object,
+  ): this is NodePath<VirtualTypeAliases["Referenced"]>;
+  isBlockScoped(
+    opts?: object,
+  ): this is NodePath<VirtualTypeAliases["BlockScoped"]>;
+  isVar(opts?: object): this is NodePath<VirtualTypeAliases["Var"]>;
+  isUser(opts?: object): this is NodePath<VirtualTypeAliases["User"]>;
+  isGenerated(opts?: object): this is NodePath<VirtualTypeAliases["Generated"]>;
+  isPure(opts?: object): this is NodePath<VirtualTypeAliases["Pure"]>;
+  isFlow(opts?: object): this is NodePath<VirtualTypeAliases["Flow"]>;
+  isRestProperty(
+    opts?: object,
+  ): this is NodePath<VirtualTypeAliases["RestProperty"]>;
+  isSpreadProperty(
+    opts?: object,
+  ): this is NodePath<VirtualTypeAliases["SpreadProperty"]>;
   isExistentialTypeParam(
     opts?: object,
-  ): this is NodePath<t.ExistsTypeAnnotation>;
+  ): this is NodePath<VirtualTypeAliases["ExistentialTypeParam"]>;
   isNumericLiteralTypeAnnotation(
     opts?: object,
-  ): this is NodePath<t.NumberLiteralTypeAnnotation>;
-  isForAwaitStatement(opts?: object): this is NodePath<t.ForOfStatement>;
+  ): this is NodePath<VirtualTypeAliases["NumericLiteralTypeAnnotation"]>;
+  isForAwaitStatement(
+    opts?: object,
+  ): this is NodePath<VirtualTypeAliases["ForAwaitStatement"]>;
 }

--- a/packages/babel-traverse/src/path/generated/validators.ts
+++ b/packages/babel-traverse/src/path/generated/validators.ts
@@ -416,22 +416,28 @@ export interface NodePathValidators {
   isWhileStatement(opts?: object): this is NodePath<t.WhileStatement>;
   isWithStatement(opts?: object): this is NodePath<t.WithStatement>;
   isYieldExpression(opts?: object): this is NodePath<t.YieldExpression>;
-  isReferencedIdentifier(opts?: object): boolean;
-  isReferencedMemberExpression(opts?: object): boolean;
-  isBindingIdentifier(opts?: object): boolean;
+  isReferencedIdentifier(opts?: object): this is NodePath<t.Identifier>;
+  isReferencedMemberExpression(
+    opts?: object,
+  ): this is NodePath<t.MemberExpression>;
+  isBindingIdentifier(opts?: object): this is NodePath<t.Identifier>;
   isStatement(opts?: object): this is NodePath<t.Statement>;
   isExpression(opts?: object): this is NodePath<t.Expression>;
-  isScope(opts?: object): boolean;
+  isScope(opts?: object): this is NodePath<t.Scopable>;
   isReferenced(opts?: object): boolean;
   isBlockScoped(opts?: object): boolean;
-  isVar(opts?: object): boolean;
+  isVar(opts?: object): this is NodePath<t.VariableDeclaration>;
   isUser(opts?: object): boolean;
   isGenerated(opts?: object): boolean;
   isPure(opts?: object): boolean;
   isFlow(opts?: object): this is NodePath<t.Flow>;
-  isRestProperty(opts?: object): boolean;
-  isSpreadProperty(opts?: object): boolean;
-  isExistentialTypeParam(opts?: object): boolean;
-  isNumericLiteralTypeAnnotation(opts?: object): boolean;
-  isForAwaitStatement(opts?: object): boolean;
+  isRestProperty(opts?: object): this is NodePath<t.RestElement>;
+  isSpreadProperty(opts?: object): this is NodePath<t.RestElement>;
+  isExistentialTypeParam(
+    opts?: object,
+  ): this is NodePath<t.ExistsTypeAnnotation>;
+  isNumericLiteralTypeAnnotation(
+    opts?: object,
+  ): this is NodePath<t.NumberLiteralTypeAnnotation>;
+  isForAwaitStatement(opts?: object): this is NodePath<t.ForOfStatement>;
 }

--- a/packages/babel-traverse/src/path/introspection.ts
+++ b/packages/babel-traverse/src/path/introspection.ts
@@ -480,7 +480,6 @@ export function _resolve(
       // otherwise it's a request for a pattern and that's a bit more tricky
     }
   } else if (this.isReferencedIdentifier()) {
-    // @ts-expect-error todo(flow->ts): think about options to improve type refinements
     const binding = this.scope.getBinding(this.node.name);
     if (!binding) return;
 


### PR DESCRIPTION


<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13576 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | No (only generated types are changed)
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

update generator script to use `virtualType.types[0]` as it's type

most of the virtual-types work fine, instead of `Scope`

given:

```ts
export const Scope = {
  // When pattern is inside the function params, it is a scope
  types: ["Scopable", "Pattern"],
  checkPath(path) {
    return t.isScope(path.node, path.parent);
  },
};
```

we got:

```ts
isScope(opts?: object): this is NodePath<t.Scopable>;
```

is this what we expected? What aboud `t.Pattern`?

fix #13576


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13578"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

