### PR TITLE
Don't manually update npm in CRA test on CircleCI

### DIFF
--- a/scripts/integration-tests/e2e-create-react-app.sh
+++ b/scripts/integration-tests/e2e-create-react-app.sh
@@ -17,8 +17,10 @@ set -x
 git clone --depth=1 https://github.com/facebook/create-react-app.git tmp/create-react-app
 cd tmp/create-react-app || exit
 
-# Print npm version (it should be 7)
-npm --version
+# CircleCI already has npm 7
+if [ "$BABEL_8_BREAKING" != true ] ; then
+  npm i -g npm@7
+fi
 
 #==============================================================================#
 #                                   TEST                                       #

--- a/scripts/integration-tests/e2e-create-react-app.sh
+++ b/scripts/integration-tests/e2e-create-react-app.sh
@@ -17,8 +17,8 @@ set -x
 git clone --depth=1 https://github.com/facebook/create-react-app.git tmp/create-react-app
 cd tmp/create-react-app || exit
 
-# Update npm to v7
-npm i -g npm@7
+# Print npm version (it should be 7)
+npm --version
 
 #==============================================================================#
 #                                   TEST                                       #


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

It fails on CircleCI because we need higher permission. I'll merge this if both GH actions and CircleCI pass, and if both of them have npm 7.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13725"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

