### PR TITLE
Replace the deprecated `produceCachedData` option used in `vm` module with `script.createCachedData()`

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -100,12 +100,9 @@ function runCacheableScriptInTestContext(
     displayErrors: true,
     lineOffset: -1,
     cachedData: cached.cachedData,
-    produceCachedData: true,
   });
 
-  if (script.cachedDataProduced) {
-    cached.cachedData = script.cachedData;
-  }
+  cached.cachedData = script.createCachedData();
 
   const module = {
     id: filename,

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -95,14 +95,27 @@ function runCacheableScriptInTestContext(
     cachedScripts.set(filename, cached);
   }
 
-  const script = new vm.Script(cached.code, {
-    filename,
-    displayErrors: true,
-    lineOffset: -1,
-    cachedData: cached.cachedData,
-  });
-
-  cached.cachedData = script.createCachedData();
+  let script: vm.Script;
+  if (process.env.BABEL_8_BREAKING) {
+    script = new vm.Script(cached.code, {
+      filename,
+      displayErrors: true,
+      lineOffset: -1,
+      cachedData: cached.cachedData,
+    });
+    cached.cachedData = script.createCachedData();
+  } else {
+    script = new vm.Script(cached.code, {
+      filename,
+      displayErrors: true,
+      lineOffset: -1,
+      cachedData: cached.cachedData,
+      produceCachedData: true,
+    });
+    if (script.cachedDataProduced) {
+      cached.cachedData = script.cachedData;
+    }
+  }
 
   const module = {
     id: filename,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
https://nodejs.org/api/vm.html#vm_class_vm_script

The `produceCachedData` is deprecated in favour of `script.createCachedData()` from 10.6.0

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13741"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

