### PR TITLE
Fix parse error when using named import "as" with flow parser

### DIFF
--- a/packages/babel-parser/src/plugins/flow/index.js
+++ b/packages/babel-parser/src/plugins/flow/index.js
@@ -2663,36 +2663,33 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           specifier.importKind = null;
           specifier.local = this.parseIdentifier();
         }
-      } else if (
-        specifierTypeKind !== null &&
-        (this.match(tt.name) || this.state.type.keyword)
-      ) {
-        // `import {type foo`
-        specifier.imported = this.parseIdentifier(true);
-        specifier.importKind = specifierTypeKind;
+      } else {
+        if (
+          specifierTypeKind !== null &&
+          (this.match(tt.name) || this.state.type.keyword)
+        ) {
+          // `import {type foo`
+          specifier.imported = this.parseIdentifier(true);
+          specifier.importKind = specifierTypeKind;
+        } else {
+          if (firstIdentIsString) {
+            /*:: invariant(firstIdent instanceof N.StringLiteral) */
+            throw this.raise(
+              specifier.start,
+              Errors.ImportBindingIsString,
+              firstIdent.value,
+            );
+          }
+          /*:: invariant(firstIdent instanceof N.Node) */
+          specifier.imported = firstIdent;
+          specifier.importKind = null;
+        }
+
         if (this.eatContextual("as")) {
           specifier.local = this.parseIdentifier();
         } else {
           isBinding = true;
           specifier.local = cloneIdentifier(specifier.imported);
-        }
-      } else {
-        if (firstIdentIsString) {
-          /*:: invariant(firstIdent instanceof N.StringLiteral) */
-          throw this.raise(
-            specifier.start,
-            Errors.ImportBindingIsString,
-            firstIdent.value,
-          );
-        }
-        /*:: invariant(firstIdent instanceof N.Node) */
-        specifier.imported = firstIdent;
-        specifier.importKind = null;
-        if (this.eatContextual("as")) {
-          specifier.local = this.parseIdentifier();
-        } else {
-          isBinding = true;
-          specifier.local = specifier.imported.__clone();
         }
       }
 

--- a/packages/babel-parser/src/plugins/flow/index.js
+++ b/packages/babel-parser/src/plugins/flow/index.js
@@ -2686,10 +2686,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           );
         }
         /*:: invariant(firstIdent instanceof N.Node) */
-        isBinding = true;
         specifier.imported = firstIdent;
         specifier.importKind = null;
-        specifier.local = cloneIdentifier(specifier.imported);
+        if (this.eatContextual("as")) {
+          specifier.local = this.parseIdentifier();
+        } else {
+          isBinding = true;
+          specifier.local = specifier.imported.__clone();
+        }
       }
 
       const nodeIsTypeImport = hasTypeImportKind(node);

--- a/packages/babel-parser/test/fixtures/flow/imports/imports-with-as-identifiers/input.js
+++ b/packages/babel-parser/test/fixtures/flow/imports/imports-with-as-identifiers/input.js
@@ -1,0 +1,4 @@
+// @flow
+import { foo as as } from "foo";
+import { as as as } from "foo";
+import { as as foo } from "foo";

