### PR TITLE
Update Rollup to `~2.54.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lodash": "^4.17.21",
     "mergeiterator": "^1.2.5",
     "prettier": "2.3.1",
-    "rollup": "^2.47.0",
+    "rollup": "~2.54.0",
     "rollup-plugin-dts": "^2.0.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-terser": "^7.0.2",

--- a/test/runtime-integration/rollup/package.json
+++ b/test/runtime-integration/rollup/package.json
@@ -5,6 +5,6 @@
     "@babel/runtime": "workspace:*",
     "@rollup/plugin-commonjs": "^18.1.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
-    "rollup": "^2.47.0"
+    "rollup": "~2.54.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,7 +39,7 @@ __metadata:
     "@babel/runtime": "workspace:*"
     "@rollup/plugin-commonjs": ^18.1.0
     "@rollup/plugin-node-resolve": ^13.0.0
-    rollup: ^2.47.0
+    rollup: ~2.54.0
   languageName: unknown
   linkType: soft
 
@@ -5768,7 +5768,7 @@ __metadata:
     lodash: ^4.17.21
     mergeiterator: ^1.2.5
     prettier: 2.3.1
-    rollup: ^2.47.0
+    rollup: ~2.54.0
     rollup-plugin-dts: ^2.0.0
     rollup-plugin-node-polyfills: ^0.2.1
     rollup-plugin-terser: ^7.0.2
@@ -8603,7 +8603,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"fsevents@^2.3.2, fsevents@~2.3.1":
+"fsevents@^2.3.2, fsevents@~2.3.1, fsevents@~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -8622,7 +8622,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.3.2#builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.1#builtin<compat/fsevents>":
+"fsevents@patch:fsevents@^2.3.2#builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.1#builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#builtin<compat/fsevents>::version=2.3.2&hash=11e9ea"
   dependencies:
@@ -13371,17 +13371,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.47.0":
-  version: 2.47.0
-  resolution: "rollup@npm:2.47.0"
+"rollup@npm:~2.54.0":
+  version: 2.54.0
+  resolution: "rollup@npm:2.54.0"
   dependencies:
-    fsevents: ~2.3.1
+    fsevents: ~2.3.2
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: bab2079fea72ebb6457e88717f64f3bd8ff52556827f77485708274aa94f2dfa19f555c022643957d604ff7329be5d010234346d28e13dcfed33d742d3e468b0
+  checksum: caf0de927d472ba085f2b313c70eb3412af4f0aba24e7abce5b4bc3f896cee0076a06c7172f1fcf0b58f1413c938f8f2987f17af746dcc144df97f7148ddeb2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Until rollup/plugins#962 or rollup/rollup#4195 are fixed, we need to pin to `~2.54.0` because `2.55.0` breaks our "old Babel" e2e test.

Ref https://github.com/babel/babel/pull/13612