### PR TITLE
Add missing local to ImportSpecifier in AST spec

### DIFF
--- a/packages/babel-parser/ast/spec.md
+++ b/packages/babel-parser/ast/spec.md
@@ -1294,6 +1294,7 @@ An import declaration, e.g., `import foo from "mod";`.
 interface ImportSpecifier <: ModuleSpecifier {
   type: "ImportSpecifier";
   imported: Identifier | StringLiteral;
+  local: Identifier;
 }
 ```
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    |  [skip ci]
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Add missing 'local' to ImportSpecifier in AST spec



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13667"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