--- a/packages/babel-parser/test/fixtures/flow/imports/imports-with-as-identifiers/output.json
+++ b/packages/babel-parser/test/fixtures/flow/imports/imports-with-as-identifiers/output.json
@@ -1,0 +1,123 @@
+{
+  "type": "File",
+  "start":0,"end":106,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":32}},
+  "errors": [
+    "SyntaxError: Identifier 'as' has already been declared. (3:15)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":106,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":32}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start":9,"end":41,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":32}},
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start":18,"end":27,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":18}},
+            "imported": {
+              "type": "Identifier",
+              "start":18,"end":21,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":12},"identifierName":"foo"},
+              "name": "foo"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start":25,"end":27,"loc":{"start":{"line":2,"column":16},"end":{"line":2,"column":18},"identifierName":"as"},
+              "name": "as"
+            }
+          }
+        ],
+        "importKind": "value",
+        "source": {
+          "type": "StringLiteral",
+          "start":35,"end":40,"loc":{"start":{"line":2,"column":26},"end":{"line":2,"column":31}},
+          "extra": {
+            "rawValue": "foo",
+            "raw": "\"foo\""
+          },
+          "value": "foo"
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow",
+            "start":0,"end":8,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":8}}
+          }
+        ]
+      },
+      {
+        "type": "ImportDeclaration",
+        "start":42,"end":73,"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":31}},
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start":51,"end":59,"loc":{"start":{"line":3,"column":9},"end":{"line":3,"column":17}},
+            "imported": {
+              "type": "Identifier",
+              "start":51,"end":53,"loc":{"start":{"line":3,"column":9},"end":{"line":3,"column":11},"identifierName":"as"},
+              "name": "as"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start":57,"end":59,"loc":{"start":{"line":3,"column":15},"end":{"line":3,"column":17},"identifierName":"as"},
+              "name": "as"
+            }
+          }
+        ],
+        "importKind": "value",
+        "source": {
+          "type": "StringLiteral",
+          "start":67,"end":72,"loc":{"start":{"line":3,"column":25},"end":{"line":3,"column":30}},
+          "extra": {
+            "rawValue": "foo",
+            "raw": "\"foo\""
+          },
+          "value": "foo"
+        }
+      },
+      {
+        "type": "ImportDeclaration",
+        "start":74,"end":106,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":32}},
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start":83,"end":92,"loc":{"start":{"line":4,"column":9},"end":{"line":4,"column":18}},
+            "imported": {
+              "type": "Identifier",
+              "start":83,"end":85,"loc":{"start":{"line":4,"column":9},"end":{"line":4,"column":11},"identifierName":"as"},
+              "name": "as"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start":89,"end":92,"loc":{"start":{"line":4,"column":15},"end":{"line":4,"column":18},"identifierName":"foo"},
+              "name": "foo"
+            }
+          }
+        ],
+        "importKind": "value",
+        "source": {
+          "type": "StringLiteral",
+          "start":100,"end":105,"loc":{"start":{"line":4,"column":26},"end":{"line":4,"column":31}},
+          "extra": {
+            "rawValue": "foo",
+            "raw": "\"foo\""
+          },
+          "value": "foo"
+        }
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow",
+      "start":0,"end":8,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":8}}
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/type-imports/import-type-shorthand-2/input.js
+++ b/packages/babel-parser/test/fixtures/flow/type-imports/import-type-shorthand-2/input.js
@@ -1,0 +1,1 @@
+import {type foo as as} from "foo";

--- a/packages/babel-parser/test/fixtures/flow/type-imports/import-type-shorthand-2/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-imports/import-type-shorthand-2/output.json
@@ -1,0 +1,44 @@
+{
+  "type": "File",
+  "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":35}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":35}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":35}},
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start":8,"end":22,"loc":{"start":{"line":1,"column":8},"end":{"line":1,"column":22}},
+            "imported": {
+              "type": "Identifier",
+              "start":13,"end":16,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":16},"identifierName":"foo"},
+              "name": "foo"
+            },
+            "importKind": "type",
+            "local": {
+              "type": "Identifier",
+              "start":20,"end":22,"loc":{"start":{"line":1,"column":20},"end":{"line":1,"column":22},"identifierName":"as"},
+              "name": "as"
+            }
+          }
+        ],
+        "importKind": "value",
+        "source": {
+          "type": "StringLiteral",
+          "start":29,"end":34,"loc":{"start":{"line":1,"column":29},"end":{"line":1,"column":34}},
+          "extra": {
+            "rawValue": "foo",
+            "raw": "\"foo\""
+          },
+          "value": "foo"
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13520  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 👍
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Update logic of the parseImportSpecifier function in the flow parser plugin to fix the issue #13520. Add related tests. 


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13659"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

