### PR TITLE
shrink output generated by `@babel/helper-module-transforms`

### DIFF
--- a/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
+++ b/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
@@ -19,6 +19,10 @@ export interface ModuleMetadata {
   // `stringSpecifiers` is Set(1) ["any unicode"]
   // In most cases `stringSpecifiers` is an empty Set
   stringSpecifiers: Set<string>;
+  // Name of the function used to initialize `export { name } from "module"`.
+  reexportByGetName: null | string;
+  // Name of the function used to initialize `export * from "module"`.
+  reexportFromThisName: null | string;
 }
 
 export type InteropType =
@@ -157,6 +161,8 @@ export default function normalizeModuleAndLoadMetadata(
   return {
     exportName,
     exportNameListName: null,
+    reexportByGetName: null,
+    reexportFromThisName: null,
     hasExports,
     local,
     source,

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-2/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-2/output.js
@@ -4,10 +4,13 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "foo", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("foo", () => _foo.foo);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-3/output.js
@@ -4,16 +4,15 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "foo", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
-  Object.defineProperty(_exports, "bar", {
-    enumerable: true,
-    get: function () {
-      return _foo.bar;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("foo", () => _foo.foo);
+
+  _export("bar", () => _foo.bar);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-4/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-4/output.js
@@ -4,10 +4,13 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "bar", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("bar", () => _foo.foo);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-5/output.js
@@ -4,10 +4,13 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "default", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("default", () => _foo.foo);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-6/output.js
@@ -4,16 +4,15 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "default", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
-  Object.defineProperty(_exports, "bar", {
-    enumerable: true,
-    get: function () {
-      return _foo.bar;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("default", () => _foo.foo);
+
+  _export("bar", () => _foo.bar);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from/output.js
@@ -4,14 +4,15 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.keys(_foo).forEach(function (key) {
+
+  function _exportFromThis(key) {
     if (key === "default" || key === "__esModule") return;
-    if (key in _exports && _exports[key] === _foo[key]) return;
+    if (key in _exports && _exports[key] === this[key]) return;
     Object.defineProperty(_exports, key, {
       enumerable: true,
-      get: function () {
-        return _foo[key];
-      }
+      get: () => this[key]
     });
-  });
+  }
+
+  Object.keys(_foo).forEach(_exportFromThis, _foo);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/noInterop-export-from/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/noInterop-export-from/output.js
@@ -4,10 +4,13 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "default", {
-    enumerable: true,
-    get: function () {
-      return _foo.default;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("default", () => _foo.default);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-6/output.js
@@ -4,9 +4,12 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.keys(_foo).forEach(function (key) {
+
+  function _exportFromThis(key) {
     if (key === "default" || key === "__esModule") return;
-    if (key in _exports && _exports[key] === _foo[key]) return;
-    _exports[key] = _foo[key];
-  });
+    if (key in _exports && _exports[key] === this[key]) return;
+    _exports[key] = this[key];
+  }
+
+  Object.keys(_foo).forEach(_exportFromThis, _foo);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/importInterop-node/export-named-and-default-from/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/importInterop-node/export-named-and-default-from/output.js
@@ -4,17 +4,17 @@ define(["exports", "dep"], function (_exports, _dep) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "default", {
-    enumerable: true,
-    get: function () {
-      return _dep.default;
-    }
-  });
-  Object.defineProperty(_exports, "name", {
-    enumerable: true,
-    get: function () {
-      return _dep.name;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("default", () => _dep.default);
+
+  _export("name", () => _dep.name);
+
   _dep = babelHelpers.interopRequireWildcard(_dep, true);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/importInterop-node/export-named-from/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/importInterop-node/export-named-from/output.js
@@ -4,10 +4,13 @@ define(["exports", "dep"], function (_exports, _dep) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "name", {
-    enumerable: true,
-    get: function () {
-      return _dep.name;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("name", () => _dep.name);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/importInterop-none/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/importInterop-none/export-from/output.js
@@ -4,10 +4,13 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "default", {
-    enumerable: true,
-    get: function () {
-      return _foo.default;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("default", () => _foo.default);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names/export-from-string-as-string/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names/export-from-string-as-string/output.js
@@ -4,10 +4,13 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "some exports", {
-    enumerable: true,
-    get: function () {
-      return _foo["some imports"];
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("some exports", () => _foo["some imports"]);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names/export-from-string/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names/export-from-string/output.js
@@ -4,10 +4,13 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "some exports", {
-    enumerable: true,
-    get: function () {
-      return _foo["some exports"];
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("some exports", () => _foo["some exports"]);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names/export-from/output.js
@@ -4,10 +4,13 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "some exports", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("some exports", () => _foo.foo);
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-from/output.js
@@ -2,9 +2,12 @@ define(["exports", "foo"], function (_exports, _foo) {
   "use strict";
 
   _exports.__esModule = true;
-  Object.keys(_foo).forEach(function (key) {
+
+  function _exportFromThis(key) {
     if (key === "default" || key === "__esModule") return;
-    if (key in _exports && _exports[key] === _foo[key]) return;
-    _exports[key] = _foo[key];
-  });
+    if (key in _exports && _exports[key] === this[key]) return;
+    _exports[key] = this[key];
+  }
+
+  Object.keys(_foo).forEach(_exportFromThis, _foo);
 });

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-6/output.js
@@ -4,10 +4,12 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+function _exportFromThis(key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === this[key]) return;
+  exports[key] = this[key];
+}
+
 var _foo = require("foo");
 
-Object.keys(_foo).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _foo[key]) return;
-  exports[key] = _foo[key];
-});
+Object.keys(_foo).forEach(_exportFromThis, _foo);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/importInterop-node/export-named-and-default-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/importInterop-node/export-named-and-default-from/output.js
@@ -3,17 +3,16 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "default", {
-  enumerable: true,
-  get: function () {
-    return _dep.default;
-  }
-});
-Object.defineProperty(exports, "name", {
-  enumerable: true,
-  get: function () {
-    return _dep.name;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("default", () => _dep.default);
+
+_export("name", () => _dep.name);
 
 var _dep = babelHelpers.interopRequireWildcard(require("dep"), true);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/importInterop-node/export-named-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/importInterop-node/export-named-from/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "name", {
-  enumerable: true,
-  get: function () {
-    return _dep.name;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("name", () => _dep.name);
 
 var _dep = require("dep");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/importInterop-none/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/importInterop-none/export-from/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "default", {
-  enumerable: true,
-  get: function () {
-    return _foo.default;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("default", () => _foo.default);
 
 var _foo = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-from/output.js
@@ -2,10 +2,12 @@
 
 exports.__esModule = true;
 
+function _exportFromThis(key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === this[key]) return;
+  exports[key] = this[key];
+}
+
 var _foo = require("foo");
 
-Object.keys(_foo).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _foo[key]) return;
-  exports[key] = _foo[key];
-});
+Object.keys(_foo).forEach(_exportFromThis, _foo);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names/export-from-string-as-string/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names/export-from-string-as-string/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "some exports", {
-  enumerable: true,
-  get: function () {
-    return _foo["some imports"];
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("some exports", () => _foo["some imports"]);
 
 var _foo = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names/export-from-string/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names/export-from-string/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "some exports", {
-  enumerable: true,
-  get: function () {
-    return _foo["some exports"];
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("some exports", () => _foo["some exports"]);
 
 var _foo = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names/export-from/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "some exports", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("some exports", () => _foo.foo);
 
 var _foo = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-all/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-all/output.js
@@ -3,22 +3,21 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-var _exportNames = {};
+
+function _exportFromThis(key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === this[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: () => this[key]
+  });
+}
+
 exports.default = void 0;
 
 var _react = babelHelpers.interopRequireWildcard(require("react"));
 
-Object.keys(_react).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
-  if (key in exports && exports[key] === _react[key]) return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function () {
-      return _react[key];
-    }
-  });
-});
+Object.keys(_react).forEach(_exportFromThis, _react);
 // The fact that this exports both a normal default, and all of the names via
 // re-export is an edge case that is important not to miss. See
 // https://github.com/babel/babel/issues/8306 as an example.

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-2/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-2/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "foo", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("foo", () => _foo.foo);
 
 var _foo = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-3/output.js
@@ -3,17 +3,16 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "foo", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo;
-  }
-});
-Object.defineProperty(exports, "bar", {
-  enumerable: true,
-  get: function () {
-    return _foo.bar;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("foo", () => _foo.foo);
+
+_export("bar", () => _foo.bar);
 
 var _foo = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-4/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-4/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "bar", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("bar", () => _foo.foo);
 
 var _foo = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-5/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "default", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("default", () => _foo.foo);
 
 var _foo = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-6/output.js
@@ -3,17 +3,16 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "default", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo;
-  }
-});
-Object.defineProperty(exports, "bar", {
-  enumerable: true,
-  get: function () {
-    return _foo.bar;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("default", () => _foo.foo);
+
+_export("bar", () => _foo.bar);
 
 var _foo = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-7/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-7/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "foo", {
-  enumerable: true,
-  get: function () {
-    return _foo.default;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("foo", () => _foo.default);
 
 var _foo = babelHelpers.interopRequireDefault(require("foo"));

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-8/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-8/output.js
@@ -3,611 +3,214 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "foo", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo;
-  }
-});
-Object.defineProperty(exports, "foo1", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo1;
-  }
-});
-Object.defineProperty(exports, "foo2", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo2;
-  }
-});
-Object.defineProperty(exports, "foo3", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo3;
-  }
-});
-Object.defineProperty(exports, "foo4", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo4;
-  }
-});
-Object.defineProperty(exports, "foo5", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo5;
-  }
-});
-Object.defineProperty(exports, "foo6", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo6;
-  }
-});
-Object.defineProperty(exports, "foo7", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo7;
-  }
-});
-Object.defineProperty(exports, "foo8", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo8;
-  }
-});
-Object.defineProperty(exports, "foo9", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo9;
-  }
-});
-Object.defineProperty(exports, "foo10", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo10;
-  }
-});
-Object.defineProperty(exports, "foo11", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo11;
-  }
-});
-Object.defineProperty(exports, "foo12", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo12;
-  }
-});
-Object.defineProperty(exports, "foo13", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo13;
-  }
-});
-Object.defineProperty(exports, "foo14", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo14;
-  }
-});
-Object.defineProperty(exports, "foo15", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo15;
-  }
-});
-Object.defineProperty(exports, "foo16", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo16;
-  }
-});
-Object.defineProperty(exports, "foo17", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo17;
-  }
-});
-Object.defineProperty(exports, "foo18", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo18;
-  }
-});
-Object.defineProperty(exports, "foo19", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo19;
-  }
-});
-Object.defineProperty(exports, "foo20", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo20;
-  }
-});
-Object.defineProperty(exports, "foo21", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo21;
-  }
-});
-Object.defineProperty(exports, "foo22", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo22;
-  }
-});
-Object.defineProperty(exports, "foo23", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo23;
-  }
-});
-Object.defineProperty(exports, "foo24", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo24;
-  }
-});
-Object.defineProperty(exports, "foo25", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo25;
-  }
-});
-Object.defineProperty(exports, "foo26", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo26;
-  }
-});
-Object.defineProperty(exports, "foo27", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo27;
-  }
-});
-Object.defineProperty(exports, "foo28", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo28;
-  }
-});
-Object.defineProperty(exports, "foo29", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo29;
-  }
-});
-Object.defineProperty(exports, "foo30", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo30;
-  }
-});
-Object.defineProperty(exports, "foo31", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo31;
-  }
-});
-Object.defineProperty(exports, "foo32", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo32;
-  }
-});
-Object.defineProperty(exports, "foo33", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo33;
-  }
-});
-Object.defineProperty(exports, "foo34", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo34;
-  }
-});
-Object.defineProperty(exports, "foo35", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo35;
-  }
-});
-Object.defineProperty(exports, "foo36", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo36;
-  }
-});
-Object.defineProperty(exports, "foo37", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo37;
-  }
-});
-Object.defineProperty(exports, "foo38", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo38;
-  }
-});
-Object.defineProperty(exports, "foo39", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo39;
-  }
-});
-Object.defineProperty(exports, "foo40", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo40;
-  }
-});
-Object.defineProperty(exports, "foo41", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo41;
-  }
-});
-Object.defineProperty(exports, "foo42", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo42;
-  }
-});
-Object.defineProperty(exports, "foo43", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo43;
-  }
-});
-Object.defineProperty(exports, "foo44", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo44;
-  }
-});
-Object.defineProperty(exports, "foo45", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo45;
-  }
-});
-Object.defineProperty(exports, "foo46", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo46;
-  }
-});
-Object.defineProperty(exports, "foo47", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo47;
-  }
-});
-Object.defineProperty(exports, "foo48", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo48;
-  }
-});
-Object.defineProperty(exports, "foo49", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo49;
-  }
-});
-Object.defineProperty(exports, "foo50", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo50;
-  }
-});
-Object.defineProperty(exports, "foo51", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo51;
-  }
-});
-Object.defineProperty(exports, "foo52", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo52;
-  }
-});
-Object.defineProperty(exports, "foo53", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo53;
-  }
-});
-Object.defineProperty(exports, "foo54", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo54;
-  }
-});
-Object.defineProperty(exports, "foo55", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo55;
-  }
-});
-Object.defineProperty(exports, "foo56", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo56;
-  }
-});
-Object.defineProperty(exports, "foo57", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo57;
-  }
-});
-Object.defineProperty(exports, "foo58", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo58;
-  }
-});
-Object.defineProperty(exports, "foo59", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo59;
-  }
-});
-Object.defineProperty(exports, "foo60", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo60;
-  }
-});
-Object.defineProperty(exports, "foo61", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo61;
-  }
-});
-Object.defineProperty(exports, "foo62", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo62;
-  }
-});
-Object.defineProperty(exports, "foo63", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo63;
-  }
-});
-Object.defineProperty(exports, "foo64", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo64;
-  }
-});
-Object.defineProperty(exports, "foo65", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo65;
-  }
-});
-Object.defineProperty(exports, "foo66", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo66;
-  }
-});
-Object.defineProperty(exports, "foo67", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo67;
-  }
-});
-Object.defineProperty(exports, "foo68", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo68;
-  }
-});
-Object.defineProperty(exports, "foo69", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo69;
-  }
-});
-Object.defineProperty(exports, "foo70", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo70;
-  }
-});
-Object.defineProperty(exports, "foo71", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo71;
-  }
-});
-Object.defineProperty(exports, "foo72", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo72;
-  }
-});
-Object.defineProperty(exports, "foo73", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo73;
-  }
-});
-Object.defineProperty(exports, "foo74", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo74;
-  }
-});
-Object.defineProperty(exports, "foo75", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo75;
-  }
-});
-Object.defineProperty(exports, "foo76", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo76;
-  }
-});
-Object.defineProperty(exports, "foo77", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo77;
-  }
-});
-Object.defineProperty(exports, "foo78", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo78;
-  }
-});
-Object.defineProperty(exports, "foo79", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo79;
-  }
-});
-Object.defineProperty(exports, "foo80", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo80;
-  }
-});
-Object.defineProperty(exports, "foo81", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo81;
-  }
-});
-Object.defineProperty(exports, "foo82", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo82;
-  }
-});
-Object.defineProperty(exports, "foo83", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo83;
-  }
-});
-Object.defineProperty(exports, "foo84", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo84;
-  }
-});
-Object.defineProperty(exports, "foo85", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo85;
-  }
-});
-Object.defineProperty(exports, "foo86", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo86;
-  }
-});
-Object.defineProperty(exports, "foo87", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo87;
-  }
-});
-Object.defineProperty(exports, "foo88", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo88;
-  }
-});
-Object.defineProperty(exports, "foo89", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo89;
-  }
-});
-Object.defineProperty(exports, "foo90", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo90;
-  }
-});
-Object.defineProperty(exports, "foo91", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo91;
-  }
-});
-Object.defineProperty(exports, "foo92", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo92;
-  }
-});
-Object.defineProperty(exports, "foo93", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo93;
-  }
-});
-Object.defineProperty(exports, "foo94", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo94;
-  }
-});
-Object.defineProperty(exports, "foo95", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo95;
-  }
-});
-Object.defineProperty(exports, "foo96", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo96;
-  }
-});
-Object.defineProperty(exports, "foo97", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo97;
-  }
-});
-Object.defineProperty(exports, "foo98", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo98;
-  }
-});
-Object.defineProperty(exports, "foo99", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo99;
-  }
-});
-Object.defineProperty(exports, "foo100", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo100;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("foo", () => _foo.foo);
+
+_export("foo1", () => _foo.foo1);
+
+_export("foo2", () => _foo.foo2);
+
+_export("foo3", () => _foo.foo3);
+
+_export("foo4", () => _foo.foo4);
+
+_export("foo5", () => _foo.foo5);
+
+_export("foo6", () => _foo.foo6);
+
+_export("foo7", () => _foo.foo7);
+
+_export("foo8", () => _foo.foo8);
+
+_export("foo9", () => _foo.foo9);
+
+_export("foo10", () => _foo.foo10);
+
+_export("foo11", () => _foo.foo11);
+
+_export("foo12", () => _foo.foo12);
+
+_export("foo13", () => _foo.foo13);
+
+_export("foo14", () => _foo.foo14);
+
+_export("foo15", () => _foo.foo15);
+
+_export("foo16", () => _foo.foo16);
+
+_export("foo17", () => _foo.foo17);
+
+_export("foo18", () => _foo.foo18);
+
+_export("foo19", () => _foo.foo19);
+
+_export("foo20", () => _foo.foo20);
+
+_export("foo21", () => _foo.foo21);
+
+_export("foo22", () => _foo.foo22);
+
+_export("foo23", () => _foo.foo23);
+
+_export("foo24", () => _foo.foo24);
+
+_export("foo25", () => _foo.foo25);
+
+_export("foo26", () => _foo.foo26);
+
+_export("foo27", () => _foo.foo27);
+
+_export("foo28", () => _foo.foo28);
+
+_export("foo29", () => _foo.foo29);
+
+_export("foo30", () => _foo.foo30);
+
+_export("foo31", () => _foo.foo31);
+
+_export("foo32", () => _foo.foo32);
+
+_export("foo33", () => _foo.foo33);
+
+_export("foo34", () => _foo.foo34);
+
+_export("foo35", () => _foo.foo35);
+
+_export("foo36", () => _foo.foo36);
+
+_export("foo37", () => _foo.foo37);
+
+_export("foo38", () => _foo.foo38);
+
+_export("foo39", () => _foo.foo39);
+
+_export("foo40", () => _foo.foo40);
+
+_export("foo41", () => _foo.foo41);
+
+_export("foo42", () => _foo.foo42);
+
+_export("foo43", () => _foo.foo43);
+
+_export("foo44", () => _foo.foo44);
+
+_export("foo45", () => _foo.foo45);
+
+_export("foo46", () => _foo.foo46);
+
+_export("foo47", () => _foo.foo47);
+
+_export("foo48", () => _foo.foo48);
+
+_export("foo49", () => _foo.foo49);
+
+_export("foo50", () => _foo.foo50);
+
+_export("foo51", () => _foo.foo51);
+
+_export("foo52", () => _foo.foo52);
+
+_export("foo53", () => _foo.foo53);
+
+_export("foo54", () => _foo.foo54);
+
+_export("foo55", () => _foo.foo55);
+
+_export("foo56", () => _foo.foo56);
+
+_export("foo57", () => _foo.foo57);
+
+_export("foo58", () => _foo.foo58);
+
+_export("foo59", () => _foo.foo59);
+
+_export("foo60", () => _foo.foo60);
+
+_export("foo61", () => _foo.foo61);
+
+_export("foo62", () => _foo.foo62);
+
+_export("foo63", () => _foo.foo63);
+
+_export("foo64", () => _foo.foo64);
+
+_export("foo65", () => _foo.foo65);
+
+_export("foo66", () => _foo.foo66);
+
+_export("foo67", () => _foo.foo67);
+
+_export("foo68", () => _foo.foo68);
+
+_export("foo69", () => _foo.foo69);
+
+_export("foo70", () => _foo.foo70);
+
+_export("foo71", () => _foo.foo71);
+
+_export("foo72", () => _foo.foo72);
+
+_export("foo73", () => _foo.foo73);
+
+_export("foo74", () => _foo.foo74);
+
+_export("foo75", () => _foo.foo75);
+
+_export("foo76", () => _foo.foo76);
+
+_export("foo77", () => _foo.foo77);
+
+_export("foo78", () => _foo.foo78);
+
+_export("foo79", () => _foo.foo79);
+
+_export("foo80", () => _foo.foo80);
+
+_export("foo81", () => _foo.foo81);
+
+_export("foo82", () => _foo.foo82);
+
+_export("foo83", () => _foo.foo83);
+
+_export("foo84", () => _foo.foo84);
+
+_export("foo85", () => _foo.foo85);
+
+_export("foo86", () => _foo.foo86);
+
+_export("foo87", () => _foo.foo87);
+
+_export("foo88", () => _foo.foo88);
+
+_export("foo89", () => _foo.foo89);
+
+_export("foo90", () => _foo.foo90);
+
+_export("foo91", () => _foo.foo91);
+
+_export("foo92", () => _foo.foo92);
+
+_export("foo93", () => _foo.foo93);
+
+_export("foo94", () => _foo.foo94);
+
+_export("foo95", () => _foo.foo95);
+
+_export("foo96", () => _foo.foo96);
+
+_export("foo97", () => _foo.foo97);
+
+_export("foo98", () => _foo.foo98);
+
+_export("foo99", () => _foo.foo99);
+
+_export("foo100", () => _foo.foo100);
 
 var _foo = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from/output.js
@@ -4,15 +4,15 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _foo = require("foo");
-
-Object.keys(_foo).forEach(function (key) {
+function _exportFromThis(key) {
   if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _foo[key]) return;
+  if (key in exports && exports[key] === this[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
-    get: function () {
-      return _foo[key];
-    }
+    get: () => this[key]
   });
-});
+}
+
+var _foo = require("foo");
+
+Object.keys(_foo).forEach(_exportFromThis, _foo);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-all/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-all/output.js
@@ -4,15 +4,15 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _foo = require("foo");
-
-Object.keys(_foo).forEach(function (key) {
+function _exportFromThis(key) {
   if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _foo[key]) return;
+  if (key in exports && exports[key] === this[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
-    get: function () {
-      return _foo[key];
-    }
+    get: () => this[key]
   });
-});
+}
+
+var _foo = require("foo");
+
+Object.keys(_foo).forEach(_exportFromThis, _foo);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-default/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-default/output.js
@@ -3,12 +3,15 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "default", {
-  enumerable: true,
-  get: function () {
-    return _foo().default;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("default", () => _foo().default);
 
 function _foo() {
   const data = babelHelpers.interopRequireDefault(require("foo"));

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-named/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-named/output.js
@@ -3,12 +3,15 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "named", {
-  enumerable: true,
-  get: function () {
-    return _foo().named;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("named", () => _foo().named);
 
 function _foo() {
   const data = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-namespace/output.js
@@ -3,6 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
 exports.namespace = void 0;
 
 function namespace() {
@@ -15,9 +23,4 @@ function namespace() {
   return data;
 }
 
-Object.defineProperty(exports, "namespace", {
-  enumerable: true,
-  get: function () {
-    return namespace();
-  }
-});
+_export("namespace", () => namespace());

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/reexport-all/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/reexport-all/output.js
@@ -4,15 +4,15 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _foo = require("./foo");
-
-Object.keys(_foo).forEach(function (key) {
+function _exportFromThis(key) {
   if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _foo[key]) return;
+  if (key in exports && exports[key] === this[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
-    get: function () {
-      return _foo[key];
-    }
+    get: () => this[key]
   });
-});
+}
+
+var _foo = require("./foo");
+
+Object.keys(_foo).forEach(_exportFromThis, _foo);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/reexport-default/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/reexport-default/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "default", {
-  enumerable: true,
-  get: function () {
-    return _foo.default;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("default", () => _foo.default);
 
 var _foo = babelHelpers.interopRequireDefault(require("./foo"));

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/reexport-named/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/reexport-named/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "named", {
-  enumerable: true,
-  get: function () {
-    return _foo.named;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("named", () => _foo.named);
 
 var _foo = require("./foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-all/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-all/output.js
@@ -4,28 +4,19 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _white = require("white");
-
-Object.keys(_white).forEach(function (key) {
+function _exportFromThis(key) {
   if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _white[key]) return;
+  if (key in exports && exports[key] === this[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
-    get: function () {
-      return _white[key];
-    }
+    get: () => this[key]
   });
-});
+}
+
+var _white = require("white");
+
+Object.keys(_white).forEach(_exportFromThis, _white);
 
 var _black = require("black");
 
-Object.keys(_black).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _black[key]) return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function () {
-      return _black[key];
-    }
-  });
-});
+Object.keys(_black).forEach(_exportFromThis, _black);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-default/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-default/output.js
@@ -3,12 +3,15 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "default", {
-  enumerable: true,
-  get: function () {
-    return _white().default;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("default", () => _white().default);
 
 function _white() {
   const data = babelHelpers.interopRequireDefault(require("white"));

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-named/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-named/output.js
@@ -3,18 +3,17 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "named1", {
-  enumerable: true,
-  get: function () {
-    return _white().named1;
-  }
-});
-Object.defineProperty(exports, "named2", {
-  enumerable: true,
-  get: function () {
-    return _black.named2;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("named1", () => _white().named1);
+
+_export("named2", () => _black.named2);
 
 function _white() {
   const data = require("white");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-namespace/output.js
@@ -3,6 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
 exports.namespace2 = exports.namespace1 = void 0;
 
 function namespace1() {
@@ -15,11 +23,7 @@ function namespace1() {
   return data;
 }
 
-Object.defineProperty(exports, "namespace1", {
-  enumerable: true,
-  get: function () {
-    return namespace1();
-  }
-});
+_export("namespace1", () => namespace1());
+
 var namespace2 = babelHelpers.interopRequireDefault(require("black"));
 exports.namespace2 = namespace2;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/output.js
@@ -3,18 +3,17 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "Foo", {
-  enumerable: true,
-  get: function () {
-    return _moduleWithGetter.default;
-  }
-});
-Object.defineProperty(exports, "baz", {
-  enumerable: true,
-  get: function () {
-    return _moduleWithGetter.baz;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("Foo", () => _moduleWithGetter.default);
+
+_export("baz", () => _moduleWithGetter.baz);
 
 var _moduleWithGetter = _interopRequireDefault(require("./moduleWithGetter"));
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/noInterop/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/noInterop/export-from/output.js
@@ -3,11 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "default", {
-  enumerable: true,
-  get: function () {
-    return _foo.default;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("default", () => _foo.default);
 
 var _foo = require("foo");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7165/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7165/output.js
@@ -4,20 +4,20 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+function _exportFromThis(key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === this[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: () => this[key]
+  });
+}
+
 var _foo = _interopRequireDefault(require("foo"));
 
 var _bar = require("bar");
 
-Object.keys(_bar).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _bar[key]) return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function () {
-      return _bar[key];
-    }
-  });
-});
+Object.keys(_bar).forEach(_exportFromThis, _bar);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-all/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-all/output.js
@@ -10,31 +10,37 @@ var _exportNames = {
   d: true,
   e: true,
   f: true,
-  c: true
+  "default": true,
+  c: true,
+  __esModule: true
 };
+
+function _exportFromThis(key) {
+  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
+  if (key in exports && exports[key] === this[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: () => this[key]
+  });
+}
+
 exports.b = b;
 exports.default = _default;
-Object.defineProperty(exports, "c", {
-  enumerable: true,
-  get: function () {
-    return _mod.c;
-  }
-});
+
+function _export(key, get) {
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get
+  });
+}
+
+_export("c", () => _mod.c);
+
 exports.f = exports.e = exports.d = exports.a = exports.z = void 0;
 
 var _mod = require("mod");
 
-Object.keys(_mod).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
-  if (key in exports && exports[key] === _mod[key]) return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function () {
-      return _mod[key];
-    }
-  });
-});
+Object.keys(_mod).forEach(_exportFromThis, _mod);
 var z = 100;
 exports.z = z;
 

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-6/output.js
@@ -16,9 +16,12 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.keys(_foo).forEach(function (key) {
+
+  function _exportFromThis(key) {
     if (key === "default" || key === "__esModule") return;
-    if (key in _exports && _exports[key] === _foo[key]) return;
-    _exports[key] = _foo[key];
-  });
+    if (key in _exports && _exports[key] === this[key]) return;
+    _exports[key] = this[key];
+  }
+
+  Object.keys(_foo).forEach(_exportFromThis, _foo);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/importInterop-node/export-named-and-default-from/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/importInterop-node/export-named-and-default-from/output.js
@@ -16,17 +16,17 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "default", {
-    enumerable: true,
-    get: function () {
-      return _dep.default;
-    }
-  });
-  Object.defineProperty(_exports, "name", {
-    enumerable: true,
-    get: function () {
-      return _dep.name;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("default", () => _dep.default);
+
+  _export("name", () => _dep.name);
+
   _dep = babelHelpers.interopRequireWildcard(_dep, true);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/importInterop-node/export-named-from/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/importInterop-node/export-named-from/output.js
@@ -16,10 +16,13 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "name", {
-    enumerable: true,
-    get: function () {
-      return _dep.name;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("name", () => _dep.name);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/importInterop-none/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/importInterop-none/export-from/output.js
@@ -16,10 +16,13 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "default", {
-    enumerable: true,
-    get: function () {
-      return _foo.default;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("default", () => _foo.default);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names/export-from-string-as-string/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names/export-from-string-as-string/output.js
@@ -16,10 +16,13 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "some exports", {
-    enumerable: true,
-    get: function () {
-      return _foo["some imports"];
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("some exports", () => _foo["some imports"]);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names/export-from-string/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names/export-from-string/output.js
@@ -16,10 +16,13 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "some exports", {
-    enumerable: true,
-    get: function () {
-      return _foo["some exports"];
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("some exports", () => _foo["some exports"]);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names/export-from/output.js
@@ -16,10 +16,13 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "some exports", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("some exports", () => _foo.foo);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-6/output.js
@@ -14,9 +14,12 @@
   "use strict";
 
   _exports.__esModule = true;
-  Object.keys(_foo).forEach(function (key) {
+
+  function _exportFromThis(key) {
     if (key === "default" || key === "__esModule") return;
-    if (key in _exports && _exports[key] === _foo[key]) return;
-    _exports[key] = _foo[key];
-  });
+    if (key in _exports && _exports[key] === this[key]) return;
+    _exports[key] = this[key];
+  }
+
+  Object.keys(_foo).forEach(_exportFromThis, _foo);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-2/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-2/output.js
@@ -16,10 +16,13 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "default", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("default", () => _foo.foo);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-3/output.js
@@ -16,16 +16,15 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "default", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
-  Object.defineProperty(_exports, "bar", {
-    enumerable: true,
-    get: function () {
-      return _foo.bar;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("default", () => _foo.foo);
+
+  _export("bar", () => _foo.bar);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-4/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-4/output.js
@@ -16,10 +16,13 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "bar", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("bar", () => _foo.foo);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-5/output.js
@@ -16,16 +16,15 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "foo", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
-  Object.defineProperty(_exports, "bar", {
-    enumerable: true,
-    get: function () {
-      return _foo.bar;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("foo", () => _foo.foo);
+
+  _export("bar", () => _foo.bar);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-6/output.js
@@ -16,14 +16,15 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.keys(_foo).forEach(function (key) {
+
+  function _exportFromThis(key) {
     if (key === "default" || key === "__esModule") return;
-    if (key in _exports && _exports[key] === _foo[key]) return;
+    if (key in _exports && _exports[key] === this[key]) return;
     Object.defineProperty(_exports, key, {
       enumerable: true,
-      get: function () {
-        return _foo[key];
-      }
+      get: () => this[key]
     });
-  });
+  }
+
+  Object.keys(_foo).forEach(_exportFromThis, _foo);
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from/output.js
@@ -16,10 +16,13 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "foo", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
+
+  function _export(key, get) {
+    Object.defineProperty(_exports, key, {
+      enumerable: true,
+      get
+    });
+  }
+
+  _export("foo", () => _foo.foo);
 });

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules/output.js
@@ -10,20 +10,20 @@ _Object$defineProperty(exports, "__esModule", {
   value: true
 });
 
+function _exportFromThis(key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === this[key]) return;
+
+  _Object$defineProperty(exports, key, {
+    enumerable: true,
+    get: () => this[key]
+  });
+}
+
 var _bar = _interopRequireDefault(require("bar"));
 
 var _mod = require("mod");
 
-_Object$keys(_mod).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _mod[key]) return;
-
-  _Object$defineProperty(exports, key, {
-    enumerable: true,
-    get: function () {
-      return _mod[key];
-    }
-  });
-});
+_Object$keys(_mod).forEach(_exportFromThis, _mod);
 
 _bar.default;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-loose/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-loose/output.js
@@ -10,8 +10,17 @@ var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequ
 
 exports.__esModule = true;
 var _exportNames = {
-  exp: true
+  exp: true,
+  "default": true,
+  __esModule: true
 };
+
+function _exportFromThis(key) {
+  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
+  if (key in exports && exports[key] === this[key]) return;
+  exports[key] = this[key];
+}
+
 exports.exp = void 0;
 
 var _bar = _interopRequireDefault(require("bar"));
@@ -20,12 +29,7 @@ var _fuz = require("fuz");
 
 var _mod = require("mod");
 
-_forEachInstanceProperty(_context = _Object$keys(_mod)).call(_context, function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
-  if (key in exports && exports[key] === _mod[key]) return;
-  exports[key] = _mod[key];
-});
+_forEachInstanceProperty(_context = _Object$keys(_mod)).call(_context, _exportFromThis, _mod);
 
 const exp = _bar.default + _fuz.baz;
 exports.exp = exp;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules/output.js
@@ -15,8 +15,21 @@ _Object$defineProperty(exports, "__esModule", {
 });
 
 var _exportNames = {
-  exp: true
+  exp: true,
+  "default": true,
+  __esModule: true
 };
+
+function _exportFromThis(key) {
+  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
+  if (key in exports && exports[key] === this[key]) return;
+
+  _Object$defineProperty(exports, key, {
+    enumerable: true,
+    get: () => this[key]
+  });
+}
+
 exports.exp = void 0;
 
 var _bar = _interopRequireDefault(require("bar"));
@@ -25,18 +38,7 @@ var _fuz = require("fuz");
 
 var _mod = require("mod");
 
-_forEachInstanceProperty(_context = _Object$keys(_mod)).call(_context, function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
-  if (key in exports && exports[key] === _mod[key]) return;
-
-  _Object$defineProperty(exports, key, {
-    enumerable: true,
-    get: function () {
-      return _mod[key];
-    }
-  });
-});
+_forEachInstanceProperty(_context = _Object$keys(_mod)).call(_context, _exportFromThis, _mod);
 
 const exp = _bar.default + _fuz.baz;
 exports.exp = exp;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/output.js
@@ -6,18 +6,18 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+function _exportFromThis(key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === this[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: () => this[key]
+  });
+}
+
 var _bar = _interopRequireDefault(require("bar"));
 
 var _mod = require("mod");
 
-Object.keys(_mod).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _mod[key]) return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function () {
-      return _mod[key];
-    }
-  });
-});
+Object.keys(_mod).forEach(_exportFromThis, _mod);
 _bar.default;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | :heavy_minus_sign: 
| Patch: Bug Fix?          | :heavy_minus_sign: 
| Major: Breaking Change?  | :heavy_minus_sign: 
| Minor: New Feature?      | :heavy_minus_sign: 
| Tests Added + Pass?      | amended existing because output changed
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Reduces the amount of code generated by `@babel/helper-module-transforms` (when there are many exports) by extracting some boilerplate into a function.

I'm creating this as a draft because I suspect some of the changes might not be okay. I will attach specific questions to test fixtures to show what I mean later. But first I'd like to know how can I make the modified `helper-module-transforms` apply to babel code itself, e.g. `babel-types/lib/index.js`?
