### PR TITLE
Reduce stat calls in register

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -56,9 +56,13 @@ function compile(code, filename) {
 
   if (env) cacheKey += `:${env}`;
 
-  let cached = cache && cache[cacheKey];
+  let cached, fileMtime;
+  if (cache) {
+    cached = cache[cacheKey];
+    fileMtime = mtime(filename);
+  }
 
-  if (!cached || cached.mtime !== mtime(filename)) {
+  if (!cached || cached.mtime !== fileMtime) {
     cached = babel.transform(code, {
       ...opts,
       sourceMaps: opts.sourceMaps === undefined ? "both" : opts.sourceMaps,
@@ -67,7 +71,7 @@ function compile(code, filename) {
 
     if (cache) {
       cache[cacheKey] = cached;
-      cached.mtime = mtime(filename);
+      cached.mtime = fileMtime;
       registerCache.setDirty();
     }
   }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | n/a
| Documentation PR Link    | n/a
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Small optimization to [@babel/register](https://babeljs.io/docs/en/babel-register).

Currently [@babel/register](https://babeljs.io/docs/en/babel-register) makes more `fs.statSync()` calls than necessary.

If a file is in the cache, it calls `statSync()` and checks if file has been updated since cached version. If it has, it calls `statSync()` again when creating the new cache entry.

This PR removes that 2nd unnecessary stat call.

I haven't added a test as it seems like overkill to go to the lengths of mocking `fs` just to test for this, when the change can be verified pretty easily by eye. But let me know if you disagree.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13654"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

