### PR TITLE
Lock `core-js-compat` version used for dev&tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "resolutions": {
     "browserslist": "npm:4.16.6",
     "caniuse-lite": "npm:1.0.30001235",
+    "core-js-compat": "npm:3.16.0",
     "electron-to-chromium": "npm:1.3.749",
     "glob-watcher/chokidar": "npm:^3.4.0",
     "@types/babel__core": "link:./nope",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6838,7 +6838,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.16.0, core-js-compat@npm:^3.9.1":
+"core-js-compat@npm:3.16.0":
   version: 3.16.0
   resolution: "core-js-compat@npm:3.16.0"
   dependencies:


### PR DESCRIPTION
Our Babel e2e tests regenerate the lockfile. This is a problem because
whenever there is a new `core-js-compat` version, the `babel-preset-env`
fixtures need to be updated and thus the e2e test fails.

This commit adds `core-js-compat` to `"resolutions"`,

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13660"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

