### PR TITLE
id in import attributes should not be referenced

### DIFF
--- a/packages/babel-types/src/validators/isReferenced.ts
+++ b/packages/babel-types/src/validators/isReferenced.ts
@@ -13,14 +13,14 @@ export default function isReferenced(
     // yes: NODE.child
     // no: parent.NODE
     case "MemberExpression":
-    case "JSXMemberExpression":
     case "OptionalMemberExpression":
       if (parent.property === node) {
-        // @ts-expect-error todo(flow->ts): computed is missing on JSXMemberExpression
         return !!parent.computed;
       }
       return parent.object === node;
 
+    case "JSXMemberExpression":
+      return parent.object === node;
     // no: let NODE = init;
     // yes: let id = NODE;
     case "VariableDeclarator":
@@ -44,31 +44,34 @@ export default function isReferenced(
     case "ClassMethod":
     case "ClassPrivateMethod":
     case "ObjectMethod":
-      // @ts-expect-error todo(flow->ts) params have more specific type comparing to node
-      if (parent.params.includes(node)) {
-        return false;
+      if (parent.key === node) {
+        return !!parent.computed;
       }
-    // fall through
+      return false;
 
     // yes: { [NODE]: "" }
     // no: { NODE: "" }
     // depends: { NODE }
     // depends: { key: NODE }
-    // fall through
     case "ObjectProperty":
+      if (parent.key === node) {
+        return !!parent.computed;
+      }
+      if (parent.value === node) {
+        return !grandparent || grandparent.type !== "ObjectPattern";
+      }
+      return true;
     // no: class { NODE = value; }
     // yes: class { [NODE] = value; }
     // yes: class { key = NODE; }
-    // fall through
     case "ClassProperty":
-    case "ClassPrivateProperty":
       if (parent.key === node) {
-        // @ts-expect-error todo(flow->ts): computed might not exist
         return !!parent.computed;
       }
-      // @ts-expect-error todo(flow->ts): ObjectMethod does not have value property
-      if (parent.value === node) {
-        return !grandparent || grandparent.type !== "ObjectPattern";
+      return true;
+    case "ClassPrivateProperty":
+      if (parent.key === node) {
+        return false;
       }
       return true;
 

--- a/packages/babel-types/src/validators/isReferenced.ts
+++ b/packages/babel-types/src/validators/isReferenced.ts
@@ -57,10 +57,8 @@ export default function isReferenced(
       if (parent.key === node) {
         return !!parent.computed;
       }
-      if (parent.value === node) {
-        return !grandparent || grandparent.type !== "ObjectPattern";
-      }
-      return true;
+      // parent.value === node
+      return !grandparent || grandparent.type !== "ObjectPattern";
     // no: class { NODE = value; }
     // yes: class { [NODE] = value; }
     // yes: class { key = NODE; }
@@ -70,10 +68,7 @@ export default function isReferenced(
       }
       return true;
     case "ClassPrivateProperty":
-      if (parent.key === node) {
-        return false;
-      }
-      return true;
+      return parent.key !== node;
 
     // no: class NODE {}
     // yes: class Foo extends NODE {}

--- a/packages/babel-types/src/validators/isReferenced.ts
+++ b/packages/babel-types/src/validators/isReferenced.ts
@@ -139,6 +139,10 @@ export default function isReferenced(
     case "ImportSpecifier":
       return false;
 
+    // no: import "foo" assert { NODE: "json" }
+    case "ImportAttribute":
+      return false;
+
     // no: <div NODE="foo" />
     case "JSXAttribute":
       return false;

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -122,20 +122,38 @@ describe("validators", function () {
       expect(t.isReferenced(node, parent)).toBe(true);
     });
 
-    it("returns true if node is a value of ObjectProperty of an expression", function () {
-      const node = t.identifier("a");
-      const parent = t.objectProperty(t.identifier("key"), node);
-      const grandparent = t.objectExpression([parent]);
+    describe("ObjectProperty", () => {
+      it("returns true if node is a value of ObjectProperty of an expression", function () {
+        const node = t.identifier("a");
+        const parent = t.objectProperty(t.identifier("key"), node);
+        const grandparent = t.objectExpression([parent]);
 
-      expect(t.isReferenced(node, parent, grandparent)).toBe(true);
-    });
+        expect(t.isReferenced(node, parent, grandparent)).toBe(true);
+      });
 
-    it("returns false if node is a value of ObjectProperty of a pattern", function () {
-      const node = t.identifier("a");
-      const parent = t.objectProperty(t.identifier("key"), node);
-      const grandparent = t.objectPattern([parent]);
+      it("returns false if node is a value of ObjectProperty of a pattern", function () {
+        const node = t.identifier("a");
+        const parent = t.objectProperty(t.identifier("key"), node);
+        const grandparent = t.objectPattern([parent]);
 
-      expect(t.isReferenced(node, parent, grandparent)).toBe(false);
+        expect(t.isReferenced(node, parent, grandparent)).toBe(false);
+      });
+
+      it("returns true if node is computed property key of an expression", function () {
+        const node = t.identifier("a");
+        const parent = t.objectProperty(node, t.identifier("value"), true);
+        const grandparent = t.objectExpression([parent]);
+
+        expect(t.isReferenced(node, parent, grandparent)).toBe(true);
+      });
+
+      it("returns true if node is computed property key of a pattern", function () {
+        const node = t.identifier("a");
+        const parent = t.objectProperty(node, t.identifier("value"), true);
+        const grandparent = t.objectPattern([parent]);
+
+        expect(t.isReferenced(node, parent, grandparent)).toBe(true);
+      });
     });
 
     describe("TSPropertySignature", function () {

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -287,6 +287,15 @@ describe("validators", function () {
         expect(t.isReferenced(node, parent, grandparent)).toBe(true);
       });
     });
+
+    describe("import attributes", function () {
+      it("returns false for import attributes", function () {
+        const node = t.identifier("foo");
+        const parent = t.importAttribute(node, t.stringLiteral("bar"));
+
+        expect(t.isReferenced(node, parent)).toBe(false);
+      });
+    });
   });
 
   describe("isBinding", function () {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `t.isReferenced` returns `true` for id in import attributes, e.g. the `type` in `import json from "./foo.json" assert { type: "json" }`
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR starts from `(todo) flow->ts` cleanups. Found this bug when reading source.

Also simplified the class elements handling. All the `fall through` annotations are removed.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13733"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

