### PR TITLE
Optimization of string splitting

### DIFF
--- a/packages/babel-code-frame/src/index.ts
+++ b/packages/babel-code-frame/src/index.ts
@@ -147,7 +147,7 @@ export function codeFrameColumns(
   const highlightedLines = highlighted ? highlight(rawLines, opts) : rawLines;
 
   let frame = highlightedLines
-    .split(NEWLINE)
+    .split(NEWLINE, end)
     .slice(start, end)
     .map((line, index) => {
       const number = start + 1 + index;


### PR DESCRIPTION
Added a limit for split operation. It decreases the count of the new strings.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13812"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

