### PR TITLE
getBindingIdentifiers should return params for private methods

### DIFF
--- a/packages/babel-traverse/src/scope/binding.ts
+++ b/packages/babel-traverse/src/scope/binding.ts
@@ -3,14 +3,14 @@ import type * as t from "@babel/types";
 import type Scope from "./index";
 
 type BindingKind =
-  | "var"
-  | "let"
-  | "const"
-  | "module"
-  | "hoisted"
-  | "param"
-  | "local"
-  | "unknown";
+  | "var" /* var declarator */
+  | "let" /* let declarator, class declaration id, catch clause parameters */
+  | "const" /* const declarator */
+  | "module" /* import specifiers */
+  | "hoisted" /* function declaration id */
+  | "param" /* function declaration parameters */
+  | "local" /* function expression id, class expression id */
+  | "unknown"; /* export specifiers */
 /**
  * This class is responsible for a binding inside of a scope.
  *

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -284,12 +284,12 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
         if (!id) return;
 
         const binding = scope.getBinding(id.name);
-        if (binding) binding.reference(path);
+        binding?.reference(path);
       } else if (isVariableDeclaration(declar)) {
         for (const decl of declar.declarations) {
           for (const name of Object.keys(getBindingIdentifiers(decl))) {
             const binding = scope.getBinding(name);
-            if (binding) binding.reference(path);
+            binding?.reference(path);
           }
         }
       }

--- a/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
+++ b/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
@@ -121,6 +121,7 @@ getBindingIdentifiers.keys = {
   ArrowFunctionExpression: ["params"],
   ObjectMethod: ["params"],
   ClassMethod: ["params"],
+  ClassPrivateMethod: ["params"],
 
   ForInStatement: ["left"],
   ForOfStatement: ["left"],

--- a/packages/babel-types/test/retrievers.js
+++ b/packages/babel-types/test/retrievers.js
@@ -19,10 +19,58 @@ describe("retrievers", function () {
         ["bar", "foo"],
       ],
       [
+        "object methods",
+        getBody("({ a(b) { let c } })")[0].expression.properties[0],
+        ["b"],
+      ],
+      [
+        "class methods",
+        getBody("(class { a(b) { let c } })")[0].expression.body.body,
+        ["b"],
+      ],
+      [
+        "class private methods",
+        getBody("(class { #a(b) { let c } })")[0].expression.body.body,
+        ["b"],
+      ],
+      [
         "export named declarations",
         getBody("export const foo = 'foo';"),
         ["foo"],
       ],
+      [
+        "export default class declarations",
+        getBody("export default class foo {}"),
+        ["foo"],
+      ],
+      [
+        "export default referenced identifiers",
+        getBody("export default foo"),
+        [],
+      ],
+      ["export all declarations", getBody("export * from 'x'"), []],
+      [
+        "export all as namespace declarations",
+        getBody("export * as ns from 'x'"),
+        [], // exported bindings are not associated with declarations
+      ],
+      [
+        "export namespace specifiers",
+        getBody("export * as ns from 'x'")[0].specifiers,
+        ["ns"],
+      ],
+      [
+        "object patterns",
+        getBody("const { a, b: { ...c } = { d } } = {}"),
+        ["a", "c"],
+      ],
+      [
+        "array patterns",
+        getBody("var [ a, ...{ b, ...c } ] = {}"),
+        ["a", "b", "c"],
+      ],
+      ["update expression", getBody("++x")[0].expression, ["x"]],
+      ["assignment expression", getBody("x ??= 1")[0].expression, ["x"]],
     ])("%s", (_, program, bindingNames) => {
       const ids = t.getBindingIdentifiers(program);
       expect(Object.keys(ids)).toEqual(bindingNames);

--- a/packages/babel-types/test/retrievers.js
+++ b/packages/babel-types/test/retrievers.js
@@ -7,20 +7,25 @@ function getBody(program) {
 
 describe("retrievers", function () {
   describe("getBindingIdentifiers", function () {
-    it("variable declarations", function () {
-      const program = "var a = 1; let b = 2; const c = 3;";
-      const ids = t.getBindingIdentifiers(getBody(program));
-      expect(Object.keys(ids)).toEqual(["a", "b", "c"]);
-    });
-    it("function declarations", function () {
-      const program = "var foo = 1; function bar() { var baz = 2; }";
-      const ids = t.getBindingIdentifiers(getBody(program));
-      expect(Object.keys(ids)).toEqual(["bar", "foo"]);
-    });
-    it("export named declarations", function () {
-      const program = "export const foo = 'foo';";
-      const ids = t.getBindingIdentifiers(getBody(program));
-      expect(Object.keys(ids)).toEqual(["foo"]);
+    it.each([
+      [
+        "variable declarations",
+        getBody("var a = 1; let b = 2; const c = 3;"),
+        ["a", "b", "c"],
+      ],
+      [
+        "function declarations",
+        getBody("var foo = 1; function bar() { var baz = 2; }"),
+        ["bar", "foo"],
+      ],
+      [
+        "export named declarations",
+        getBody("export const foo = 'foo';"),
+        ["foo"],
+      ],
+    ])("%s", (_, program, bindingNames) => {
+      const ids = t.getBindingIdentifiers(program);
+      expect(Object.keys(ids)).toEqual(bindingNames);
     });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `t.getBindingIdentifiers` does not return parameter bindings for private class methods
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Also include minor tweaks around scope tracking.

## Performant issue
The `getBindingIdentifiers` is generally slow due to heavy dynamics: it even allows monkey-patching its visitor keys: `getBindingIdentifiers.keys` can be modified by external plugins. In my local perf test, dropping `getBindingIdentifiers.keys` can achieves 10x performance boost:

<details>

```
baseline 16 binding identifiers in patterns: 61_364 ops/sec ±0.78% (0.016ms)
baseline 32 binding identifiers in patterns: 27_504 ops/sec ±1.76% (0.036ms)
baseline 64 binding identifiers in patterns: 11_901 ops/sec ±0.75% (0.084ms)
baseline 128 binding identifiers in patterns: 4_260 ops/sec ±1.49% (0.235ms)
current 16 binding identifiers in patterns: 422_790 ops/sec ±1.03% (0.002ms)
current 32 binding identifiers in patterns: 193_291 ops/sec ±1.5% (0.005ms)
current 64 binding identifiers in patterns: 75_164 ops/sec ±1.45% (0.013ms)
current 128 binding identifiers in patterns: 27_211 ops/sec ±1.04% (0.037ms)
current2 16 binding identifiers in patterns: 432_890 ops/sec ±1.55% (0.002ms)
current2 32 binding identifiers in patterns: 250_765 ops/sec ±0.94% (0.004ms)
current2 64 binding identifiers in patterns: 118_529 ops/sec ±1.45% (0.008ms)
current2 128 binding identifiers in patterns: 58_682 ops/sec ±1.88% (0.017ms)
```

`current` is new implementation inlining visitor keys, `current2` is a new implementation based on `current` which returns bindings in tail-first order: so we can avoid unnecessary memcpy introduced by `array.shift` in 

https://github.com/babel/babel/blob/804a94f829a3b2429d591b2f65bde92254c6ad21/packages/babel-types/src/retrievers/getBindingIdentifiers.ts#L43

</details>

we should reconsider whether we are going to support `getBindingIdentifiers.keys` in Babel 8.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13723"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

