### PR TITLE
Add the `decoratorsAutoAccessors` parser plugin

### DIFF
--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -379,7 +379,7 @@
     "chrome": "46",
     "opera": "33",
     "edge": "14",
-    "firefox": "45",
+    "firefox": "41",
     "safari": "10",
     "node": "5",
     "ios": "10",

--- a/packages/babel-generator/src/generators/classes.ts
+++ b/packages/babel-generator/src/generators/classes.ts
@@ -114,6 +114,48 @@ export function ClassProperty(this: Printer, node: t.ClassProperty) {
   this.semicolon();
 }
 
+export function ClassAccessorProperty(
+  this: Printer,
+  node: t.ClassAccessorProperty,
+) {
+  this.printJoin(node.decorators, node);
+
+  // catch up to property key, avoid line break
+  // between member modifiers and the property key.
+  this.source("end", node.key.loc);
+
+  this.tsPrintClassMemberModifiers(node, /* isField */ true);
+
+  this.word("accessor");
+  this.space();
+
+  if (node.computed) {
+    this.token("[");
+    this.print(node.key, node);
+    this.token("]");
+  } else {
+    this._variance(node);
+    this.print(node.key, node);
+  }
+
+  // TS
+  if (node.optional) {
+    this.token("?");
+  }
+  if (node.definite) {
+    this.token("!");
+  }
+
+  this.print(node.typeAnnotation, node);
+  if (node.value) {
+    this.space();
+    this.token("=");
+    this.space();
+    this.print(node.value, node);
+  }
+  this.semicolon();
+}
+
 export function ClassPrivateProperty(
   this: Printer,
   node: t.ClassPrivateProperty,

--- a/packages/babel-generator/src/generators/classes.ts
+++ b/packages/babel-generator/src/generators/classes.ts
@@ -127,6 +127,7 @@ export function ClassAccessorProperty(
   this.tsPrintClassMemberModifiers(node, /* isField */ true);
 
   this.word("accessor");
+  this.printInnerComments(node);
   this.space();
 
   if (node.computed) {

--- a/packages/babel-parser/ast/spec.md
+++ b/packages/babel-parser/ast/spec.md
@@ -1213,6 +1213,18 @@ interface ClassPrivateProperty <: Node {
 }
 ```
 
+## ClassAccessorProperty
+
+```js
+interface ClassAccessorProperty <: Node {
+  type: "ClassAccessorProperty";
+  key: Expression | PrivateName;
+  value: Expression;
+  static: boolean;
+  computed: boolean;
+}
+```
+
 ## StaticBlock
 
 ```js

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1394,6 +1394,7 @@ export default class StatementParser extends ExpressionParser {
       prop.computed = false;
       prop.key = key;
       prop.static = false;
+
       classBody.body.push(this.parseClassProperty(prop));
       return true;
     }
@@ -1430,8 +1431,9 @@ export default class StatementParser extends ExpressionParser {
   ) {
     const publicMethod: $FlowSubtype<N.ClassMethod> = member;
     const privateMethod: $FlowSubtype<N.ClassPrivateMethod> = member;
-    const publicProp: $FlowSubtype<N.ClassMethod> = member;
-    const privateProp: $FlowSubtype<N.ClassPrivateMethod> = member;
+    const publicProp: $FlowSubtype<N.ClassProperty> = member;
+    const privateProp: $FlowSubtype<N.ClassPrivateProperty> = member;
+    const accessorProp: $FlowSubtype<N.ClassAccessorProperty> = member;
 
     const method: typeof publicMethod | typeof privateMethod = publicMethod;
     const publicMember: typeof publicMethod | typeof publicProp = publicMethod;
@@ -1585,6 +1587,18 @@ export default class StatementParser extends ExpressionParser {
       }
 
       this.checkGetterSetterParams(publicMethod);
+    } else if (
+      isContextual &&
+      key.name === "accessor" &&
+      !this.isLineTerminator()
+    ) {
+      this.expectPlugin("decoratorAutoAccessors");
+      this.resetPreviousNodeTrailingComments(key);
+
+      // The so-called parsed name would have been "accessor": get the real name.
+      const isPrivate = this.match(tt.privateName);
+      this.parseClassElementName(publicProp);
+      this.pushClassAccessorProperty(classBody, accessorProp, isPrivate);
     } else if (this.isLineTerminator()) {
       // an uninitialized class property (due to ASI, since we don't otherwise recognize the next token)
       if (isPrivate) {
@@ -1666,6 +1680,34 @@ export default class StatementParser extends ExpressionParser {
     );
   }
 
+  pushClassAccessorProperty(
+    classBody: N.ClassBody,
+    prop: N.ClassAccessorProperty,
+    isPrivate: boolean,
+  ) {
+    if (!isPrivate && !prop.computed) {
+      // Not private, so not node is not a PrivateName and we can safely cast
+      const key = (prop.key: N.Expression);
+
+      if (key.name === "constructor" || key.value === "constructor") {
+        // Non-computed field, which is either an identifier named "constructor"
+        // or a string literal named "constructor"
+        this.raise(prop.key.start, Errors.ConstructorClassField);
+      }
+    }
+
+    const node = this.parseClassAccessorProperty(prop);
+    classBody.body.push(node);
+
+    if (isPrivate) {
+      this.classScope.declarePrivateName(
+        this.getPrivateNameSV(node.key),
+        CLASS_ELEMENT_OTHER,
+        node.key.start,
+      );
+    }
+  }
+
   pushClassMethod(
     classBody: N.ClassBody,
     method: N.ClassMethod,
@@ -1743,8 +1785,18 @@ export default class StatementParser extends ExpressionParser {
     return this.finishNode(node, "ClassProperty");
   }
 
+  parseClassAccessorProperty(
+    node: N.ClassAccessorProperty,
+  ): N.ClassAccessorProperty {
+    this.parseInitializer(node);
+    this.semicolon();
+    return this.finishNode(node, "ClassAccessorProperty");
+  }
+
   // https://tc39.es/proposal-class-fields/#prod-Initializer
-  parseInitializer(node: N.ClassProperty | N.ClassPrivateProperty): void {
+  parseInitializer(
+    node: N.ClassProperty | N.ClassPrivateProperty | N.ClassAccessorProperty,
+  ): void {
     this.scope.enter(SCOPE_CLASS | SCOPE_SUPER);
     this.expressionScope.enter(newExpressionScope());
     this.prodParam.enter(PARAM);

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -782,7 +782,8 @@ export type ClassMember =
   | ClassMethod
   | ClassPrivateMethod
   | ClassProperty
-  | ClassPrivateProperty;
+  | ClassPrivateProperty
+  | ClassAccessorProperty;
 
 export type MethodLike =
   | ObjectMethod
@@ -848,6 +849,20 @@ export type ClassPrivateProperty = NodeBase & {
   readonly?: true,
   override?: true,
 };
+
+export type ClassAccessorProperty = ClassMemberBase &
+  DeclarationBase & {
+    type: "ClassAccessorProperty",
+    key: Expression | PrivateName,
+    value: ?Expression,
+
+    typeAnnotation?: ?TypeAnnotationBase, // TODO: Not in spec
+    variance?: ?FlowVariance, // TODO: Not in spec
+
+    // TypeScript only: (TODO: Not in spec)
+    readonly?: true,
+    definite?: true,
+  };
 
 export type OptClassDeclaration = ClassBase &
   DeclarationBase &

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/auto-accessors/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/auto-accessors/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  accessor bar;
+}

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/auto-accessors/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/auto-accessors/options.json
@@ -1,0 +1,4 @@
+{
+  "throws": "This experimental syntax requires enabling the parser plugin: 'decoratorAutoAccessors' (2:11)",
+  "plugins": []
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/accessor-named-constructor/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/accessor-named-constructor/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  accessor constructor;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/accessor-named-constructor/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/accessor-named-constructor/output.json
@@ -1,0 +1,44 @@
+{
+  "type": "File",
+  "start":0,"end":37,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: Classes may not have a field named 'constructor'. (2:11)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":37,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":37,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":37,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassAccessorProperty",
+              "start":14,"end":35,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":23}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":23,"end":34,"loc":{"start":{"line":2,"column":11},"end":{"line":2,"column":22},"identifierName":"constructor"},
+                "name": "constructor"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/basic-accessor-with-newline/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/basic-accessor-with-newline/input.js
@@ -1,0 +1,4 @@
+class Foo {
+  accessor
+  bar;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/basic-accessor-with-newline/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/basic-accessor-with-newline/output.json
@@ -1,0 +1,53 @@
+{
+  "type": "File",
+  "start":0,"end":31,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":31,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":31,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":31,"loc":{"start":{"line":1,"column":10},"end":{"line":4,"column":1}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":14,"end":22,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":10}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":14,"end":22,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":10},"identifierName":"accessor"},
+                "name": "accessor"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start":25,"end":29,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":6}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":25,"end":28,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":5},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/basic-accessor/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/basic-accessor/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  accessor bar;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/basic-accessor/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/basic-accessor/output.json
@@ -1,0 +1,41 @@
+{
+  "type": "File",
+  "start":0,"end":29,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":29,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":29,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":29,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassAccessorProperty",
+              "start":14,"end":27,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":15}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":23,"end":26,"loc":{"start":{"line":2,"column":11},"end":{"line":2,"column":14},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor-named-constructor/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor-named-constructor/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  accessor ["constructor"];
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor-named-constructor/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor-named-constructor/output.json
@@ -1,0 +1,45 @@
+{
+  "type": "File",
+  "start":0,"end":41,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":41,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":41,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":41,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassAccessorProperty",
+              "start":14,"end":39,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":27}},
+              "static": false,
+              "key": {
+                "type": "StringLiteral",
+                "start":24,"end":37,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":25}},
+                "extra": {
+                  "rawValue": "constructor",
+                  "raw": "\"constructor\""
+                },
+                "value": "constructor"
+              },
+              "computed": true,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor-with-newline/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor-with-newline/input.js
@@ -1,0 +1,4 @@
+class Foo {
+  accessor
+  ["bar"];
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor-with-newline/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor-with-newline/output.json
@@ -1,0 +1,57 @@
+{
+  "type": "File",
+  "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":35,"loc":{"start":{"line":1,"column":10},"end":{"line":4,"column":1}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":14,"end":22,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":10}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":14,"end":22,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":10},"identifierName":"accessor"},
+                "name": "accessor"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start":25,"end":33,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":10}},
+              "static": false,
+              "computed": true,
+              "key": {
+                "type": "StringLiteral",
+                "start":26,"end":31,"loc":{"start":{"line":3,"column":3},"end":{"line":3,"column":8}},
+                "extra": {
+                  "rawValue": "bar",
+                  "raw": "\"bar\""
+                },
+                "value": "bar"
+              },
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  accessor ["bar"];
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-accessor/output.json
@@ -1,0 +1,45 @@
+{
+  "type": "File",
+  "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":33,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassAccessorProperty",
+              "start":14,"end":31,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":19}},
+              "static": false,
+              "key": {
+                "type": "StringLiteral",
+                "start":24,"end":29,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":17}},
+                "extra": {
+                  "rawValue": "bar",
+                  "raw": "\"bar\""
+                },
+                "value": "bar"
+              },
+              "computed": true,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-static-accesor/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-static-accesor/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  static accessor ["bar"];
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-static-accesor/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/computed-static-accesor/output.json
@@ -1,0 +1,45 @@
+{
+  "type": "File",
+  "start":0,"end":40,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":40,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":40,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":40,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassAccessorProperty",
+              "start":14,"end":38,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":26}},
+              "static": true,
+              "key": {
+                "type": "StringLiteral",
+                "start":31,"end":36,"loc":{"start":{"line":2,"column":19},"end":{"line":2,"column":24}},
+                "extra": {
+                  "rawValue": "bar",
+                  "raw": "\"bar\""
+                },
+                "value": "bar"
+              },
+              "computed": true,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/field-named-accessor/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/field-named-accessor/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  accessor = 123;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/field-named-accessor/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/field-named-accessor/output.json
@@ -1,0 +1,49 @@
+{
+  "type": "File",
+  "start":0,"end":31,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":31,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":31,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":31,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":14,"end":29,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":17}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":14,"end":22,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":10},"identifierName":"accessor"},
+                "name": "accessor"
+              },
+              "computed": false,
+              "value": {
+                "type": "NumericLiteral",
+                "start":25,"end":28,"loc":{"start":{"line":2,"column":13},"end":{"line":2,"column":16}},
+                "extra": {
+                  "rawValue": 123,
+                  "raw": "123"
+                },
+                "value": 123
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/invalid-static-keyword-order-newline/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/invalid-static-keyword-order-newline/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  accessor static bar;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/invalid-static-keyword-order-newline/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/invalid-static-keyword-order-newline/output.json
@@ -1,0 +1,56 @@
+{
+  "type": "File",
+  "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: Missing semicolon. (2:17)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":36,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassAccessorProperty",
+              "start":14,"end":29,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":17}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":23,"end":29,"loc":{"start":{"line":2,"column":11},"end":{"line":2,"column":17},"identifierName":"static"},
+                "name": "static"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start":30,"end":34,"loc":{"start":{"line":2,"column":18},"end":{"line":2,"column":22}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":30,"end":33,"loc":{"start":{"line":2,"column":18},"end":{"line":2,"column":21},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/invalid-static-keyword-order/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/invalid-static-keyword-order/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  accessor static bar;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/invalid-static-keyword-order/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/invalid-static-keyword-order/output.json
@@ -1,0 +1,56 @@
+{
+  "type": "File",
+  "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: Missing semicolon. (2:17)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":36,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassAccessorProperty",
+              "start":14,"end":29,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":17}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":23,"end":29,"loc":{"start":{"line":2,"column":11},"end":{"line":2,"column":17},"identifierName":"static"},
+                "name": "static"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start":30,"end":34,"loc":{"start":{"line":2,"column":18},"end":{"line":2,"column":22}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":30,"end":33,"loc":{"start":{"line":2,"column":18},"end":{"line":2,"column":21},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/method-named-accessor/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/method-named-accessor/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  accessor() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/method-named-accessor/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/method-named-accessor/output.json
@@ -1,0 +1,51 @@
+{
+  "type": "File",
+  "start":0,"end":29,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":29,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":29,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":29,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start":14,"end":27,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":15}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":14,"end":22,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":10},"identifierName":"accessor"},
+                "name": "accessor"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":25,"end":27,"loc":{"start":{"line":2,"column":13},"end":{"line":2,"column":15}},
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/not-allowed-on-methods/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/not-allowed-on-methods/input.js
@@ -1,0 +1,5 @@
+class Foo {
+  accessor bar() {
+
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/not-allowed-on-methods/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/not-allowed-on-methods/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (2:14)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "decoratorAutoAccessors"
+  ]
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/private-accessor/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/private-accessor/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  accessor #bar;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/private-accessor/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/private-accessor/output.json
@@ -1,0 +1,45 @@
+{
+  "type": "File",
+  "start":0,"end":30,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":30,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":30,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":30,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassAccessorProperty",
+              "start":14,"end":28,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":16}},
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start":23,"end":27,"loc":{"start":{"line":2,"column":11},"end":{"line":2,"column":15}},
+                "id": {
+                  "type": "Identifier",
+                  "start":24,"end":27,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":15},"identifierName":"bar"},
+                  "name": "bar"
+                }
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/private-static-accessor/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/private-static-accessor/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  static accessor #bar;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/private-static-accessor/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/private-static-accessor/output.json
@@ -1,0 +1,45 @@
+{
+  "type": "File",
+  "start":0,"end":37,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":37,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":37,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":37,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassAccessorProperty",
+              "start":14,"end":35,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":23}},
+              "static": true,
+              "key": {
+                "type": "PrivateName",
+                "start":30,"end":34,"loc":{"start":{"line":2,"column":18},"end":{"line":2,"column":22}},
+                "id": {
+                  "type": "Identifier",
+                  "start":31,"end":34,"loc":{"start":{"line":2,"column":19},"end":{"line":2,"column":22},"identifierName":"bar"},
+                  "name": "bar"
+                }
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/static-accessor-with-newline/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/static-accessor-with-newline/input.js
@@ -1,0 +1,4 @@
+class Foo {
+  static accessor
+  bar;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/static-accessor-with-newline/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/static-accessor-with-newline/output.json
@@ -1,0 +1,53 @@
+{
+  "type": "File",
+  "start":0,"end":38,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":38,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":38,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":38,"loc":{"start":{"line":1,"column":10},"end":{"line":4,"column":1}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":14,"end":29,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":17}},
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start":21,"end":29,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":17},"identifierName":"accessor"},
+                "name": "accessor"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start":32,"end":36,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":6}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":32,"end":35,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":5},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/static-accessor/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/static-accessor/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  static accessor bar;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/static-accessor/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorator-auto-accessors/static-accessor/output.json
@@ -1,0 +1,41 @@
+{
+  "type": "File",
+  "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":36,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":36,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+          "body": [
+            {
+              "type": "ClassAccessorProperty",
+              "start":14,"end":34,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":22}},
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start":30,"end":33,"loc":{"start":{"line":2,"column":18},"end":{"line":2,"column":21},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-traverse/src/path/generated/asserts.ts
+++ b/packages/babel-traverse/src/path/generated/asserts.ts
@@ -6,6 +6,7 @@ import * as t from "@babel/types";
 import NodePath from "../index";
 
 export interface NodePathAssetions {
+  assertAccessor(opts?: object): asserts this is NodePath<t.Accessor>;
   assertAnyTypeAnnotation(
     opts?: object,
   ): asserts this is NodePath<t.AnyTypeAnnotation>;
@@ -61,6 +62,9 @@ export interface NodePathAssetions {
   ): asserts this is NodePath<t.CallExpression>;
   assertCatchClause(opts?: object): asserts this is NodePath<t.CatchClause>;
   assertClass(opts?: object): asserts this is NodePath<t.Class>;
+  assertClassAccessorProperty(
+    opts?: object,
+  ): asserts this is NodePath<t.ClassAccessorProperty>;
   assertClassBody(opts?: object): asserts this is NodePath<t.ClassBody>;
   assertClassDeclaration(
     opts?: object,

--- a/packages/babel-traverse/src/path/generated/validators.ts
+++ b/packages/babel-traverse/src/path/generated/validators.ts
@@ -7,6 +7,7 @@ import NodePath from "../index";
 import type { VirtualTypeAliases } from "./virtual-types";
 
 export interface NodePathValidators {
+  isAccessor(opts?: object): this is NodePath<t.Accessor>;
   isAnyTypeAnnotation(opts?: object): this is NodePath<t.AnyTypeAnnotation>;
   isArgumentPlaceholder(opts?: object): this is NodePath<t.ArgumentPlaceholder>;
   isArrayExpression(opts?: object): this is NodePath<t.ArrayExpression>;
@@ -38,6 +39,9 @@ export interface NodePathValidators {
   isCallExpression(opts?: object): this is NodePath<t.CallExpression>;
   isCatchClause(opts?: object): this is NodePath<t.CatchClause>;
   isClass(opts?: object): this is NodePath<t.Class>;
+  isClassAccessorProperty(
+    opts?: object,
+  ): this is NodePath<t.ClassAccessorProperty>;
   isClassBody(opts?: object): this is NodePath<t.ClassBody>;
   isClassDeclaration(opts?: object): this is NodePath<t.ClassDeclaration>;
   isClassExpression(opts?: object): this is NodePath<t.ClassExpression>;

--- a/packages/babel-types/src/asserts/generated/index.ts
+++ b/packages/babel-types/src/asserts/generated/index.ts
@@ -506,6 +506,12 @@ export function assertClassProperty(
 ): asserts node is t.ClassProperty {
   assert("ClassProperty", node, opts);
 }
+export function assertClassAccessorProperty(
+  node: object | null | undefined,
+  opts?: object | null,
+): asserts node is t.ClassAccessorProperty {
+  assert("ClassAccessorProperty", node, opts);
+}
 export function assertClassPrivateProperty(
   node: object | null | undefined,
   opts?: object | null,
@@ -1687,6 +1693,12 @@ export function assertModuleSpecifier(
   opts?: object | null,
 ): asserts node is t.ModuleSpecifier {
   assert("ModuleSpecifier", node, opts);
+}
+export function assertAccessor(
+  node: object | null | undefined,
+  opts?: object | null,
+): asserts node is t.Accessor {
+  assert("Accessor", node, opts);
 }
 export function assertPrivate(
   node: object | null | undefined,

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -46,6 +46,7 @@ interface BaseNode {
 export type CommentTypeShorthand = "leading" | "inner" | "trailing";
 
 export type Node =
+  | Accessor
   | AnyTypeAnnotation
   | ArgumentPlaceholder
   | ArrayExpression
@@ -69,6 +70,7 @@ export type Node =
   | CallExpression
   | CatchClause
   | Class
+  | ClassAccessorProperty
   | ClassBody
   | ClassDeclaration
   | ClassExpression
@@ -1017,6 +1019,24 @@ export interface OptionalCallExpression extends BaseNode {
 export interface ClassProperty extends BaseNode {
   type: "ClassProperty";
   key: Identifier | StringLiteral | NumericLiteral | Expression;
+  value?: Expression | null;
+  typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
+  decorators?: Array<Decorator> | null;
+  computed?: boolean;
+  static?: boolean;
+  abstract?: boolean | null;
+  accessibility?: "public" | "private" | "protected" | null;
+  declare?: boolean | null;
+  definite?: boolean | null;
+  optional?: boolean | null;
+  override?: boolean;
+  readonly?: boolean | null;
+  variance?: Variance | null;
+}
+
+export interface ClassAccessorProperty extends BaseNode {
+  type: "ClassAccessorProperty";
+  key: Identifier | StringLiteral | NumericLiteral | Expression | PrivateName;
   value?: Expression | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
   decorators?: Array<Decorator> | null;
@@ -2322,7 +2342,11 @@ export type UserWhitespacable =
   | ObjectTypeSpreadProperty;
 export type Method = ObjectMethod | ClassMethod | ClassPrivateMethod;
 export type ObjectMember = ObjectMethod | ObjectProperty;
-export type Property = ObjectProperty | ClassProperty | ClassPrivateProperty;
+export type Property =
+  | ObjectProperty
+  | ClassProperty
+  | ClassAccessorProperty
+  | ClassPrivateProperty;
 export type UnaryLike = UnaryExpression | SpreadElement;
 export type Pattern = AssignmentPattern | ArrayPattern | ObjectPattern;
 export type Class = ClassExpression | ClassDeclaration;
@@ -2342,6 +2366,7 @@ export type ModuleSpecifier =
   | ImportSpecifier
   | ExportNamespaceSpecifier
   | ExportDefaultSpecifier;
+export type Accessor = ClassAccessorProperty;
 export type Private = ClassPrivateProperty | ClassPrivateMethod | PrivateName;
 export type Flow =
   | AnyTypeAnnotation
@@ -2572,6 +2597,7 @@ export interface Aliases {
   ModuleDeclaration: ModuleDeclaration;
   ExportDeclaration: ExportDeclaration;
   ModuleSpecifier: ModuleSpecifier;
+  Accessor: Accessor;
   Private: Private;
   Flow: Flow;
   FlowType: FlowType;

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -525,6 +525,21 @@ export function classProperty(
 ): t.ClassProperty {
   return builder("ClassProperty", ...arguments);
 }
+export function classAccessorProperty(
+  key:
+    | t.Identifier
+    | t.StringLiteral
+    | t.NumericLiteral
+    | t.Expression
+    | t.PrivateName,
+  value?: t.Expression | null,
+  typeAnnotation?: t.TypeAnnotation | t.TSTypeAnnotation | t.Noop | null,
+  decorators?: Array<t.Decorator> | null,
+  computed?: boolean,
+  _static?: boolean,
+): t.ClassAccessorProperty {
+  return builder("ClassAccessorProperty", ...arguments);
+}
 export function classPrivateProperty(
   key: t.PrivateName,
   value: t.Expression | null | undefined,

--- a/packages/babel-types/src/builders/generated/uppercase.js
+++ b/packages/babel-types/src/builders/generated/uppercase.js
@@ -91,6 +91,7 @@ export {
   optionalMemberExpression as OptionalMemberExpression,
   optionalCallExpression as OptionalCallExpression,
   classProperty as ClassProperty,
+  classAccessorProperty as ClassAccessorProperty,
   classPrivateProperty as ClassPrivateProperty,
   classPrivateMethod as ClassPrivateMethod,
   privateName as PrivateName,

--- a/packages/babel-types/src/constants/generated/index.ts
+++ b/packages/babel-types/src/constants/generated/index.ts
@@ -38,6 +38,7 @@ export const CLASS_TYPES = FLIPPED_ALIAS_KEYS["Class"];
 export const MODULEDECLARATION_TYPES = FLIPPED_ALIAS_KEYS["ModuleDeclaration"];
 export const EXPORTDECLARATION_TYPES = FLIPPED_ALIAS_KEYS["ExportDeclaration"];
 export const MODULESPECIFIER_TYPES = FLIPPED_ALIAS_KEYS["ModuleSpecifier"];
+export const ACCESSOR_TYPES = FLIPPED_ALIAS_KEYS["Accessor"];
 export const PRIVATE_TYPES = FLIPPED_ALIAS_KEYS["Private"];
 export const FLOW_TYPES = FLIPPED_ALIAS_KEYS["Flow"];
 export const FLOWTYPE_TYPES = FLIPPED_ALIAS_KEYS["FlowType"];

--- a/packages/babel-types/src/converters/toComputedKey.ts
+++ b/packages/babel-types/src/converters/toComputedKey.ts
@@ -8,6 +8,7 @@ export default function toComputedKey(
     | t.ObjectProperty
     | t.ClassMethod
     | t.ClassProperty
+    | t.ClassAccessorProperty
     | t.MemberExpression
     | t.OptionalMemberExpression,
   // @ts-expect-error todo(flow->ts): maybe check the type of node before accessing .key and .property

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -2117,6 +2117,80 @@ defineType("ClassProperty", {
   },
 });
 
+defineType("ClassAccessorProperty", {
+  visitor: ["key", "value", "typeAnnotation", "decorators"],
+  builder: [
+    "key",
+    "value",
+    "typeAnnotation",
+    "decorators",
+    "computed",
+    "static",
+  ],
+  aliases: ["Property", "Accessor"],
+  fields: {
+    ...classMethodOrPropertyCommon,
+    key: {
+      validate: chain(
+        (function () {
+          const normal = assertNodeType(
+            "Identifier",
+            "StringLiteral",
+            "NumericLiteral",
+            "PrivateName",
+          );
+          const computed = assertNodeType("Expression");
+
+          return function (node: any, key: string, val: any) {
+            const validator = node.computed ? computed : normal;
+            validator(node, key, val);
+          };
+        })(),
+        assertNodeType(
+          "Identifier",
+          "StringLiteral",
+          "NumericLiteral",
+          "Expression",
+          "PrivateName",
+        ),
+      ),
+    },
+    value: {
+      validate: assertNodeType("Expression"),
+      optional: true,
+    },
+    definite: {
+      validate: assertValueType("boolean"),
+      optional: true,
+    },
+    typeAnnotation: {
+      validate: process.env.BABEL_8_BREAKING
+        ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
+        : assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
+      optional: true,
+    },
+    decorators: {
+      validate: chain(
+        assertValueType("array"),
+        assertEach(assertNodeType("Decorator")),
+      ),
+      optional: true,
+    },
+    readonly: {
+      validate: assertValueType("boolean"),
+      optional: true,
+    },
+    declare: {
+      validate: assertValueType("boolean"),
+      optional: true,
+    },
+    variance: {
+      validate: assertNodeType("Variance"),
+      optional: true,
+    },
+  },
+});
+
 defineType("ClassPrivateProperty", {
   visitor: ["key", "value", "decorators", "typeAnnotation"],
   builder: ["key", "value", "decorators", "static"],

--- a/packages/babel-types/src/validators/generated/index.ts
+++ b/packages/babel-types/src/validators/generated/index.ts
@@ -1399,6 +1399,23 @@ export function isClassProperty(
 
   return false;
 }
+export function isClassAccessorProperty(
+  node: object | null | undefined,
+  opts?: object | null,
+): node is t.ClassAccessorProperty {
+  if (!node) return false;
+
+  const nodeType = (node as t.Node).type;
+  if (nodeType === "ClassAccessorProperty") {
+    if (typeof opts === "undefined") {
+      return true;
+    } else {
+      return shallowEqual(node, opts);
+    }
+  }
+
+  return false;
+}
 export function isClassPrivateProperty(
   node: object | null | undefined,
   opts?: object | null,
@@ -4942,6 +4959,7 @@ export function isProperty(
   if (
     "ObjectProperty" === nodeType ||
     "ClassProperty" === nodeType ||
+    "ClassAccessorProperty" === nodeType ||
     "ClassPrivateProperty" === nodeType
   ) {
     if (typeof opts === "undefined") {
@@ -5068,6 +5086,23 @@ export function isModuleSpecifier(
     "ExportNamespaceSpecifier" === nodeType ||
     "ExportDefaultSpecifier" === nodeType
   ) {
+    if (typeof opts === "undefined") {
+      return true;
+    } else {
+      return shallowEqual(node, opts);
+    }
+  }
+
+  return false;
+}
+export function isAccessor(
+  node: object | null | undefined,
+  opts?: object | null,
+): node is t.Accessor {
+  if (!node) return false;
+
+  const nodeType = (node as t.Node).type;
+  if ("ClassAccessorProperty" === nodeType) {
     if (typeof opts === "undefined") {
       return true;
     } else {

--- a/packages/babel-types/src/validators/isReferenced.ts
+++ b/packages/babel-types/src/validators/isReferenced.ts
@@ -63,6 +63,7 @@ export default function isReferenced(
     // yes: class { [NODE] = value; }
     // yes: class { key = NODE; }
     case "ClassProperty":
+    case "ClassAccessorProperty":
       if (parent.key === node) {
         return !!parent.computed;
       }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  N/A <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A<!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

This is the first part of the implementation of the latest version of
the decorators proposal: https://github.com/tc39/proposal-decorators

The keyword is outlined here in the README: https://github.com/tc39/proposal-decorators#class-auto-accessors

It adds a `simpleAutoAccessors` plugin which can be used to parse the
`accessor` keyword into ClassAccessorProperty and ClassPrivateAccessorProperty
node types.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->



<!-- Describe your changes below in as much detail as possible -->

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13681"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

