### PR TITLE
test(parser): add no_plugin tests for module blocks

### DIFF
--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/module-blocks/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/module-blocks/input.js
@@ -1,0 +1,4 @@
+let moduleBlock = module {
+  export let y = 1;
+};
+let moduleExports = await import(moduleBlock);

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/module-blocks/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/module-blocks/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "This experimental syntax requires enabling the parser plugin: 'moduleBlocks' (1:18)"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I noticed that we don't have no_plugin tests for module blocks proposal.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13714"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

