### PR TITLE
fix: ignore browserslist config when given targets

### DIFF
--- a/packages/babel-core/src/config/resolve-targets.ts
+++ b/packages/babel-core/src/config/resolve-targets.ts
@@ -31,7 +31,7 @@ export function resolveTargets(
     targets = { ...targets, esmodules: "intersect" };
   }
 
-  const { browserslistConfigFile } = options;
+  const { browserslistConfigFile = false } = options;
   let configFile;
   let ignoreBrowserslistConfig = false;
   if (typeof browserslistConfigFile === "string") {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13780
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Manually tested on https://github.com/loynoir/reproduce-babel-13780.js
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Normalize `browserslistConfigFile` to `false` when it is `undefined`, so we correctly set `ignoreBrowserslistConfig` later.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13790"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

