### PR TITLE
[CI] Fixed typo in issues' welcome comment

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -35,7 +35,7 @@ jobs:
 
             If you need any help, or just have general Babel or JavaScript questions, we have a 
             vibrant [Slack community](https://babeljs.slack.com) that typically always has someone 
-            willing to help. You can sign-up [here](https://slack.babeljs.io/) for an invite."
+            willing to help. You can sign-up [here](https://slack.babeljs.io/) for an invite.
 
   needs_info:
     name: Needs Info


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | -
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 👎
| Minor: New Feature?      | 👎
| Tests Added + Pass?      | 👎
| Any Dependency Changes?  | 👎
| License                  | MIT

Since September 2019 the babel-bot has had a dangling double-quote at the end of its new-issue welcome comments:

[Last issue without the bug, 15 Sep 2019](https://github.com/babel/babel/issues/10442#issuecomment-531585941)
![image](https://user-images.githubusercontent.com/26556598/134827540-1d578fe8-a849-4fe7-bda9-d7e0cdb69f51.png)

[First issue with the bug, 17 Sep 2019](https://github.com/babel/babel/issues/10450#issuecomment-532046534)
![image](https://user-images.githubusercontent.com/26556598/134827552-7e2dff60-ab98-4c72-8e46-5f9699ed3da7.png)

On 16 Sep 2019 the welcome comment logic was moved to GitHub CI, this fixes the typo there.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13797"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

