### PR TITLE
Don't load top-level config in internal test

### DIFF
--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/util.test.js
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/util.test.js
@@ -15,6 +15,7 @@ function getPath(input, parserOpts = {}) {
         ...parserOpts,
       },
       filename: "example.js",
+      configFile: false,
     }),
     {
       "OptionalMemberExpression|OptionalCallExpression"(path) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I accidentally found this while working on https://github.com/babel/babel/pull/13414. This test was loading the top-level `babel.config.js` file, rather than being isolated.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13720"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

