### PR TITLE
Fix `regexpu-core` bundling in `@babel/standalone`

### DIFF
--- a/.yarn/patches/@rollup__plugin-commonjs.patch
+++ b/.yarn/patches/@rollup__plugin-commonjs.patch
@@ -13,3 +13,16 @@ index 81cb408c8482fc7591a3381eb00b46abc9d21b14..1816113246e075ba7ae99638b64f004f
        // eslint-disable-next-line no-param-reassign
        code =
          getDynamicPackagesEntryIntro(dynamicRequireModuleDirPaths, dynamicRequireModuleSet) + code;
+diff --git a/dist/index.js b/dist/index.js
+index 8ef2184001cb697c6fc2466e9b5fe084c7f1d08c..056ded21d0bb35b8a7c36d1ec50a6ddb5508d386 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1650,7 +1650,7 @@ function commonjs(options = {}) {
+   const sourceMap = options.sourceMap !== false;
+
+   function transformAndCheckExports(code, id) {
+-    if (isDynamicRequireModulesEnabled && this.getModuleInfo(id).isEntry) {
++    if (isDynamicRequireModulesEnabled && (this.getModuleInfo(id).isEntry || id.endsWith("/dynamic-require-entrypoint.cjs"))) {
+       // eslint-disable-next-line no-param-reassign
+       code =
+         getDynamicPackagesEntryIntro(dynamicRequireModuleDirPaths, dynamicRequireModuleSet) + code;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3966,7 +3966,7 @@ __metadata:
 
 "@rollup/plugin-commonjs@patch:@rollup/plugin-commonjs@^18.1.0#./.yarn/patches/@rollup__plugin-commonjs.patch::locator=babel%40workspace%3A.":
   version: 18.1.0
-  resolution: "@rollup/plugin-commonjs@patch:@rollup/plugin-commonjs@npm%3A18.1.0#./.yarn/patches/@rollup__plugin-commonjs.patch::version=18.1.0&hash=6f70f1&locator=babel%40workspace%3A."
+  resolution: "@rollup/plugin-commonjs@patch:@rollup/plugin-commonjs@npm%3A18.1.0#./.yarn/patches/@rollup__plugin-commonjs.patch::version=18.1.0&hash=6733ff&locator=babel%40workspace%3A."
   dependencies:
     "@rollup/pluginutils": ^3.1.0
     commondir: ^1.0.1
@@ -3977,7 +3977,7 @@ __metadata:
     resolve: ^1.17.0
   peerDependencies:
     rollup: ^2.30.0
-  checksum: a6826d2e03d4fc952bd6bab57c0acd0eb412dbf9a8e1bd47ce0647eac2c2d2f94aa129b9d0e29dee0d8da819e38651ee7f11e2d330a9acb0dbee35c0cba1ff91
+  checksum: a3215f9c90838086e01f06227b0bc2d1d79ae4c6c1fd145fe99cf93e721cb84375a6116b98a4f9753d9a8b8ae7a88fb7a0ec7ebdafd74894bbf5e56b809df184
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13765
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I'm not sure how it could work in the past, since Node.js loads the CJS version of the plugin and we only patched the ESM version.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13767"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

