### PR TITLE
fix(parser): add `attachComment` to `ParserOptions` type

### DIFF
--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -49,6 +49,17 @@ export interface ParserOptions {
   allowUndeclaredExports?: boolean;
 
   /**
+   * By default, Babel attaches comments to adjacent AST nodes.
+   * When this option is set to false, comments are not attached.
+   * It can provide up to 30% performance improvement when the input code has many comments.
+   * @babel/eslint-parser will set it for you.
+   * It is not recommended to use attachComment: false with Babel transform,
+   * as doing so removes all the comments in output code, and renders annotations such as
+   * /* istanbul ignore next *\/ nonfunctional.
+   */
+  attachComment?: boolean;
+
+  /**
    * By default, Babel always throws an error when it finds some invalid code.
    * When this option is set to true, it will store the parsing error and
    * try to continue parsing the invalid input file.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Add `attachComment` to `ParserOptions` type ( https://babeljs.io/docs/en/babel-parser#options ).
This is reported by @fisker at https://github.com/prettier/prettier/pull/11331#discussion_r684799637

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13657"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

