### PR TITLE
Use `import.meta.url` instead of `__dirname`

### DIFF
--- a/packages/babel-types/test/fields.js
+++ b/packages/babel-types/test/fields.js
@@ -3,9 +3,10 @@ import glob from "glob";
 import path from "path";
 import fs from "fs";
 import { inspect } from "util";
+import { fileURLToPath } from "url";
 
-// eslint-disable-next-line no-restricted-globals
-const packages = path.resolve(__dirname, "..", "..");
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const packages = path.resolve(dirname, "..", "..");
 
 function readJson(file) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This aligns with the rest of the code base, where we use `import.meta.url` to make the transition to ESM easier.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13721"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

