### PR TITLE
Sort module export names

### DIFF
--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -458,7 +458,7 @@ function buildExportInitializationStatements(
     }
   } else {
     // We generate init statements (`exports.a = exports.b = ... = void 0`)
-    // for every 100 exported names.
+    // for every 100 exported names to avoid deeply-nested AST structures.
     const chunkSize = 100;
     for (
       let i = 0, uninitializedExportNames = [];

--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -241,7 +241,7 @@ export function buildNamespaceInitStatements(
 const ReexportTemplate = {
   constant: template.statement`EXPORTS.EXPORT_NAME = NAMESPACE_IMPORT;`,
   constantComputed: template.statement`EXPORTS["EXPORT_NAME"] = NAMESPACE_IMPORT;`,
-  spec: template`
+  spec: template.statement`
     Object.defineProperty(EXPORTS, "EXPORT_NAME", {
       enumerable: true,
       get: function() {
@@ -412,43 +412,94 @@ function buildExportInitializationStatements(
   constantReexports: boolean = false,
   noIncompleteNsImportDetection = false,
 ) {
-  const initStatements = [];
+  const initStatements = new Map<string, t.Statement | null>();
 
-  const exportNames = [];
   for (const [localName, data] of metadata.local) {
     if (data.kind === "import") {
       // No-open since these are explicitly set with the "reexports" block.
     } else if (data.kind === "hoisted") {
-      initStatements.push(
+      initStatements.set(
+        // data.names is always of length 1 because a hoisted export
+        // name must be id of a function declaration
+        data.names[0],
         buildInitStatement(metadata, data.names, identifier(localName)),
       );
-    } else {
-      exportNames.push(...data.names);
+    } else if (!noIncompleteNsImportDetection) {
+      for (const exportName of data.names) {
+        initStatements.set(exportName, null);
+      }
     }
   }
 
   for (const data of metadata.source.values()) {
     if (!constantReexports) {
-      initStatements.push(...buildReexportsFromMeta(metadata, data, false));
+      const reexportsStatements = buildReexportsFromMeta(metadata, data, false);
+      const reexports = [...data.reexports.keys()];
+      for (let i = 0; i < reexportsStatements.length; i++) {
+        initStatements.set(reexports[i], reexportsStatements[i]);
+      }
     }
-    for (const exportName of data.reexportNamespace) {
-      exportNames.push(exportName);
+    if (!noIncompleteNsImportDetection) {
+      for (const exportName of data.reexportNamespace) {
+        initStatements.set(exportName, null);
+      }
     }
   }
 
-  if (!noIncompleteNsImportDetection) {
-    initStatements.push(
-      ...chunk(exportNames, 100).map(members => {
-        return buildInitStatement(
-          metadata,
-          members,
-          programPath.scope.buildUndefinedNode(),
+  // https://tc39.es/ecma262/#sec-module-namespace-exotic-objects
+  // The [Exports] list is ordered as if an Array of those String values
+  // had been sorted using %Array.prototype.sort% using undefined as comparefn
+  const sortedExportNames = [...initStatements.keys()].sort();
+
+  const results = [];
+  if (noIncompleteNsImportDetection) {
+    for (const exportName of sortedExportNames) {
+      const initStatement = initStatements.get(exportName);
+      results.push(initStatement);
+    }
+  } else {
+    // We generate init statements (`exports.a = exports.b = ... = void 0`)
+    // for every 100 exported names.
+    const chunkSize = 100;
+    for (
+      let i = 0, uninitializedExportNames = [];
+      i < sortedExportNames.length;
+      i += chunkSize
+    ) {
+      for (let j = 0; j < chunkSize && i + j < sortedExportNames.length; j++) {
+        const exportName = sortedExportNames[i + j];
+        const initStatement = initStatements.get(sortedExportNames[i + j]);
+        if (initStatement !== null) {
+          if (uninitializedExportNames.length > 0) {
+            results.push(
+              buildInitStatement(
+                metadata,
+                uninitializedExportNames,
+                programPath.scope.buildUndefinedNode(),
+              ),
+            );
+            // reset after uninitializedExportNames has been transformed
+            // to init statements
+            uninitializedExportNames = [];
+          }
+          results.push(initStatement);
+        } else {
+          uninitializedExportNames.push(exportName);
+        }
+      }
+      if (uninitializedExportNames.length > 0) {
+        results.push(
+          buildInitStatement(
+            metadata,
+            uninitializedExportNames,
+            programPath.scope.buildUndefinedNode(),
+          ),
         );
-      }),
-    );
+      }
+    }
   }
 
-  return initStatements;
+  return results;
 }
 
 /**
@@ -476,12 +527,4 @@ function buildInitStatement(metadata: ModuleMetadata, exportNames, initExpr) {
       }
     }, initExpr),
   );
-}
-
-function chunk(array, size) {
-  const chunks = [];
-  for (let i = 0; i < array.length; i += size) {
-    chunks.push(array.slice(i, i + size));
-  }
-  return chunks;
 }

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-3/output.js
@@ -4,16 +4,16 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "foo", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
   Object.defineProperty(_exports, "bar", {
     enumerable: true,
     get: function () {
       return _foo.bar;
+    }
+  });
+  Object.defineProperty(_exports, "foo", {
+    enumerable: true,
+    get: function () {
+      return _foo.foo;
     }
   });
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-from-6/output.js
@@ -4,16 +4,16 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "default", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
   Object.defineProperty(_exports, "bar", {
     enumerable: true,
     get: function () {
       return _foo.bar;
+    }
+  });
+  Object.defineProperty(_exports, "default", {
+    enumerable: true,
+    get: function () {
+      return _foo.foo;
     }
   });
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-named-2/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-named-2/output.js
@@ -4,7 +4,7 @@ define(["exports"], function (_exports) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports.foo = void 0;
+  _exports.foo = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.foo = foo;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-named-5/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/export-named-5/output.js
@@ -4,7 +4,7 @@ define(["exports"], function (_exports) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports.default = void 0;
+  _exports.default = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.default = foo;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/exports-variable/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/exports-variable/output.js
@@ -4,8 +4,9 @@ define(["exports"], function (_exports) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.foo7 = _exports.foo6 = _exports.foo5 = _exports.foo4 = _exports.foo3 = _exports.foo2 = _exports.foo = _exports.bar = void 0;
   _exports.foo8 = foo8;
-  _exports.foo9 = _exports.foo7 = _exports.foo6 = _exports.foo5 = _exports.foo4 = _exports.foo3 = _exports.bar = _exports.foo2 = _exports.foo = void 0;
+  _exports.foo9 = void 0;
   var foo = 1;
   _exports.foo = foo;
   var foo2 = 1,

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/hoist-function-exports/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/hoist-function-exports/output.js
@@ -4,8 +4,8 @@ define(["exports", "./evens"], function (_exports, _evens) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.nextOdd = nextOdd;
   _exports.isOdd = void 0;
+  _exports.nextOdd = nextOdd;
 
   function nextOdd(n) {
     return (0, _evens.isEven)(n) ? n + 1 : n + 2;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/overview/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/overview/output.js
@@ -4,7 +4,7 @@ define(["exports", "foo", "foo-bar", "./directory/foo-bar"], function (_exports,
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.default = _exports.test2 = _exports.test = void 0;
+  _exports.test2 = _exports.test = _exports.default = void 0;
   foo2 = babelHelpers.interopRequireWildcard(foo2);
   var test;
   _exports.test = test;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/remap/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/remap/output.js
@@ -4,7 +4,7 @@ define(["exports"], function (_exports) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.f = _exports.e = _exports.c = _exports.a = _exports.test = void 0;
+  _exports.test = _exports.f = _exports.e = _exports.c = _exports.a = void 0;
   var test = 2;
   _exports.test = test;
   _exports.test = test = 5;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-3/output.js
@@ -4,7 +4,7 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports.default = void 0;
+  _exports.default = _exports.bar = void 0;
   _exports.default = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/assumption-constantReexports/export-from-5/output.js
@@ -4,7 +4,7 @@ define(["exports", "foo"], function (_exports, _foo) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports.foo = void 0;
+  _exports.foo = _exports.bar = void 0;
   _exports.foo = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names-loose/export-named-string-can-be-identifier/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names-loose/export-named-string-can-be-identifier/output.js
@@ -2,7 +2,7 @@ define(["exports"], function (_exports) {
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports.defaultExports = void 0;
+  _exports.defaultExports = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.defaultExports = foo;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names-loose/export-named/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names-loose/export-named/output.js
@@ -2,7 +2,7 @@ define(["exports"], function (_exports) {
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports["default exports"] = void 0;
+  _exports["default exports"] = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports["default exports"] = foo;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier/output.js
@@ -4,7 +4,7 @@ define(["exports"], function (_exports) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports.defaultExports = void 0;
+  _exports.defaultExports = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.defaultExports = foo;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names/export-named/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/interop-module-string-names/export-named/output.js
@@ -4,7 +4,7 @@ define(["exports"], function (_exports) {
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports["default exports"] = void 0;
+  _exports["default exports"] = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports["default exports"] = foo;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-from-3/output.js
@@ -2,7 +2,7 @@ define(["exports", "foo"], function (_exports, _foo) {
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports.foo = void 0;
+  _exports.foo = _exports.bar = void 0;
   _exports.foo = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-from-6/output.js
@@ -2,7 +2,7 @@ define(["exports", "foo"], function (_exports, _foo) {
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports.default = void 0;
+  _exports.default = _exports.bar = void 0;
   _exports.default = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-named-2/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-named-2/output.js
@@ -2,7 +2,7 @@ define(["exports"], function (_exports) {
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports.foo = void 0;
+  _exports.foo = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.foo = foo;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-named-5/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/export-named-5/output.js
@@ -2,7 +2,7 @@ define(["exports"], function (_exports) {
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports.default = void 0;
+  _exports.default = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.default = foo;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/exports-variable/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/exports-variable/output.js
@@ -2,8 +2,9 @@ define(["exports"], function (_exports) {
   "use strict";
 
   _exports.__esModule = true;
+  _exports.foo7 = _exports.foo6 = _exports.foo5 = _exports.foo4 = _exports.foo3 = _exports.foo2 = _exports.foo = _exports.bar = void 0;
   _exports.foo8 = foo8;
-  _exports.foo9 = _exports.foo7 = _exports.foo6 = _exports.foo5 = _exports.foo4 = _exports.foo3 = _exports.bar = _exports.foo2 = _exports.foo = void 0;
+  _exports.foo9 = void 0;
   var foo = 1;
   _exports.foo = foo;
   var foo2 = 1,

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/hoist-function-exports/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/hoist-function-exports/output.js
@@ -2,8 +2,8 @@ define(["exports", "./evens"], function (_exports, _evens) {
   "use strict";
 
   _exports.__esModule = true;
-  _exports.nextOdd = nextOdd;
   _exports.isOdd = void 0;
+  _exports.nextOdd = nextOdd;
 
   function nextOdd(n) {
     return (0, _evens.isEven)(n) ? n + 1 : n + 2;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/overview/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/overview/output.js
@@ -2,7 +2,7 @@ define(["exports", "foo", "foo-bar", "./directory/foo-bar"], function (_exports,
   "use strict";
 
   _exports.__esModule = true;
-  _exports.default = _exports.test2 = _exports.test = void 0;
+  _exports.test2 = _exports.test = _exports.default = void 0;
   foo2 = babelHelpers.interopRequireWildcard(foo2);
   var test;
   _exports.test = test;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/remap/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/remap/output.js
@@ -2,7 +2,7 @@ define(["exports"], function (_exports) {
   "use strict";
 
   _exports.__esModule = true;
-  _exports.f = _exports.e = _exports.c = _exports.a = _exports.test = void 0;
+  _exports.test = _exports.f = _exports.e = _exports.c = _exports.a = void 0;
   var test = 2;
   _exports.test = test;
   _exports.test = test = 5;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-3/output.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.bar = exports.default = void 0;
+exports.default = exports.bar = void 0;
 
 var _foo = require("foo");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/assumption-constantReexports/export-from-5/output.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.bar = exports.foo = void 0;
+exports.foo = exports.bar = void 0;
 
 var _foo = require("foo");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-from-3/output.js
@@ -1,7 +1,7 @@
 "use strict";
 
 exports.__esModule = true;
-exports.bar = exports.foo = void 0;
+exports.foo = exports.bar = void 0;
 
 var _foo = require("foo");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-from-6/output.js
@@ -1,7 +1,7 @@
 "use strict";
 
 exports.__esModule = true;
-exports.bar = exports.default = void 0;
+exports.default = exports.bar = void 0;
 
 var _foo = require("foo");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-named-2/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-named-2/output.js
@@ -1,7 +1,7 @@
 "use strict";
 
 exports.__esModule = true;
-exports.bar = exports.foo = void 0;
+exports.foo = exports.bar = void 0;
 var foo, bar;
 exports.bar = bar;
 exports.foo = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-named-5/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/export-named-5/output.js
@@ -1,7 +1,7 @@
 "use strict";
 
 exports.__esModule = true;
-exports.bar = exports.default = void 0;
+exports.default = exports.bar = void 0;
 var foo, bar;
 exports.bar = bar;
 exports.default = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/exports-variable/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/exports-variable/output.js
@@ -1,8 +1,9 @@
 "use strict";
 
 exports.__esModule = true;
+exports.foo7 = exports.foo6 = exports.foo5 = exports.foo4 = exports.foo3 = exports.foo2 = exports.foo = exports.bar = void 0;
 exports.foo8 = foo8;
-exports.foo9 = exports.foo7 = exports.foo6 = exports.foo5 = exports.foo4 = exports.foo3 = exports.bar = exports.foo2 = exports.foo = void 0;
+exports.foo9 = void 0;
 var foo = 1;
 exports.foo = foo;
 var foo2 = 1,

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/hoist-function-exports/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/hoist-function-exports/output.js
@@ -1,8 +1,8 @@
 "use strict";
 
 exports.__esModule = true;
-exports.nextOdd = nextOdd;
 exports.isOdd = void 0;
+exports.nextOdd = nextOdd;
 
 var _evens = require("./evens");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/remap/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/remap/output.js
@@ -1,7 +1,7 @@
 "use strict";
 
 exports.__esModule = true;
-exports.f = exports.e = exports.c = exports.a = exports.test = void 0;
+exports.test = exports.f = exports.e = exports.c = exports.a = void 0;
 var test = 2;
 exports.test = test;
 exports.test = test = 5;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names-loose/export-named-string-can-be-identifier/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names-loose/export-named-string-can-be-identifier/output.js
@@ -1,7 +1,7 @@
 "use strict";
 
 exports.__esModule = true;
-exports.bar = exports.defaultExports = void 0;
+exports.defaultExports = exports.bar = void 0;
 var foo, bar;
 exports.bar = bar;
 exports.defaultExports = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names-loose/export-named/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names-loose/export-named/output.js
@@ -1,7 +1,7 @@
 "use strict";
 
 exports.__esModule = true;
-exports.bar = exports["default exports"] = void 0;
+exports["default exports"] = exports.bar = void 0;
 var foo, bar;
 exports.bar = bar;
 exports["default exports"] = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier/output.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.bar = exports.defaultExports = void 0;
+exports.defaultExports = exports.bar = void 0;
 var foo, bar;
 exports.bar = bar;
 exports.defaultExports = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names/export-named/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-module-string-names/export-named/output.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.bar = exports["default exports"] = void 0;
+exports["default exports"] = exports.bar = void 0;
 var foo, bar;
 exports.bar = bar;
 exports["default exports"] = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-3/output.js
@@ -3,16 +3,16 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "foo", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo;
-  }
-});
 Object.defineProperty(exports, "bar", {
   enumerable: true,
   get: function () {
     return _foo.bar;
+  }
+});
+Object.defineProperty(exports, "foo", {
+  enumerable: true,
+  get: function () {
+    return _foo.foo;
   }
 });
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-6/output.js
@@ -3,16 +3,16 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "default", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo;
-  }
-});
 Object.defineProperty(exports, "bar", {
   enumerable: true,
   get: function () {
     return _foo.bar;
+  }
+});
+Object.defineProperty(exports, "default", {
+  enumerable: true,
+  get: function () {
+    return _foo.foo;
   }
 });
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-8/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-from-8/output.js
@@ -15,58 +15,16 @@ Object.defineProperty(exports, "foo1", {
     return _foo.foo1;
   }
 });
-Object.defineProperty(exports, "foo2", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo2;
-  }
-});
-Object.defineProperty(exports, "foo3", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo3;
-  }
-});
-Object.defineProperty(exports, "foo4", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo4;
-  }
-});
-Object.defineProperty(exports, "foo5", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo5;
-  }
-});
-Object.defineProperty(exports, "foo6", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo6;
-  }
-});
-Object.defineProperty(exports, "foo7", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo7;
-  }
-});
-Object.defineProperty(exports, "foo8", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo8;
-  }
-});
-Object.defineProperty(exports, "foo9", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo9;
-  }
-});
 Object.defineProperty(exports, "foo10", {
   enumerable: true,
   get: function () {
     return _foo.foo10;
+  }
+});
+Object.defineProperty(exports, "foo100", {
+  enumerable: true,
+  get: function () {
+    return _foo.foo100;
   }
 });
 Object.defineProperty(exports, "foo11", {
@@ -121,6 +79,12 @@ Object.defineProperty(exports, "foo19", {
   enumerable: true,
   get: function () {
     return _foo.foo19;
+  }
+});
+Object.defineProperty(exports, "foo2", {
+  enumerable: true,
+  get: function () {
+    return _foo.foo2;
   }
 });
 Object.defineProperty(exports, "foo20", {
@@ -183,6 +147,12 @@ Object.defineProperty(exports, "foo29", {
     return _foo.foo29;
   }
 });
+Object.defineProperty(exports, "foo3", {
+  enumerable: true,
+  get: function () {
+    return _foo.foo3;
+  }
+});
 Object.defineProperty(exports, "foo30", {
   enumerable: true,
   get: function () {
@@ -241,6 +211,12 @@ Object.defineProperty(exports, "foo39", {
   enumerable: true,
   get: function () {
     return _foo.foo39;
+  }
+});
+Object.defineProperty(exports, "foo4", {
+  enumerable: true,
+  get: function () {
+    return _foo.foo4;
   }
 });
 Object.defineProperty(exports, "foo40", {
@@ -303,6 +279,12 @@ Object.defineProperty(exports, "foo49", {
     return _foo.foo49;
   }
 });
+Object.defineProperty(exports, "foo5", {
+  enumerable: true,
+  get: function () {
+    return _foo.foo5;
+  }
+});
 Object.defineProperty(exports, "foo50", {
   enumerable: true,
   get: function () {
@@ -361,6 +343,12 @@ Object.defineProperty(exports, "foo59", {
   enumerable: true,
   get: function () {
     return _foo.foo59;
+  }
+});
+Object.defineProperty(exports, "foo6", {
+  enumerable: true,
+  get: function () {
+    return _foo.foo6;
   }
 });
 Object.defineProperty(exports, "foo60", {
@@ -423,6 +411,12 @@ Object.defineProperty(exports, "foo69", {
     return _foo.foo69;
   }
 });
+Object.defineProperty(exports, "foo7", {
+  enumerable: true,
+  get: function () {
+    return _foo.foo7;
+  }
+});
 Object.defineProperty(exports, "foo70", {
   enumerable: true,
   get: function () {
@@ -481,6 +475,12 @@ Object.defineProperty(exports, "foo79", {
   enumerable: true,
   get: function () {
     return _foo.foo79;
+  }
+});
+Object.defineProperty(exports, "foo8", {
+  enumerable: true,
+  get: function () {
+    return _foo.foo8;
   }
 });
 Object.defineProperty(exports, "foo80", {
@@ -543,6 +543,12 @@ Object.defineProperty(exports, "foo89", {
     return _foo.foo89;
   }
 });
+Object.defineProperty(exports, "foo9", {
+  enumerable: true,
+  get: function () {
+    return _foo.foo9;
+  }
+});
 Object.defineProperty(exports, "foo90", {
   enumerable: true,
   get: function () {
@@ -601,12 +607,6 @@ Object.defineProperty(exports, "foo99", {
   enumerable: true,
   get: function () {
     return _foo.foo99;
-  }
-});
-Object.defineProperty(exports, "foo100", {
-  enumerable: true,
-  get: function () {
-    return _foo.foo100;
   }
 });
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-named-2/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-named-2/output.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.bar = exports.foo = void 0;
+exports.foo = exports.bar = void 0;
 var foo, bar;
 exports.bar = bar;
 exports.foo = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-named-5/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/export-named-5/output.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.bar = exports.default = void 0;
+exports.default = exports.bar = void 0;
 var foo, bar;
 exports.bar = bar;
 exports.default = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/exports-variable/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/exports-variable/output.js
@@ -3,8 +3,9 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.foo7 = exports.foo6 = exports.foo5 = exports.foo4 = exports.foo3 = exports.foo2 = exports.foo = exports.bar = void 0;
 exports.foo8 = foo8;
-exports.foo9 = exports.foo7 = exports.foo6 = exports.foo5 = exports.foo4 = exports.foo3 = exports.bar = exports.foo2 = exports.foo = void 0;
+exports.foo9 = void 0;
 var foo = 1;
 exports.foo = foo;
 var foo2 = 1,

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/hoist-function-exports/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/hoist-function-exports/output.js
@@ -3,8 +3,8 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.nextOdd = nextOdd;
 exports.isOdd = void 0;
+exports.nextOdd = nextOdd;
 
 var _evens = require("./evens");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/remap/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/remap/output.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.f = exports.e = exports.c = exports.a = exports.test = void 0;
+exports.test = exports.f = exports.e = exports.c = exports.a = void 0;
 var test = 2;
 exports.test = test;
 exports.test = test = 5;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/for-of-in-export/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/for-of-in-export/output.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.bar = exports.foo = void 0;
+exports.foo = exports.bar = void 0;
 let foo;
 exports.bar = exports.foo = foo;
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7160/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7160/output.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.bar = exports.foo = void 0;
+exports.foo = exports.bar = void 0;
 
 var foo = function foo(gen) {
   var ctx = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-all/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-all/output.js
@@ -12,15 +12,17 @@ var _exportNames = {
   f: true,
   c: true
 };
+exports.a = void 0;
 exports.b = b;
-exports.default = _default;
 Object.defineProperty(exports, "c", {
   enumerable: true,
   get: function () {
     return _mod.c;
   }
 });
-exports.f = exports.e = exports.d = exports.a = exports.z = void 0;
+exports.d = void 0;
+exports.default = _default;
+exports.z = exports.f = exports.e = void 0;
 
 var _mod = require("mod");
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-const-destructuring-array-default-params/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-const-destructuring-array-default-params/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.bar = exports.foo = void 0;
+exports.foo = exports.bar = void 0;
 const [foo, bar = 2] = [];
 exports.bar = bar;
 exports.foo = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-const-destructuring-array-rest/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-const-destructuring-array-rest/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.baz = exports.bar = exports.foo = void 0;
+exports.foo = exports.baz = exports.bar = void 0;
 const [foo, bar, ...baz] = [];
 exports.baz = baz;
 exports.bar = bar;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-const-destructuring-array/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-const-destructuring-array/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.bar = exports.foo = void 0;
+exports.foo = exports.bar = void 0;
 const [foo, bar] = [];
 exports.bar = bar;
 exports.foo = foo;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-const-destructuring-object-default-params/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-const-destructuring-object-default-params/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.bar = exports.foo = void 0;
+exports.foo = exports.bar = void 0;
 const {
   foo,
   bar = 1

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-const-destructuring-object-rest/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/export-const-destructuring-object-rest/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.bar = exports.foo = void 0;
+exports.foo = exports.bar = void 0;
 const {
   foo,
   ...bar

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-3/output.js
@@ -16,7 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports.default = void 0;
+  _exports.default = _exports.bar = void 0;
   _exports.default = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/assumption-constantReexports/export-from-5/output.js
@@ -16,7 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports.foo = void 0;
+  _exports.foo = _exports.bar = void 0;
   _exports.foo = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names-loose/export-named-string-can-be-identifier/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names-loose/export-named-string-can-be-identifier/output.js
@@ -14,7 +14,7 @@
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports.defaultExports = void 0;
+  _exports.defaultExports = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.defaultExports = foo;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names-loose/export-named/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names-loose/export-named/output.js
@@ -14,7 +14,7 @@
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports["default exports"] = void 0;
+  _exports["default exports"] = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports["default exports"] = foo;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier/output.js
@@ -16,7 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports.defaultExports = void 0;
+  _exports.defaultExports = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.defaultExports = foo;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names/export-named/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/interop-module-string-names/export-named/output.js
@@ -16,7 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports["default exports"] = void 0;
+  _exports["default exports"] = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports["default exports"] = foo;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-3/output.js
@@ -14,7 +14,7 @@
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports.default = void 0;
+  _exports.default = _exports.bar = void 0;
   _exports.default = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-5/output.js
@@ -14,7 +14,7 @@
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports.foo = void 0;
+  _exports.foo = _exports.bar = void 0;
   _exports.foo = _foo.foo;
   _exports.bar = _foo.bar;
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-3/output.js
@@ -14,7 +14,7 @@
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports.default = void 0;
+  _exports.default = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.default = foo;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-5/output.js
@@ -14,7 +14,7 @@
   "use strict";
 
   _exports.__esModule = true;
-  _exports.bar = _exports.foo = void 0;
+  _exports.foo = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.foo = foo;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/exports-variable/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/exports-variable/output.js
@@ -14,8 +14,9 @@
   "use strict";
 
   _exports.__esModule = true;
+  _exports.foo7 = _exports.foo6 = _exports.foo5 = _exports.foo4 = _exports.foo3 = _exports.foo2 = _exports.foo = _exports.bar = void 0;
   _exports.foo8 = foo8;
-  _exports.foo9 = _exports.foo7 = _exports.foo6 = _exports.foo5 = _exports.foo4 = _exports.foo3 = _exports.bar = _exports.foo2 = _exports.foo = void 0;
+  _exports.foo9 = void 0;
   var foo = 1;
   _exports.foo = foo;
   var foo2 = 1,

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/hoist-function-exports/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/hoist-function-exports/output.js
@@ -14,8 +14,8 @@
   "use strict";
 
   _exports.__esModule = true;
-  _exports.nextOdd = nextOdd;
   _exports.isOdd = void 0;
+  _exports.nextOdd = nextOdd;
 
   function nextOdd(n) {
     return (0, _evens.isEven)(n) ? n + 1 : n + 2;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/overview/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/overview/output.js
@@ -14,7 +14,7 @@
   "use strict";
 
   _exports.__esModule = true;
-  _exports.default = _exports.test2 = _exports.test = void 0;
+  _exports.test2 = _exports.test = _exports.default = void 0;
   foo2 = babelHelpers.interopRequireWildcard(foo2);
   var test;
   _exports.test = test;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/remap/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/remap/output.js
@@ -14,7 +14,7 @@
   "use strict";
 
   _exports.__esModule = true;
-  _exports.f = _exports.e = _exports.c = _exports.a = _exports.test = void 0;
+  _exports.test = _exports.f = _exports.e = _exports.c = _exports.a = void 0;
   var test = 2;
   _exports.test = test;
   _exports.test = test = 5;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-3/output.js
@@ -16,16 +16,16 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "default", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
   Object.defineProperty(_exports, "bar", {
     enumerable: true,
     get: function () {
       return _foo.bar;
+    }
+  });
+  Object.defineProperty(_exports, "default", {
+    enumerable: true,
+    get: function () {
+      return _foo.foo;
     }
   });
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-5/output.js
@@ -16,16 +16,16 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(_exports, "foo", {
-    enumerable: true,
-    get: function () {
-      return _foo.foo;
-    }
-  });
   Object.defineProperty(_exports, "bar", {
     enumerable: true,
     get: function () {
       return _foo.bar;
+    }
+  });
+  Object.defineProperty(_exports, "foo", {
+    enumerable: true,
+    get: function () {
+      return _foo.foo;
     }
   });
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-3/output.js
@@ -16,7 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports.default = void 0;
+  _exports.default = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.default = foo;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-5/output.js
@@ -16,7 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.bar = _exports.foo = void 0;
+  _exports.foo = _exports.bar = void 0;
   var foo, bar;
   _exports.bar = bar;
   _exports.foo = foo;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/exports-variable/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/exports-variable/output.js
@@ -16,8 +16,9 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
+  _exports.foo7 = _exports.foo6 = _exports.foo5 = _exports.foo4 = _exports.foo3 = _exports.foo2 = _exports.foo = _exports.bar = void 0;
   _exports.foo8 = foo8;
-  _exports.foo9 = _exports.foo7 = _exports.foo6 = _exports.foo5 = _exports.foo4 = _exports.foo3 = _exports.bar = _exports.foo2 = _exports.foo = void 0;
+  _exports.foo9 = void 0;
   var foo = 1;
   _exports.foo = foo;
   var foo2 = 1,

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/hoist-function-exports/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/hoist-function-exports/output.js
@@ -16,8 +16,8 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.nextOdd = nextOdd;
   _exports.isOdd = void 0;
+  _exports.nextOdd = nextOdd;
 
   function nextOdd(n) {
     return (0, _evens.isEven)(n) ? n + 1 : n + 2;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/overview/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/overview/output.js
@@ -16,7 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.default = _exports.test2 = _exports.test = void 0;
+  _exports.test2 = _exports.test = _exports.default = void 0;
   foo2 = babelHelpers.interopRequireWildcard(foo2);
   var test;
   _exports.test = test;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/remap/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/remap/output.js
@@ -16,7 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.f = _exports.e = _exports.c = _exports.a = _exports.test = void 0;
+  _exports.test = _exports.f = _exports.e = _exports.c = _exports.a = void 0;
   var test = 2;
   _exports.test = test;
   _exports.test = test = 5;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13785 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we sort the export initialization statements by the export names. The `initStatements` and `exportsNames` are merged to an array of tuple`<string, Statement>` so we can sort the init statements by their names.

We didn't add new tests as current tests are sufficient to show that the initializations are ordered by names.

Note that under the `noIncompleteNsImportDetection` assumption, the issue can not be fixed _without_ adding new initialization statements, which are exactly removed by definition of the assumption. We can add an extra note about the effects of this assumption.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13788"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

