### PR TITLE
[@babel/node] Forward the signal SIGTERM as well

### DIFF
--- a/packages/babel-node/src/babel-node.js
+++ b/packages/babel-node/src/babel-node.js
@@ -104,5 +104,6 @@ getV8Flags(async function (err, v8Flags) {
       proc.on("message", message => process.send(message));
     }
     process.on("SIGINT", () => proc.kill("SIGINT"));
+    process.on("SIGTERM", () => proc.kill("SIGTERM"));
   }
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | I haven't found any open issue about that.
| Patch: Bug Fix?          | This forwards the TERM signal (default for `kill`) in addition to the existing INT signal.
| Major: Breaking Change?  | It could be.
| Minor: New Feature?      |
| Tests Added + Pass?      | I'm not sure how to add one, but happy to with some guidance.
| Documentation PR Link    | Is it necessary to document this?
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In a script I wanted to kill a previously babel-node-spawned server, but this would never kill the server, only the babel-node process.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13784"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

