### PR TITLE
[estree] Fix conversion of `PrivateName` in `MemberExpression`

### DIFF
--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -181,15 +181,12 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       classBody.body.push(method);
     }
 
-    parseMaybePrivateName(...args: [boolean]): any {
-      const node = super.parseMaybePrivateName(...args);
-      if (
-        node.type === "PrivateName" &&
-        this.getPluginOption("estree", "classFeatures")
-      ) {
-        return this.convertPrivateNameToPrivateIdentifier(node);
+    parsePrivateName(): any {
+      const node = super.parsePrivateName();
+      if (!this.getPluginOption("estree", "classFeatures")) {
+        return node;
       }
-      return node;
+      return this.convertPrivateNameToPrivateIdentifier(node);
     }
 
     convertPrivateNameToPrivateIdentifier(

--- a/packages/babel-parser/test/fixtures/estree/class-private-property/basic/input.js
+++ b/packages/babel-parser/test/fixtures/estree/class-private-property/basic/input.js
@@ -1,4 +1,8 @@
 class A {
   #foo = "bar";
   static #bar = foo;
+
+  method() {
+    this.#foo;
+  }
 }

--- a/packages/babel-parser/test/fixtures/estree/class-private-property/basic/output.json
+++ b/packages/babel-parser/test/fixtures/estree/class-private-property/basic/output.json
@@ -1,15 +1,15 @@
 {
   "type": "File",
-  "start":0,"end":48,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "start":0,"end":81,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":1}},
   "program": {
     "type": "Program",
-    "start":0,"end":48,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "start":0,"end":81,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":1}},
     "sourceType": "script",
     "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
-        "start":0,"end":48,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "start":0,"end":81,"loc":{"start":{"line":1,"column":0},"end":{"line":8,"column":1}},
         "id": {
           "type": "Identifier",
           "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"A"},
@@ -18,7 +18,7 @@
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start":8,"end":48,"loc":{"start":{"line":1,"column":8},"end":{"line":4,"column":1}},
+          "start":8,"end":81,"loc":{"start":{"line":1,"column":8},"end":{"line":8,"column":1}},
           "body": [
             {
               "type": "PropertyDefinition",
@@ -52,6 +52,56 @@
                 "name": "foo"
               },
               "computed": false
+            },
+            {
+              "type": "MethodDefinition",
+              "start":50,"end":79,"loc":{"start":{"line":5,"column":2},"end":{"line":7,"column":3}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":50,"end":56,"loc":{"start":{"line":5,"column":2},"end":{"line":5,"column":8},"identifierName":"method"},
+                "name": "method"
+              },
+              "computed": false,
+              "kind": "method",
+              "value": {
+                "type": "FunctionExpression",
+                "start":56,"end":79,"loc":{"start":{"line":5,"column":8},"end":{"line":7,"column":3}},
+                "id": null,
+                "generator": false,
+                "async": false,
+                "expression": false,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start":59,"end":79,"loc":{"start":{"line":5,"column":11},"end":{"line":7,"column":3}},
+                  "body": [
+                    {
+                      "type": "ExpressionStatement",
+                      "start":65,"end":75,"loc":{"start":{"line":6,"column":4},"end":{"line":6,"column":14}},
+                      "expression": {
+                        "type": "MemberExpression",
+                        "start":65,"end":74,"loc":{"start":{"line":6,"column":4},"end":{"line":6,"column":13}},
+                        "object": {
+                          "type": "ThisExpression",
+                          "start":65,"end":69,"loc":{"start":{"line":6,"column":4},"end":{"line":6,"column":8}}
+                        },
+                        "computed": false,
+                        "property": {
+                          "type": "PrivateName",
+                          "start":70,"end":74,"loc":{"start":{"line":6,"column":9},"end":{"line":6,"column":13}},
+                          "id": {
+                            "type": "Identifier",
+                            "start":71,"end":74,"loc":{"start":{"line":6,"column":10},"end":{"line":6,"column":13},"identifierName":"foo"},
+                            "name": "foo"
+                          }
+                        },
+                        "optional": false
+                      }
+                    }
+                  ]
+                }
+              }
             }
           ]
         }

--- a/packages/babel-parser/test/fixtures/estree/class-private-property/basic/output.json
+++ b/packages/babel-parser/test/fixtures/estree/class-private-property/basic/output.json
@@ -88,13 +88,9 @@
                         },
                         "computed": false,
                         "property": {
-                          "type": "PrivateName",
+                          "type": "PrivateIdentifier",
                           "start":70,"end":74,"loc":{"start":{"line":6,"column":9},"end":{"line":6,"column":13}},
-                          "id": {
-                            "type": "Identifier",
-                            "start":71,"end":74,"loc":{"start":{"line":6,"column":10},"end":{"line":6,"column":13},"identifierName":"foo"},
-                            "name": "foo"
-                          }
+                          "name": "foo"
                         },
                         "optional": false
                       }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The first commit updates the test and has a wrong output; the second commit fixes it.

The reason of the bug was that when parsing member expressions we don't call `maybeParsePrivateName`, but just `parsePrivateName`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13755"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

