### PR TITLE
chore: add constraint for duplicate dependency declarations

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -67,3 +67,8 @@ gen_enforced_field(WorkspaceCwd, FieldName, ExpectedValue) :-
   \+ atom_concat('./', _, CurrentValue),
   % Store './' + CurrentValue in ExpectedValue
   atom_concat('./', CurrentValue, ExpectedValue).
+
+% Enforces that a dependency doesn't appear in both `dependencies` and `devDependencies`
+gen_enforced_dependency(WorkspaceCwd, DependencyIdent, null, 'devDependencies') :-
+  workspace_has_dependency(WorkspaceCwd, DependencyIdent, _, 'devDependencies'),
+  workspace_has_dependency(WorkspaceCwd, DependencyIdent, _, 'dependencies').


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

Added a constraint to enforce the change in https://github.com/babel/babel/pull/13737, while it doesn't cause issues in published packages since `devDependencies` are ignored, it can cause an issue in the monorepo since `devDependencies` wins when a dependency is declared in both `dependencies` and `devDependencies`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13744"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

