### PR TITLE
Improve debug logging for IgnoreList

### DIFF
--- a/packages/babel-core/src/config/config-chain.ts
+++ b/packages/babel-core/src/config/config-chain.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { inspect } from "util";
 import buildDebug from "debug";
 import type { Handler } from "gensync";
 import { validate } from "./validation/options";
@@ -780,6 +781,20 @@ function configFieldIsApplicable(
 }
 
 /**
+ * Print the ignoreList-values in a more helpful way than the default.
+ */
+function ignoreListReplacer(
+  _key: string,
+  value: IgnoreList | IgnoreItem,
+): IgnoreList | IgnoreItem | string {
+  if (value instanceof RegExp) {
+    return inspect(value);
+  }
+
+  return value;
+}
+
+/**
  * Tests if a filename should be ignored based on "ignore" and "only" options.
  */
 function shouldIgnore(
@@ -793,6 +808,7 @@ function shouldIgnore(
       context.filename ?? "(unknown)"
     }" because it matches one of \`ignore: ${JSON.stringify(
       ignore,
+      ignoreListReplacer,
     )}\` from "${dirname}"`;
     debug(message);
     if (context.showConfig) {
@@ -806,6 +822,7 @@ function shouldIgnore(
       context.filename ?? "(unknown)"
     }" because it fails to match one of \`only: ${JSON.stringify(
       only,
+      ignoreListReplacer,
     )}\` from "${dirname}"`;
     debug(message);
     if (context.showConfig) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Changes debug output
| Tests Added + Pass?      | Not sure
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR changes the output of the debug logs when running with `DEBUG="babel:config:config-chain"`.

Example:

Note how `ignore: [{}]` becomes `ignore: [/some-script/i]`:

```
babel:config:config-chain No config is applied to "~/dev/my-repo/node_modules/@some-lib/server/some-script.js" because it matches one of `ignore: [{}]` from "~/dev/my-repo"
```

becomes

```
babel:config:config-chain No config is applied to "~/dev/my-repo/node_modules/@some-lib/server/some-script.js" because it matches one of `ignore: [/some-script/i]` from "~/dev/my-repo"
```