### PR TITLE
Improve `path.get` typings with TS template literal types

### DIFF
--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -312,10 +312,8 @@ export function getAllPrevSiblings(this: NodePath): NodePath[] {
   return siblings;
 }
 
-type digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
-
 // convert "1" to 1 (string index to number index)
-type MaybeToIndex<T extends string> = T extends digit ? number : T;
+type MaybeToIndex<T extends string> = T extends `${bigint}` ? number : T;
 
 type Pattern<Obj extends string, Prop extends string> = `${Obj}.${Prop}`;
 

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -312,26 +312,19 @@ export function getAllPrevSiblings(this: NodePath): NodePath[] {
   return siblings;
 }
 
-type digitalWithoutZero = "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
-type digital = "0" | digitalWithoutZero;
+type digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
 
-// only support 0 to 999 (since we won't use too large number in path.get())
-type Num =
-  | `${digital}`
-  | `${digitalWithoutZero}${digital}`
-  | `${digitalWithoutZero}${digital}${digital}`;
-
-// convert "1" to 0 (string index to number index)
-type ToNumber<T extends string> = T extends Num ? 0 : T;
+// convert "1" to 1 (string index to number index)
+type MaybeToIndex<T extends string> = T extends digit ? number : T;
 
 type Pattern<Obj extends string, Prop extends string> = `${Obj}.${Prop}`;
 
 // split "body.body.1" to ["body", "body", 1]
 type Split<P extends string> = P extends Pattern<infer O, infer U>
-  ? [ToNumber<O>, ...Split<U>]
-  : [ToNumber<P>];
+  ? [MaybeToIndex<O>, ...Split<U>]
+  : [MaybeToIndex<P>];
 
-// get all K with Node[K] is t.Node
+// get all K with Node[K] is t.Node | t.Node[]
 type NodeKeyOf<Node extends t.Node | t.Node[]> = keyof Pick<
   Node,
   {

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -341,7 +341,7 @@ type Trav<
   ? K extends NodeKeyOf<Node>
     ? R extends []
       ? Node[K]
-      : // @ts-ignore ignore since TS is not smart enough
+      : // @ts-expect-error ignore since TS is not smart enough
         Trav<Node[K], R>
     : never
   : never;

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -359,6 +359,16 @@ type ToNodePath<T> = T extends Array<t.Node | null | undefined>
   ? NodePath<T>
   : never;
 
+function get<T extends t.Node, K extends keyof T>(
+  this: NodePath<T>,
+  key: K,
+  context?: boolean | TraversalContext,
+): T[K] extends Array<t.Node | null | undefined>
+  ? Array<NodePath<T[K][number]>>
+  : T[K] extends t.Node | null | undefined
+  ? NodePath<T[K]>
+  : never;
+
 function get<T extends t.Node, K extends string>(
   this: NodePath<T>,
   key: K,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13587 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Using TS template literal types to get correct types for codes like `path.get("body.body.1")`
Currently, we have:

`classPath.get("body.body.1")` resolved to `t.ClassMethod | t.ClassPrivateMethod | t.ClassPrivateProperty | t.ClassProperty | t.TSDeclareMethod | t.TSIndexSignature`

`classPath.get("body")` resolved to `t.ClassBody` (work as previous)

`classPath.get("body.type")` resolved to `never` (should not use like this, so resolved to `never`)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13588"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

