### PR TITLE
fix(babel-parser): Allow line break before `assert` return type

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1316,11 +1316,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     tsParseTypePredicateAsserts(): boolean {
-      if (
-        !this.match(tt.name) ||
-        this.state.value !== "asserts" ||
-        this.hasPrecedingLineBreak()
-      ) {
+      if (!this.match(tt.name) || this.state.value !== "asserts") {
         return false;
       }
       const containsEsc = this.state.containsEsc;

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration-with-line-break/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration-with-line-break/input.ts
@@ -1,0 +1,2 @@
+function assert(condition: any):
+asserts condition {}

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration-with-line-break/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration-with-line-break/output.json
@@ -1,0 +1,184 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 53,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 20
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 53,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 20
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 53,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 20
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 9,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            },
+            "identifierName": "assert"
+          },
+          "name": "assert"
+        },
+        "generator": false,
+        "async": false,
+        "params": [
+          {
+            "type": "Identifier",
+            "start": 16,
+            "end": 30,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 16
+              },
+              "end": {
+                "line": 1,
+                "column": 30
+              },
+              "identifierName": "condition"
+            },
+            "name": "condition",
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 25,
+              "end": 30,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 25
+                },
+                "end": {
+                  "line": 1,
+                  "column": 30
+                }
+              },
+              "typeAnnotation": {
+                "type": "TSAnyKeyword",
+                "start": 27,
+                "end": 30,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 30
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType": {
+          "type": "TSTypeAnnotation",
+          "start": 31,
+          "end": 50,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 31
+            },
+            "end": {
+              "line": 2,
+              "column": 17
+            }
+          },
+          "typeAnnotation": {
+            "type": "TSTypePredicate",
+            "start": 33,
+            "end": 50,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 0
+              },
+              "end": {
+                "line": 2,
+                "column": 17
+              }
+            },
+            "parameterName": {
+              "type": "Identifier",
+              "start": 41,
+              "end": 50,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 8
+                },
+                "end": {
+                  "line": 2,
+                  "column": 17
+                },
+                "identifierName": "condition"
+              },
+              "name": "condition"
+            },
+            "asserts": true,
+            "typeAnnotation": null
+          }
+        },
+        "body": {
+          "type": "BlockStatement",
+          "start": 51,
+          "end": 53,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 18
+            },
+            "end": {
+              "line": 2,
+              "column": 20
+            }
+          },
+          "body": [],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fix #13761 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    |  No <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Remove `this.hasPrecedingLineBreak()` to allow use `line break` before [Typescript function assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions).

Avoid throw Error for [Babel playground example](https://babel.dev/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.6&spec=false&loose=false&code_lz=GYVwdgxgLglg9mABAQwM6oKYCcoAoIIAmMsCAXCmAJ4CUFAUGpjqogWMaUgN4C-QA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact%2Cstage-2%2Ctypescript&prettier=false&targets=&version=7.15.6&externalPlugins=&assumptions=%7B%7D).

Remain consistent with [Typescript playground behavior](https://www.typescriptlang.org/play?#code/GYVwdgxgLglg9mABAQwM6oKYCcoAoIIAmMsCAXCmAJ4CUZAUGpjqogWMaUgN4C+QA).

|   | Before Fix  | After Fix |
|---|---|---|
| Screenshot | ![46fc4e1f0589fd91212e8eeb71a0c16](https://user-images.githubusercontent.com/14243906/133662353-67a352fd-f85d-4d27-a255-c232a2910172.png) | ![998e1169cfa19c86e2cac499a56e941](https://user-images.githubusercontent.com/14243906/133662238-055bab6c-7b8a-4ef8-95a7-d9873dbc501d.png)



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13771"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

