### PR TITLE
copy source map option from babel cli to babel node to enable source map support

### DIFF
--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -28,6 +28,18 @@ function collect(value, previousValue): Array<string> {
   return values;
 }
 
+function booleanify(val: any): boolean | any {
+  if (val === "true" || val == 1) {
+    return true;
+  }
+
+  if (val === "false" || val == 0 || !val) {
+    return false;
+  }
+
+  return val;
+}
+
 program.option("-e, --eval [script]", "Evaluate script");
 program.option(
   "--no-babelrc",
@@ -66,6 +78,7 @@ program.option(
 );
 program.option("-w, --plugins [string]", "", collect);
 program.option("-b, --presets [string]", "", collect);
+program.option("-s, --source-maps [true|false|inline|both]", "", booleanify);
 
 program.version(PACKAGE_JSON.version);
 program.usage("[options] [ -e script | script.js ] [arguments]");
@@ -83,6 +96,7 @@ const babelOptions = {
   configFile: program.configFile,
   envName: program.envName,
   rootMode: program.rootMode,
+  sourceMaps: program.sourceMaps,
 
   // Commander will default the "--no-" arguments to true, but we want to
   // leave them undefined so that @babel/core can handle the


### PR DESCRIPTION
<!-- Describe your changes below in as much detail as possible -->

Fixes #1556, #7694

Source map of babel register is not working correctly for exception stack trace even if sourceMaps option is set to a non-false value in babel config. With the explicit --source-maps argument as advised at https://babeljs.io/docs/en/babel-cli#compile-with-source-maps, babel cli works perfectly. However, babel node does not accept a source map option to be passed to babel register. Copying the option from babel cli to babel node just fix this issue.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13704"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

