### PR TITLE
Workaround for hanging e2e-breaking Babel test

### DIFF
--- a/scripts/integration-tests/e2e-babel.sh
+++ b/scripts/integration-tests/e2e-babel.sh
@@ -37,7 +37,7 @@ if [ "$BABEL_8_BREAKING" = true ] ; then
   # Until we figure it out (see https://github.com/babel/babel/pull/13618)
   # we can force exit so that CircleCI doesn't report it as a failure.
   make -j build-standalone-ci
-  BABEL_ENV=test yarn jest --maxWorkers=4 --ci --forceExit
+  BABEL_ENV=test yarn jest --maxWorkers=4 --ci --forceExit --runInBand
   make -j test-clean
 else
   make -j test-ci

--- a/scripts/integration-tests/e2e-babel.sh
+++ b/scripts/integration-tests/e2e-babel.sh
@@ -32,6 +32,15 @@ startLocalRegistry "$PWD"/scripts/integration-tests/verdaccio-config.yml
 node "$PWD"/scripts/integration-tests/utils/bump-babel-dependencies.js
 
 # Update deps, build and test
-make -j test-ci
+if [ "$BABEL_8_BREAKING" = true ] ; then
+  # Jest hangs forever in the Babel 8 e2e test, but we don't know yet why.
+  # Until we figure it out (see https://github.com/babel/babel/pull/13618)
+  # we can force exit so that CircleCI doesn't report it as a failure.
+  make -j build-standalone-ci
+  BABEL_ENV=test yarn jest --maxWorkers=4 --ci --forceExit
+  make -j test-clean
+else
+  make -j test-ci
+fi
 
 cleanup

--- a/scripts/integration-tests/e2e-babel.sh
+++ b/scripts/integration-tests/e2e-babel.sh
@@ -33,11 +33,11 @@ node "$PWD"/scripts/integration-tests/utils/bump-babel-dependencies.js
 
 # Update deps, build and test
 if [ "$BABEL_8_BREAKING" = true ] ; then
-  # Jest hangs forever in the Babel 8 e2e test, but we don't know yet why.
-  # Until we figure it out (see https://github.com/babel/babel/pull/13618)
-  # we can force exit so that CircleCI doesn't report it as a failure.
+  # Jest hangs forever in the Babel 8 e2e test when using multiple workers,
+  # but we don't know yet why. Until we figure it out (see
+  # https://github.com/babel/babel/pull/13618) we can use --runInBand.
   make -j build-standalone-ci
-  BABEL_ENV=test yarn jest --ci --forceExit --runInBand
+  BABEL_ENV=test yarn jest --ci --runInBand
   make -j test-clean
 else
   make -j test-ci

--- a/scripts/integration-tests/e2e-babel.sh
+++ b/scripts/integration-tests/e2e-babel.sh
@@ -37,7 +37,7 @@ if [ "$BABEL_8_BREAKING" = true ] ; then
   # Until we figure it out (see https://github.com/babel/babel/pull/13618)
   # we can force exit so that CircleCI doesn't report it as a failure.
   make -j build-standalone-ci
-  BABEL_ENV=test yarn jest --maxWorkers=4 --ci --forceExit --runInBand
+  BABEL_ENV=test yarn jest --ci --forceExit --runInBand
   make -j test-clean
 else
   make -j test-ci


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

> Jest hangs forever in the Babel 8 e2e test, but we don't know yet why.
> Until we figure it out (see https://github.com/babel/babel/pull/13618 we can force exit so that CircleCI doesn't report it as a failure.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13623"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

