### PR TITLE
test(babel-parser): add tests for static blocks with line breaks

### DIFF
--- a/packages/babel-parser/test/fixtures/typescript/static-blocks/valid-static-block-with-line-breaks/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/static-blocks/valid-static-block-with-line-breaks/input.ts
@@ -1,0 +1,6 @@
+class Foo {
+  static
+  {
+    something();
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/static-blocks/valid-static-block-with-line-breaks/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/static-blocks/valid-static-block-with-line-breaks/output.json
@@ -1,0 +1,49 @@
+{
+  "type": "File",
+  "start":0,"end":47,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":47,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":47,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"Foo"},
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":10,"end":47,"loc":{"start":{"line":1,"column":10},"end":{"line":6,"column":1}},
+          "body": [
+            {
+              "type": "StaticBlock",
+              "start":14,"end":45,"loc":{"start":{"line":2,"column":2},"end":{"line":5,"column":3}},
+              "body": [
+                {
+                  "type": "ExpressionStatement",
+                  "start":29,"end":41,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":16}},
+                  "expression": {
+                    "type": "CallExpression",
+                    "start":29,"end":40,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":15}},
+                    "callee": {
+                      "type": "Identifier",
+                      "start":29,"end":38,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":13},"identifierName":"something"},
+                      "name": "something"
+                    },
+                    "arguments": []
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Adds a test for

```ts
class Foo {
 static
  {
  }
}
```
in TS.

#13680 just happened to fix this bug.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13734"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

