### PR TITLE
Add `.errors` to the `@babel/parser` return type definitions

### DIFF
--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -11,7 +11,7 @@
 export function parse(
   input: string,
   options?: ParserOptions
-): import("@babel/types").File;
+): ParseResult<import("@babel/types").File>;
 
 /**
  * Parse the provided code as a single expression.
@@ -19,7 +19,7 @@ export function parse(
 export function parseExpression(
   input: string,
   options?: ParserOptions
-): import("@babel/types").Expression;
+): ParseResult<import("@babel/types").Expression>;
 
 export interface ParserOptions {
   /**
@@ -179,4 +179,13 @@ export interface TypeScriptPluginOptions {
 export const tokTypes: {
   // todo(flow->ts) real token type
   [name: string]: any;
+};
+
+export interface ParseError {
+  code: string;
+  reasonCode: string;
+}
+
+type ParseResult<Result> = Result & {
+  errors: ParseError[];
 };


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR fixes it on the babel-parser side, or should fix it on the babel-types side?

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13653"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

