### PR TITLE
fix: remove imported types from export

### DIFF
--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/imported-types-only-remove-type-imports/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/imported-types-only-remove-type-imports/input.ts
@@ -1,0 +1,5 @@
+import type A from "A";
+import type { B } from "B";
+import C from "C";
+
+export { A, B, C } // <-- A and B will be removed

--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/imported-types-only-remove-type-imports/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/imported-types-only-remove-type-imports/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "transform-typescript",
+      {
+        "onlyRemoveTypeImports": true
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/imported-types-only-remove-type-imports/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/imported-types-only-remove-type-imports/output.mjs
@@ -1,0 +1,2 @@
+import C from "C";
+export { C }; // <-- A and B will be removed

--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/imported-types/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/imported-types/input.ts
@@ -1,0 +1,5 @@
+import type A from "A";
+import type { B } from "B";
+import C from "C";
+
+export { A, B, C } // <-- A and B will be removed

--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/imported-types/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/imported-types/output.mjs
@@ -1,0 +1,2 @@
+import C from "C";
+export { C }; // <-- A and B will be removed


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12499
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we register global types for imported types, so that when they are exported as values, they will be removed from exports just like other type declarations. This aligns to current [tsc behaviour](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBDAnmApnA3nAchAJmgXzgDMoIQ4AiJVAZwGMpgwZKBuAKBQA9JYNseQkA).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13800"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

