### PR TITLE
[ts] precise return type on `createTypeAnnotationBasedOnTypeof` (babel-types)

### DIFF
--- a/packages/babel-types/src/builders/flow/createTypeAnnotationBasedOnTypeof.ts
+++ b/packages/babel-types/src/builders/flow/createTypeAnnotationBasedOnTypeof.ts
@@ -9,44 +9,40 @@ import {
 } from "../generated";
 import type * as t from "../..";
 
+export default createTypeAnnotationBasedOnTypeof as {
+  (type: "string"): t.StringTypeAnnotation;
+  (type: "number"): t.NumberTypeAnnotation;
+  (type: "undefined"): t.VoidTypeAnnotation;
+  (type: "boolean"): t.BooleanTypeAnnotation;
+  (type: "function"): t.GenericTypeAnnotation;
+  (type: "object"): t.GenericTypeAnnotation;
+  (type: "symbol"): t.GenericTypeAnnotation;
+  (type: "bigint"): t.AnyTypeAnnotation;
+};
+
 /**
  * Create a type annotation based on typeof expression.
  */
-export default function createTypeAnnotationBasedOnTypeof(
-  type:
-    | "string"
-    | "number"
-    | "undefined"
-    | "boolean"
-    | "function"
-    | "object"
-    | "symbol",
-):
-  | t.StringTypeAnnotation
-  | t.VoidTypeAnnotation
-  | t.NumberTypeAnnotation
-  | t.BooleanTypeAnnotation
-  | t.GenericTypeAnnotation
-  | t.AnyTypeAnnotation {
-  if (type === "string") {
-    return stringTypeAnnotation();
-  } else if (type === "number") {
-    return numberTypeAnnotation();
-  } else if (type === "undefined") {
-    return voidTypeAnnotation();
-  } else if (type === "boolean") {
-    return booleanTypeAnnotation();
-  } else if (type === "function") {
-    return genericTypeAnnotation(identifier("Function"));
-  } else if (type === "object") {
-    return genericTypeAnnotation(identifier("Object"));
-  } else if (type === "symbol") {
-    return genericTypeAnnotation(identifier("Symbol"));
-  } else if (type === "bigint") {
-    // todo: use BigInt annotation when Flow supports BigInt
-    // https://github.com/facebook/flow/issues/6639
-    return anyTypeAnnotation();
-  } else {
-    throw new Error("Invalid typeof value: " + type);
+function createTypeAnnotationBasedOnTypeof(type: string): t.FlowType {
+  switch (type) {
+    case "string":
+      return stringTypeAnnotation();
+    case "number":
+      return numberTypeAnnotation();
+    case "undefined":
+      return voidTypeAnnotation();
+    case "boolean":
+      return booleanTypeAnnotation();
+    case "function":
+      return genericTypeAnnotation(identifier("Function"));
+    case "object":
+      return genericTypeAnnotation(identifier("Object"));
+    case "symbol":
+      return genericTypeAnnotation(identifier("Symbol"));
+    case "bigint":
+      // todo: use BigInt annotation when Flow supports BigInt
+      // https://github.com/facebook/flow/issues/6639
+      return anyTypeAnnotation();
   }
+  throw new Error("Invalid typeof value: " + type);
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | none
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | none added
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Diff best viewed ignoring whitespace changes, it'll show more clearly that only the function type is changed to be more granular — instead of a union argument type and a union return type, the argument now selects the return type. Remaining changes are just rewriting `if-else` chain to a `switch`.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13844"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

