### PR TITLE
fix: pass `browserslistEnv` to `resolveTargets`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ packages/babel-standalone/babel.min.js
 /eslint/*/LICENSE
 !/packages/babel-eslint-plugin/LICENSE
 /.vscode
+# local directory for VSCode Extension - https://marketplace.visualstudio.com/items?itemName=xyz.local-history
+/.history
 
 /dts
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
     "/test/helpers/",
     "<rootDir>/test/warning\\.js",
     "<rootDir>/build/",
+    "<rootDir>/.history/", // local directory for VSCode Extension - https://marketplace.visualstudio.com/items?itemName=xyz.local-history
     "_browser\\.js",
   ],
   testEnvironment: "node",

--- a/packages/babel-helper-compilation-targets/src/index.ts
+++ b/packages/babel-helper-compilation-targets/src/index.ts
@@ -154,8 +154,11 @@ function generateTargets(inputTargets: InputTargets): Targets {
   return input as any as Targets;
 }
 
-function resolveTargets(queries: Browsers): Targets {
-  const resolved = browserslist(queries, { mobileToDesktop: true });
+function resolveTargets(queries: Browsers, env?: string): Targets {
+  const resolved = browserslist(queries, {
+    mobileToDesktop: true,
+    env,
+  });
   return getLowestVersions(resolved);
 }
 
@@ -217,7 +220,7 @@ export default function getTargets(
   }
 
   if (browsers) {
-    const queryBrowsers = resolveTargets(browsers);
+    const queryBrowsers = resolveTargets(browsers, options.browserslistEnv);
 
     if (esmodules === "intersect") {
       for (const browser of Object.keys(queryBrowsers)) {

--- a/packages/babel-helper-compilation-targets/test/browserslist-extends/browserslist-extends.spec.js
+++ b/packages/babel-helper-compilation-targets/test/browserslist-extends/browserslist-extends.spec.js
@@ -1,0 +1,37 @@
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import getTargets from "../../lib";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+const oldEnv = process.env.BROWSERSLIST_DANGEROUS_EXTEND;
+
+beforeAll(() => {
+  process.env.BROWSERSLIST_DANGEROUS_EXTEND = true;
+});
+
+afterAll(() => {
+  process.env.BROWSERSLIST_DANGEROUS_EXTEND = oldEnv;
+});
+
+it("pass env to configs used with extends", async () => {
+  const actual = getTargets(
+    {
+      browsers: [
+        `extends ${resolve(
+          currentDir,
+          "fixtures",
+          "@babel",
+          "browserslist-config-fixture.cjs",
+        )}`,
+        "chrome >= 71",
+      ],
+    },
+    {
+      configPath: currentDir,
+      browserslistEnv: "custom",
+    },
+  );
+
+  expect(actual).toEqual({ chrome: "71.0.0", firefox: "75.0.0" });
+});

--- a/packages/babel-helper-compilation-targets/test/browserslist-extends/fixtures/@babel/browserslist-config-fixture.cjs
+++ b/packages/babel-helper-compilation-targets/test/browserslist-extends/fixtures/@babel/browserslist-config-fixture.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  custom: ["firefox >= 75"],
+  defaults: ["chrome >= 5"],
+};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In case of explicitly specifying browserslist query with `extends` keyword, `browserslistEnv` option was not passed to browserslist itself leading to wrong resolved targets

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13697"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

