### PR TITLE
Force loading plugins/presets from the monorepo in tests

### DIFF
--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -284,13 +284,25 @@ function wrapPackagesArray(type, names, optionsDir) {
 
       val[0] = path.resolve(optionsDir, val[0]);
     } else {
+      let name = val[0];
+      const match = name.match(/^(@babel\/(?:plugin-|preset-)?)(.*)$/);
+      if (match) {
+        name = match[2];
+      }
+
       const monorepoPath = path.join(
         path.dirname(fileURLToPath(import.meta.url)),
         "../..",
-        `babel-${type}-${val[0]}`,
+        `babel-${type}-${name}`,
       );
 
       if (fs.existsSync(monorepoPath)) {
+        if (match) {
+          throw new Error(
+            `Remove the "${match[1]}" prefix from "${val[0]}", to load it from the monorepo`,
+          );
+        }
+
         val[0] = monorepoPath;
       }
     }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/tagged-template/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/tagged-template/options.json
@@ -1,13 +1,13 @@
 {
-    "presets": [
-      [
-        "@babel/preset-env",
-        {
-          "shippedProposals": true,
-          "targets": {
-            "chrome": "75"
-          }
+  "presets": [
+    [
+      "env",
+      {
+        "shippedProposals": true,
+        "targets": {
+          "chrome": "75"
         }
-      ]
+      }
     ]
-  }
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/windows/absoluteRuntime/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/windows/absoluteRuntime/options.json
@@ -2,7 +2,7 @@
   "externalHelpers": false,
   "presets": [
     [
-      "@babel/preset-env",
+      "env",
       {
         "corejs": 3,
         "useBuiltIns": "entry"

--- a/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/options.json
+++ b/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/options.json
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/preset-react", { "development": true }],
+    ["react", { "development": true }],
     "./emotion-css-prop-preset.js"
   ],
   "os": ["linux", "darwin"]

--- a/packages/babel-preset-react/test/fixtures/regression/runtime-classic-allow-multiple-source-self/options.json
+++ b/packages/babel-preset-react/test/fixtures/regression/runtime-classic-allow-multiple-source-self/options.json
@@ -1,4 +1,7 @@
 {
-  "presets": [["@babel/preset-react", { "development": true, "runtime": "classic" }], "./my-preset"],
+  "presets": [
+    ["react", { "development": true, "runtime": "classic" }],
+    "./my-preset"
+  ],
   "os": ["linux", "darwin"]
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes the CI failure in https://github.com/babel/babel/pull/13856
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When using `@babel/`-prefixed plugins/presets, they are always loaded from `node_modules`. With Yarn 2 and Yarn 3 we were lucky enough that the version resolved in `node_modules` was a symlink to the monorepo version, but due to some changes to the hoisting algorithm this isn't true anymore in Yarn 3.1 (so it uncovered the bug).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13858"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

