### PR TITLE
Replace generic __clone call by specific methods

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@babel-baseline/generator": "npm:@babel/generator@7.14.5",
     "@babel-baseline/helper-validator-identifier": "npm:@babel/helper-validator-identifier@7.10.4",
-    "@babel-baseline/parser": "npm:@babel/parser@7.14.5",
+    "@babel-baseline/parser": "npm:@babel/parser@7.14.8",
     "@babel/generator": "workspace:*",
     "@babel/helper-validator-identifier": "workspace:*",
     "@babel/parser": "workspace:*",

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -57,6 +57,7 @@ import {
 import { Errors, SourceTypeModuleErrors } from "./error";
 import type { ParsingError } from "./error";
 import { setInnerComments } from "./comments";
+import { cloneIdentifier } from "./node";
 
 /*::
 import type { SourceType } from "../options";
@@ -1938,7 +1939,7 @@ export default class ExpressionParser extends LValParser {
         prop.value = this.parseMaybeDefault(
           startPos,
           startLoc,
-          prop.key.__clone(),
+          cloneIdentifier(prop.key),
         );
       } else if (this.match(tt.eq) && refExpressionErrors) {
         if (refExpressionErrors.shorthandAssign === -1) {
@@ -1947,10 +1948,10 @@ export default class ExpressionParser extends LValParser {
         prop.value = this.parseMaybeDefault(
           startPos,
           startLoc,
-          prop.key.__clone(),
+          cloneIdentifier(prop.key),
         );
       } else {
-        prop.value = prop.key.__clone();
+        prop.value = cloneIdentifier(prop.key);
       }
       prop.shorthand = true;
 

--- a/packages/babel-parser/src/parser/node.js
+++ b/packages/babel-parser/src/parser/node.js
@@ -27,6 +27,7 @@ class Node implements NodeBase {
   innerComments: Array<Comment>;
   extra: { [key: string]: any };
 
+  // todo(Babel 8): remove this method in Babel 8
   __clone(): this {
     // $FlowIgnore
     const newNode: any = new Node();
@@ -46,6 +47,46 @@ class Node implements NodeBase {
 
     return newNode;
   }
+}
+const NodePrototype = Node.prototype;
+
+function clonePlaceholder(node: any): any {
+  return cloneIdentifier(node);
+}
+
+export function cloneIdentifier(node: any): any {
+  // We don't need to clone `typeAnnotations` and `optional`: because
+  // cloneIdentifier is only used in object shorthand and named import/export.
+  // Neither of them allow type annotations after the identifier or optional identifier
+  const { type, start, end, loc, range, extra, name } = node;
+  const cloned = Object.create(NodePrototype);
+  cloned.type = type;
+  cloned.start = start;
+  cloned.end = end;
+  cloned.loc = loc;
+  cloned.range = range;
+  cloned.extra = extra;
+  cloned.name = name;
+  if (type === "Placeholder") {
+    cloned.expectedNode = node.expectedNode;
+  }
+  return cloned;
+}
+
+export function cloneStringLiteral(node: any): any {
+  const { type, start, end, loc, range, extra } = node;
+  if (type === "Placeholder") {
+    return clonePlaceholder(node);
+  }
+  const cloned = Object.create(NodePrototype);
+  cloned.type = "StringLiteral";
+  cloned.start = start;
+  cloned.end = end;
+  cloned.loc = loc;
+  cloned.range = range;
+  cloned.extra = extra;
+  cloned.value = node.value;
+  return cloned;
 }
 
 export class NodeUtils extends UtilParser {

--- a/packages/babel-parser/src/parser/node.js
+++ b/packages/babel-parser/src/parser/node.js
@@ -26,9 +26,12 @@ class Node implements NodeBase {
   trailingComments: Array<Comment>;
   innerComments: Array<Comment>;
   extra: { [key: string]: any };
+}
+const NodePrototype = Node.prototype;
 
-  // todo(Babel 8): remove this method in Babel 8
-  __clone(): this {
+if (!process.env.BABEL_8_BREAKING) {
+  // $FlowIgnore
+  NodePrototype.__clone = function (): Node {
     // $FlowIgnore
     const newNode: any = new Node();
     const keys = Object.keys(this);
@@ -40,15 +43,13 @@ class Node implements NodeBase {
         key !== "trailingComments" &&
         key !== "innerComments"
       ) {
-        // $FlowIgnore
         newNode[key] = this[key];
       }
     }
 
     return newNode;
-  }
+  };
 }
-const NodePrototype = Node.prototype;
 
 function clonePlaceholder(node: any): any {
   return cloneIdentifier(node);

--- a/packages/babel-parser/src/plugins/flow/index.js
+++ b/packages/babel-parser/src/plugins/flow/index.js
@@ -25,6 +25,7 @@ import {
 } from "../../util/scopeflags";
 import type { ExpressionErrors } from "../../parser/util";
 import { Errors, makeErrorTemplates, ErrorCodes } from "../../parser/error";
+import { cloneIdentifier } from "../../parser/node";
 
 const reservedTypes = new Set([
   "_",
@@ -2655,7 +2656,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           // `import {type as ,` or `import {type as }`
           specifier.imported = as_ident;
           specifier.importKind = specifierTypeKind;
-          specifier.local = as_ident.__clone();
+          specifier.local = cloneIdentifier(as_ident);
         } else {
           // `import {type as foo`
           specifier.imported = firstIdent;
@@ -2673,7 +2674,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           specifier.local = this.parseIdentifier();
         } else {
           isBinding = true;
-          specifier.local = specifier.imported.__clone();
+          specifier.local = cloneIdentifier(specifier.imported);
         }
       } else {
         if (firstIdentIsString) {
@@ -2688,7 +2689,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         isBinding = true;
         specifier.imported = firstIdent;
         specifier.importKind = null;
-        specifier.local = specifier.imported.__clone();
+        specifier.local = cloneIdentifier(specifier.imported);
       }
 
       const nodeIsTypeImport = hasTypeImportKind(node);

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -98,6 +98,7 @@ export type Identifier = PatternBase & {
   type: "Identifier",
   name: string,
 
+  // @deprecated
   __clone(): Identifier,
 
   // TypeScript only. Used in case of an optional parameter.

--- a/packages/babel-traverse/test/replacement.js
+++ b/packages/babel-traverse/test/replacement.js
@@ -122,7 +122,7 @@ describe("path/replacement", function () {
         OptionalMemberExpression(path) {
           path.node.type = "MemberExpression";
           // force `replaceWith` to replace `path.node`
-          path.replaceWith(path.node.__clone());
+          path.replaceWith(t.cloneNode(path.node));
           path.parentPath.ensureBlock();
 
           const aQuestionDotBNode = path.node.object.expression;

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,12 +23,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel-baseline/parser@npm:@babel/parser@7.14.5":
-  version: 7.14.5
-  resolution: "@babel/parser@npm:7.14.5"
+"@babel-baseline/parser@npm:@babel/parser@7.14.8":
+  version: 7.14.8
+  resolution: "@babel/parser@npm:7.14.8"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 55c14793888cb7d54275811e7f13136875df1ee4fc368f3f10cff46ebdf95b6a072e706a0486be0ac5686a597cbfb82f33b5f66aa6ba80ff50b73bca945035c6
+  checksum: 1f900e92675bac6120dfb3e9ea86841fdaba11d338a220017dbcb9e95815a3854ea479da8027e80acaa7f0e618b96e59bbbf3a230a05aaa3407c9419eb742cfe
   languageName: node
   linkType: hard
 
@@ -87,7 +87,7 @@ __metadata:
   dependencies:
     "@babel-baseline/generator": "npm:@babel/generator@7.14.5"
     "@babel-baseline/helper-validator-identifier": "npm:@babel/helper-validator-identifier@7.10.4"
-    "@babel-baseline/parser": "npm:@babel/parser@7.14.5"
+    "@babel-baseline/parser": "npm:@babel/parser@7.14.8"
     "@babel/generator": "workspace:*"
     "@babel/helper-validator-identifier": "workspace:*"
     "@babel/parser": "workspace:*"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In this PR we replace the generic `Node#__clone` by specific methods. We observe 80% performance boost compared to `@babel/parser` 7.14.8 in the `length-1 named export` benchmark cases. In this case the named export specifier is cloned as export values.

```
baseline 256 length-1 named export: 4_704 ops/sec ±1.59% (0.213ms)
baseline 512 length-1 named export: 2_426 ops/sec ±0.52% (0.412ms)
baseline 1024 length-1 named export: 1_118 ops/sec ±1.23% (0.895ms)
baseline 2048 length-1 named export: 556 ops/sec ±0.77% (1.799ms)
current 256 length-1 named export: 7_073 ops/sec ±33.67% (0.141ms)
current 512 length-1 named export: 4_441 ops/sec ±0.79% (0.225ms)
current 1024 length-1 named export: 2_142 ops/sec ±1.09% (0.467ms)
current 2048 length-1 named export: 943 ops/sec ±2.12% (1.06ms)
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13611"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

