### PR TITLE
Use named imports for babel types

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -202,6 +202,7 @@ module.exports = function (api) {
       {
         test: sources.map(normalize),
         assumptions: sourceAssumptions,
+        plugins: [transformNamedBabelTypesImportToDestructuring],
       },
       {
         test: unambiguousSources.map(normalize),
@@ -450,6 +451,45 @@ function pluginPackageJsonMacro({ types: t }) {
 
         const value = JSON.parse(pkg)[field];
         path.replaceWith(t.valueToNode(value));
+      },
+    },
+  };
+}
+
+// transform `import { x } from "@babel/types"` to `import * as _t from "@babel/types"; const { x } = _t;
+function transformNamedBabelTypesImportToDestructuring({ types: t }) {
+  return {
+    name: "transform-babel-types-named-imports",
+    visitor: {
+      ImportDeclaration(path) {
+        const { node } = path;
+        if (
+          node.importKind === "value" &&
+          node.source.value === "@babel/types" &&
+          node.specifiers[0].type === "ImportSpecifier"
+        ) {
+          const hoistedDestructuringProperties = [];
+          for (const { imported, local } of node.specifiers) {
+            hoistedDestructuringProperties.push(
+              t.objectProperty(
+                imported,
+                local,
+                false,
+                imported.name === local.name
+              )
+            );
+          }
+          const babelTypeNsImport = path.scope.generateUidIdentifier("t");
+          node.specifiers = [t.importNamespaceSpecifier(babelTypeNsImport)];
+          path.insertAfter([
+            t.variableDeclaration("const", [
+              t.variableDeclarator(
+                t.objectPattern(hoistedDestructuringProperties),
+                t.cloneNode(babelTypeNsImport)
+              ),
+            ]),
+          ]);
+        }
       },
     },
   };

--- a/babel.config.js
+++ b/babel.config.js
@@ -457,7 +457,16 @@ function pluginPackageJsonMacro({ types: t }) {
 }
 
 // transform `import { x } from "@babel/types"` to `import * as _t from "@babel/types"; const { x } = _t;
-function transformNamedBabelTypesImportToDestructuring({ types: t }) {
+function transformNamedBabelTypesImportToDestructuring({
+  types: {
+    cloneNode,
+    importNamespaceSpecifier,
+    objectPattern,
+    objectProperty,
+    variableDeclarator,
+    variableDeclaration,
+  },
+}) {
   return {
     name: "transform-babel-types-named-imports",
     visitor: {
@@ -471,7 +480,7 @@ function transformNamedBabelTypesImportToDestructuring({ types: t }) {
           const hoistedDestructuringProperties = [];
           for (const { imported, local } of node.specifiers) {
             hoistedDestructuringProperties.push(
-              t.objectProperty(
+              objectProperty(
                 imported,
                 local,
                 false,
@@ -480,12 +489,12 @@ function transformNamedBabelTypesImportToDestructuring({ types: t }) {
             );
           }
           const babelTypeNsImport = path.scope.generateUidIdentifier("t");
-          node.specifiers = [t.importNamespaceSpecifier(babelTypeNsImport)];
+          node.specifiers = [importNamespaceSpecifier(babelTypeNsImport)];
           path.insertAfter([
-            t.variableDeclaration("const", [
-              t.variableDeclarator(
-                t.objectPattern(hoistedDestructuringProperties),
-                t.cloneNode(babelTypeNsImport)
+            variableDeclaration("const", [
+              variableDeclarator(
+                objectPattern(hoistedDestructuringProperties),
+                cloneNode(babelTypeNsImport)
               ),
             ]),
           ]);

--- a/packages/babel-core/src/transformation/file/file.ts
+++ b/packages/babel-core/src/transformation/file/file.ts
@@ -3,7 +3,8 @@ import { NodePath, Scope } from "@babel/traverse";
 import type { HubInterface } from "@babel/traverse";
 import { codeFrameColumns } from "@babel/code-frame";
 import traverse from "@babel/traverse";
-import * as t from "@babel/types";
+import { cloneNode, interpreterDirective } from "@babel/types";
+import type * as t from "@babel/types";
 import { getModuleName } from "@babel/helper-module-transforms";
 import semver from "semver";
 
@@ -89,7 +90,7 @@ export default class File {
   }
   set shebang(value: string) {
     if (value) {
-      this.path.get("interpreter").replaceWith(t.interpreterDirective(value));
+      this.path.get("interpreter").replaceWith(interpreterDirective(value));
     } else {
       this.path.get("interpreter").remove();
     }
@@ -176,7 +177,7 @@ export default class File {
 
   addHelper(name: string): t.Identifier {
     const declar = this.declarations[name];
-    if (declar) return t.cloneNode(declar);
+    if (declar) return cloneNode(declar);
 
     const generator = this.get("helperGenerator");
     if (generator) {

--- a/packages/babel-core/src/transformation/normalize-file.ts
+++ b/packages/babel-core/src/transformation/normalize-file.ts
@@ -2,7 +2,8 @@ import fs from "fs";
 import path from "path";
 import buildDebug from "debug";
 import type { Handler } from "gensync";
-import * as t from "@babel/types";
+import { file, traverseFast } from "@babel/types";
+import type * as t from "@babel/types";
 import type { PluginPasses } from "../config";
 import convertSourceMap from "convert-source-map";
 import type { SourceMapConverter as Converter } from "convert-source-map";
@@ -29,7 +30,7 @@ export default function* normalizeFile(
 
   if (ast) {
     if (ast.type === "Program") {
-      ast = t.file(ast, [], []);
+      ast = file(ast, [], []);
     } else if (ast.type !== "File") {
       throw new Error("AST root must be a Program or File node");
     }
@@ -119,7 +120,7 @@ function extractCommentsFromList(regex, comments, lastComment) {
 
 function extractComments(regex, ast) {
   let lastComment = null;
-  t.traverseFast(ast, node => {
+  traverseFast(ast, node => {
     [node.leadingComments, lastComment] = extractCommentsFromList(
       regex,
       node.leadingComments,

--- a/packages/babel-generator/src/generators/base.ts
+++ b/packages/babel-generator/src/generators/base.ts
@@ -1,5 +1,5 @@
 import type Printer from "../printer";
-import * as t from "@babel/types";
+import type * as t from "@babel/types";
 import * as charCodes from "charcodes";
 
 export function File(this: Printer, node: t.File) {

--- a/packages/babel-generator/src/generators/classes.ts
+++ b/packages/babel-generator/src/generators/classes.ts
@@ -1,8 +1,10 @@
 import type Printer from "../printer";
-import * as t from "@babel/types";
+import {
+  isExportDefaultDeclaration,
+  isExportNamedDeclaration,
+} from "@babel/types";
+import type * as t from "@babel/types";
 import * as charCodes from "charcodes";
-
-const { isExportDefaultDeclaration, isExportNamedDeclaration } = t;
 
 export function ClassDeclaration(
   this: Printer,

--- a/packages/babel-generator/src/generators/expressions.ts
+++ b/packages/babel-generator/src/generators/expressions.ts
@@ -1,8 +1,13 @@
 import type Printer from "../printer";
-import * as t from "@babel/types";
+import {
+  isCallExpression,
+  isLiteral,
+  isMemberExpression,
+  isNewExpression,
+} from "@babel/types";
+import type * as t from "@babel/types";
 import * as n from "../node";
 
-const { isCallExpression, isLiteral, isMemberExpression, isNewExpression } = t;
 export function UnaryExpression(this: Printer, node: t.UnaryExpression) {
   if (
     node.operator === "void" ||

--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -1,8 +1,8 @@
 import type Printer from "../printer";
-import * as t from "@babel/types";
+import { isDeclareExportDeclaration, isStatement } from "@babel/types";
+import type * as t from "@babel/types";
 import { ExportAllDeclaration } from "./modules";
 
-const { isDeclareExportDeclaration, isStatement } = t;
 export function AnyTypeAnnotation(this: Printer) {
   this.word("any");
 }

--- a/packages/babel-generator/src/generators/jsx.ts
+++ b/packages/babel-generator/src/generators/jsx.ts
@@ -1,5 +1,5 @@
 import type Printer from "../printer";
-import * as t from "@babel/types";
+import type * as t from "@babel/types";
 
 export function JSXAttribute(this: Printer, node: t.JSXAttribute) {
   this.print(node.name, node);

--- a/packages/babel-generator/src/generators/methods.ts
+++ b/packages/babel-generator/src/generators/methods.ts
@@ -1,7 +1,7 @@
 import type Printer from "../printer";
-import * as t from "@babel/types";
+import { isIdentifier } from "@babel/types";
+import type * as t from "@babel/types";
 
-const { isIdentifier } = t;
 export function _params(this: Printer, node: any) {
   this.print(node.typeParameters, node);
   this.token("(");

--- a/packages/babel-generator/src/generators/modules.ts
+++ b/packages/babel-generator/src/generators/modules.ts
@@ -1,14 +1,13 @@
 import type Printer from "../printer";
-import * as t from "@babel/types";
-
-const {
+import {
   isClassDeclaration,
   isExportDefaultSpecifier,
   isExportNamespaceSpecifier,
   isImportDefaultSpecifier,
   isImportNamespaceSpecifier,
   isStatement,
-} = t;
+} from "@babel/types";
+import type * as t from "@babel/types";
 
 export function ImportSpecifier(this: Printer, node: t.ImportSpecifier) {
   if (node.importKind === "type" || node.importKind === "typeof") {

--- a/packages/babel-generator/src/generators/statements.ts
+++ b/packages/babel-generator/src/generators/statements.ts
@@ -1,8 +1,13 @@
 import type Printer from "../printer";
-import * as t from "@babel/types";
+import {
+  isFor,
+  isForStatement,
+  isIfStatement,
+  isStatement,
+} from "@babel/types";
+import type * as t from "@babel/types";
 import * as charCodes from "charcodes";
 
-const { isFor, isForStatement, isIfStatement, isStatement } = t;
 export function WithStatement(this: Printer, node: t.WithStatement) {
   this.word("with");
   this.space();

--- a/packages/babel-generator/src/generators/template-literals.ts
+++ b/packages/babel-generator/src/generators/template-literals.ts
@@ -1,5 +1,5 @@
 import type Printer from "../printer";
-import * as t from "@babel/types";
+import type * as t from "@babel/types";
 
 export function TaggedTemplateExpression(
   this: Printer,

--- a/packages/babel-generator/src/generators/types.ts
+++ b/packages/babel-generator/src/generators/types.ts
@@ -1,8 +1,8 @@
 import type Printer from "../printer";
-import * as t from "@babel/types";
+import { isAssignmentPattern, isIdentifier } from "@babel/types";
+import type * as t from "@babel/types";
 import jsesc from "jsesc";
 
-const { isAssignmentPattern, isIdentifier } = t;
 export function Identifier(this: Printer, node: t.Identifier) {
   this.exactSource(node.loc, () => {
     this.word(node.name);

--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -1,5 +1,5 @@
 import type Printer from "../printer";
-import * as t from "@babel/types";
+import type * as t from "@babel/types";
 
 export function TSTypeAnnotation(this: Printer, node: t.TSTypeAnnotation) {
   this.token(":");

--- a/packages/babel-generator/src/node/index.ts
+++ b/packages/babel-generator/src/node/index.ts
@@ -1,12 +1,13 @@
 import * as whitespace from "./whitespace";
 import * as parens from "./parentheses";
-import * as t from "@babel/types";
-const {
+import {
+  FLIPPED_ALIAS_KEYS,
   isCallExpression,
   isExpressionStatement,
   isMemberExpression,
   isNewExpression,
-} = t;
+} from "@babel/types";
+
 function expandAliases(obj) {
   const newObj = {};
 
@@ -22,7 +23,7 @@ function expandAliases(obj) {
   }
 
   for (const type of Object.keys(obj)) {
-    const aliases = t.FLIPPED_ALIAS_KEYS[type];
+    const aliases = FLIPPED_ALIAS_KEYS[type];
     if (aliases) {
       for (const alias of aliases) {
         add(alias, obj[type]);

--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -1,6 +1,4 @@
-import * as t from "@babel/types";
-
-const {
+import {
   isArrayTypeAnnotation,
   isArrowFunctionExpression,
   isAssignmentExpression,
@@ -48,7 +46,8 @@ const {
   isVariableDeclarator,
   isWhileStatement,
   isYieldExpression,
-} = t;
+} from "@babel/types";
+import type * as t from "@babel/types";
 const PRECEDENCE = {
   "||": 0,
   "??": 0,

--- a/packages/babel-generator/src/node/whitespace.ts
+++ b/packages/babel-generator/src/node/whitespace.ts
@@ -1,6 +1,5 @@
-import * as t from "@babel/types";
-
-const {
+import {
+  FLIPPED_ALIAS_KEYS,
   isArrayExpression,
   isAssignmentExpression,
   isBinary,
@@ -14,7 +13,9 @@ const {
   isOptionalCallExpression,
   isOptionalMemberExpression,
   isStringLiteral,
-} = t;
+} from "@babel/types";
+
+import type * as t from "@babel/types";
 type WhitespaceObject = {
   before?: boolean;
   after?: boolean;
@@ -319,7 +320,7 @@ export const list = {
     amounts = { after: amounts, before: amounts };
   }
   [type as string]
-    .concat(t.FLIPPED_ALIAS_KEYS[type] || [])
+    .concat(FLIPPED_ALIAS_KEYS[type] || [])
     .forEach(function (type) {
       nodes[type] = function () {
         return amounts;

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -1,6 +1,7 @@
 import Buffer from "./buffer";
 import * as n from "./node";
-import * as t from "@babel/types";
+import { isProgram, isFile, isEmptyStatement } from "@babel/types";
+import type * as t from "@babel/types";
 
 import * as generatorFunctions from "./generators";
 import type SourceMap from "./source-map";
@@ -11,7 +12,6 @@ const ZERO_DECIMAL_INTEGER = /\.0+$/;
 const NON_DECIMAL_LITERAL = /^0[box]/;
 const PURE_ANNOTATION_RE = /^\s*[@#]__PURE__\s*$/;
 
-const { isProgram, isFile, isEmptyStatement } = t;
 const { needsParens, needsWhitespaceAfter, needsWhitespaceBefore } = n;
 
 export type Format = {

--- a/packages/babel-helper-annotate-as-pure/src/index.ts
+++ b/packages/babel-helper-annotate-as-pure/src/index.ts
@@ -1,4 +1,4 @@
-import * as t from "@babel/types";
+import { addComment } from "@babel/types";
 import type { Node } from "@babel/types";
 
 const PURE_ANNOTATION = "#__PURE__";
@@ -14,5 +14,5 @@ export default function annotateAsPure(
   if (isPureAnnotated(node)) {
     return;
   }
-  t.addComment(node, "leading", PURE_ANNOTATION);
+  addComment(node, "leading", PURE_ANNOTATION);
 }

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
@@ -1,5 +1,5 @@
 import explode from "@babel/helper-explode-assignable-expression";
-import * as t from "@babel/types";
+import { assignmentExpression, sequenceExpression } from "@babel/types";
 
 export default function (opts: { build: Function, operator: string }): Object {
   const { build, operator } = opts;
@@ -12,13 +12,13 @@ export default function (opts: { build: Function, operator: string }): Object {
       const nodes = [];
       const exploded = explode(node.left, nodes, this, scope);
       nodes.push(
-        t.assignmentExpression(
+        assignmentExpression(
           "=",
           exploded.ref,
           build(exploded.uid, node.right),
         ),
       );
-      path.replaceWith(t.sequenceExpression(nodes));
+      path.replaceWith(sequenceExpression(nodes));
     },
 
     BinaryExpression(path) {

--- a/packages/babel-helper-define-map/src/index.js
+++ b/packages/babel-helper-define-map/src/index.js
@@ -1,8 +1,25 @@
 import nameFunction from "@babel/helper-function-name";
-import * as t from "@babel/types";
+import {
+  arrayExpression,
+  booleanLiteral,
+  functionExpression,
+  identifier,
+  inheritsComments,
+  isClassMethod,
+  isFunctionExpression,
+  isObjectMethod,
+  isObjectProperty,
+  isProperty,
+  isStringLiteral,
+  objectExpression,
+  objectProperty,
+  removeComments,
+  toComputedKey,
+  toKeyAlias,
+} from "@babel/types";
 
 function toKind(node: Object) {
-  if (t.isClassMethod(node) || t.isObjectMethod(node)) {
+  if (isClassMethod(node) || isObjectMethod(node)) {
     if (node.kind === "get" || node.kind === "set") {
       return node.kind;
     }
@@ -20,7 +37,7 @@ export function push(
   file,
   scope?,
 ): Object {
-  const alias = t.toKeyAlias(node);
+  const alias = toKeyAlias(node);
 
   //
 
@@ -40,8 +57,7 @@ export function push(
   }
 
   if (node.decorators) {
-    const decorators = (map.decorators =
-      map.decorators || t.arrayExpression([]));
+    const decorators = (map.decorators = map.decorators || arrayExpression([]));
     decorators.elements.push(
       ...node.decorators.map(dec => dec.expression).reverse(),
     );
@@ -54,18 +70,14 @@ export function push(
   let key, value;
 
   // save the key so we can possibly do function name inferences
-  if (
-    t.isObjectProperty(node) ||
-    t.isObjectMethod(node) ||
-    t.isClassMethod(node)
-  ) {
-    key = t.toComputedKey(node, node.key);
+  if (isObjectProperty(node) || isObjectMethod(node) || isClassMethod(node)) {
+    key = toComputedKey(node, node.key);
   }
 
-  if (t.isProperty(node)) {
+  if (isProperty(node)) {
     value = node.value;
-  } else if (t.isObjectMethod(node) || t.isClassMethod(node)) {
-    value = t.functionExpression(
+  } else if (isObjectMethod(node) || isClassMethod(node)) {
+    value = functionExpression(
       null,
       node.params,
       node.body,
@@ -83,15 +95,15 @@ export function push(
   // infer function name
   if (
     scope &&
-    t.isStringLiteral(key) &&
+    isStringLiteral(key) &&
     (kind === "value" || kind === "initializer") &&
-    t.isFunctionExpression(value)
+    isFunctionExpression(value)
   ) {
     value = nameFunction({ id: key, node: value, scope });
   }
 
   if (value) {
-    t.inheritsComments(value, node);
+    inheritsComments(value, node);
     map[kind] = value;
   }
 
@@ -108,13 +120,13 @@ export function hasComputed(mutatorMap: Object): boolean {
 }
 
 export function toComputedObjectFromClass(obj: Object): Object {
-  const objExpr = t.arrayExpression([]);
+  const objExpr = arrayExpression([]);
 
   for (let i = 0; i < obj.properties.length; i++) {
     const prop = obj.properties[i];
     const val = prop.value;
     val.properties.unshift(
-      t.objectProperty(t.identifier("key"), t.toComputedKey(prop)),
+      objectProperty(identifier("key"), toComputedKey(prop)),
     );
     objExpr.elements.push(val);
   }
@@ -123,21 +135,21 @@ export function toComputedObjectFromClass(obj: Object): Object {
 }
 
 export function toClassObject(mutatorMap: Object): Object {
-  const objExpr = t.objectExpression([]);
+  const objExpr = objectExpression([]);
 
   Object.keys(mutatorMap).forEach(function (mutatorMapKey) {
     const map = mutatorMap[mutatorMapKey];
-    const mapNode = t.objectExpression([]);
+    const mapNode = objectExpression([]);
 
-    const propNode = t.objectProperty(map._key, mapNode, map._computed);
+    const propNode = objectProperty(map._key, mapNode, map._computed);
 
     Object.keys(map).forEach(function (key) {
       const node = map[key];
       if (key[0] === "_") return;
 
-      const prop = t.objectProperty(t.identifier(key), node);
-      t.inheritsComments(prop, node);
-      t.removeComments(node);
+      const prop = objectProperty(identifier(key), node);
+      inheritsComments(prop, node);
+      removeComments(node);
 
       mapNode.properties.push(prop);
     });
@@ -151,9 +163,9 @@ export function toClassObject(mutatorMap: Object): Object {
 export function toDefineObject(mutatorMap: Object): Object {
   Object.keys(mutatorMap).forEach(function (key) {
     const map = mutatorMap[key];
-    if (map.value) map.writable = t.booleanLiteral(true);
-    map.configurable = t.booleanLiteral(true);
-    map.enumerable = t.booleanLiteral(true);
+    if (map.value) map.writable = booleanLiteral(true);
+    map.configurable = booleanLiteral(true);
+    map.enumerable = booleanLiteral(true);
   });
 
   return toClassObject(mutatorMap);

--- a/packages/babel-helper-get-function-arity/src/index.ts
+++ b/packages/babel-helper-get-function-arity/src/index.ts
@@ -1,10 +1,11 @@
-import * as t from "@babel/types";
+import { isAssignmentPattern, isRestElement } from "@babel/types";
+import type * as t from "@babel/types";
 
 export default function (node: t.Function): number {
   const params = node.params;
   for (let i = 0; i < params.length; i++) {
     const param = params[i];
-    if (t.isAssignmentPattern(param) || t.isRestElement(param)) {
+    if (isAssignmentPattern(param) || isRestElement(param)) {
       return i;
     }
   }

--- a/packages/babel-helper-hoist-variables/src/index.ts
+++ b/packages/babel-helper-hoist-variables/src/index.ts
@@ -1,4 +1,9 @@
-import * as t from "@babel/types";
+import {
+  assignmentExpression,
+  expressionStatement,
+  identifier,
+} from "@babel/types";
+import type * as t from "@babel/types";
 import type { NodePath } from "@babel/traverse";
 
 export type EmitFunction = (
@@ -38,14 +43,14 @@ const visitor = {
 
       if (declar.node.init) {
         nodes.push(
-          t.expressionStatement(
-            t.assignmentExpression("=", declar.node.id, declar.node.init),
+          expressionStatement(
+            assignmentExpression("=", declar.node.id, declar.node.init),
           ),
         );
       }
 
       for (const name of Object.keys(declar.getBindingIdentifiers())) {
-        state.emit(t.identifier(name), name, declar.node.init !== null);
+        state.emit(identifier(name), name, declar.node.init !== null);
       }
     }
 

--- a/packages/babel-helper-module-imports/src/import-injector.ts
+++ b/packages/babel-helper-module-imports/src/import-injector.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
-import * as t from "@babel/types";
+import { numericLiteral, sequenceExpression } from "@babel/types";
+import type * as t from "@babel/types";
 import type { NodePath, Scope, HubInterface } from "@babel/traverse";
 
 import ImportBuilder from "./import-builder";
@@ -416,7 +417,7 @@ export default class ImportInjector {
       ensureNoContext &&
       resultName.type !== "Identifier"
     ) {
-      return t.sequenceExpression([t.numericLiteral(0), resultName]);
+      return sequenceExpression([numericLiteral(0), resultName]);
     }
     return resultName;
   }

--- a/packages/babel-helper-module-transforms/src/rewrite-this.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-this.ts
@@ -1,6 +1,7 @@
 import { environmentVisitor } from "@babel/helper-replace-supers";
 import traverse from "@babel/traverse";
-import * as t from "@babel/types";
+import { numericLiteral, unaryExpression } from "@babel/types";
+import type * as t from "@babel/types";
 
 import type { NodePath, Visitor } from "@babel/traverse";
 export default function rewriteThis(programPath: NodePath) {
@@ -16,7 +17,7 @@ const rewriteThisVisitor: Visitor = traverse.visitors.merge([
   environmentVisitor,
   {
     ThisExpression(path: NodePath<t.ThisExpression>) {
-      path.replaceWith(t.unaryExpression("void", t.numericLiteral(0), true));
+      path.replaceWith(unaryExpression("void", numericLiteral(0), true));
     },
   },
 ]);

--- a/packages/babel-helper-optimise-call-expression/src/index.ts
+++ b/packages/babel-helper-optimise-call-expression/src/index.ts
@@ -1,4 +1,12 @@
-import * as t from "@babel/types";
+import {
+  callExpression,
+  identifier,
+  isIdentifier,
+  isSpreadElement,
+  memberExpression,
+  optionalCallExpression,
+  optionalMemberExpression,
+} from "@babel/types";
 import type {
   CallExpression,
   Expression,
@@ -25,33 +33,33 @@ export default function optimiseCallExpression(
 ): CallExpression | OptionalCallExpression {
   if (
     args.length === 1 &&
-    t.isSpreadElement(args[0]) &&
-    t.isIdentifier(args[0].argument, { name: "arguments" })
+    isSpreadElement(args[0]) &&
+    isIdentifier(args[0].argument, { name: "arguments" })
   ) {
     // a.b?.(...arguments);
     if (optional) {
-      return t.optionalCallExpression(
-        t.optionalMemberExpression(callee, t.identifier("apply"), false, true),
+      return optionalCallExpression(
+        optionalMemberExpression(callee, identifier("apply"), false, true),
         [thisNode, args[0].argument],
         false,
       );
     }
     // a.b(...arguments);
-    return t.callExpression(t.memberExpression(callee, t.identifier("apply")), [
+    return callExpression(memberExpression(callee, identifier("apply")), [
       thisNode,
       args[0].argument,
     ]);
   } else {
     // a.b?.(arg1, arg2)
     if (optional) {
-      return t.optionalCallExpression(
-        t.optionalMemberExpression(callee, t.identifier("call"), false, true),
+      return optionalCallExpression(
+        optionalMemberExpression(callee, identifier("call"), false, true),
         [thisNode, ...args],
         false,
       );
     }
     // a.b(arg1, arg2)
-    return t.callExpression(t.memberExpression(callee, t.identifier("call")), [
+    return callExpression(memberExpression(callee, identifier("call")), [
       thisNode,
       ...args,
     ]);

--- a/packages/babel-helper-skip-transparent-expression-wrappers/src/index.js
+++ b/packages/babel-helper-skip-transparent-expression-wrappers/src/index.js
@@ -1,6 +1,12 @@
 // @flow
 
-import * as t from "@babel/types";
+import {
+  isParenthesizedExpression,
+  isTSAsExpression,
+  isTSNonNullExpression,
+  isTSTypeAssertion,
+  isTypeCastExpression,
+} from "@babel/types";
 import type { NodePath } from "@babel/traverse";
 
 // A transparent expression wrapper is an AST node that most plugins will wish
@@ -10,11 +16,11 @@ import type { NodePath } from "@babel/traverse";
 // determining the callee.
 export function isTransparentExprWrapper(node: Node) {
   return (
-    t.isTSAsExpression(node) ||
-    t.isTSTypeAssertion(node) ||
-    t.isTSNonNullExpression(node) ||
-    t.isTypeCastExpression(node) ||
-    t.isParenthesizedExpression(node)
+    isTSAsExpression(node) ||
+    isTSTypeAssertion(node) ||
+    isTSNonNullExpression(node) ||
+    isTypeCastExpression(node) ||
+    isParenthesizedExpression(node)
   );
 }
 

--- a/packages/babel-helper-split-export-declaration/src/index.ts
+++ b/packages/babel-helper-split-export-declaration/src/index.ts
@@ -1,4 +1,11 @@
-import * as t from "@babel/types";
+import {
+  cloneNode,
+  exportNamedDeclaration,
+  exportSpecifier,
+  identifier,
+  variableDeclaration,
+  variableDeclarator,
+} from "@babel/types";
 
 export default function splitExportDeclaration(exportDeclaration) {
   if (!exportDeclaration.isExportDeclaration()) {
@@ -31,18 +38,18 @@ export default function splitExportDeclaration(exportDeclaration) {
         declaration.isFunctionExpression() ||
         declaration.isClassExpression()
       ) {
-        declaration.node.id = t.cloneNode(id);
+        declaration.node.id = cloneNode(id);
       }
     }
 
     const updatedDeclaration = standaloneDeclaration
       ? declaration
-      : t.variableDeclaration("var", [
-          t.variableDeclarator(t.cloneNode(id), declaration.node),
+      : variableDeclaration("var", [
+          variableDeclarator(cloneNode(id), declaration.node),
         ]);
 
-    const updatedExportDeclaration = t.exportNamedDeclaration(null, [
-      t.exportSpecifier(t.cloneNode(id), t.identifier("default")),
+    const updatedExportDeclaration = exportNamedDeclaration(null, [
+      exportSpecifier(cloneNode(id), identifier("default")),
     ]);
 
     exportDeclaration.insertAfter(updatedExportDeclaration);
@@ -62,10 +69,10 @@ export default function splitExportDeclaration(exportDeclaration) {
   const bindingIdentifiers = declaration.getOuterBindingIdentifiers();
 
   const specifiers = Object.keys(bindingIdentifiers).map(name => {
-    return t.exportSpecifier(t.identifier(name), t.identifier(name));
+    return exportSpecifier(identifier(name), identifier(name));
   });
 
-  const aliasDeclar = t.exportNamedDeclaration(null, specifiers);
+  const aliasDeclar = exportNamedDeclaration(null, specifiers);
 
   exportDeclaration.insertAfter(aliasDeclar);
   exportDeclaration.replaceWith(declaration.node);

--- a/packages/babel-helpers/src/index.ts
+++ b/packages/babel-helpers/src/index.ts
@@ -1,7 +1,16 @@
 import type { File } from "@babel/core";
 import type { NodePath, Visitor } from "@babel/traverse";
 import traverse from "@babel/traverse";
-import * as t from "@babel/types";
+import {
+  assignmentExpression,
+  cloneNode,
+  expressionStatement,
+  file as t_file,
+  identifier,
+  variableDeclaration,
+  variableDeclarator,
+} from "@babel/types";
+import type t from "@babel/types";
 import helpers from "./helpers";
 
 function makePath(path: NodePath) {
@@ -213,8 +222,8 @@ function permuteHelperAST(
           exp.replaceWith(decl);
         } else {
           exp.replaceWith(
-            t.variableDeclaration("var", [
-              t.variableDeclarator(id, decl.node as t.Expression),
+            variableDeclaration("var", [
+              variableDeclarator(id, decl.node as t.Expression),
             ]),
           );
         }
@@ -222,19 +231,19 @@ function permuteHelperAST(
         if (decl.isFunctionDeclaration()) {
           exportBindingAssignments.forEach(assignPath => {
             const assign: NodePath<t.Expression> = path.get(assignPath);
-            assign.replaceWith(t.assignmentExpression("=", id, assign.node));
+            assign.replaceWith(assignmentExpression("=", id, assign.node));
           });
           exp.replaceWith(decl);
           path.pushContainer(
             "body",
-            t.expressionStatement(
-              t.assignmentExpression("=", id, t.identifier(exportName)),
+            expressionStatement(
+              assignmentExpression("=", id, identifier(exportName)),
             ),
           );
         } else {
           exp.replaceWith(
-            t.expressionStatement(
-              t.assignmentExpression("=", id, decl.node as t.Expression),
+            expressionStatement(
+              assignmentExpression("=", id, decl.node as t.Expression),
             ),
           );
         }
@@ -248,7 +257,7 @@ function permuteHelperAST(
 
       for (const path of imps) path.remove();
       for (const path of impsBindingRefs) {
-        const node = t.cloneNode(dependenciesRefs[path.node.name]);
+        const node = cloneNode(dependenciesRefs[path.node.name]);
         path.replaceWith(node);
       }
 
@@ -285,7 +294,7 @@ function loadHelper(name: string) {
     }
 
     const fn = (): File => {
-      const file = { ast: t.file(helper.ast()) };
+      const file = { ast: t_file(helper.ast()) };
       if (fileClass) {
         return new fileClass(
           {

--- a/packages/babel-helpers/src/index.ts
+++ b/packages/babel-helpers/src/index.ts
@@ -10,7 +10,7 @@ import {
   variableDeclaration,
   variableDeclarator,
 } from "@babel/types";
-import type t from "@babel/types";
+import type * as t from "@babel/types";
 import helpers from "./helpers";
 
 function makePath(path: NodePath) {

--- a/packages/babel-preset-env/src/polyfills/babel-polyfill.ts
+++ b/packages/babel-preset-env/src/polyfills/babel-polyfill.ts
@@ -1,7 +1,7 @@
 import { getImportSource, getRequireSource, isPolyfillSource } from "./utils";
 
 import type { NodePath } from "@babel/traverse";
-import * as t from "@babel/types";
+import type * as t from "@babel/types";
 
 const BABEL_POLYFILL_DEPRECATION = `
   \`@babel/polyfill\` is deprecated. Please, use required parts of \`core-js\`

--- a/packages/babel-preset-env/src/polyfills/utils.ts
+++ b/packages/babel-preset-env/src/polyfills/utils.ts
@@ -1,4 +1,10 @@
-import * as t from "@babel/types";
+import {
+  isCallExpression,
+  isExpressionStatement,
+  isIdentifier,
+  isStringLiteral,
+} from "@babel/types";
+import type * as t from "@babel/types";
 import type { NodePath } from "@babel/traverse";
 
 export function getImportSource({ node }: NodePath<t.ImportDeclaration>) {
@@ -6,14 +12,14 @@ export function getImportSource({ node }: NodePath<t.ImportDeclaration>) {
 }
 
 export function getRequireSource({ node }: NodePath) {
-  if (!t.isExpressionStatement(node)) return;
+  if (!isExpressionStatement(node)) return;
   const { expression } = node;
   if (
-    t.isCallExpression(expression) &&
-    t.isIdentifier(expression.callee) &&
+    isCallExpression(expression) &&
+    isIdentifier(expression.callee) &&
     expression.callee.name === "require" &&
     expression.arguments.length === 1 &&
-    t.isStringLiteral(expression.arguments[0])
+    isStringLiteral(expression.arguments[0])
   ) {
     return expression.arguments[0].value;
   }

--- a/packages/babel-template/src/formatters.ts
+++ b/packages/babel-template/src/formatters.ts
@@ -1,4 +1,5 @@
-import * as t from "@babel/types";
+import { assertExpressionStatement } from "@babel/types";
+import type * as t from "@babel/types";
 
 export type Formatter<T> = {
   code: (source: string) => string;
@@ -58,7 +59,7 @@ export const expression: Formatter<t.Expression> = {
   },
   unwrap: ({ program }) => {
     const [stmt] = program.body;
-    t.assertExpressionStatement(stmt);
+    assertExpressionStatement(stmt);
     return stmt.expression;
   },
 };

--- a/packages/babel-template/src/populate.ts
+++ b/packages/babel-template/src/populate.ts
@@ -1,4 +1,15 @@
-import * as t from "@babel/types";
+import {
+  blockStatement,
+  cloneNode,
+  emptyStatement,
+  expressionStatement,
+  identifier,
+  isStatement,
+  isStringLiteral,
+  stringLiteral,
+  validate,
+} from "@babel/types";
+import type * as t from "@babel/types";
 
 import type { TemplateReplacements } from "./options";
 import type { Metadata, Placeholder } from "./parse";
@@ -7,7 +18,7 @@ export default function populatePlaceholders(
   metadata: Metadata,
   replacements: TemplateReplacements,
 ): t.File {
-  const ast = t.cloneNode(metadata.ast);
+  const ast = cloneNode(metadata.ast);
 
   if (replacements) {
     metadata.placeholders.forEach(placeholder => {
@@ -61,9 +72,9 @@ function applyReplacement(
   // once to avoid injecting the same node multiple times.
   if (placeholder.isDuplicate) {
     if (Array.isArray(replacement)) {
-      replacement = replacement.map(node => t.cloneNode(node));
+      replacement = replacement.map(node => cloneNode(node));
     } else if (typeof replacement === "object") {
-      replacement = t.cloneNode(replacement);
+      replacement = cloneNode(replacement);
     }
   }
 
@@ -71,41 +82,41 @@ function applyReplacement(
 
   if (placeholder.type === "string") {
     if (typeof replacement === "string") {
-      replacement = t.stringLiteral(replacement);
+      replacement = stringLiteral(replacement);
     }
-    if (!replacement || !t.isStringLiteral(replacement)) {
+    if (!replacement || !isStringLiteral(replacement)) {
       throw new Error("Expected string substitution");
     }
   } else if (placeholder.type === "statement") {
     if (index === undefined) {
       if (!replacement) {
-        replacement = t.emptyStatement();
+        replacement = emptyStatement();
       } else if (Array.isArray(replacement)) {
-        replacement = t.blockStatement(replacement);
+        replacement = blockStatement(replacement);
       } else if (typeof replacement === "string") {
-        replacement = t.expressionStatement(t.identifier(replacement));
-      } else if (!t.isStatement(replacement)) {
-        replacement = t.expressionStatement(replacement as any);
+        replacement = expressionStatement(identifier(replacement));
+      } else if (!isStatement(replacement)) {
+        replacement = expressionStatement(replacement as any);
       }
     } else {
       if (replacement && !Array.isArray(replacement)) {
         if (typeof replacement === "string") {
-          replacement = t.identifier(replacement);
+          replacement = identifier(replacement);
         }
-        if (!t.isStatement(replacement)) {
-          replacement = t.expressionStatement(replacement as any);
+        if (!isStatement(replacement)) {
+          replacement = expressionStatement(replacement as any);
         }
       }
     }
   } else if (placeholder.type === "param") {
     if (typeof replacement === "string") {
-      replacement = t.identifier(replacement);
+      replacement = identifier(replacement);
     }
 
     if (index === undefined) throw new Error("Assertion failure.");
   } else {
     if (typeof replacement === "string") {
-      replacement = t.identifier(replacement);
+      replacement = identifier(replacement);
     }
     if (Array.isArray(replacement)) {
       throw new Error("Cannot replace single expression with an array.");
@@ -113,7 +124,7 @@ function applyReplacement(
   }
 
   if (index === undefined) {
-    t.validate(parent, key, replacement);
+    validate(parent, key, replacement);
 
     (parent as any)[key] = replacement;
   } else {
@@ -131,7 +142,7 @@ function applyReplacement(
       items[index] = replacement;
     }
 
-    t.validate(parent, key, items);
+    validate(parent, key, items);
     (parent as any)[key] = items;
   }
 }

--- a/packages/babel-traverse/src/context.ts
+++ b/packages/babel-traverse/src/context.ts
@@ -1,5 +1,5 @@
 import NodePath from "./path";
-import * as t from "@babel/types";
+import { VISITOR_KEYS } from "@babel/types";
 import type Scope from "./scope";
 
 export default class TraversalContext {
@@ -30,7 +30,7 @@ export default class TraversalContext {
     if (opts[node.type]) return true;
 
     // check if we're going to traverse into this node
-    const keys: Array<string> | undefined = t.VISITOR_KEYS[node.type];
+    const keys: Array<string> | undefined = VISITOR_KEYS[node.type];
     if (!keys?.length) return false;
 
     // we need to traverse into this node so ensure that it has children to traverse into!

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -1,6 +1,7 @@
 import TraversalContext from "./context";
 import * as visitors from "./visitors";
-import * as t from "@babel/types";
+import { VISITOR_KEYS, removeProperties, traverseFast } from "@babel/types";
+import type * as t from "@babel/types";
 import * as cache from "./cache";
 import type NodePath from "./path";
 import type { default as Scope, Binding } from "./scope";
@@ -57,7 +58,7 @@ function traverse(
     }
   }
 
-  if (!t.VISITOR_KEYS[parent.type]) {
+  if (!VISITOR_KEYS[parent.type]) {
     return;
   }
 
@@ -73,7 +74,7 @@ traverse.verify = visitors.verify;
 traverse.explode = visitors.explode;
 
 traverse.cheap = function (node, enter) {
-  return t.traverseFast(node, enter);
+  return traverseFast(node, enter);
 };
 
 traverse.node = function (
@@ -84,7 +85,7 @@ traverse.node = function (
   parentPath?: NodePath,
   skipKeys?,
 ) {
-  const keys = t.VISITOR_KEYS[node.type];
+  const keys = VISITOR_KEYS[node.type];
   if (!keys) return;
 
   const context = new TraversalContext(scope, opts, state, parentPath);
@@ -95,13 +96,13 @@ traverse.node = function (
 };
 
 traverse.clearNode = function (node: t.Node, opts?) {
-  t.removeProperties(node, opts);
+  removeProperties(node, opts);
 
   cache.path.delete(node);
 };
 
 traverse.removeProperties = function (tree, opts?) {
-  t.traverseFast(tree, traverse.clearNode, opts);
+  traverseFast(tree, traverse.clearNode, opts);
   return tree;
 };
 

--- a/packages/babel-traverse/src/path/ancestry.ts
+++ b/packages/babel-traverse/src/path/ancestry.ts
@@ -1,6 +1,7 @@
 // This file contains that retrieve or validate anything related to the current paths ancestry.
 
-import * as t from "@babel/types";
+import { VISITOR_KEYS } from "@babel/types";
+import type * as t from "@babel/types";
 import NodePath from "./index";
 
 /**
@@ -88,7 +89,7 @@ export function getEarliestCommonAncestorFrom(
     paths,
     function (deepest, i, ancestries) {
       let earliest;
-      const keys = t.VISITOR_KEYS[deepest.type];
+      const keys = VISITOR_KEYS[deepest.type];
 
       for (const ancestry of ancestries) {
         const path = ancestry[i + 1];

--- a/packages/babel-traverse/src/path/comments.ts
+++ b/packages/babel-traverse/src/path/comments.ts
@@ -1,6 +1,10 @@
 // This file contains methods responsible for dealing with comments.
-import * as t from "@babel/types";
+import type * as t from "@babel/types";
 import type NodePath from "./index";
+import {
+  addComment as _addComment,
+  addComments as _addComments,
+} from "@babel/types";
 
 /**
  * Share comments amongst siblings.
@@ -34,7 +38,7 @@ export function addComment(
   content: string,
   line?: boolean,
 ) {
-  t.addComment(this.node, type, content, line);
+  _addComment(this.node, type, content, line);
 }
 
 /**
@@ -46,5 +50,5 @@ export function addComments(
   type: t.CommentTypeShorthand,
   comments: readonly t.Comment[],
 ) {
-  t.addComments(this.node, type, comments);
+  _addComments(this.node, type, comments);
 }

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -2,7 +2,13 @@
 
 import type TraversalContext from "../context";
 import NodePath from "./index";
-import * as t from "@babel/types";
+import {
+  getBindingIdentifiers as _getBindingIdentifiers,
+  getOuterBindingIdentifiers as _getOuterBindingIdentifiers,
+  numericLiteral,
+  unaryExpression,
+} from "@babel/types";
+import type * as t from "@babel/types";
 
 const NORMAL_COMPLETION = 0;
 const BREAK_COMPLETION = 1;
@@ -107,7 +113,7 @@ function replaceBreakStatementInBreakCompletion(
   completions.forEach(c => {
     if (c.path.isBreakStatement({ label: null })) {
       if (reachable) {
-        c.path.replaceWith(t.unaryExpression("void", t.numericLiteral(0)));
+        c.path.replaceWith(unaryExpression("void", numericLiteral(0)));
       } else {
         c.path.remove();
       }
@@ -463,7 +469,7 @@ function getBindingIdentifiers(
 function getBindingIdentifiers(
   duplicates?: boolean,
 ): Record<string, t.Identifier[] | t.Identifier> {
-  return t.getBindingIdentifiers(this.node, duplicates);
+  return _getBindingIdentifiers(this.node, duplicates);
 }
 
 export { getBindingIdentifiers };
@@ -481,7 +487,7 @@ function getOuterBindingIdentifiers(
 function getOuterBindingIdentifiers(
   duplicates?: boolean,
 ): Record<string, t.Identifier[] | t.Identifier> {
-  return t.getOuterBindingIdentifiers(this.node, duplicates);
+  return _getOuterBindingIdentifiers(this.node, duplicates);
 }
 
 export { getOuterBindingIdentifiers };
@@ -505,7 +511,7 @@ export function getBindingIdentifierPaths(
     if (!id) continue;
     if (!id.node) continue;
 
-    const keys = t.getBindingIdentifiers.keys[id.node.type];
+    const keys = _getBindingIdentifiers.keys[id.node.type];
 
     if (id.isIdentifier()) {
       if (duplicates) {

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -5,6 +5,7 @@ import NodePath from "./index";
 import {
   getBindingIdentifiers as _getBindingIdentifiers,
   getOuterBindingIdentifiers as _getOuterBindingIdentifiers,
+  isDeclaration,
   numericLiteral,
   unaryExpression,
 } from "@babel/types";
@@ -525,7 +526,7 @@ export function getBindingIdentifierPaths(
 
     if (id.isExportDeclaration()) {
       const declaration = id.get("declaration");
-      if (t.isDeclaration(declaration)) {
+      if (isDeclaration(declaration)) {
         search.push(declaration);
       }
       continue;

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -5,6 +5,7 @@ import buildDebug from "debug";
 import traverse from "../index";
 import type { Visitor } from "../types";
 import Scope from "../scope";
+import { validate } from "@babel/types";
 import * as t from "@babel/types";
 import { path as pathCache } from "../cache";
 import generator from "@babel/generator";
@@ -135,7 +136,7 @@ class NodePath<T extends t.Node = t.Node> {
   }
 
   set(key: string, node: any) {
-    t.validate(this.node, key, node);
+    validate(this.node, key, node);
     this.node[key] = node;
   }
 
@@ -225,6 +226,10 @@ Object.assign(
   NodePath_comments,
 );
 
+// we can not use `import { TYPES } from "@babel/types"` here
+// because the transformNamedBabelTypesImportToDestructuring plugin in babel.config.js
+// does not offer live bindings for `TYPES`
+// we can change to `import { TYPES }` when we are publishing ES modules only
 for (const type of t.TYPES) {
   const typeKey = `is${type}`;
   const fn = t[typeKey];

--- a/packages/babel-traverse/src/path/inference/index.ts
+++ b/packages/babel-traverse/src/path/inference/index.ts
@@ -1,6 +1,23 @@
 import type NodePath from "../index";
 import * as inferers from "./inferers";
-import * as t from "@babel/types";
+import {
+  anyTypeAnnotation,
+  isAnyTypeAnnotation,
+  isBooleanTypeAnnotation,
+  isEmptyTypeAnnotation,
+  isFlowBaseAnnotation,
+  isGenericTypeAnnotation,
+  isIdentifier,
+  isMixedTypeAnnotation,
+  isNumberTypeAnnotation,
+  isStringTypeAnnotation,
+  isTypeAnnotation,
+  isUnionTypeAnnotation,
+  isVoidTypeAnnotation,
+  stringTypeAnnotation,
+  voidTypeAnnotation,
+} from "@babel/types";
+import type * as t from "@babel/types";
 
 /**
  * Infer the type of the current `NodePath`.
@@ -9,8 +26,8 @@ import * as t from "@babel/types";
 export function getTypeAnnotation(): t.FlowType {
   if (this.typeAnnotation) return this.typeAnnotation;
 
-  let type = this._getTypeAnnotation() || t.anyTypeAnnotation();
-  if (t.isTypeAnnotation(type)) type = type.typeAnnotation;
+  let type = this._getTypeAnnotation() || anyTypeAnnotation();
+  if (isTypeAnnotation(type)) type = type.typeAnnotation;
   return (this.typeAnnotation = type);
 }
 
@@ -34,15 +51,15 @@ export function _getTypeAnnotation(): any {
 
       // for (let NODE in bar) {}
       if (declar.key === "left" && declarParent.isForInStatement()) {
-        return t.stringTypeAnnotation();
+        return stringTypeAnnotation();
       }
 
       // for (let NODE of bar) {}
       if (declar.key === "left" && declarParent.isForOfStatement()) {
-        return t.anyTypeAnnotation();
+        return anyTypeAnnotation();
       }
 
-      return t.voidTypeAnnotation();
+      return voidTypeAnnotation();
     } else {
       return;
     }
@@ -79,19 +96,19 @@ export function isBaseType(baseName: string, soft?: boolean): boolean {
 
 function _isBaseType(baseName: string, type?, soft?): boolean {
   if (baseName === "string") {
-    return t.isStringTypeAnnotation(type);
+    return isStringTypeAnnotation(type);
   } else if (baseName === "number") {
-    return t.isNumberTypeAnnotation(type);
+    return isNumberTypeAnnotation(type);
   } else if (baseName === "boolean") {
-    return t.isBooleanTypeAnnotation(type);
+    return isBooleanTypeAnnotation(type);
   } else if (baseName === "any") {
-    return t.isAnyTypeAnnotation(type);
+    return isAnyTypeAnnotation(type);
   } else if (baseName === "mixed") {
-    return t.isMixedTypeAnnotation(type);
+    return isMixedTypeAnnotation(type);
   } else if (baseName === "empty") {
-    return t.isEmptyTypeAnnotation(type);
+    return isEmptyTypeAnnotation(type);
   } else if (baseName === "void") {
-    return t.isVoidTypeAnnotation(type);
+    return isVoidTypeAnnotation(type);
   } else {
     if (soft) {
       return false;
@@ -103,11 +120,11 @@ function _isBaseType(baseName: string, type?, soft?): boolean {
 
 export function couldBeBaseType(name: string): boolean {
   const type = this.getTypeAnnotation();
-  if (t.isAnyTypeAnnotation(type)) return true;
+  if (isAnyTypeAnnotation(type)) return true;
 
-  if (t.isUnionTypeAnnotation(type)) {
+  if (isUnionTypeAnnotation(type)) {
     for (const type2 of type.types) {
-      if (t.isAnyTypeAnnotation(type2) || _isBaseType(name, type2, true)) {
+      if (isAnyTypeAnnotation(type2) || _isBaseType(name, type2, true)) {
         return true;
       }
     }
@@ -121,7 +138,7 @@ export function baseTypeStrictlyMatches(rightArg: NodePath): boolean {
   const left = this.getTypeAnnotation();
   const right = rightArg.getTypeAnnotation();
 
-  if (!t.isAnyTypeAnnotation(left) && t.isFlowBaseAnnotation(left)) {
+  if (!isAnyTypeAnnotation(left) && isFlowBaseAnnotation(left)) {
     return right.type === left.type;
   }
   return false;
@@ -130,7 +147,7 @@ export function baseTypeStrictlyMatches(rightArg: NodePath): boolean {
 export function isGenericType(genericName: string): boolean {
   const type = this.getTypeAnnotation();
   return (
-    t.isGenericTypeAnnotation(type) &&
-    t.isIdentifier(type.id, { name: genericName })
+    isGenericTypeAnnotation(type) &&
+    isIdentifier(type.id, { name: genericName })
   );
 }

--- a/packages/babel-traverse/src/path/inference/inferer-reference.ts
+++ b/packages/babel-traverse/src/path/inference/inferer-reference.ts
@@ -1,5 +1,15 @@
 import type NodePath from "../index";
-import * as t from "@babel/types";
+import {
+  BOOLEAN_NUMBER_BINARY_OPERATORS,
+  createFlowUnionType,
+  createTSUnionType,
+  createTypeAnnotationBasedOnTypeof,
+  createUnionTypeAnnotation,
+  isTSTypeAnnotation,
+  numberTypeAnnotation,
+  voidTypeAnnotation,
+} from "@babel/types";
+import type * as t from "@babel/types";
 import type Binding from "../../scope/binding";
 
 export default function (node: any) {
@@ -22,9 +32,9 @@ export default function (node: any) {
 
   // built-in values
   if (node.name === "undefined") {
-    return t.voidTypeAnnotation();
+    return voidTypeAnnotation();
   } else if (node.name === "NaN" || node.name === "Infinity") {
-    return t.numberTypeAnnotation();
+    return numberTypeAnnotation();
   } else if (node.name === "arguments") {
     // todo
   }
@@ -96,15 +106,15 @@ function getTypeAnnotationBindingConstantViolations(binding, path, name) {
     return;
   }
 
-  if (t.isTSTypeAnnotation(types[0]) && t.createTSUnionType) {
-    return t.createTSUnionType(types);
+  if (isTSTypeAnnotation(types[0]) && createTSUnionType) {
+    return createTSUnionType(types);
   }
 
-  if (t.createFlowUnionType) {
-    return t.createFlowUnionType(types);
+  if (createFlowUnionType) {
+    return createFlowUnionType(types);
   }
 
-  return t.createUnionTypeAnnotation(types);
+  return createUnionTypeAnnotation(types);
 }
 
 function getConstantViolationsBefore(binding: Binding, path, functions?) {
@@ -138,8 +148,8 @@ function inferAnnotationFromBinaryExpression(
     if (operator === "===") {
       return target.getTypeAnnotation();
     }
-    if (t.BOOLEAN_NUMBER_BINARY_OPERATORS.indexOf(operator) >= 0) {
-      return t.numberTypeAnnotation();
+    if (BOOLEAN_NUMBER_BINARY_OPERATORS.indexOf(operator) >= 0) {
+      return numberTypeAnnotation();
     }
 
     return;
@@ -173,7 +183,7 @@ function inferAnnotationFromBinaryExpression(
 
   // turn type value into a type annotation
   // @ts-expect-error todo(flow->ts): move validation from helper or relax type constraint to just a string
-  return t.createTypeAnnotationBasedOnTypeof(typeValue);
+  return createTypeAnnotationBasedOnTypeof(typeValue);
 }
 
 function getParentConditionalPath(binding, path, name) {
@@ -221,22 +231,22 @@ function getConditionalAnnotation<T extends t.Node>(
   }
 
   if (types.length) {
-    if (t.isTSTypeAnnotation(types[0]) && t.createTSUnionType) {
+    if (isTSTypeAnnotation(types[0]) && createTSUnionType) {
       return {
-        typeAnnotation: t.createTSUnionType(types),
+        typeAnnotation: createTSUnionType(types),
         ifStatement,
       };
     }
 
-    if (t.createFlowUnionType) {
+    if (createFlowUnionType) {
       return {
-        typeAnnotation: t.createFlowUnionType(types),
+        typeAnnotation: createFlowUnionType(types),
         ifStatement,
       };
     }
 
     return {
-      typeAnnotation: t.createUnionTypeAnnotation(types),
+      typeAnnotation: createUnionTypeAnnotation(types),
       ifStatement,
     };
   }

--- a/packages/babel-traverse/src/path/inference/inferers.ts
+++ b/packages/babel-traverse/src/path/inference/inferers.ts
@@ -1,4 +1,26 @@
-import * as t from "@babel/types";
+import {
+  BOOLEAN_BINARY_OPERATORS,
+  BOOLEAN_UNARY_OPERATORS,
+  NUMBER_BINARY_OPERATORS,
+  NUMBER_UNARY_OPERATORS,
+  STRING_UNARY_OPERATORS,
+  anyTypeAnnotation,
+  arrayTypeAnnotation,
+  booleanTypeAnnotation,
+  buildMatchMemberExpression,
+  createFlowUnionType,
+  createTSUnionType,
+  createUnionTypeAnnotation,
+  genericTypeAnnotation,
+  identifier,
+  isTSTypeAnnotation,
+  nullLiteralTypeAnnotation,
+  numberTypeAnnotation,
+  stringTypeAnnotation,
+  tupleTypeAnnotation,
+  unionTypeAnnotation,
+  voidTypeAnnotation,
+} from "@babel/types";
 
 export { default as Identifier } from "./inferer-reference";
 
@@ -33,51 +55,51 @@ TypeCastExpression.validParent = true;
 export function NewExpression(node) {
   if (this.get("callee").isIdentifier()) {
     // only resolve identifier callee
-    return t.genericTypeAnnotation(node.callee);
+    return genericTypeAnnotation(node.callee);
   }
 }
 
 export function TemplateLiteral() {
-  return t.stringTypeAnnotation();
+  return stringTypeAnnotation();
 }
 
 export function UnaryExpression(node) {
   const operator = node.operator;
 
   if (operator === "void") {
-    return t.voidTypeAnnotation();
-  } else if (t.NUMBER_UNARY_OPERATORS.indexOf(operator) >= 0) {
-    return t.numberTypeAnnotation();
-  } else if (t.STRING_UNARY_OPERATORS.indexOf(operator) >= 0) {
-    return t.stringTypeAnnotation();
-  } else if (t.BOOLEAN_UNARY_OPERATORS.indexOf(operator) >= 0) {
-    return t.booleanTypeAnnotation();
+    return voidTypeAnnotation();
+  } else if (NUMBER_UNARY_OPERATORS.indexOf(operator) >= 0) {
+    return numberTypeAnnotation();
+  } else if (STRING_UNARY_OPERATORS.indexOf(operator) >= 0) {
+    return stringTypeAnnotation();
+  } else if (BOOLEAN_UNARY_OPERATORS.indexOf(operator) >= 0) {
+    return booleanTypeAnnotation();
   }
 }
 
 export function BinaryExpression(node) {
   const operator = node.operator;
 
-  if (t.NUMBER_BINARY_OPERATORS.indexOf(operator) >= 0) {
-    return t.numberTypeAnnotation();
-  } else if (t.BOOLEAN_BINARY_OPERATORS.indexOf(operator) >= 0) {
-    return t.booleanTypeAnnotation();
+  if (NUMBER_BINARY_OPERATORS.indexOf(operator) >= 0) {
+    return numberTypeAnnotation();
+  } else if (BOOLEAN_BINARY_OPERATORS.indexOf(operator) >= 0) {
+    return booleanTypeAnnotation();
   } else if (operator === "+") {
     const right = this.get("right");
     const left = this.get("left");
 
     if (left.isBaseType("number") && right.isBaseType("number")) {
       // both numbers so this will be a number
-      return t.numberTypeAnnotation();
+      return numberTypeAnnotation();
     } else if (left.isBaseType("string") || right.isBaseType("string")) {
       // one is a string so the result will be a string
-      return t.stringTypeAnnotation();
+      return stringTypeAnnotation();
     }
 
     // unsure if left and right are strings or numbers so stay on the safe side
-    return t.unionTypeAnnotation([
-      t.stringTypeAnnotation(),
-      t.numberTypeAnnotation(),
+    return unionTypeAnnotation([
+      stringTypeAnnotation(),
+      numberTypeAnnotation(),
     ]);
   }
 }
@@ -88,15 +110,15 @@ export function LogicalExpression() {
     this.get("right").getTypeAnnotation(),
   ];
 
-  if (t.isTSTypeAnnotation(argumentTypes[0]) && t.createTSUnionType) {
-    return t.createTSUnionType(argumentTypes);
+  if (isTSTypeAnnotation(argumentTypes[0]) && createTSUnionType) {
+    return createTSUnionType(argumentTypes);
   }
 
-  if (t.createFlowUnionType) {
-    return t.createFlowUnionType(argumentTypes);
+  if (createFlowUnionType) {
+    return createFlowUnionType(argumentTypes);
   }
 
-  return t.createUnionTypeAnnotation(argumentTypes);
+  return createUnionTypeAnnotation(argumentTypes);
 }
 
 export function ConditionalExpression() {
@@ -105,15 +127,15 @@ export function ConditionalExpression() {
     this.get("alternate").getTypeAnnotation(),
   ];
 
-  if (t.isTSTypeAnnotation(argumentTypes[0]) && t.createTSUnionType) {
-    return t.createTSUnionType(argumentTypes);
+  if (isTSTypeAnnotation(argumentTypes[0]) && createTSUnionType) {
+    return createTSUnionType(argumentTypes);
   }
 
-  if (t.createFlowUnionType) {
-    return t.createFlowUnionType(argumentTypes);
+  if (createFlowUnionType) {
+    return createFlowUnionType(argumentTypes);
   }
 
-  return t.createUnionTypeAnnotation(argumentTypes);
+  return createUnionTypeAnnotation(argumentTypes);
 }
 
 export function SequenceExpression() {
@@ -131,36 +153,36 @@ export function AssignmentExpression() {
 export function UpdateExpression(node) {
   const operator = node.operator;
   if (operator === "++" || operator === "--") {
-    return t.numberTypeAnnotation();
+    return numberTypeAnnotation();
   }
 }
 
 export function StringLiteral() {
-  return t.stringTypeAnnotation();
+  return stringTypeAnnotation();
 }
 
 export function NumericLiteral() {
-  return t.numberTypeAnnotation();
+  return numberTypeAnnotation();
 }
 
 export function BooleanLiteral() {
-  return t.booleanTypeAnnotation();
+  return booleanTypeAnnotation();
 }
 
 export function NullLiteral() {
-  return t.nullLiteralTypeAnnotation();
+  return nullLiteralTypeAnnotation();
 }
 
 export function RegExpLiteral() {
-  return t.genericTypeAnnotation(t.identifier("RegExp"));
+  return genericTypeAnnotation(identifier("RegExp"));
 }
 
 export function ObjectExpression() {
-  return t.genericTypeAnnotation(t.identifier("Object"));
+  return genericTypeAnnotation(identifier("Object"));
 }
 
 export function ArrayExpression() {
-  return t.genericTypeAnnotation(t.identifier("Array"));
+  return genericTypeAnnotation(identifier("Array"));
 }
 
 export function RestElement() {
@@ -170,7 +192,7 @@ export function RestElement() {
 RestElement.validParent = true;
 
 function Func() {
-  return t.genericTypeAnnotation(t.identifier("Function"));
+  return genericTypeAnnotation(identifier("Function"));
 }
 
 export {
@@ -181,19 +203,19 @@ export {
   Func as ClassDeclaration,
 };
 
-const isArrayFrom = t.buildMatchMemberExpression("Array.from");
-const isObjectKeys = t.buildMatchMemberExpression("Object.keys");
-const isObjectValues = t.buildMatchMemberExpression("Object.values");
-const isObjectEntries = t.buildMatchMemberExpression("Object.entries");
+const isArrayFrom = buildMatchMemberExpression("Array.from");
+const isObjectKeys = buildMatchMemberExpression("Object.keys");
+const isObjectValues = buildMatchMemberExpression("Object.values");
+const isObjectEntries = buildMatchMemberExpression("Object.entries");
 export function CallExpression() {
   const { callee } = this.node;
   if (isObjectKeys(callee)) {
-    return t.arrayTypeAnnotation(t.stringTypeAnnotation());
+    return arrayTypeAnnotation(stringTypeAnnotation());
   } else if (isArrayFrom(callee) || isObjectValues(callee)) {
-    return t.arrayTypeAnnotation(t.anyTypeAnnotation());
+    return arrayTypeAnnotation(anyTypeAnnotation());
   } else if (isObjectEntries(callee)) {
-    return t.arrayTypeAnnotation(
-      t.tupleTypeAnnotation([t.stringTypeAnnotation(), t.anyTypeAnnotation()]),
+    return arrayTypeAnnotation(
+      tupleTypeAnnotation([stringTypeAnnotation(), anyTypeAnnotation()]),
     );
   }
 
@@ -210,9 +232,9 @@ function resolveCall(callee) {
   if (callee.isFunction()) {
     if (callee.is("async")) {
       if (callee.is("generator")) {
-        return t.genericTypeAnnotation(t.identifier("AsyncIterator"));
+        return genericTypeAnnotation(identifier("AsyncIterator"));
       } else {
-        return t.genericTypeAnnotation(t.identifier("Promise"));
+        return genericTypeAnnotation(identifier("Promise"));
       }
     } else {
       if (callee.node.returnType) {

--- a/packages/babel-traverse/src/path/lib/hoister.ts
+++ b/packages/babel-traverse/src/path/lib/hoister.ts
@@ -1,5 +1,11 @@
 import { react } from "@babel/types";
-import * as t from "@babel/types";
+import {
+  cloneNode,
+  jsxExpressionContainer,
+  variableDeclaration,
+  variableDeclarator,
+} from "@babel/types";
+import type * as t from "@babel/types";
 import type Scope from "../../scope";
 import type NodePath from "../index";
 import type Binding from "../../scope/binding";
@@ -235,23 +241,23 @@ export default class PathHoister<T extends t.Node = t.Node> {
     let uid = attachTo.scope.generateUidIdentifier("ref");
 
     // @ts-expect-error todo(flow->ts): more specific type for this.path
-    const declarator = t.variableDeclarator(uid, this.path.node);
+    const declarator = variableDeclarator(uid, this.path.node);
 
     const insertFn = this.attachAfter ? "insertAfter" : "insertBefore";
     const [attached] = attachTo[insertFn]([
       attachTo.isVariableDeclarator()
         ? declarator
-        : t.variableDeclaration("var", [declarator]),
+        : variableDeclaration("var", [declarator]),
     ]);
 
     const parent = this.path.parentPath;
     if (parent.isJSXElement() && this.path.container === parent.node.children) {
       // turning the `span` in `<div><span /></div>` to an expression so we need to wrap it with
       // an expression container
-      uid = t.jsxExpressionContainer(uid);
+      uid = jsxExpressionContainer(uid);
     }
 
-    this.path.replaceWith(t.cloneNode(uid));
+    this.path.replaceWith(cloneNode(uid));
 
     return attachTo.isVariableDeclarator()
       ? attached.get("init")

--- a/packages/babel-traverse/src/path/lib/virtual-types.ts
+++ b/packages/babel-traverse/src/path/lib/virtual-types.ts
@@ -1,14 +1,35 @@
 import type NodePath from "../index";
-import { react } from "@babel/types";
-import * as t from "@babel/types";
+import {
+  isBinding,
+  isBlockScoped,
+  isExportDeclaration,
+  isExpression,
+  isFlow,
+  isForStatement,
+  isForXStatement,
+  isIdentifier,
+  isImportDeclaration,
+  isImportSpecifier,
+  isJSXIdentifier,
+  isJSXMemberExpression,
+  isMemberExpression,
+  isReferenced,
+  isScope,
+  isStatement,
+  isVar,
+  isVariableDeclaration,
+  react,
+} from "@babel/types";
+import type * as t from "@babel/types";
+const { isCompatTag } = react;
 
 export const ReferencedIdentifier = {
   types: ["Identifier", "JSXIdentifier"],
   checkPath(path: NodePath, opts?: any): boolean {
     const { node, parent } = path;
-    if (!t.isIdentifier(node, opts) && !t.isJSXMemberExpression(parent, opts)) {
-      if (t.isJSXIdentifier(node, opts)) {
-        if (react.isCompatTag(node.name)) return false;
+    if (!isIdentifier(node, opts) && !isJSXMemberExpression(parent, opts)) {
+      if (isJSXIdentifier(node, opts)) {
+        if (isCompatTag(node.name)) return false;
       } else {
         // not a JSXIdentifier or an Identifier
         return false;
@@ -16,14 +37,14 @@ export const ReferencedIdentifier = {
     }
 
     // check if node is referenced
-    return t.isReferenced(node, parent, path.parentPath.parent);
+    return isReferenced(node, parent, path.parentPath.parent);
   },
 };
 
 export const ReferencedMemberExpression = {
   types: ["MemberExpression"],
   checkPath({ node, parent }) {
-    return t.isMemberExpression(node) && t.isReferenced(node, parent);
+    return isMemberExpression(node) && isReferenced(node, parent);
   },
 };
 
@@ -32,17 +53,17 @@ export const BindingIdentifier = {
   checkPath(path: NodePath): boolean {
     const { node, parent } = path;
     const grandparent = path.parentPath.parent;
-    return t.isIdentifier(node) && t.isBinding(node, parent, grandparent);
+    return isIdentifier(node) && isBinding(node, parent, grandparent);
   },
 };
 
 export const Statement = {
   types: ["Statement"],
   checkPath({ node, parent }: NodePath): boolean {
-    if (t.isStatement(node)) {
-      if (t.isVariableDeclaration(node)) {
-        if (t.isForXStatement(parent, { left: node })) return false;
-        if (t.isForStatement(parent, { init: node })) return false;
+    if (isStatement(node)) {
+      if (isVariableDeclaration(node)) {
+        if (isForXStatement(parent, { left: node })) return false;
+        if (isForStatement(parent, { init: node })) return false;
       }
 
       return true;
@@ -58,7 +79,7 @@ export const Expression = {
     if (path.isIdentifier()) {
       return path.isReferencedIdentifier();
     } else {
-      return t.isExpression(path.node);
+      return isExpression(path.node);
     }
   },
 };
@@ -67,26 +88,26 @@ export const Scope = {
   // When pattern is inside the function params, it is a scope
   types: ["Scopable", "Pattern"],
   checkPath(path) {
-    return t.isScope(path.node, path.parent);
+    return isScope(path.node, path.parent);
   },
 };
 
 export const Referenced = {
   checkPath(path: NodePath): boolean {
-    return t.isReferenced(path.node, path.parent);
+    return isReferenced(path.node, path.parent);
   },
 };
 
 export const BlockScoped = {
   checkPath(path: NodePath): boolean {
-    return t.isBlockScoped(path.node);
+    return isBlockScoped(path.node);
   },
 };
 
 export const Var = {
   types: ["VariableDeclaration"],
   checkPath(path: NodePath): boolean {
-    return t.isVar(path.node);
+    return isVar(path.node);
   },
 };
 
@@ -111,13 +132,13 @@ export const Pure = {
 export const Flow = {
   types: ["Flow", "ImportDeclaration", "ExportDeclaration", "ImportSpecifier"],
   checkPath({ node }: NodePath): boolean {
-    if (t.isFlow(node)) {
+    if (isFlow(node)) {
       return true;
-    } else if (t.isImportDeclaration(node)) {
+    } else if (isImportDeclaration(node)) {
       return node.importKind === "type" || node.importKind === "typeof";
-    } else if (t.isExportDeclaration(node)) {
+    } else if (isExportDeclaration(node)) {
       return node.exportKind === "type";
-    } else if (t.isImportSpecifier(node)) {
+    } else if (isImportSpecifier(node)) {
       return node.importKind === "type" || node.importKind === "typeof";
     } else {
       return false;

--- a/packages/babel-traverse/src/path/replacement.ts
+++ b/packages/babel-traverse/src/path/replacement.ts
@@ -5,7 +5,29 @@ import traverse from "../index";
 import NodePath from "./index";
 import { path as pathCache } from "../cache";
 import { parse } from "@babel/parser";
-import * as t from "@babel/types";
+import {
+  FUNCTION_TYPES,
+  arrowFunctionExpression,
+  assignmentExpression,
+  awaitExpression,
+  blockStatement,
+  callExpression,
+  cloneNode,
+  expressionStatement,
+  identifier,
+  inheritLeadingComments,
+  inheritTrailingComments,
+  inheritsComments,
+  isExpression,
+  isProgram,
+  isStatement,
+  removeComments,
+  returnStatement,
+  toSequenceExpression,
+  validate,
+  yieldExpression,
+} from "@babel/types";
+import type * as t from "@babel/types";
 import hoistVariables from "@babel/helper-hoist-variables";
 
 /**
@@ -23,8 +45,8 @@ export function replaceWithMultiple<Nodes extends Array<t.Node>>(
   this.resync();
 
   nodes = this._verifyNodeList(nodes);
-  t.inheritLeadingComments(nodes[0], this.node);
-  t.inheritTrailingComments(nodes[nodes.length - 1], this.node);
+  inheritLeadingComments(nodes[0], this.node);
+  inheritTrailingComments(nodes[nodes.length - 1], this.node);
   pathCache.get(this.parent)?.delete(this.node);
   this.node = this.container[this.key] = null;
   const paths = this.insertAfter(nodes);
@@ -97,7 +119,7 @@ export function replaceWith(this: NodePath, replacement: t.Node | NodePath) {
     return [this];
   }
 
-  if (this.isProgram() && !t.isProgram(replacement)) {
+  if (this.isProgram() && !isProgram(replacement)) {
     throw new Error(
       "You can only replace a Program root node with another Program node",
     );
@@ -117,19 +139,19 @@ export function replaceWith(this: NodePath, replacement: t.Node | NodePath) {
 
   let nodePath = "";
 
-  if (this.isNodeType("Statement") && t.isExpression(replacement)) {
+  if (this.isNodeType("Statement") && isExpression(replacement)) {
     if (
       !this.canHaveVariableDeclarationOrExpression() &&
       !this.canSwapBetweenExpressionAndStatement(replacement) &&
       !this.parentPath.isExportDefaultDeclaration()
     ) {
       // replacing a statement with an expression so wrap it in an expression statement
-      replacement = t.expressionStatement(replacement);
+      replacement = expressionStatement(replacement);
       nodePath = "expression";
     }
   }
 
-  if (this.isNodeType("Expression") && t.isStatement(replacement)) {
+  if (this.isNodeType("Expression") && isStatement(replacement)) {
     if (
       !this.canHaveVariableDeclarationOrExpression() &&
       !this.canSwapBetweenExpressionAndStatement(replacement)
@@ -141,8 +163,8 @@ export function replaceWith(this: NodePath, replacement: t.Node | NodePath) {
 
   const oldNode = this.node;
   if (oldNode) {
-    t.inheritsComments(replacement, oldNode);
-    t.removeComments(oldNode);
+    inheritsComments(replacement, oldNode);
+    removeComments(oldNode);
   }
 
   // replace the node
@@ -168,10 +190,10 @@ export function _replaceWith(this: NodePath, node) {
   }
 
   if (this.inList) {
-    // @ts-expect-error todo(flow->ts): check if t.validate accepts a numeric key
-    t.validate(this.parent, this.key, [node]);
+    // @ts-expect-error todo(flow->ts): check if validate accepts a numeric key
+    validate(this.parent, this.key, [node]);
   } else {
-    t.validate(this.parent, this.key as string, node);
+    validate(this.parent, this.key as string, node);
   }
 
   this.debug(`Replace with ${node?.type}`);
@@ -192,19 +214,19 @@ export function replaceExpressionWithStatements(
 ) {
   this.resync();
 
-  const toSequenceExpression = t.toSequenceExpression(nodes, this.scope);
+  const nodesAsSequenceExpression = toSequenceExpression(nodes, this.scope);
 
-  if (toSequenceExpression) {
-    return this.replaceWith(toSequenceExpression)[0].get("expressions");
+  if (nodesAsSequenceExpression) {
+    return this.replaceWith(nodesAsSequenceExpression)[0].get("expressions");
   }
 
   const functionParent = this.getFunctionParent();
   const isParentAsync = functionParent?.is("async");
   const isParentGenerator = functionParent?.is("generator");
 
-  const container = t.arrowFunctionExpression([], t.blockStatement(nodes));
+  const container = arrowFunctionExpression([], blockStatement(nodes));
 
-  this.replaceWith(t.callExpression(container, []));
+  this.replaceWith(callExpression(container, []));
   // replaceWith changes the type of "this", but it isn't trackable by TS
   type ThisType = NodePath<
     t.CallExpression & { callee: t.ArrowFunctionExpression }
@@ -236,19 +258,19 @@ export function replaceExpressionWithStatements(
         uid = callee.scope.generateDeclaredUidIdentifier("ret");
         callee
           .get("body")
-          .pushContainer("body", t.returnStatement(t.cloneNode(uid)));
+          .pushContainer("body", returnStatement(cloneNode(uid)));
         loop.setData("expressionReplacementReturnUid", uid);
       } else {
-        uid = t.identifier(uid.name);
+        uid = identifier(uid.name);
       }
 
       path
         .get("expression")
         .replaceWith(
-          t.assignmentExpression("=", t.cloneNode(uid), path.node.expression),
+          assignmentExpression("=", cloneNode(uid), path.node.expression),
         );
     } else {
-      path.replaceWith(t.returnStatement(path.node.expression));
+      path.replaceWith(returnStatement(path.node.expression));
     }
   }
 
@@ -264,25 +286,25 @@ export function replaceExpressionWithStatements(
     traverse.hasType(
       (this.get("callee.body") as NodePath<t.BlockStatement>).node,
       "AwaitExpression",
-      t.FUNCTION_TYPES,
+      FUNCTION_TYPES,
     );
   const needToYieldFunction =
     isParentGenerator &&
     traverse.hasType(
       (this.get("callee.body") as NodePath<t.BlockStatement>).node,
       "YieldExpression",
-      t.FUNCTION_TYPES,
+      FUNCTION_TYPES,
     );
   if (needToAwaitFunction) {
     newCallee.set("async", true);
     // yield* will await the generator return result
     if (!needToYieldFunction) {
-      this.replaceWith(t.awaitExpression((this as ThisType).node));
+      this.replaceWith(awaitExpression((this as ThisType).node));
     }
   }
   if (needToYieldFunction) {
     newCallee.set("generator", true);
-    this.replaceWith(t.yieldExpression((this as ThisType).node, true));
+    this.replaceWith(yieldExpression((this as ThisType).node, true));
   }
 
   return newCallee.get("body.body");

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -4,7 +4,46 @@ import traverse from "../index";
 import type { TraverseOptions } from "../index";
 import Binding from "./binding";
 import globals from "globals";
-import * as t from "@babel/types";
+import {
+  FOR_INIT_KEYS,
+  NOT_LOCAL_BINDING,
+  callExpression,
+  cloneNode,
+  getBindingIdentifiers,
+  identifier,
+  isArrayExpression,
+  isBinary,
+  isClass,
+  isClassBody,
+  isClassDeclaration,
+  isExportAllDeclaration,
+  isExportDefaultDeclaration,
+  isExportNamedDeclaration,
+  isFunctionDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isLiteral,
+  isMethod,
+  isModuleDeclaration,
+  isModuleSpecifier,
+  isObjectExpression,
+  isProperty,
+  isPureish,
+  isSuper,
+  isTaggedTemplateExpression,
+  isTemplateLiteral,
+  isThisExpression,
+  isUnaryExpression,
+  isVariableDeclaration,
+  matchesPattern,
+  memberExpression,
+  numericLiteral,
+  toIdentifier,
+  unaryExpression,
+  variableDeclaration,
+  variableDeclarator,
+} from "@babel/types";
+import type * as t from "@babel/types";
 import { scope as scopeCache } from "../cache";
 import type { Visitor } from "../types";
 
@@ -12,28 +51,28 @@ import type { Visitor } from "../types";
 function gatherNodeParts(node: t.Node, parts: any[]) {
   switch (node?.type) {
     default:
-      if (t.isModuleDeclaration(node)) {
+      if (isModuleDeclaration(node)) {
         if (
-          (t.isExportAllDeclaration(node) ||
-            t.isExportNamedDeclaration(node) ||
-            t.isImportDeclaration(node)) &&
+          (isExportAllDeclaration(node) ||
+            isExportNamedDeclaration(node) ||
+            isImportDeclaration(node)) &&
           node.source
         ) {
           gatherNodeParts(node.source, parts);
         } else if (
-          (t.isExportNamedDeclaration(node) || t.isImportDeclaration(node)) &&
+          (isExportNamedDeclaration(node) || isImportDeclaration(node)) &&
           node.specifiers &&
           node.specifiers.length
         ) {
           for (const e of node.specifiers) gatherNodeParts(e, parts);
         } else if (
-          (t.isExportDefaultDeclaration(node) ||
-            t.isExportNamedDeclaration(node)) &&
+          (isExportDefaultDeclaration(node) ||
+            isExportNamedDeclaration(node)) &&
           node.declaration
         ) {
           gatherNodeParts(node.declaration, parts);
         }
-      } else if (t.isModuleSpecifier(node)) {
+      } else if (isModuleSpecifier(node)) {
         // todo(flow->ts): should condition instead be:
         //    ```
         //    t.isExportSpecifier(node) ||
@@ -44,12 +83,12 @@ function gatherNodeParts(node: t.Node, parts: any[]) {
         //    allowing only nodes with `.local`?
         // @ts-expect-error todo(flow->ts)
         gatherNodeParts(node.local, parts);
-      } else if (t.isLiteral(node)) {
+      } else if (isLiteral(node)) {
         // todo(flow->ts): should condition be stricter to ensure value is there
         //   ```
         //   !t.isNullLiteral(node) &&
         //   !t.isRegExpLiteral(node) &&
-        //   !t.isTemplateLiteral(node)
+        //   !isTemplateLiteral(node)
         //   ```
         // @ts-expect-error todo(flow->ts)
         parts.push(node.value);
@@ -186,7 +225,7 @@ interface CollectVisitorState {
 
 const collectorVisitor: Visitor<CollectVisitorState> = {
   For(path) {
-    for (const key of t.FOR_INIT_KEYS) {
+    for (const key of FOR_INIT_KEYS) {
       // todo: might be not needed with improvement to babel-types
       const declar = path.get(key) as NodePath;
       // delegate block scope handling to the `BlockScoped` method
@@ -236,17 +275,17 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
     exit(path) {
       const { node, scope } = path;
       // ExportAllDeclaration does not have `declaration`
-      if (t.isExportAllDeclaration(node)) return;
+      if (isExportAllDeclaration(node)) return;
       const declar = node.declaration;
-      if (t.isClassDeclaration(declar) || t.isFunctionDeclaration(declar)) {
+      if (isClassDeclaration(declar) || isFunctionDeclaration(declar)) {
         const id = declar.id;
         if (!id) return;
 
         const binding = scope.getBinding(id.name);
         if (binding) binding.reference(path);
-      } else if (t.isVariableDeclaration(declar)) {
+      } else if (isVariableDeclaration(declar)) {
         for (const decl of declar.declarations) {
-          for (const name of Object.keys(t.getBindingIdentifiers(decl))) {
+          for (const name of Object.keys(getBindingIdentifiers(decl))) {
             const binding = scope.getBinding(name);
             if (binding) binding.reference(path);
           }
@@ -297,7 +336,7 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
     if (
       path.isFunctionExpression() &&
       path.has("id") &&
-      !path.get("id").node[t.NOT_LOCAL_BINDING]
+      !path.get("id").node[NOT_LOCAL_BINDING]
     ) {
       path.scope.registerBinding("local", path.get("id"), path);
     }
@@ -309,7 +348,7 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
   },
 
   ClassExpression(path) {
-    if (path.has("id") && !path.get("id").node[t.NOT_LOCAL_BINDING]) {
+    if (path.has("id") && !path.get("id").node[NOT_LOCAL_BINDING]) {
       path.scope.registerBinding("local", path);
     }
   },
@@ -412,7 +451,7 @@ export default class Scope {
   generateDeclaredUidIdentifier(name?: string) {
     const id = this.generateUidIdentifier(name);
     this.push({ id });
-    return t.cloneNode(id);
+    return cloneNode(id);
   }
 
   /**
@@ -420,7 +459,7 @@ export default class Scope {
    */
 
   generateUidIdentifier(name?: string) {
-    return t.identifier(this.generateUid(name));
+    return identifier(this.generateUid(name));
   }
 
   /**
@@ -428,8 +467,7 @@ export default class Scope {
    */
 
   generateUid(name: string = "temp"): string {
-    name = t
-      .toIdentifier(name)
+    name = toIdentifier(name)
       .replace(/^_+/, "")
       .replace(/[0-9]+$/g, "");
 
@@ -477,7 +515,7 @@ export default class Scope {
    */
 
   generateUidIdentifierBasedOnNode(node: t.Node, defaultName?: string) {
-    return t.identifier(this.generateUidBasedOnNode(node, defaultName));
+    return identifier(this.generateUidBasedOnNode(node, defaultName));
   }
 
   /**
@@ -491,11 +529,11 @@ export default class Scope {
    */
 
   isStatic(node: t.Node): boolean {
-    if (t.isThisExpression(node) || t.isSuper(node)) {
+    if (isThisExpression(node) || isSuper(node)) {
       return true;
     }
 
-    if (t.isIdentifier(node)) {
+    if (isIdentifier(node)) {
       const binding = this.getBinding(node.name);
       if (binding) {
         return binding.constant;
@@ -518,7 +556,7 @@ export default class Scope {
       const id = this.generateUidIdentifierBasedOnNode(node);
       if (!dontPush) {
         this.push({ id });
-        return t.cloneNode(id);
+        return cloneNode(id);
       }
       return id;
     }
@@ -591,28 +629,25 @@ export default class Scope {
 
   // TODO: (Babel 8) Split i in two parameters, and use an object of flags
   toArray(node: t.Node, i?: number | boolean, arrayLikeIsIterable?: boolean) {
-    if (t.isIdentifier(node)) {
+    if (isIdentifier(node)) {
       const binding = this.getBinding(node.name);
       if (binding?.constant && binding.path.isGenericType("Array")) {
         return node;
       }
     }
 
-    if (t.isArrayExpression(node)) {
+    if (isArrayExpression(node)) {
       return node;
     }
 
-    if (t.isIdentifier(node, { name: "arguments" })) {
-      return t.callExpression(
-        t.memberExpression(
-          t.memberExpression(
-            t.memberExpression(
-              t.identifier("Array"),
-              t.identifier("prototype"),
-            ),
-            t.identifier("slice"),
+    if (isIdentifier(node, { name: "arguments" })) {
+      return callExpression(
+        memberExpression(
+          memberExpression(
+            memberExpression(identifier("Array"), identifier("prototype")),
+            identifier("slice"),
           ),
-          t.identifier("call"),
+          identifier("call"),
         ),
         [node],
       );
@@ -624,7 +659,7 @@ export default class Scope {
       // Used in array-spread to create an array.
       helperName = "toConsumableArray";
     } else if (i) {
-      args.push(t.numericLiteral(i));
+      args.push(numericLiteral(i));
 
       // Used in array-rest to create an array from a subset of an iterable.
       helperName = "slicedToArray";
@@ -640,7 +675,7 @@ export default class Scope {
     }
 
     // @ts-expect-error todo(flow->ts): t.Node is not valid to use in args, function argument typeneeds to be clarified
-    return t.callExpression(this.hub.addHelper(helperName), args);
+    return callExpression(this.hub.addHelper(helperName), args);
   }
 
   hasLabel(name: string) {
@@ -688,7 +723,7 @@ export default class Scope {
   }
 
   buildUndefinedNode() {
-    return t.unaryExpression("void", t.numericLiteral(0), true);
+    return unaryExpression("void", numericLiteral(0), true);
   }
 
   registerConstantViolation(path: NodePath) {
@@ -776,59 +811,59 @@ export default class Scope {
   }
 
   isPure(node: t.Node, constantsOnly?: boolean) {
-    if (t.isIdentifier(node)) {
+    if (isIdentifier(node)) {
       const binding = this.getBinding(node.name);
       if (!binding) return false;
       if (constantsOnly) return binding.constant;
       return true;
-    } else if (t.isClass(node)) {
+    } else if (isClass(node)) {
       if (node.superClass && !this.isPure(node.superClass, constantsOnly)) {
         return false;
       }
       return this.isPure(node.body, constantsOnly);
-    } else if (t.isClassBody(node)) {
+    } else if (isClassBody(node)) {
       for (const method of node.body) {
         if (!this.isPure(method, constantsOnly)) return false;
       }
       return true;
-    } else if (t.isBinary(node)) {
+    } else if (isBinary(node)) {
       return (
         this.isPure(node.left, constantsOnly) &&
         this.isPure(node.right, constantsOnly)
       );
-    } else if (t.isArrayExpression(node)) {
+    } else if (isArrayExpression(node)) {
       for (const elem of node.elements) {
         if (!this.isPure(elem, constantsOnly)) return false;
       }
       return true;
-    } else if (t.isObjectExpression(node)) {
+    } else if (isObjectExpression(node)) {
       for (const prop of node.properties) {
         if (!this.isPure(prop, constantsOnly)) return false;
       }
       return true;
-    } else if (t.isMethod(node)) {
+    } else if (isMethod(node)) {
       if (node.computed && !this.isPure(node.key, constantsOnly)) return false;
       if (node.kind === "get" || node.kind === "set") return false;
       return true;
-    } else if (t.isProperty(node)) {
+    } else if (isProperty(node)) {
       // @ts-expect-error todo(flow->ts): computed in not present on private properties
       if (node.computed && !this.isPure(node.key, constantsOnly)) return false;
       return this.isPure(node.value, constantsOnly);
-    } else if (t.isUnaryExpression(node)) {
+    } else if (isUnaryExpression(node)) {
       return this.isPure(node.argument, constantsOnly);
-    } else if (t.isTaggedTemplateExpression(node)) {
+    } else if (isTaggedTemplateExpression(node)) {
       return (
-        t.matchesPattern(node.tag, "String.raw") &&
+        matchesPattern(node.tag, "String.raw") &&
         !this.hasBinding("String", true) &&
         this.isPure(node.quasi, constantsOnly)
       );
-    } else if (t.isTemplateLiteral(node)) {
+    } else if (isTemplateLiteral(node)) {
       for (const expression of node.expressions) {
         if (!this.isPure(expression, constantsOnly)) return false;
       }
       return true;
     } else {
-      return t.isPureish(node);
+      return isPureish(node);
     }
   }
 
@@ -969,7 +1004,7 @@ export default class Scope {
     let declarPath = !unique && path.getData(dataKey);
 
     if (!declarPath) {
-      const declar = t.variableDeclaration(kind, []);
+      const declar = variableDeclaration(kind, []);
       // @ts-expect-error todo(flow->ts): avoid modifying nodes
       declar._blockHoist = blockHoist;
 
@@ -977,7 +1012,7 @@ export default class Scope {
       if (!unique) path.setData(dataKey, declarPath);
     }
 
-    const declarator = t.variableDeclarator(opts.id, opts.init);
+    const declarator = variableDeclarator(opts.id, opts.init);
     declarPath.node.declarations.push(declarator);
     this.registerBinding(kind, declarPath.get("declarations").pop());
   }

--- a/packages/babel-traverse/src/types.ts
+++ b/packages/babel-traverse/src/types.ts
@@ -1,4 +1,4 @@
-import * as t from "@babel/types";
+import type * as t from "@babel/types";
 import { NodePath } from "./index";
 import { VirtualTypeAliases } from "./path/generated/virtual-types";
 

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -1,5 +1,5 @@
 import * as virtualTypes from "./path/lib/virtual-types";
-import * as t from "@babel/types";
+import { DEPRECATED_KEYS, FLIPPED_ALIAS_KEYS, TYPES } from "@babel/types";
 
 /**
  * explode() will take a visitor object with all of the various shorthands
@@ -85,9 +85,9 @@ export function explode(visitor) {
 
     const fns = visitor[nodeType];
 
-    let aliases: Array<string> | undefined = t.FLIPPED_ALIAS_KEYS[nodeType];
+    let aliases: Array<string> | undefined = FLIPPED_ALIAS_KEYS[nodeType];
 
-    const deprecatedKey = t.DEPRECATED_KEYS[nodeType];
+    const deprecatedKey = DEPRECATED_KEYS[nodeType];
     if (deprecatedKey) {
       console.trace(
         `Visitor defined for ${nodeType} but it has been renamed to ${deprecatedKey}`,
@@ -136,7 +136,7 @@ export function verify(visitor) {
 
     if (shouldIgnoreKey(nodeType)) continue;
 
-    if (t.TYPES.indexOf(nodeType) < 0) {
+    if (TYPES.indexOf(nodeType) < 0) {
       throw new Error(
         `You gave us a visitor for the node type ${nodeType} but it's not a valid type`,
       );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is a follow-up to https://github.com/babel/babel/pull/13593#pullrequestreview-713153031. In this PR we transform `@babel/types` namespace imports (e.g. `import * as t from "@babel/types"` to named imports (e.g. `import { isIdentifier } from "@babel/types"`). The named imports allow us to perform further optimization when transforming to commonjs modules. 

## Example
For example, before this PR, the named imports

```js
import { isIdentifier } from "@babel/types";
isIdentifier(node)
```
are transformed as

```js
const babel$types = require("@babel/types");
babel$types.isIdentifier(node)
```

After this PR, the named imports are transformed as
```js
const _t = require("@babel/types");
const { isIdentifier } = _t
isIdentifier(node)
```

In #13593 we have identified a bottleneck of generator performance, accessing methods from `@babel/types` namespace is very slow. The optimized output now accesses namespace only once (per module).

Note that we can not generalize the optimization to any imports because ES imports are live bindings, which means if a module changed its exports on-the-fly, the updated values will be synchronized to the consumers. However, in the transpiled code, we takes a snapshot of these imports once and they won't be updated since then. 

This approach is safe for most `@babel/types` usage in our current codebase since we don't modify the types exports, except in [`babel-traverse/src/path/index.ts`](https://github.com/babel/babel/pull/13685/files#diff-27416390498f2592e145d52827962ebec3148a504602e5ba9755746f3d13afbbR229-R232) where `@babel/traverse` is modifying the exports of `@babel/types`. Such usage is rare and we should consider if we should move on to a new approach.

The first commit is produced by a custom [codemod](https://gist.github.com/JLHwung/1f7e3234b960a6ffdd58e3b100cb9020).

## Comparison to plugin-only approach
My first draft is a plugin transforming namespace `import * as t` to destructuring. Compared to current approach, the first approach has the following constraints:

- Hard to determine which packages should be published because changes are only in build settings.
- A valid method usage like `const addComment = t.addComment` becomes invalid after built, though we could avoid naming conflicts by sacrificing code readability.

## Limitations
This PR does not change the indirect `@babel/types` usage such as

- Use `@babel/types` from `@babel/core`
```js
import { types as t } from "@babel/core"
```
- Use `@babel/types` from the callback parameters of a plugin
```js
module.exports = function({ types: t }) {
  
}
```

I think they should be updated, too. I will address them in separate PRs.

## Further thoughts
Should we come up with a parameterized (🤷) assumption for commonjs transform?
```js
{
  noImportLiveBindings: ["@babel/types"]
}
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13685"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

