### PR TITLE
minor: remove ineffectual helper names filter

### DIFF
--- a/packages/babel-helpers/src/index.ts
+++ b/packages/babel-helpers/src/index.ts
@@ -354,8 +354,6 @@ export function ensure(name: string, newFileClass?) {
   loadHelper(name);
 }
 
-export const list = Object.keys(helpers)
-  .map(name => name.replace(/^_/, ""))
-  .filter(name => name !== "__esModule");
+export const list = Object.keys(helpers).map(name => name.replace(/^_/, ""));
 
 export default get;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | none
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Property `__esModule` is not enumerable, so it won't appear in `Object.keys`. If it did, the filter that was there wouldn't see it because it ran after one leading `_` was removed ;)


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13841"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

