### PR TITLE
[babel 8] fix: stricter rest element builder check

### DIFF
--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -898,7 +898,12 @@ defineType("RestElement", {
     argument: {
       validate: !process.env.BABEL_TYPES_8_BREAKING
         ? assertNodeType("LVal")
-        : assertNodeType("Identifier", "Pattern", "MemberExpression"),
+        : assertNodeType(
+            "Identifier",
+            "ArrayPattern",
+            "ObjectPattern",
+            "MemberExpression",
+          ),
     },
     // For Flow
     optional: {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | When `BABEL_TYPES_8_BREAKING` is enabled, the `RestElement` constructor incorrectly allows AssignmentPattern as argument
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Per https://tc39.es/ecma262/#prod-BindingPattern, a binding pattern can only be either ArrayPattern or ObjectPattern.