### PR TITLE
remove verifyPackageTree patch

### DIFF
--- a/scripts/integration-tests/e2e-create-react-app.sh
+++ b/scripts/integration-tests/e2e-create-react-app.sh
@@ -33,13 +33,6 @@ fi
 # This change replaces useBuiltIns: true with runtime: "classic"
 sed -i 's/useBuiltIns: true/runtime: "classic"/' packages/babel-preset-react-app/create.js
 
-# create-react-app throws if `@babel/eslint-parser` is not pinned, but we
-# must upgrade it for test purposes
-sed -i "s#'@babel/eslint-parser',##" packages/react-scripts/scripts/utils/verifyPackageTree.js
-
-# remove this line when https://github.com/facebook/create-react-app/pull/11216 gets merged
-sed -i "s#isESLintPluginEnabled && 'babel-eslint',##" packages/react-scripts/scripts/utils/verifyPackageTree.js
-
 bump_deps="$PWD/../../utils/bump-babel-dependencies.js"
 node "$bump_deps"
 for d in ./packages/*/


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fix failing react e2e test
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The `verifyPackageTree.js` was removed in https://github.com/facebook/create-react-app/pull/11474, we don't need to patch it now.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13805"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

