### PR TITLE
Tokenize keywords-like identifier as new tokens

### DIFF
--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -179,7 +179,7 @@ export default class StatementParser extends ExpressionParser {
   }
 
   isLet(context: ?string): boolean {
-    if (!this.isContextual("let")) {
+    if (!this.isContextual(tt._let)) {
       return false;
     }
     return this.isLetKeyword(context);
@@ -573,7 +573,7 @@ export default class StatementParser extends ExpressionParser {
     this.state.labels.push(loopLabel);
 
     let awaitAt = -1;
-    if (this.isAwaitAllowed() && this.eatContextual("await")) {
+    if (this.isAwaitAllowed() && this.eatContextual(tt._await)) {
       awaitAt = this.state.lastTokStart;
     }
     this.scope.enter(SCOPE_OTHER);
@@ -586,7 +586,7 @@ export default class StatementParser extends ExpressionParser {
       return this.parseFor(node, null);
     }
 
-    const startsWithLet = this.isContextual("let");
+    const startsWithLet = this.isContextual(tt._let);
     const isLet = startsWithLet && this.isLetKeyword();
     if (this.match(tt._var) || this.match(tt._const) || isLet) {
       const init = this.startNode();
@@ -596,7 +596,7 @@ export default class StatementParser extends ExpressionParser {
       this.finishNode(init, "VariableDeclaration");
 
       if (
-        (this.match(tt._in) || this.isContextual("of")) &&
+        (this.match(tt._in) || this.isContextual(tt._of)) &&
         init.declarations.length === 1
       ) {
         return this.parseForIn(node, init, awaitAt);
@@ -609,12 +609,11 @@ export default class StatementParser extends ExpressionParser {
 
     // Check whether the first token is possibly a contextual keyword, so that
     // we can forbid `for (async of` if this turns out to be a for-of loop.
-    const startsWithUnescapedName =
-      tokenIsIdentifier(this.state.type) && !this.state.containsEsc;
+    const startsWithAsync = this.isContextual(tt._async);
 
     const refExpressionErrors = new ExpressionErrors();
     const init = this.parseExpression(true, refExpressionErrors);
-    const isForOf = this.isContextual("of");
+    const isForOf = this.isContextual(tt._of);
     if (isForOf) {
       // Check for leading tokens that are forbidden in for-of loops:
       if (startsWithLet) {
@@ -622,9 +621,8 @@ export default class StatementParser extends ExpressionParser {
       } else if (
         // `for await (async of []);` is allowed.
         awaitAt === -1 &&
-        startsWithUnescapedName &&
-        init.type === "Identifier" &&
-        init.name === "async"
+        startsWithAsync &&
+        init.type === "Identifier"
       ) {
         // This catches the case where the `async` in `for (async of` was
         // parsed as an identifier. If it was parsed as the start of an async
@@ -1120,7 +1118,7 @@ export default class StatementParser extends ExpressionParser {
       } else {
         if (
           kind === "const" &&
-          !(this.match(tt._in) || this.isContextual("of"))
+          !(this.match(tt._in) || this.isContextual(tt._of))
         ) {
           // `const` with no initializer is allowed in TypeScript.
           // It could be a declaration like `const x: number;`.
@@ -1133,7 +1131,7 @@ export default class StatementParser extends ExpressionParser {
           }
         } else if (
           decl.id.type !== "Identifier" &&
-          !(isFor && (this.match(tt._in) || this.isContextual("of")))
+          !(isFor && (this.match(tt._in) || this.isContextual(tt._of)))
         ) {
           this.raise(
             this.state.lastTokEnd,
@@ -1408,7 +1406,7 @@ export default class StatementParser extends ExpressionParser {
     member: N.ClassMember,
     state: N.ParseClassMemberState,
   ): void {
-    const isStatic = this.isContextual("static");
+    const isStatic = this.isContextual(tt._static);
 
     if (isStatic) {
       if (this.parseClassMemberFromModifier(classBody, member)) {
@@ -1852,7 +1850,7 @@ export default class StatementParser extends ExpressionParser {
   }
 
   maybeParseExportNamespaceSpecifier(node: N.Node): boolean {
-    if (this.isContextual("as")) {
+    if (this.isContextual(tt._as)) {
       if (!node.specifiers) node.specifiers = [];
 
       const specifier = this.startNodeAt(
@@ -1895,7 +1893,7 @@ export default class StatementParser extends ExpressionParser {
   }
 
   isAsyncFunction(): boolean {
-    if (!this.isContextual("async")) return false;
+    if (!this.isContextual(tt._async)) return false;
     const next = this.nextTokenStart();
     return (
       !lineBreak.test(this.input.slice(this.state.pos, next)) &&
@@ -1945,23 +1943,23 @@ export default class StatementParser extends ExpressionParser {
   }
 
   isExportDefaultSpecifier(): boolean {
-    if (tokenIsIdentifier(this.state.type)) {
-      const value = this.state.value;
-      if ((value === "async" && !this.state.containsEsc) || value === "let") {
+    const { type } = this.state;
+    if (tokenIsIdentifier(type)) {
+      if ((type === tt._async && !this.state.containsEsc) || type === tt._let) {
         return false;
       }
       if (
-        (value === "type" || value === "interface") &&
+        (type === tt._type || type === tt._interface) &&
         !this.state.containsEsc
       ) {
-        const l = this.lookahead();
+        const { type: nextType } = this.lookahead();
         // If we see any variable name other than `from` after `type` keyword,
         // we consider it as flow/typescript type exports
         // note that this approach may fail on some pedantic cases
         // export type from = number
         if (
-          (tokenIsIdentifier(l.type) && l.value !== "from") ||
-          l.type === tt.braceL
+          (tokenIsIdentifier(nextType) && nextType !== tt._from) ||
+          nextType === tt.braceL
         ) {
           this.expectOnePlugin(["flow", "typescript"]);
           return false;
@@ -1993,7 +1991,7 @@ export default class StatementParser extends ExpressionParser {
   }
 
   parseExportFrom(node: N.ExportNamedDeclaration, expect?: boolean): void {
-    if (this.eatContextual("from")) {
+    if (this.eatContextual(tt._from)) {
       node.source = this.parseImportSource();
       this.checkExport(node);
       const assertions = this.maybeParseImportAssertions();
@@ -2173,7 +2171,7 @@ export default class StatementParser extends ExpressionParser {
       const isString = this.match(tt.string);
       const local = this.parseModuleExportName();
       node.local = local;
-      if (this.eatContextual("as")) {
+      if (this.eatContextual(tt._as)) {
         node.exported = this.parseModuleExportName();
       } else if (isString) {
         node.exported = cloneStringLiteral(local);
@@ -2226,7 +2224,7 @@ export default class StatementParser extends ExpressionParser {
       // now we check if we need to parse the next imports
       // but only if they are not importing * (everything)
       if (parseNext && !hasStar) this.parseNamedImportSpecifiers(node);
-      this.expectContextual("from");
+      this.expectContextual(tt._from);
     }
     node.source = this.parseImportSource();
     // https://github.com/tc39/proposal-import-assertions
@@ -2372,7 +2370,7 @@ export default class StatementParser extends ExpressionParser {
 
   maybeParseImportAssertions() {
     // [no LineTerminator here] AssertClause
-    if (this.isContextual("assert") && !this.hasPrecedingLineBreak()) {
+    if (this.isContextual(tt._assert) && !this.hasPrecedingLineBreak()) {
       this.expectPlugin("importAssertions");
       this.next(); // eat `assert`
     } else {
@@ -2405,7 +2403,7 @@ export default class StatementParser extends ExpressionParser {
     if (this.match(tt.star)) {
       const specifier = this.startNode();
       this.next();
-      this.expectContextual("as");
+      this.expectContextual(tt._as);
 
       this.parseImportSpecifierLocal(
         node,
@@ -2443,7 +2441,7 @@ export default class StatementParser extends ExpressionParser {
     const specifier = this.startNode();
     const importedIsString = this.match(tt.string);
     specifier.imported = this.parseModuleExportName();
-    if (this.eatContextual("as")) {
+    if (this.eatContextual(tt._as)) {
       specifier.local = this.parseIdentifier();
     } else {
       const { imported } = specifier;

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -2,7 +2,6 @@
 
 import {
   isTokenType,
-  tokenIsIdentifier,
   tokenIsLiteralPropertyName,
   tokenLabelName,
   tt,
@@ -69,12 +68,8 @@ export default class UtilParser extends Tokenizer {
 
   // Tests whether parsed token is a contextual keyword.
 
-  isContextual(name: string): boolean {
-    return (
-      tokenIsIdentifier(this.state.type) &&
-      this.state.value === name &&
-      !this.state.containsEsc
-    );
+  isContextual(token: TokenType): boolean {
+    return this.state.type === token && !this.state.containsEsc;
   }
 
   isUnparsedContextual(nameStart: number, name: string): boolean {
@@ -99,8 +94,8 @@ export default class UtilParser extends Tokenizer {
 
   // Consumes contextual keyword if possible.
 
-  eatContextual(name: string): boolean {
-    if (this.isContextual(name)) {
+  eatContextual(token: TokenType): boolean {
+    if (this.isContextual(token)) {
       this.next();
       return true;
     }
@@ -109,8 +104,8 @@ export default class UtilParser extends Tokenizer {
 
   // Asserts that following token is given contextual keyword.
 
-  expectContextual(name: string, template?: ErrorTemplate): void {
-    if (!this.eatContextual(name)) this.unexpected(null, template);
+  expectContextual(token: TokenType, template?: ErrorTemplate): void {
+    if (!this.eatContextual(token)) this.unexpected(null, template);
   }
 
   // Test whether a semicolon can be inserted at the current position.

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -2,7 +2,8 @@
 
 import {
   isTokenType,
-  tokenIsKeyword,
+  tokenIsIdentifier,
+  tokenIsLiteralPropertyName,
   tokenLabelName,
   tt,
   type TokenType,
@@ -70,7 +71,7 @@ export default class UtilParser extends Tokenizer {
 
   isContextual(name: string): boolean {
     return (
-      this.match(tt.name) &&
+      tokenIsIdentifier(this.state.type) &&
       this.state.value === name &&
       !this.state.containsEsc
     );
@@ -99,7 +100,11 @@ export default class UtilParser extends Tokenizer {
   // Consumes contextual keyword if possible.
 
   eatContextual(name: string): boolean {
-    return this.isContextual(name) && this.eat(tt.name);
+    if (this.isContextual(name)) {
+      this.next();
+      return true;
+    }
+    return false;
   }
 
   // Asserts that following token is given contextual keyword.
@@ -306,14 +311,7 @@ export default class UtilParser extends Tokenizer {
    *   BigIntLiteral
    */
   isLiteralPropertyName(): boolean {
-    return (
-      this.match(tt.name) ||
-      tokenIsKeyword(this.state.type) ||
-      this.match(tt.string) ||
-      this.match(tt.num) ||
-      this.match(tt.bigint) ||
-      this.match(tt.decimal)
-    );
+    return tokenIsLiteralPropertyName(this.state.type);
   }
 
   /*

--- a/packages/babel-parser/src/plugins/flow/index.js
+++ b/packages/babel-parser/src/plugins/flow/index.js
@@ -1818,11 +1818,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     // interfaces and enums
     parseStatement(context: ?string, topLevel?: boolean): N.Statement {
       // strict mode handling of `interface` since it's a reserved word
-      if (
-        this.state.strict &&
-        tokenIsIdentifier(this.state.type) &&
-        this.state.value === "interface"
-      ) {
+      if (this.state.strict && this.isContextual(tt._interface)) {
         const lookahead = this.lookahead();
         if (tokenIsKeywordOrIdentifier(lookahead.type)) {
           const node = this.startNode();
@@ -2651,8 +2647,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         const as_ident = this.parseIdentifier(true);
         if (
           specifierTypeKind !== null &&
-          !tokenIsIdentifier(this.state.type) &&
-          !tokenIsKeyword(this.state.type)
+          !tokenIsKeywordOrIdentifier(this.state.type)
         ) {
           // `import {type as ,` or `import {type as }`
           specifier.imported = as_ident;
@@ -2667,8 +2662,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       } else {
         if (
           specifierTypeKind !== null &&
-          (tokenIsIdentifier(this.state.type) ||
-            tokenIsKeyword(this.state.type))
+          tokenIsKeywordOrIdentifier(this.state.type)
         ) {
           // `import {type foo`
           specifier.imported = this.parseIdentifier(true);

--- a/packages/babel-parser/src/plugins/flow/index.js
+++ b/packages/babel-parser/src/plugins/flow/index.js
@@ -266,7 +266,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const node = this.startNode();
       const moduloPos = this.state.start;
       this.next(); // eat `%`
-      this.expectContextual("checks");
+      this.expectContextual(tt._checks);
       // Force '%' and 'checks' to be adjacent
       if (this.state.lastTokStart > moduloPos + 1) {
         this.raise(moduloPos, FlowErrors.UnexpectedSpaceBetweenModuloChecks);
@@ -360,7 +360,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return this.flowParseDeclareFunction(node);
       } else if (this.match(tt._var)) {
         return this.flowParseDeclareVariable(node);
-      } else if (this.eatContextual("module")) {
+      } else if (this.eatContextual(tt._module)) {
         if (this.match(tt.dot)) {
           return this.flowParseDeclareModuleExports(node);
         } else {
@@ -369,11 +369,11 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           }
           return this.flowParseDeclareModule(node);
         }
-      } else if (this.isContextual("type")) {
+      } else if (this.isContextual(tt._type)) {
         return this.flowParseDeclareTypeAlias(node);
-      } else if (this.isContextual("opaque")) {
+      } else if (this.isContextual(tt._opaque)) {
         return this.flowParseDeclareOpaqueType(node);
-      } else if (this.isContextual("interface")) {
+      } else if (this.isContextual(tt._interface)) {
         return this.flowParseDeclareInterface(node);
       } else if (this.match(tt._export)) {
         return this.flowParseDeclareExportDeclaration(node, insideModule);
@@ -411,7 +411,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
         if (this.match(tt._import)) {
           this.next();
-          if (!this.isContextual("type") && !this.match(tt._typeof)) {
+          if (!this.isContextual(tt._type) && !this.match(tt._typeof)) {
             this.raise(
               this.state.lastTokStart,
               FlowErrors.InvalidNonTypeImportInDeclareModule,
@@ -420,7 +420,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           this.parseImport(bodyNode);
         } else {
           this.expectContextual(
-            "declare",
+            tt._declare,
             FlowErrors.UnsupportedStatementInDeclareModule,
           );
 
@@ -492,7 +492,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         if (
           this.match(tt._const) ||
           this.isLet() ||
-          ((this.isContextual("type") || this.isContextual("interface")) &&
+          ((this.isContextual(tt._type) || this.isContextual(tt._interface)) &&
             !insideModule)
         ) {
           const label = this.state.value;
@@ -510,7 +510,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           this.match(tt._var) || // declare export var ...
           this.match(tt._function) || // declare export function ...
           this.match(tt._class) || // declare export class ...
-          this.isContextual("opaque") // declare export opaque ..
+          this.isContextual(tt._opaque) // declare export opaque ..
         ) {
           node.declaration = this.flowParseDeclare(this.startNode());
           node.default = false;
@@ -519,9 +519,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         } else if (
           this.match(tt.star) || // declare export * from ''
           this.match(tt.braceL) || // declare export {} ...
-          this.isContextual("interface") || // declare export interface ...
-          this.isContextual("type") || // declare export type ...
-          this.isContextual("opaque") // declare export opaque type ...
+          this.isContextual(tt._interface) || // declare export interface ...
+          this.isContextual(tt._type) || // declare export type ...
+          this.isContextual(tt._opaque) // declare export opaque type ...
         ) {
           node = this.parseExport(node);
           if (node.type === "ExportNamedDeclaration") {
@@ -547,7 +547,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       node: N.FlowDeclareModuleExports,
     ): N.FlowDeclareModuleExports {
       this.next();
-      this.expectContextual("exports");
+      this.expectContextual(tt._exports);
       node.typeAnnotation = this.flowParseTypeAnnotation();
       this.semicolon();
 
@@ -615,14 +615,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         } while (!isClass && this.eat(tt.comma));
       }
 
-      if (this.isContextual("mixins")) {
+      if (this.isContextual(tt._mixins)) {
         this.next();
         do {
           node.mixins.push(this.flowParseInterfaceExtends());
         } while (this.eat(tt.comma));
       }
 
-      if (this.isContextual("implements")) {
+      if (this.isContextual(tt._implements)) {
         this.next();
         do {
           node.implements.push(this.flowParseInterfaceExtends());
@@ -707,7 +707,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       node: N.FlowOpaqueType,
       declare: boolean,
     ): N.FlowOpaqueType {
-      this.expectContextual("type");
+      this.expectContextual(tt._type);
       node.id = this.flowParseRestrictedIdentifier(
         /* liberal */ true,
         /* declaration */ true,
@@ -844,7 +844,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     flowParseInterfaceType(): N.FlowInterfaceType {
       const node = this.startNode();
-      this.expectContextual("interface");
+      this.expectContextual(tt._interface);
 
       node.extends = [];
       if (this.eat(tt._extends)) {
@@ -1008,7 +1008,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         let inexactStart: ?number = null;
         const node = this.startNode();
 
-        if (allowProto && this.isContextual("proto")) {
+        if (allowProto && this.isContextual(tt._proto)) {
           const lookahead = this.lookahead();
 
           if (lookahead.type !== tt.colon && lookahead.type !== tt.question) {
@@ -1018,7 +1018,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           }
         }
 
-        if (allowStatic && this.isContextual("static")) {
+        if (allowStatic && this.isContextual(tt._static)) {
           const lookahead = this.lookahead();
 
           // static is a valid identifier name
@@ -1059,7 +1059,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         } else {
           let kind = "init";
 
-          if (this.isContextual("get") || this.isContextual("set")) {
+          if (this.isContextual(tt._get) || this.isContextual(tt._set)) {
             const lookahead = this.lookahead();
             if (tokenIsLiteralPropertyName(lookahead.type)) {
               kind = this.state.value;
@@ -1604,7 +1604,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             this.next();
             return super.createIdentifier(node, label);
           } else if (tokenIsIdentifier(this.state.type)) {
-            if (this.isContextual("interface")) {
+            if (this.isContextual(tt._interface)) {
               return this.flowParseInterfaceType();
             }
 
@@ -1829,7 +1829,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           this.next();
           return this.flowParseInterface(node);
         }
-      } else if (this.shouldParseEnums() && this.isContextual("enum")) {
+      } else if (this.shouldParseEnums() && this.isContextual(tt._enum)) {
         const node = this.startNode();
         this.next();
         return this.flowParseEnumDeclaration(node);
@@ -1875,10 +1875,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     // export type
     shouldParseExportDeclaration(): boolean {
       return (
-        this.isContextual("type") ||
-        this.isContextual("interface") ||
-        this.isContextual("opaque") ||
-        (this.shouldParseEnums() && this.isContextual("enum")) ||
+        this.isContextual(tt._type) ||
+        this.isContextual(tt._interface) ||
+        this.isContextual(tt._opaque) ||
+        (this.shouldParseEnums() && this.isContextual(tt._enum)) ||
         super.shouldParseExportDeclaration()
       );
     }
@@ -1898,7 +1898,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     parseExportDefaultExpression(): N.Expression | N.Declaration {
-      if (this.shouldParseEnums() && this.isContextual("enum")) {
+      if (this.shouldParseEnums() && this.isContextual(tt._enum)) {
         const node = this.startNode();
         this.next();
         return this.flowParseEnumDeclaration(node);
@@ -2119,7 +2119,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     parseExportDeclaration(node: N.ExportNamedDeclaration): ?N.Declaration {
-      if (this.isContextual("type")) {
+      if (this.isContextual(tt._type)) {
         node.exportKind = "type";
 
         const declarationNode = this.startNode();
@@ -2134,19 +2134,19 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           // export type Foo = Bar;
           return this.flowParseTypeAlias(declarationNode);
         }
-      } else if (this.isContextual("opaque")) {
+      } else if (this.isContextual(tt._opaque)) {
         node.exportKind = "type";
 
         const declarationNode = this.startNode();
         this.next();
         // export opaque type Foo = Bar;
         return this.flowParseOpaqueType(declarationNode, false);
-      } else if (this.isContextual("interface")) {
+      } else if (this.isContextual(tt._interface)) {
         node.exportKind = "type";
         const declarationNode = this.startNode();
         this.next();
         return this.flowParseInterface(declarationNode);
-      } else if (this.shouldParseEnums() && this.isContextual("enum")) {
+      } else if (this.shouldParseEnums() && this.isContextual(tt._enum)) {
         node.exportKind = "value";
         const declarationNode = this.startNode();
         this.next();
@@ -2159,7 +2159,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     eatExportStar(node: N.Node): boolean {
       if (super.eatExportStar(...arguments)) return true;
 
-      if (this.isContextual("type") && this.lookahead().type === tt.star) {
+      if (this.isContextual(tt._type) && this.lookahead().type === tt.star) {
         node.exportKind = "type";
         this.next();
         this.next();
@@ -2191,7 +2191,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       state: N.ParseClassMemberState,
     ): void {
       const pos = this.state.start;
-      if (this.isContextual("declare")) {
+      if (this.isContextual(tt._declare)) {
         if (this.parseClassMemberFromModifier(classBody, member)) {
           // 'declare' is a class element name
           return;
@@ -2451,7 +2451,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (node.superClass && this.isRelational("<")) {
         node.superTypeParameters = this.flowParseTypeParameterInstantiation();
       }
-      if (this.isContextual("implements")) {
+      if (this.isContextual(tt._implements)) {
         this.next();
         const implemented: N.FlowClassImplements[] = (node.implements = []);
         do {
@@ -2607,7 +2607,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       let kind = null;
       if (this.match(tt._typeof)) {
         kind = "typeof";
-      } else if (this.isContextual("type")) {
+      } else if (this.isContextual(tt._type)) {
         kind = "type";
       }
       if (kind) {
@@ -2647,7 +2647,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       }
 
       let isBinding = false;
-      if (this.isContextual("as") && !this.isLookaheadContextual("as")) {
+      if (this.isContextual(tt._as) && !this.isLookaheadContextual("as")) {
         const as_ident = this.parseIdentifier(true);
         if (
           specifierTypeKind !== null &&
@@ -2687,7 +2687,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           specifier.importKind = null;
         }
 
-        if (this.eatContextual("as")) {
+        if (this.eatContextual(tt._as)) {
           specifier.local = this.parseIdentifier();
         } else {
           isBinding = true;
@@ -3542,7 +3542,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }: {
       enumName: string,
     }): EnumExplicitType {
-      if (this.eatContextual("of")) {
+      if (this.eatContextual(tt._of)) {
         if (!tokenIsIdentifier(this.state.type)) {
           throw this.flowEnumErrorInvalidExplicitType(this.state.start, {
             enumName,

--- a/packages/babel-parser/src/plugins/flow/index.js
+++ b/packages/babel-parser/src/plugins/flow/index.js
@@ -163,8 +163,8 @@ function hasTypeImportKind(node: N.Node): boolean {
   return node.importKind === "type" || node.importKind === "typeof";
 }
 
-function isMaybeDefaultImport(state: { type: TokenType, value: any }): boolean {
-  return tokenIsKeywordOrIdentifier(state.type) && state.value !== "from";
+function isMaybeDefaultImport(type: TokenType): boolean {
+  return tokenIsKeywordOrIdentifier(type) && type !== tt._from;
 }
 
 const exportSuggestions = {
@@ -2576,7 +2576,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return super.shouldParseDefaultImport(node);
       }
 
-      return isMaybeDefaultImport(this.state);
+      return isMaybeDefaultImport(this.state.type);
     }
 
     parseImportSpecifierLocal(
@@ -2608,16 +2608,17 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       }
       if (kind) {
         const lh = this.lookahead();
+        const { type } = lh;
 
         // import type * is not allowed
-        if (kind === "type" && lh.type === tt.star) {
+        if (kind === "type" && type === tt.star) {
           this.unexpected(lh.start);
         }
 
         if (
-          isMaybeDefaultImport(lh) ||
-          lh.type === tt.braceL ||
-          lh.type === tt.star
+          isMaybeDefaultImport(type) ||
+          type === tt.braceL ||
+          type === tt.star
         ) {
           this.next();
           node.importKind = kind;

--- a/packages/babel-parser/src/plugins/placeholders.js
+++ b/packages/babel-parser/src/plugins/placeholders.js
@@ -163,7 +163,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
       // Replicate the original checks that lead to looking ahead for an
       // identifier.
-      if (!this.isContextual("let")) {
+      if (!this.isContextual(tt._let)) {
         return false;
       }
       if (context) return false;
@@ -263,7 +263,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const placeholder = this.parsePlaceholder("Identifier");
       if (!placeholder) return super.parseExport(...arguments);
 
-      if (!this.isContextual("from") && !this.match(tt.comma)) {
+      if (!this.isContextual(tt._from) && !this.match(tt.comma)) {
         // export %%DECL%%;
         node.specifiers = [];
         node.source = null;
@@ -324,7 +324,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
       node.specifiers = [];
 
-      if (!this.isContextual("from") && !this.match(tt.comma)) {
+      if (!this.isContextual(tt._from) && !this.match(tt.comma)) {
         // import %%STRING%%;
         node.source = this.finishPlaceholder(placeholder, "StringLiteral");
         this.semicolon();
@@ -345,7 +345,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         if (!hasStarImport) this.parseNamedImportSpecifiers(node);
       }
 
-      this.expectContextual("from");
+      this.expectContextual(tt._from);
       node.source = this.parseImportSource();
       this.semicolon();
       return this.finishNode(node, "ImportDeclaration");

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2364,7 +2364,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
       // export default interface allowed in:
       // https://github.com/Microsoft/TypeScript/pull/16040
-      if (this.state.value === "interface") {
+      if (this.match(tt._interface)) {
         const interfaceNode = this.startNode();
         this.next();
         const result = this.tsParseInterfaceDeclaration(interfaceNode);

--- a/packages/babel-parser/src/plugins/v8intrinsic.js
+++ b/packages/babel-parser/src/plugins/v8intrinsic.js
@@ -1,5 +1,5 @@
 import type Parser from "../parser";
-import { tt } from "../tokenizer/types";
+import { tokenIsIdentifier, tt } from "../tokenizer/types";
 import * as N from "../types";
 
 export default (superClass: Class<Parser>): Class<Parser> =>
@@ -9,8 +9,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         const v8IntrinsicStart = this.state.start;
         // let the `loc` of Identifier starts from `%`
         const node = this.startNode();
-        this.eat(tt.modulo);
-        if (this.match(tt.name)) {
+        this.next(); // eat '%'
+        if (tokenIsIdentifier(this.state.type)) {
           const name = this.parseIdentifierName(this.state.start);
           const identifier = this.createIdentifier(node, name);
           identifier.type = "V8IntrinsicIdentifier";

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -1565,8 +1565,14 @@ export default class Tokenizer extends ParserErrors {
 
   readWord(firstCode: number | void): void {
     const word = this.readWord1(firstCode);
-    const type = keywordTypes.get(word) || tt.name;
-    this.finishToken(type, word);
+    const type = keywordTypes.get(word);
+    if (type !== undefined) {
+      // We don't use word as state.value here because word is a dynamic string
+      // while token label is a shared constant string
+      this.finishToken(type, tokenLabelName(type));
+    } else {
+      this.finishToken(tt.name, word);
+    }
   }
 
   checkKeywordEscapes(): void {

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -180,8 +180,13 @@ export default class Tokenizer extends ParserErrors {
     }
   }
 
-  // TODO
-
+  /**
+   * Whether current token matches given type
+   *
+   * @param {TokenType} type
+   * @returns {boolean}
+   * @memberof Tokenizer
+   */
   match(type: TokenType): boolean {
     return this.state.type === type;
   }

--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -115,15 +115,6 @@ function createToken(name: string, options: TokenOptions = {}): TokenType {
 // When adding new token types, please also check if the token helpers need update.
 
 export const tt: { [name: string]: TokenType } = {
-  num: createToken("num", { startsExpr }),
-  bigint: createToken("bigint", { startsExpr }),
-  decimal: createToken("decimal", { startsExpr }),
-  regexp: createToken("regexp", { startsExpr }),
-  string: createToken("string", { startsExpr }),
-  name: createToken("name", { startsExpr }),
-  privateName: createToken("#name", { startsExpr }),
-  eof: createToken("eof"),
-
   // Punctuation token types.
   bracketL: createToken("[", { beforeExpr, startsExpr }),
   bracketHashL: createToken("#[", { beforeExpr, startsExpr }),
@@ -248,6 +239,19 @@ export const tt: { [name: string]: TokenType } = {
   // end: isLoop
   // end: isKeyword
 
+  // Primary literals
+  // start: isIdentifier
+  name: createToken("name", { startsExpr }),
+  // end: isIdentifier
+
+  string: createToken("string", { startsExpr }),
+  num: createToken("num", { startsExpr }),
+  bigint: createToken("bigint", { startsExpr }),
+  decimal: createToken("decimal", { startsExpr }),
+  regexp: createToken("regexp", { startsExpr }),
+  privateName: createToken("#name", { startsExpr }),
+  eof: createToken("eof"),
+
   // jsx plugin
   jsxName: createToken("jsxName"),
   jsxText: createToken("jsxText", { beforeExpr: true }),
@@ -257,6 +261,18 @@ export const tt: { [name: string]: TokenType } = {
   // placeholder plugin
   placeholder: createToken("%%", { startsExpr: true }),
 };
+
+export function tokenIsIdentifier(token: TokenType): boolean {
+  return token === tt.name;
+}
+
+export function tokenIsKeywordOrIdentifier(token: TokenType): boolean {
+  return token >= tt._in && token <= tt.name;
+}
+
+export function tokenIsLiteralPropertyName(token: TokenType): boolean {
+  return token >= tt._in && token <= tt.decimal;
+}
 
 export function tokenComesBeforeExpression(token: TokenType): boolean {
   return tokenBeforeExprs[token];

--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -78,6 +78,7 @@ export class ExportedTokenType {
   }
 }
 
+// A map from keyword/keyword-like string value to the token type
 export const keywords = new Map<string, TokenType>();
 
 function createKeyword(name: string, options: TokenOptions = {}): TokenType {

--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -111,6 +111,23 @@ function createToken(name: string, options: TokenOptions = {}): TokenType {
   return tokenTypeCounter;
 }
 
+function createKeywordLike(
+  name: string,
+  options: TokenOptions = {},
+): TokenType {
+  ++tokenTypeCounter;
+  keywords.set(name, tokenTypeCounter);
+  tokenLabels.push(name);
+  tokenBinops.push(options.binop ?? -1);
+  tokenBeforeExprs.push(options.beforeExpr ?? false);
+  tokenStartsExprs.push(options.startsExpr ?? false);
+  tokenPrefixes.push(options.prefix ?? false);
+  // In the exported token type, we set the label as "name" for backward compatibility with Babel 7
+  tokenTypes.push(new ExportedTokenType("name", options));
+
+  return tokenTypeCounter;
+}
+
 // For performance the token type helpers depend on the following declarations order.
 // When adding new token types, please also check if the token helpers need update.
 
@@ -241,6 +258,49 @@ export const tt: { [name: string]: TokenType } = {
 
   // Primary literals
   // start: isIdentifier
+  _as: createKeywordLike("as", { startsExpr }),
+  _assert: createKeywordLike("assert", { startsExpr }),
+  _async: createKeywordLike("async", { startsExpr }),
+  _await: createKeywordLike("await", { startsExpr }),
+  _from: createKeywordLike("from", { startsExpr }),
+  _get: createKeywordLike("get", { startsExpr }),
+  _let: createKeywordLike("let", { startsExpr }),
+  _meta: createKeywordLike("meta", { startsExpr }),
+  _of: createKeywordLike("of", { startsExpr }),
+  _sent: createKeywordLike("sent", { startsExpr }),
+  _set: createKeywordLike("set", { startsExpr }),
+  _static: createKeywordLike("static", { startsExpr }),
+  _yield: createKeywordLike("yield", { startsExpr }),
+
+  // Flow and TypeScript Keywordlike
+  _asserts: createKeywordLike("asserts", { startsExpr }),
+  _checks: createKeywordLike("checks", { startsExpr }),
+  _exports: createKeywordLike("exports", { startsExpr }),
+  _global: createKeywordLike("global", { startsExpr }),
+  _implements: createKeywordLike("implements", { startsExpr }),
+  _intrinsic: createKeywordLike("intrinsic", { startsExpr }),
+  _infer: createKeywordLike("infer", { startsExpr }),
+  _is: createKeywordLike("is", { startsExpr }),
+  _mixins: createKeywordLike("mixins", { startsExpr }),
+  _proto: createKeywordLike("proto", { startsExpr }),
+  _require: createKeywordLike("require", { startsExpr }),
+  // start: isTSTypeOperator
+  _keyof: createKeywordLike("keyof", { startsExpr }),
+  _readonly: createKeywordLike("readonly", { startsExpr }),
+  _unique: createKeywordLike("unique", { startsExpr }),
+  // end: isTSTypeOperator
+  // start: isTSDeclarationStart
+  _abstract: createKeywordLike("abstract", { startsExpr }),
+  _declare: createKeywordLike("declare", { startsExpr }),
+  _enum: createKeywordLike("enum", { startsExpr }),
+  _module: createKeywordLike("module", { startsExpr }),
+  _namespace: createKeywordLike("namespace", { startsExpr }),
+  // start: isFlowInterfaceOrTypeOrOpaque
+  _interface: createKeywordLike("interface", { startsExpr }),
+  _type: createKeywordLike("type", { startsExpr }),
+  // end: isTSDeclarationStart
+  _opaque: createKeywordLike("opaque", { startsExpr }),
+  // end: isFlowInterfaceOrTypeOrOpaque
   name: createToken("name", { startsExpr }),
   // end: isIdentifier
 
@@ -263,7 +323,7 @@ export const tt: { [name: string]: TokenType } = {
 };
 
 export function tokenIsIdentifier(token: TokenType): boolean {
-  return token === tt.name;
+  return token >= tt._as && token <= tt.name;
 }
 
 export function tokenIsKeywordOrIdentifier(token: TokenType): boolean {
@@ -286,6 +346,10 @@ export function tokenIsAssignment(token: TokenType): boolean {
   return token >= tt.eq && token <= tt.moduloAssign;
 }
 
+export function tokenIsFlowInterfaceOrTypeOrOpaque(token: TokenType): boolean {
+  return token >= tt._interface && token <= tt._opaque;
+}
+
 export function tokenIsLoop(token: TokenType): boolean {
   return token >= tt._do && token <= tt._while;
 }
@@ -304,6 +368,14 @@ export function tokenIsPostfix(token: TokenType): boolean {
 
 export function tokenIsPrefix(token: TokenType): boolean {
   return tokenPrefixes[token];
+}
+
+export function tokenIsTSTypeOperator(token: TokenType): boolean {
+  return token >= tt._keyof && token <= tt._unique;
+}
+
+export function tokenIsTSDeclarationStart(token: TokenType): boolean {
+  return token >= tt._abstract && token <= tt._type;
 }
 
 export function tokenLabelName(token: TokenType): string {

--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -216,6 +216,7 @@ export const tt: { [name: string]: TokenType } = {
   // Keywords
   // Don't forget to update packages/babel-helper-validator-identifier/src/keyword.js
   // when new keywords are added
+  // start: isLiteralPropertyName
   // start: isKeyword
   _in: createKeyword("in", { beforeExpr, binop: 7 }),
   _instanceof: createKeyword("instanceof", { beforeExpr, binop: 7 }),
@@ -309,6 +310,7 @@ export const tt: { [name: string]: TokenType } = {
   num: createToken("num", { startsExpr }),
   bigint: createToken("bigint", { startsExpr }),
   decimal: createToken("decimal", { startsExpr }),
+  // end: isLiteralPropertyName
   regexp: createToken("regexp", { startsExpr }),
   privateName: createToken("#name", { startsExpr }),
   eof: createToken("eof"),

--- a/packages/babel-parser/test/fixtures/flow/interface-types/escape-in-interface/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/escape-in-interface/input.js
@@ -1,0 +1,1 @@
+interf\u{61}ce A {}

--- a/packages/babel-parser/test/fixtures/flow/interface-types/escape-in-interface/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/escape-in-interface/output.json
@@ -1,0 +1,38 @@
+{
+  "type": "File",
+  "start":0,"end":19,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":19}},
+  "errors": [
+    "SyntaxError: Unexpected reserved word 'interface'. (1:0)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":19,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":19}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "InterfaceDeclaration",
+        "start":0,"end":19,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":19}},
+        "id": {
+          "type": "Identifier",
+          "start":15,"end":16,"loc":{"start":{"line":1,"column":15},"end":{"line":1,"column":16},"identifierName":"A"},
+          "name": "A"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "implements": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start":17,"end":19,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":19}},
+          "callProperties": [],
+          "properties": [],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/flow/object-types/getter-key-is-keyword/input.js
+++ b/packages/babel-parser/test/fixtures/flow/object-types/getter-key-is-keyword/input.js
@@ -1,0 +1,3 @@
+type B = {
+  get if(): number;
+}

--- a/packages/babel-parser/test/fixtures/flow/object-types/getter-key-is-keyword/output.json
+++ b/packages/babel-parser/test/fixtures/flow/object-types/getter-key-is-keyword/output.json
@@ -1,0 +1,60 @@
+{
+  "type": "File",
+  "start":0,"end":32,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":32,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start":0,"end":32,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":5,"end":6,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":6},"identifierName":"B"},
+          "name": "B"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start":9,"end":32,"loc":{"start":{"line":1,"column":9},"end":{"line":3,"column":1}},
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start":13,"end":29,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":18}},
+              "key": {
+                "type": "Identifier",
+                "start":17,"end":19,"loc":{"start":{"line":2,"column":6},"end":{"line":2,"column":8},"identifierName":"if"},
+                "name": "if"
+              },
+              "static": false,
+              "proto": false,
+              "kind": "get",
+              "method": true,
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start":13,"end":29,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":18}},
+                "params": [],
+                "rest": null,
+                "typeParameters": null,
+                "this": null,
+                "returnType": {
+                  "type": "NumberTypeAnnotation",
+                  "start":23,"end":29,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":18}}
+                }
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false,
+          "inexact": false
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Babel parser incorrectly allows `interf\u{61}ce A {}` when `flows` is enabled.
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is based on #13768. The `tt.name` is now exploded into multiple tokens, each of them represents an "interested" identifier name (such as `async`, `static`) which subjects to additional parsing logic. The tokens is not limited to ES, the Flow/TS keyword-likes are also tokenized differently for parsing convenience.

The `isContextual`, `expectContextual` now accept a token type instead of a string since these names are tokenized into different types. The verification is simplified because, e.g. `token === tt._async` already implies that `token` is an identifier token.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13769"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

