### PR TITLE
[eslint-parser] Represent `static` using a `Keyword` token

### DIFF
--- a/eslint/babel-eslint-parser/src/convert/convertTokens.cjs
+++ b/eslint/babel-eslint-parser/src/convert/convertTokens.cjs
@@ -95,7 +95,11 @@ function convertToken(token, source, tl) {
   token.range = [token.start, token.end];
 
   if (label === tl.name) {
-    token.type = "Identifier";
+    if (token.value === "static") {
+      token.type = "Keyword";
+    } else {
+      token.type = "Identifier";
+    }
   } else if (
     label === tl.semi ||
     label === tl.comma ||

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -405,6 +405,31 @@ describe("Babel and Espree", () => {
     });
   }
 
+  it("static (token)", () => {
+    const code = `
+      import { static as foo } from "foo";
+
+      class A {
+        static m() {}
+        static() {}
+      }
+    `;
+
+    parseAndAssertSame(code);
+
+    const babylonAST = parseForESLint(code, {
+      eslintVisitorKeys: true,
+      eslintScopeManager: true,
+      babelOptions: BABEL_OPTIONS,
+    }).ast;
+
+    const staticKw = { type: "Keyword", value: "static" };
+
+    expect(babylonAST.tokens[2]).toMatchObject(staticKw);
+    expect(babylonAST.tokens[12]).toMatchObject(staticKw);
+    expect(babylonAST.tokens[18]).toMatchObject(staticKw);
+  });
+
   it("parse to PropertyDeclaration when `classFeatures: true`", () => {
     const code = "class A { #x }";
     const babylonAST = parseForESLint(code, {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This matches ESLint's behavior - https://astexplorer.net/#/gist/f9cf0a5789035bf20a616f3d2ef06699/latest

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13751"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

