### PR TITLE
chore(doc): add jest specific pckg command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,12 @@ $ TEST_ONLY=babel-cli make test
 $ TEST_ONLY=babel-plugin-transform-classes make test
 ```
 
+Or you can use Jest:
+
+```sh
+yarn jest babel-cli --watch
+```
+
 Use the `TEST_GREP` variable to run a subset of tests by name:
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,13 +125,19 @@ $ TEST_ONLY=babel-plugin-transform-classes make test
 Or you can use Jest:
 
 ```sh
-yarn jest babel-cli --watch
+yarn jest babel-cli
 ```
 
 Use the `TEST_GREP` variable to run a subset of tests by name:
 
 ```sh
 $ TEST_GREP=transformation make test
+```
+
+Or you can use Jest:
+
+```sh
+yarn jest -t transformation
 ```
 
 Substitute spaces for hyphens and forward slashes when targeting specific test names:
@@ -144,6 +150,12 @@ To enable the Node.js debugger added in v6.3.0, set the `TEST_DEBUG` environment
 
 ```sh
 $ TEST_DEBUG=true make test
+```
+
+Or you can use Node
+
+```sh
+yarn node --inspect-brk node_modules/jest/bin/jest.js --runInBand
 ```
 
 You can combine `TEST_DEBUG` with `TEST_GREP` or `TEST_ONLY` to debug a subset of tests. If you plan to stay long in the debugger (which you'll likely do!), you may increase the test timeout by editing [test/testSetupFile.js](https://github.com/babel/babel/blob/main/test/testSetupFile.js).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,8 +180,8 @@ You can combine `TEST_DEBUG` with `TEST_GREP` or `TEST_ONLY` to debug a subset o
 
 To overwrite any test fixtures when fixing a bug or anything, add the env variable `OVERWRITE=true`
 
-  ```sh
-  $ OVERWRITE=true TEST_ONLY=babel-plugin-transform-classes make test-only
+```sh
+$ OVERWRITE=true TEST_ONLY=babel-plugin-transform-classes make test-only
 ```
 
 #### Test coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,30 +84,30 @@ $ make build-dist
 
 #### You can run lint via:
 
-  ```sh
-  # ~6 sec on a MacBook Pro (Mid 2015)
-  $ make lint
-  ```
+```sh
+# ~6 sec on a MacBook Pro (Mid 2015)
+$ make lint
+```
 
 - You can run eslint's autofix via:
 
-  ```sh
-  $ make fix
-  ```
+```sh
+$ make fix
+```
 
 #### You can run tests + lint for all packages (slow) via:
 
-  ```sh
-  # ~46 sec on a MacBook Pro (Mid 2015)
-  $ make test
-  ```
+```sh
+# ~46 sec on a MacBook Pro (Mid 2015)
+$ make test
+```
 
 #### If you just want to run all tests:
 
-  ```sh
-  # ~40 sec on a MacBook Pro (Mid 2015)
-  $ make test-only
-  ```
+```sh
+# ~40 sec on a MacBook Pro (Mid 2015)
+$ make test-only
+```
 
 #### Run tests for a specific package
 
@@ -119,7 +119,7 @@ $ TEST_ONLY=babel-cli make test
 
 <details>
   <summary>More options</summary>
-  `TEST_ONLY` will also match substrings of the package name:
+  <code>TEST_ONLY</code> will also match substrings of the package name:
 
   ```sh
   # Run tests for the @babel/plugin-transform-classes package.
@@ -144,23 +144,23 @@ $ TEST_GREP=transformation make test
 
 <details>
   <summary>More options</summary>
-  Or you can use Yarn:
-
-  ```sh
-  $ yarn jest -t transformation
-  ```
-
   Substitute spaces for hyphens and forward slashes when targeting specific test names:
 
   ```sh
   $ TEST_GREP="arrow functions destructuring parameters" make test
+  ```
+
+  Or you can use Yarn:
+
+  ```sh
+  $ yarn jest -t transformation
   ```
 </details>
 <br>
 
 #### Run test with Node debugger
 
-To enable the Node.js debugger added in v6.3.0, set the `TEST_DEBUG` environment variable:
+To enable the Node.js debugger added in v6.3.0, set the <code>TEST_DEBUG</code> environment variable:
 
 ```sh
 $ TEST_DEBUG=true make test
@@ -173,10 +173,10 @@ $ TEST_DEBUG=true make test
   ```sh
   $ yarn node --inspect-brk node_modules/jest/bin/jest.js --runInBand
   ```
