### PR TITLE
ignore non-js files in `babel-helpers/src/helpers`

### DIFF
--- a/packages/babel-helpers/scripts/generate-helpers.js
+++ b/packages/babel-helpers/scripts/generate-helpers.js
@@ -5,7 +5,7 @@ import { URL, fileURLToPath } from "url";
 const HELPERS_FOLDER = new URL("../src/helpers", import.meta.url);
 const IGNORED_FILES = new Set(["package.json"]);
 
-export default async function generateAsserts() {
+export default async function generateHelpers() {
   let output = `/*
  * This file is auto-generated! Do not modify it directly.
  * To re-generate run 'make build'


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | none
| Patch: Bug Fix?          | not really a bug, just nuissance
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | none added
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I've encountered an issue where I had some `.js.orig` files from a failed merge in helpers dir, and these ended up in `helpers-generated.ts`.

Previously I made `generate-helpers.js` silently ignore files starting with a dot (hidden). This time I'm ignoring any files not ending with `.js`, loudly with a message to console.error, in order to avoid surprising anyone who would for whatever reason expect a non-js file to be included; and also to report actual garbage that should probably be deleted ;)


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13833"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

