### PR TITLE
fix: make syntax error accesibility after readonly more friendly

### DIFF
--- a/packages/babel-parser/test/fixtures/typescript/class/modifiers-properties2/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/modifiers-properties2/input.ts
@@ -1,0 +1,3 @@
+class Foo {
+  readonly private foo; // Error
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/modifiers-properties2/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/modifiers-properties2/output.json
@@ -1,0 +1,60 @@
+{
+  "type": "File",
+  "start":0,"end":46,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: 'private' modifier must precede 'readonly' modifier. (2:2)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":46,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":46,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":46,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":14,"end":35,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":23}},
+              "readonly": true,
+              "accessibility": "private",
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":31,"end":34,"loc":{"start":{"line":2,"column":19},"end":{"line":2,"column":22},"identifierName":"foo"},
+                "name": "foo"
+              },
+              "computed": false,
+              "value": null,
+              "trailingComments": [
+                {
+                  "type": "CommentLine",
+                  "value": " Error",
+                  "start":36,"end":44,"loc":{"start":{"line":2,"column":24},"end":{"line":2,"column":32}}
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " Error",
+      "start":36,"end":44,"loc":{"start":{"line":2,"column":24},"end":{"line":2,"column":32}}
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12772
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Throw an error like TypeScript when an accessible modifier is placed after readonly. 


AS IS
Unexpected token

TO BE
'private' modifier must precede 'readonly' modifier.



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13603"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