-
-  You can combine `TEST_DEBUG` with `TEST_GREP` or `TEST_ONLY` to debug a subset of tests. If you plan to stay long in the debugger (which you'll likely do!), you may increase the test timeout by editing [test/testSetupFile.js](https://github.com/babel/babel/blob/main/test/testSetupFile.js).
 </details>
 <br>
+
+You can combine `TEST_DEBUG` with `TEST_GREP` or `TEST_ONLY` to debug a subset of tests. If you plan to stay long in the debugger (which you'll likely do!), you may increase the test timeout by editing [test/testSetupFile.js](https://github.com/babel/babel/blob/main/test/testSetupFile.js).
 
 To overwrite any test fixtures when fixing a bug or anything, add the env variable `OVERWRITE=true`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,32 +82,34 @@ $ make build-dist
 
 ### Running linting/tests
 
-You can run lint via:
+#### You can run lint via:
 
-```sh
-# ~6 sec on a MacBook Pro (Mid 2015)
-$ make lint
-```
+  ```sh
+  # ~6 sec on a MacBook Pro (Mid 2015)
+  $ make lint
+  ```
 
-You can run eslint's autofix via:
+- You can run eslint's autofix via:
 
-```sh
-$ make fix
-```
+  ```sh
+  $ make fix
+  ```
 
-You can run tests + lint for all packages (slow) via:
+#### You can run tests + lint for all packages (slow) via:
 
-```sh
-# ~46 sec on a MacBook Pro (Mid 2015)
-$ make test
-```
+  ```sh
+  # ~46 sec on a MacBook Pro (Mid 2015)
+  $ make test
+  ```
 
-If you just want to run all tests:
+#### If you just want to run all tests:
 
-```sh
-# ~40 sec on a MacBook Pro (Mid 2015)
-$ make test-only
-```
+  ```sh
+  # ~40 sec on a MacBook Pro (Mid 2015)
+  $ make test-only
+  ```
+
+#### Run tests for a specific package
 
 When working on an issue, you will most likely want to focus on a particular [packages](https://github.com/babel/babel/tree/main/packages). Using `TEST_ONLY` will only run tests for that specific package.
 
@@ -115,18 +117,24 @@ When working on an issue, you will most likely want to focus on a particular [pa
 $ TEST_ONLY=babel-cli make test
 ```
 
-`TEST_ONLY` will also match substrings of the package name:
+<details>
+  <summary>More options</summary>
+  `TEST_ONLY` will also match substrings of the package name:
 
-```sh
-# Run tests for the @babel/plugin-transform-classes package.
-$ TEST_ONLY=babel-plugin-transform-classes make test
-```
+  ```sh
+  # Run tests for the @babel/plugin-transform-classes package.
+  $ TEST_ONLY=babel-plugin-transform-classes make test
+  ```
 
-Or you can use Yarn:
+  Or you can use Yarn: 
 
-```sh
-$ yarn jest babel-cli
-```
+  ```sh
+  $ yarn jest babel-cli
+  ```
+</details>
+<br>
+
+#### Run a subset of tests
 
 Use the `TEST_GREP` variable to run a subset of tests by name:
 
@@ -134,17 +142,23 @@ Use the `TEST_GREP` variable to run a subset of tests by name:
 $ TEST_GREP=transformation make test
 ```
 
-Or you can use Yarn:
+<details>
+  <summary>More options</summary>
+  Or you can use Yarn:
 
-```sh
-$ yarn jest -t transformation
-```
+  ```sh
+  $ yarn jest -t transformation
+  ```
 
-Substitute spaces for hyphens and forward slashes when targeting specific test names:
+  Substitute spaces for hyphens and forward slashes when targeting specific test names:
 
-```sh
-$ TEST_GREP="arrow functions destructuring parameters" make test
-```
+  ```sh
+  $ TEST_GREP="arrow functions destructuring parameters" make test
+  ```
+</details>
+<br>
+
+#### Run test with Node debugger
 
 To enable the Node.js debugger added in v6.3.0, set the `TEST_DEBUG` environment variable:
 
@@ -152,19 +166,25 @@ To enable the Node.js debugger added in v6.3.0, set the `TEST_DEBUG` environment
 $ TEST_DEBUG=true make test
 ```
 
-Or you can use Yarn
+<details>
+  <summary>More options</summary>
+  Or you can use Yarn
 
-```sh
-$ yarn node --inspect-brk node_modules/jest/bin/jest.js --runInBand
-```
+  ```sh
+  $ yarn node --inspect-brk node_modules/jest/bin/jest.js --runInBand
+  ```
 
-You can combine `TEST_DEBUG` with `TEST_GREP` or `TEST_ONLY` to debug a subset of tests. If you plan to stay long in the debugger (which you'll likely do!), you may increase the test timeout by editing [test/testSetupFile.js](https://github.com/babel/babel/blob/main/test/testSetupFile.js).
+  You can combine `TEST_DEBUG` with `TEST_GREP` or `TEST_ONLY` to debug a subset of tests. If you plan to stay long in the debugger (which you'll likely do!), you may increase the test timeout by editing [test/testSetupFile.js](https://github.com/babel/babel/blob/main/test/testSetupFile.js).
+</details>
+<br>
 
 To overwrite any test fixtures when fixing a bug or anything, add the env variable `OVERWRITE=true`
 
-```sh
-$ OVERWRITE=true TEST_ONLY=babel-plugin-transform-classes make test-only
+  ```sh
+  $ OVERWRITE=true TEST_ONLY=babel-plugin-transform-classes make test-only
 ```
+
+#### Test coverage
 
 To test the code coverage, use:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,10 +122,10 @@ $ TEST_ONLY=babel-cli make test
 $ TEST_ONLY=babel-plugin-transform-classes make test
 ```
 
-Or you can use Jest:
+Or you can use Yarn:
 
 ```sh
-yarn jest babel-cli
+$ yarn jest babel-cli
 ```
 
 Use the `TEST_GREP` variable to run a subset of tests by name:
@@ -134,10 +134,10 @@ Use the `TEST_GREP` variable to run a subset of tests by name:
 $ TEST_GREP=transformation make test
 ```
 
-Or you can use Jest:
+Or you can use Yarn:
 
 ```sh
-yarn jest -t transformation
+$ yarn jest -t transformation
 ```
 
 Substitute spaces for hyphens and forward slashes when targeting specific test names:
@@ -152,10 +152,10 @@ To enable the Node.js debugger added in v6.3.0, set the `TEST_DEBUG` environment
 $ TEST_DEBUG=true make test
 ```
 
-Or you can use Node
+Or you can use Yarn
 
 ```sh
-yarn node --inspect-brk node_modules/jest/bin/jest.js --runInBand
+$ yarn node --inspect-brk node_modules/jest/bin/jest.js --runInBand
 ```
 
 You can combine `TEST_DEBUG` with `TEST_GREP` or `TEST_ONLY` to debug a subset of tests. If you plan to stay long in the debugger (which you'll likely do!), you may increase the test timeout by editing [test/testSetupFile.js](https://github.com/babel/babel/blob/main/test/testSetupFile.js).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ $ make build-dist
 
 ### Running linting/tests
 
-#### You can run lint via:
+#### Lint
 
 ```sh
 # ~6 sec on a MacBook Pro (Mid 2015)
@@ -95,14 +95,14 @@ $ make lint
 $ make fix
 ```
 
-#### You can run tests + lint for all packages (slow) via:
+#### Tests + lint for all packages (slow) via:
 
 ```sh
 # ~46 sec on a MacBook Pro (Mid 2015)
 $ make test
 ```
 
-#### If you just want to run all tests:
+#### All tests:
 
 ```sh
 # ~40 sec on a MacBook Pro (Mid 2015)
@@ -146,12 +146,17 @@ $ TEST_GREP=transformation make test
   <summary>More options</summary>
   Substitute spaces for hyphens and forward slashes when targeting specific test names:
 
+  For example, for the following path:
+  ```sh
+  packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/destructuring-parameters
+  ```
+
+  You can use:
   ```sh
   $ TEST_GREP="arrow functions destructuring parameters" make test
   ```
 
-  Or you can use Yarn:
-
+  Or you can directly use Yarn:
   ```sh
   $ yarn jest -t transformation
   ```
@@ -160,7 +165,7 @@ $ TEST_GREP=transformation make test
 
 #### Run test with Node debugger
 
-To enable the Node.js debugger added in v6.3.0, set the <code>TEST_DEBUG</code> environment variable:
+To enable the Node.js debugger, set the <code>TEST_DEBUG</code> environment variable:
 
 ```sh
 $ TEST_DEBUG=true make test
@@ -168,7 +173,7 @@ $ TEST_DEBUG=true make test
 
 <details>
   <summary>More options</summary>
-  Or you can use Yarn
+  Or you can directly use Yarn
 
   ```sh
   $ yarn node --inspect-brk node_modules/jest/bin/jest.js --runInBand

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,26 +142,22 @@ Use the `TEST_GREP` variable to run a subset of tests by name:
 $ TEST_GREP=transformation make test
 ```
 
-<details>
-  <summary>More options</summary>
-  Substitute spaces for hyphens and forward slashes when targeting specific test names:
+Substitute spaces for hyphens and forward slashes when targeting specific test names:
 
-  For example, for the following path:
-  ```sh
-  packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/destructuring-parameters
-  ```
+For example, for the following path:
+```sh
+packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/destructuring-parameters
+```
 
-  You can use:
-  ```sh
-  $ TEST_GREP="arrow functions destructuring parameters" make test
-  ```
+You can use:
+```sh
+$ TEST_GREP="arrow functions destructuring parameters" make test
+```
 
-  Or you can directly use Yarn:
-  ```sh
-  $ yarn jest -t transformation
-  ```
-</details>
-<br>
+Or you can directly use Yarn:
+```sh
+$ yarn jest -t "arrow functions destructuring parameters"
+```
 
 #### Run test with Node debugger
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | ❌
| Patch: Bug Fix?          | ❌
| Major: Breaking Change?  | ❌
| Minor: New Feature?      | ❌
| Tests Added + Pass?      | ❌
| Documentation PR Link    | ❌
| Any Dependency Changes?  | ❌
| License                  | MIT

Hi 👋 

Yesterday, chatting with @JLHwung we figured out that the command: `yarn jest <name-of-the-pckg> --watch` wasn't mentioned in the documentation.

A tiny PR to add it ^^

Let me know if it's useful or not.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13607"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

