### PR TITLE
Fix Gulpfile path separator issue on Windows

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -53,9 +53,9 @@ const buildTypingsWatchGlob = [
  * @returns {string}
  */
 function mapSrcToLib(srcPath) {
-  const parts = srcPath.replace(/(?<!\.d)\.ts$/, ".js").split(path.sep);
+  const parts = srcPath.replace(/(?<!\.d)\.ts$/, ".js").split("/");
   parts[2] = "lib";
-  return parts.join(path.sep);
+  return parts.join("/");
 }
 
 function mapToDts(packageName) {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #13794
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 👎
| Minor: New Feature?      | 👎
| Tests Added + Pass?      | Added: 👎, Pass: 👍
| Any Dependency Changes?  | 👎
| License                  | MIT

As described in the linked issue, I changed `mapSrcToLib` in `Gulpfile.mjs` to always use forward slashes regardless of the platform, since the Windows build was broken.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13795"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

