### PR TITLE
Adds the `@init:` modifier to decorator plugins

### DIFF
--- a/packages/babel-core/test/fixtures/parse/output-legacy.json
+++ b/packages/babel-core/test/fixtures/parse/output-legacy.json
@@ -49,7 +49,6 @@
             "type": "Decorator",
             "start": 0,
             "end": 11,
-            "init": false,
             "loc": {
               "start": {
                 "line": 1,

--- a/packages/babel-core/test/parse.js
+++ b/packages/babel-core/test/parse.js
@@ -18,7 +18,7 @@ function fixture(...args) {
 describe("parse", function () {
   it("should parse using configuration from .babelrc when a filename is provided", function () {
     const input = fs.readFileSync(fixture("input.js"), "utf8");
-    const output = require(fixture("output"));
+    const output = require(fixture("output-legacy.json"));
 
     const result = parse(input, {
       filename: fixture("input.js"),

--- a/packages/babel-parser/ast/spec.md
+++ b/packages/babel-parser/ast/spec.md
@@ -598,6 +598,7 @@ A variable declarator.
 interface Decorator <: Node {
   type: "Decorator";
   expression: Expression;
+  init: boolean;
 }
 ```
 

--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -223,6 +223,8 @@ export const ErrorMessages = makeErrorTemplates(
     UnsupportedBind: "Binding should be performed on object property.",
     UnsupportedDecoratorExport:
       "A decorated export must export a class declaration.",
+    UnsupportedDecoratorModifier:
+      "Unsupported decorator modifier. `@init:` is the only modifier currently supported for decorators.",
     UnsupportedDefaultExport:
       "Only expressions, functions or classes are allowed as the `default` export.",
     UnsupportedImport:

--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -229,6 +229,8 @@ export const ErrorMessages = makeErrorTemplates(
       "Only expressions, functions or classes are allowed as the `default` export.",
     UnsupportedImport:
       "`import` can only be used in `import()` or `import.meta`.",
+    UnsupportedLegacyDecoratorModifier:
+      "Legacy decorators do not support modifiers.",
     UnsupportedMetaProperty: "The only valid meta property for %0 is %0.%1.",
     UnsupportedParameterDecorator:
       "Decorators cannot be used to decorate parameters.",

--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -229,8 +229,6 @@ export const ErrorMessages = makeErrorTemplates(
       "Only expressions, functions or classes are allowed as the `default` export.",
     UnsupportedImport:
       "`import` can only be used in `import()` or `import.meta`.",
-    UnsupportedLegacyDecoratorModifier:
-      "Legacy decorators do not support modifiers.",
     UnsupportedMetaProperty: "The only valid meta property for %0 is %0.%1.",
     UnsupportedParameterDecorator:
       "Decorators cannot be used to decorate parameters.",

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -32,6 +32,7 @@ import {
   tokenOperatorPrecedence,
   tt,
   type TokenType,
+  tokenIsDecorator,
 } from "../tokenizer/types";
 import * as N from "../types";
 import LValParser from "./lval";
@@ -1143,6 +1144,7 @@ export default class ExpressionParser extends LValParser {
         return this.parseFunctionOrFunctionSent();
 
       case tt.at:
+      case tt.atInit:
         this.parseDecorators();
       // fall through
       case tt._class:
@@ -1955,7 +1957,7 @@ export default class ExpressionParser extends LValParser {
     refExpressionErrors?: ?ExpressionErrors,
   ): N.ObjectMember | N.SpreadElement {
     let decorators = [];
-    if (this.match(tt.at)) {
+    if (tokenIsDecorator(this.state.type)) {
       if (this.hasPlugin("decorators")) {
         this.raise(this.state.start, Errors.UnsupportedPropertyDecorator);
       }

--- a/packages/babel-parser/src/parser/lval.js
+++ b/packages/babel-parser/src/parser/lval.js
@@ -390,7 +390,10 @@ export default class LValParser extends NodeUtils {
         break;
       } else {
         const decorators = [];
-        if (this.match(tt.at) && this.hasPlugin("decorators")) {
+        if (
+          (this.match(tt.at) && this.hasPlugin("decorators")) ||
+          this.match(tt.atInit)
+        ) {
           this.raise(this.state.start, Errors.UnsupportedParameterDecorator);
         }
         // invariant: hasPlugin("decorators-legacy")

--- a/packages/babel-parser/src/parser/lval.js
+++ b/packages/babel-parser/src/parser/lval.js
@@ -2,7 +2,7 @@
 
 /*:: declare var invariant; */
 import * as charCodes from "charcodes";
-import { tt, type TokenType } from "../tokenizer/types";
+import { tt, tokenIsDecorator, type TokenType } from "../tokenizer/types";
 import type {
   TSParameterProperty,
   Decorator,
@@ -390,10 +390,7 @@ export default class LValParser extends NodeUtils {
         break;
       } else {
         const decorators = [];
-        if (
-          (this.match(tt.at) && this.hasPlugin("decorators")) ||
-          this.match(tt.atInit)
-        ) {
+        if (tokenIsDecorator(this.state.type) && this.hasPlugin("decorators")) {
           this.raise(this.state.start, Errors.UnsupportedParameterDecorator);
         }
         // invariant: hasPlugin("decorators-legacy")

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -475,10 +475,6 @@ export default class StatementParser extends ExpressionParser {
       node.expression = this.parseMaybeDecoratorArguments(expr);
       this.state.decoratorStack.pop();
     } else {
-      if (isAtInit) {
-        throw this.raise(node.start, Errors.UnsupportedLegacyDecoratorModifier);
-      }
-
       node.expression = this.parseExprSubscripts();
     }
     return this.finishNode(node, "Decorator");

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -855,6 +855,8 @@ export default class Tokenizer extends ParserErrors {
         // @a::b is a valid decorator when using decorators-legacy and functionBind
         this.input.charCodeAt(workEndPos + 1) !== charCodes.colon
       ) {
+        this.expectPlugin("decorators");
+
         if (word !== "init") {
           this.raise(this.state.pos, Errors.UnsupportedDecoratorModifier);
         } else if (containsEsc) {

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -843,13 +843,18 @@ export default class Tokenizer extends ParserErrors {
       this.state = this.createLookaheadState(old);
 
       const word = this.readWord1(next);
-      const wordNext = this.input.charCodeAt(this.state.pos);
+      const workEndPos = this.state.pos;
+      const wordNext = this.input.charCodeAt(workEndPos);
       const containsEsc = this.state.containsEsc;
 
       // Replace the previous state
       this.state = old;
 
-      if (wordNext === charCodes.colon) {
+      if (
+        wordNext === charCodes.colon &&
+        // @a::b is a valid decorator when using decorators-legacy and functionBind
+        this.input.charCodeAt(workEndPos + 1) !== charCodes.colon
+      ) {
         if (word !== "init") {
           this.raise(this.state.pos, Errors.UnsupportedDecoratorModifier);
         } else if (containsEsc) {

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -829,6 +829,43 @@ export default class Tokenizer extends ParserErrors {
     }
   }
 
+  readToken_at(): void {
+    // Increase past @
+    ++this.state.pos;
+    const next = this.input.charCodeAt(this.state.pos);
+
+    if (isIdentifierStart(next)) {
+      // Read the next word with a lookahead state that we'll
+      // throw away afterwards. Cheaper than doing a full lookahead,
+      // since we know that we're trying to read a word/identifier.
+      const old = this.state;
+      // $FlowIgnore
+      this.state = this.createLookaheadState(old);
+
+      const word = this.readWord1(next);
+      const wordNext = this.input.charCodeAt(this.state.pos);
+      const containsEsc = this.state.containsEsc;
+
+      // Replace the previous state
+      this.state = old;
+
+      if (wordNext === charCodes.colon) {
+        if (word !== "init") {
+          this.raise(this.state.pos, Errors.UnsupportedDecoratorModifier);
+        } else if (containsEsc) {
+          this.raise(this.state.pos, Errors.InvalidEscapedReservedWord);
+        }
+
+        // Increase the pos by word.length + `:`
+        this.state.pos += word.length + 1;
+        this.finishToken(tt.atInit);
+        return;
+      }
+    }
+
+    this.finishToken(tt.at);
+  }
+
   getTokenFromCode(code: number): void {
     switch (code) {
       // The interpretation of a dot depends on whether it is followed
@@ -1009,8 +1046,7 @@ export default class Tokenizer extends ParserErrors {
         return;
 
       case charCodes.atSign:
-        ++this.state.pos;
-        this.finishToken(tt.at);
+        this.readToken_at();
         return;
 
       case charCodes.numberSign:

--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -159,6 +159,7 @@ export const tt: { [name: string]: TokenType } = {
   backQuote: createToken("`", { startsExpr }),
   dollarBraceL: createToken("${", { beforeExpr, startsExpr }),
   at: createToken("@"),
+  atInit: createToken("@init:"),
   hash: createToken("#", { startsExpr }),
 
   // Special hashbang token.
@@ -400,6 +401,10 @@ export function tokenOperatorPrecedence(token: TokenType): number {
 
 export function tokenIsRightAssociative(token: TokenType): boolean {
   return token === tt.exponent;
+}
+
+export function tokenIsDecorator(token: TokenType): boolean {
+  return token === tt.at || token === tt.atInit;
 }
 
 export function getExportedToken(token: TokenType): ExportedTokenType {

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -381,6 +381,7 @@ export type ArgumentPlaceholder = NodeBase & { type: "ArgumentPlaceholder" };
 export type Decorator = NodeBase & {
   type: "Decorator",
   expression: Expression,
+  init?: boolean,
   arguments?: Array<Expression | SpreadElement>,
 };
 

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -381,7 +381,7 @@ export type ArgumentPlaceholder = NodeBase & { type: "ArgumentPlaceholder" };
 export type Decorator = NodeBase & {
   type: "Decorator",
   expression: Expression,
-  init?: boolean,
+  init: boolean,
   arguments?: Array<Expression | SpreadElement>,
 };
 

--- a/packages/babel-parser/test/fixtures/es2022/class-properties/arguments-in-nested-class-decorator-call-expression/output.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-properties/arguments-in-nested-class-decorator-call-expression/output.json
@@ -68,6 +68,7 @@
                               {
                                 "type": "Decorator",
                                 "start":48,"end":63,"loc":{"start":{"line":3,"column":20},"end":{"line":3,"column":35}},
+                                "init": false,
                                 "expression": {
                                   "type": "CallExpression",
                                   "start":49,"end":63,"loc":{"start":{"line":3,"column":21},"end":{"line":3,"column":35}},

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/deorators-modifier-with-legacy/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/deorators-modifier-with-legacy/input.js
@@ -1,0 +1,4 @@
+class A {
+  @init:deco
+  method() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/deorators-modifier-with-legacy/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/deorators-modifier-with-legacy/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["decorators-legacy"],
+  "throws": "This experimental syntax requires enabling the parser plugin: 'decorators' (2:2)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-static-block/invalid-decorators/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-static-block/invalid-decorators/output.json
@@ -52,6 +52,7 @@
                 {
                   "type": "Decorator",
                   "start":30,"end":34,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":31,"end":34,"loc":{"start":{"line":3,"column":3},"end":{"line":3,"column":6},"identifierName":"dec"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/class-decorator-call-expr/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/class-decorator-call-expr/output.json
@@ -14,6 +14,7 @@
           {
             "type": "Decorator",
             "start":0,"end":11,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":11}},
+            "init": false,
             "expression": {
               "type": "CallExpression",
               "start":1,"end":11,"loc":{"start":{"line":1,"column":1},"end":{"line":1,"column":11}},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/class-decorator/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/class-decorator/output.json
@@ -14,6 +14,7 @@
           {
             "type": "Decorator",
             "start":0,"end":4,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":4}},
+            "init": false,
             "expression": {
               "type": "Identifier",
               "start":1,"end":4,"loc":{"start":{"line":1,"column":1},"end":{"line":1,"column":4},"identifierName":"abc"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/class-expression/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/class-expression/output.json
@@ -26,6 +26,7 @@
                 {
                   "type": "Decorator",
                   "start":10,"end":14,"loc":{"start":{"line":1,"column":10},"end":{"line":1,"column":14}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":11,"end":14,"loc":{"start":{"line":1,"column":11},"end":{"line":1,"column":14},"identifierName":"dec"},
@@ -50,6 +51,7 @@
                       {
                         "type": "Decorator",
                         "start":29,"end":33,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                        "init": false,
                         "expression": {
                           "type": "Identifier",
                           "start":30,"end":33,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"baz"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/class-generator/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/class-generator/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":12,"end":16,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":13,"end":16,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"dec"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/class-property/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/class-property/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":12,"end":16,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":13,"end":16,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"dec"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/complex-expr/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/complex-expr/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":12,"end":26,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":16}},
+                  "init": false,
                   "expression": {
                     "type": "CallExpression",
                     "start":13,"end":26,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":16}},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/compued-property/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/compued-property/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":14,"end":18,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":15,"end":18,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"bar"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-with-parens/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-with-parens/output.json
@@ -17,6 +17,7 @@
             {
               "type": "Decorator",
               "start":16,"end":26,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":26}},
+              "init": false,
               "expression": {
                 "type": "Identifier",
                 "start":17,"end":26,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":26},"identifierName":"decorator"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-without-parens/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-without-parens/output.json
@@ -20,6 +20,7 @@
             {
               "type": "Decorator",
               "start":15,"end":25,"loc":{"start":{"line":1,"column":15},"end":{"line":1,"column":25}},
+              "init": false,
               "expression": {
                 "type": "Identifier",
                 "start":16,"end":25,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":25},"identifierName":"decorator"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default/output.json
@@ -17,6 +17,7 @@
             {
               "type": "Decorator",
               "start":0,"end":10,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":10}},
+              "init": false,
               "expression": {
                 "type": "Identifier",
                 "start":1,"end":10,"loc":{"start":{"line":1,"column":1},"end":{"line":1,"column":10},"identifierName":"decorator"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export/output.json
@@ -19,6 +19,7 @@
             {
               "type": "Decorator",
               "start":0,"end":10,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":10}},
+              "init": false,
               "expression": {
                 "type": "Identifier",
                 "start":1,"end":10,"loc":{"start":{"line":1,"column":1},"end":{"line":1,"column":10},"identifierName":"decorator"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/export-decorated-class/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/export-decorated-class/output.json
@@ -19,6 +19,7 @@
             {
               "type": "Decorator",
               "start":7,"end":11,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":11}},
+              "init": false,
               "expression": {
                 "type": "Identifier",
                 "start":8,"end":11,"loc":{"start":{"line":1,"column":8},"end":{"line":1,"column":11},"identifierName":"bar"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/export-default-decorated-class/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/export-default-decorated-class/output.json
@@ -17,6 +17,7 @@
             {
               "type": "Decorator",
               "start":16,"end":20,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":4}},
+              "init": false,
               "expression": {
                 "type": "Identifier",
                 "start":17,"end":20,"loc":{"start":{"line":2,"column":1},"end":{"line":2,"column":4},"identifierName":"bar"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/get-decorator/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/get-decorator/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":12,"end":16,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":13,"end":16,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"foo"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/init-modifier/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/init-modifier/input.js
@@ -1,0 +1,14 @@
+@init:foo
+class A {
+  @init:foo bar;
+
+  @init:foo baz = 123;
+
+  @init:foo get qux() {}
+
+  @init:foo quux() {}
+
+  @init:(foo) foobar;
+
+  @init:foo.bar barbaz;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/init-modifier/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/init-modifier/output.json
@@ -1,0 +1,223 @@
+{
+  "type": "File",
+  "start":0,"end":159,"loc":{"start":{"line":1,"column":0},"end":{"line":14,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":159,"loc":{"start":{"line":1,"column":0},"end":{"line":14,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":159,"loc":{"start":{"line":1,"column":0},"end":{"line":14,"column":1}},
+        "decorators": [
+          {
+            "type": "Decorator",
+            "start":0,"end":9,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":9}},
+            "init": true,
+            "expression": {
+              "type": "Identifier",
+              "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"foo"},
+              "name": "foo"
+            }
+          }
+        ],
+        "id": {
+          "type": "Identifier",
+          "start":16,"end":17,"loc":{"start":{"line":2,"column":6},"end":{"line":2,"column":7},"identifierName":"A"},
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":18,"end":159,"loc":{"start":{"line":2,"column":8},"end":{"line":14,"column":1}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":22,"end":36,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":16}},
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start":22,"end":31,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":11}},
+                  "init": true,
+                  "expression": {
+                    "type": "Identifier",
+                    "start":28,"end":31,"loc":{"start":{"line":3,"column":8},"end":{"line":3,"column":11},"identifierName":"foo"},
+                    "name": "foo"
+                  }
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":32,"end":35,"loc":{"start":{"line":3,"column":12},"end":{"line":3,"column":15},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start":40,"end":60,"loc":{"start":{"line":5,"column":2},"end":{"line":5,"column":22}},
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start":40,"end":49,"loc":{"start":{"line":5,"column":2},"end":{"line":5,"column":11}},
+                  "init": true,
+                  "expression": {
+                    "type": "Identifier",
+                    "start":46,"end":49,"loc":{"start":{"line":5,"column":8},"end":{"line":5,"column":11},"identifierName":"foo"},
+                    "name": "foo"
+                  }
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":50,"end":53,"loc":{"start":{"line":5,"column":12},"end":{"line":5,"column":15},"identifierName":"baz"},
+                "name": "baz"
+              },
+              "computed": false,
+              "value": {
+                "type": "NumericLiteral",
+                "start":56,"end":59,"loc":{"start":{"line":5,"column":18},"end":{"line":5,"column":21}},
+                "extra": {
+                  "rawValue": 123,
+                  "raw": "123"
+                },
+                "value": 123
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":64,"end":86,"loc":{"start":{"line":7,"column":2},"end":{"line":7,"column":24}},
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start":64,"end":73,"loc":{"start":{"line":7,"column":2},"end":{"line":7,"column":11}},
+                  "init": true,
+                  "expression": {
+                    "type": "Identifier",
+                    "start":70,"end":73,"loc":{"start":{"line":7,"column":8},"end":{"line":7,"column":11},"identifierName":"foo"},
+                    "name": "foo"
+                  }
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":78,"end":81,"loc":{"start":{"line":7,"column":16},"end":{"line":7,"column":19},"identifierName":"qux"},
+                "name": "qux"
+              },
+              "computed": false,
+              "kind": "get",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":84,"end":86,"loc":{"start":{"line":7,"column":22},"end":{"line":7,"column":24}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":90,"end":109,"loc":{"start":{"line":9,"column":2},"end":{"line":9,"column":21}},
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start":90,"end":99,"loc":{"start":{"line":9,"column":2},"end":{"line":9,"column":11}},
+                  "init": true,
+                  "expression": {
+                    "type": "Identifier",
+                    "start":96,"end":99,"loc":{"start":{"line":9,"column":8},"end":{"line":9,"column":11},"identifierName":"foo"},
+                    "name": "foo"
+                  }
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":100,"end":104,"loc":{"start":{"line":9,"column":12},"end":{"line":9,"column":16},"identifierName":"quux"},
+                "name": "quux"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":107,"end":109,"loc":{"start":{"line":9,"column":19},"end":{"line":9,"column":21}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassProperty",
+              "start":113,"end":132,"loc":{"start":{"line":11,"column":2},"end":{"line":11,"column":21}},
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start":113,"end":124,"loc":{"start":{"line":11,"column":2},"end":{"line":11,"column":13}},
+                  "init": true,
+                  "expression": {
+                    "type": "Identifier",
+                    "start":120,"end":123,"loc":{"start":{"line":11,"column":9},"end":{"line":11,"column":12},"identifierName":"foo"},
+                    "name": "foo"
+                  }
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":125,"end":131,"loc":{"start":{"line":11,"column":14},"end":{"line":11,"column":20},"identifierName":"foobar"},
+                "name": "foobar"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start":136,"end":157,"loc":{"start":{"line":13,"column":2},"end":{"line":13,"column":23}},
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start":136,"end":149,"loc":{"start":{"line":13,"column":2},"end":{"line":13,"column":15}},
+                  "init": true,
+                  "expression": {
+                    "type": "MemberExpression",
+                    "start":137,"end":149,"loc":{"start":{"line":13,"column":3},"end":{"line":13,"column":15}},
+                    "object": {
+                      "type": "Identifier",
+                      "start":142,"end":145,"loc":{"start":{"line":13,"column":8},"end":{"line":13,"column":11},"identifierName":"foo"},
+                      "name": "foo"
+                    },
+                    "property": {
+                      "type": "Identifier",
+                      "start":146,"end":149,"loc":{"start":{"line":13,"column":12},"end":{"line":13,"column":15},"identifierName":"bar"},
+                      "name": "bar"
+                    },
+                    "computed": false
+                  }
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":150,"end":156,"loc":{"start":{"line":13,"column":16},"end":{"line":13,"column":22},"identifierName":"barbaz"},
+                "name": "barbaz"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/init-modifier/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/init-modifier/output.json
@@ -190,7 +190,7 @@
                   "init": true,
                   "expression": {
                     "type": "MemberExpression",
-                    "start":137,"end":149,"loc":{"start":{"line":13,"column":3},"end":{"line":13,"column":15}},
+                    "start":142,"end":149,"loc":{"start":{"line":13,"column":8},"end":{"line":13,"column":15}},
                     "object": {
                       "type": "Identifier",
                       "start":142,"end":145,"loc":{"start":{"line":13,"column":8},"end":{"line":13,"column":11},"identifierName":"foo"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/nested-class-decorator-parameters/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/nested-class-decorator-parameters/output.json
@@ -14,6 +14,7 @@
           {
             "type": "Decorator",
             "start":0,"end":40,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":2}},
+            "init": false,
             "expression": {
               "type": "CallExpression",
               "start":1,"end":40,"loc":{"start":{"line":1,"column":1},"end":{"line":3,"column":2}},
@@ -45,6 +46,7 @@
                           {
                             "type": "Decorator",
                             "start":18,"end":24,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":15}},
+                            "init": false,
                             "expression": {
                               "type": "Identifier",
                               "start":19,"end":24,"loc":{"start":{"line":2,"column":10},"end":{"line":2,"column":15},"identifierName":"inner"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/nested-class-decorator/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/nested-class-decorator/output.json
@@ -14,6 +14,7 @@
           {
             "type": "Decorator",
             "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":2}},
+            "init": false,
             "expression": {
               "type": "ObjectExpression",
               "start":2,"end":34,"loc":{"start":{"line":1,"column":2},"end":{"line":3,"column":1}},
@@ -36,6 +37,7 @@
                       {
                         "type": "Decorator",
                         "start":13,"end":19,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":15}},
+                        "init": false,
                         "expression": {
                           "type": "Identifier",
                           "start":14,"end":19,"loc":{"start":{"line":2,"column":10},"end":{"line":2,"column":15},"identifierName":"inner"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/nested-method-decorator-parameters/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/nested-method-decorator-parameters/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":13,"end":91,"loc":{"start":{"line":2,"column":2},"end":{"line":7,"column":3}},
+                  "init": false,
                   "expression": {
                     "type": "CallExpression",
                     "start":14,"end":91,"loc":{"start":{"line":2,"column":3},"end":{"line":7,"column":3}},
@@ -43,6 +44,7 @@
                           {
                             "type": "Decorator",
                             "start":25,"end":34,"loc":{"start":{"line":3,"column":4},"end":{"line":3,"column":13}},
+                            "init": false,
                             "expression": {
                               "type": "Identifier",
                               "start":26,"end":34,"loc":{"start":{"line":3,"column":5},"end":{"line":3,"column":13},"identifierName":"classDec"},
@@ -63,6 +65,7 @@
                                 {
                                   "type": "Decorator",
                                   "start":50,"end":56,"loc":{"start":{"line":4,"column":6},"end":{"line":4,"column":12}},
+                                  "init": false,
                                   "expression": {
                                     "type": "Identifier",
                                     "start":51,"end":56,"loc":{"start":{"line":4,"column":7},"end":{"line":4,"column":12},"identifierName":"inner"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/nested-method-decorator/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/nested-method-decorator/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":13,"end":86,"loc":{"start":{"line":2,"column":2},"end":{"line":7,"column":3}},
+                  "init": false,
                   "expression": {
                     "type": "ClassExpression",
                     "start":20,"end":82,"loc":{"start":{"line":3,"column":4},"end":{"line":6,"column":5}},
@@ -34,6 +35,7 @@
                       {
                         "type": "Decorator",
                         "start":20,"end":29,"loc":{"start":{"line":3,"column":4},"end":{"line":3,"column":13}},
+                        "init": false,
                         "expression": {
                           "type": "Identifier",
                           "start":21,"end":29,"loc":{"start":{"line":3,"column":5},"end":{"line":3,"column":13},"identifierName":"classDec"},
@@ -54,6 +56,7 @@
                             {
                               "type": "Decorator",
                               "start":45,"end":51,"loc":{"start":{"line":4,"column":6},"end":{"line":4,"column":12}},
+                              "init": false,
                               "expression": {
                                 "type": "Identifier",
                                 "start":46,"end":51,"loc":{"start":{"line":4,"column":7},"end":{"line":4,"column":12},"identifierName":"inner"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/no-class-method-parameter/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/no-class-method-parameter/output.json
@@ -46,6 +46,7 @@
                     {
                       "type": "Decorator",
                       "start":26,"end":30,"loc":{"start":{"line":2,"column":14},"end":{"line":2,"column":18}},
+                      "init": false,
                       "expression": {
                         "type": "Identifier",
                         "start":27,"end":30,"loc":{"start":{"line":2,"column":15},"end":{"line":2,"column":18},"identifierName":"foo"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/no-constructor-decorators/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/no-constructor-decorators/output.json
@@ -30,6 +30,7 @@
                 {
                   "type": "Decorator",
                   "start":14,"end":18,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":15,"end":18,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"abc"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/no-export-decorators-on-class/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/no-export-decorators-on-class/output.json
@@ -20,6 +20,7 @@
             {
               "type": "Decorator",
               "start":0,"end":4,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":4}},
+              "init": false,
               "expression": {
                 "type": "Identifier",
                 "start":1,"end":4,"loc":{"start":{"line":1,"column":1},"end":{"line":1,"column":4},"identifierName":"foo"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/no-function-parameters/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/no-function-parameters/output.json
@@ -29,6 +29,7 @@
               {
                 "type": "Decorator",
                 "start":14,"end":18,"loc":{"start":{"line":1,"column":14},"end":{"line":1,"column":18}},
+                "init": false,
                 "expression": {
                   "type": "Identifier",
                   "start":15,"end":18,"loc":{"start":{"line":1,"column":15},"end":{"line":1,"column":18},"identifierName":"foo"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/no-object-method-parameters/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/no-object-method-parameters/output.json
@@ -49,6 +49,7 @@
                         {
                           "type": "Decorator",
                           "start":21,"end":25,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":13}},
+                          "init": false,
                           "expression": {
                             "type": "Identifier",
                             "start":22,"end":25,"loc":{"start":{"line":2,"column":10},"end":{"line":2,"column":13},"identifierName":"foo"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/no-object-methods/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/no-object-methods/output.json
@@ -33,6 +33,7 @@
                     {
                       "type": "Decorator",
                       "start":12,"end":16,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                      "init": false,
                       "expression": {
                         "type": "Identifier",
                         "start":13,"end":16,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"baz"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/on-computed-name-method/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/on-computed-name-method/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":12,"end":16,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":13,"end":16,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"dec"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/parenthesized/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/parenthesized/output.json
@@ -14,6 +14,7 @@
           {
             "type": "Decorator",
             "start":0,"end":12,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":12}},
+            "init": false,
             "expression": {
               "type": "MemberExpression",
               "start":2,"end":11,"loc":{"start":{"line":1,"column":2},"end":{"line":1,"column":11}},
@@ -53,6 +54,7 @@
                 {
                   "type": "Decorator",
                   "start":27,"end":48,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":23}},
+                  "init": false,
                   "expression": {
                     "type": "MemberExpression",
                     "start":29,"end":47,"loc":{"start":{"line":3,"column":4},"end":{"line":3,"column":22}},
@@ -96,6 +98,7 @@
                 {
                   "type": "Decorator",
                   "start":64,"end":76,"loc":{"start":{"line":5,"column":2},"end":{"line":5,"column":14}},
+                  "init": false,
                   "expression": {
                     "type": "BinaryExpression",
                     "start":66,"end":75,"loc":{"start":{"line":5,"column":4},"end":{"line":5,"column":13}},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/private-property/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/private-property/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":12,"end":16,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":13,"end":16,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"dec"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/set-decorator/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/set-decorator/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":12,"end":16,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":13,"end":16,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"foo"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/static-method/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/static-method/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":14,"end":18,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":15,"end":18,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"dec"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/static-property/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/static-property/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":12,"end":16,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":13,"end":16,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"dec"},

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/unknown-modifier/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/unknown-modifier/input.js
@@ -1,0 +1,3 @@
+@unknown:foo
+class A {
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/unknown-modifier/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/unknown-modifier/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    [
+      "decorators",
+      {
+        "decoratorsBeforeExport": false
+      }
+    ]
+  ],
+  "throws": "Unsupported decorator modifier. `@init:` is the only modifier currently supported for decorators. (1:1)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/unknown-modifier/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/unknown-modifier/options.json
@@ -6,6 +6,5 @@
         "decoratorsBeforeExport": false
       }
     ]
-  ],
-  "throws": "Unsupported decorator modifier. `@init:` is the only modifier currently supported for decorators. (1:1)"
+  ]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/unknown-modifier/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/unknown-modifier/output.json
@@ -1,0 +1,43 @@
+{
+  "type": "File",
+  "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+  "errors": [
+    "SyntaxError: Unsupported decorator modifier. `@init:` is the only modifier currently supported for decorators. (1:1)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
+        "decorators": [
+          {
+            "type": "Decorator",
+            "start":0,"end":12,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":12}},
+            "init": true,
+            "expression": {
+              "type": "Identifier",
+              "start":9,"end":12,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":12},"identifierName":"foo"},
+              "name": "foo"
+            }
+          }
+        ],
+        "id": {
+          "type": "Identifier",
+          "start":19,"end":20,"loc":{"start":{"line":2,"column":6},"end":{"line":2,"column":7},"identifierName":"A"},
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":21,"end":24,"loc":{"start":{"line":2,"column":8},"end":{"line":3,"column":1}},
+          "body": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorators/function-bind/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/function-bind/input.js
@@ -1,0 +1,4 @@
+class A {
+  @init::x
+  p
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorators/function-bind/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/function-bind/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["decorators-legacy", "functionBind"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorators/function-bind/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/function-bind/output.json
@@ -1,0 +1,61 @@
+{
+  "type": "File",
+  "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":26,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"A"},
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":8,"end":26,"loc":{"start":{"line":1,"column":8},"end":{"line":4,"column":1}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":12,"end":24,"loc":{"start":{"line":2,"column":2},"end":{"line":3,"column":3}},
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start":12,"end":20,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":10}},
+                  "expression": {
+                    "type": "BindExpression",
+                    "start":13,"end":20,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":10}},
+                    "object": {
+                      "type": "Identifier",
+                      "start":13,"end":17,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":7},"identifierName":"init"},
+                      "name": "init"
+                    },
+                    "callee": {
+                      "type": "Identifier",
+                      "start":19,"end":20,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":10},"identifierName":"x"},
+                      "name": "x"
+                    }
+                  }
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":23,"end":24,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":3},"identifierName":"p"},
+                "name": "p"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-caret-proposal-class-expression-with-decorators/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-caret-proposal-class-expression-with-decorators/output.json
@@ -25,14 +25,11 @@
             "callee": {
               "type": "ClassExpression",
               "start":17,"end":127,"loc":{"start":{"line":2,"column":2},"end":{"line":8,"column":3}},
-              "extra": {
-                "parenthesized": true,
-                "parenStart": 13
-              },
               "decorators": [
                 {
                   "type": "Decorator",
                   "start":17,"end":32,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":17}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":18,"end":32,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":17},"identifierName":"classDecorator"},
@@ -57,6 +54,7 @@
                       {
                         "type": "Decorator",
                         "start":53,"end":69,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":20}},
+                        "init": false,
                         "expression": {
                           "type": "Identifier",
                           "start":54,"end":69,"loc":{"start":{"line":4,"column":5},"end":{"line":4,"column":20},"identifierName":"methodDecorator"},
@@ -112,6 +110,10 @@
                     }
                   }
                 ]
+              },
+              "extra": {
+                "parenthesized": true,
+                "parenStart": 13
               }
             },
             "arguments": []

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-hash-proposal-class-expression-with-decorators/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-hash-proposal-class-expression-with-decorators/output.json
@@ -29,6 +29,7 @@
                 {
                   "type": "Decorator",
                   "start":17,"end":32,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":17}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":18,"end":32,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":17},"identifierName":"classDecorator"},
@@ -53,6 +54,7 @@
                       {
                         "type": "Decorator",
                         "start":53,"end":69,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":20}},
+                        "init": false,
                         "expression": {
                           "type": "Identifier",
                           "start":54,"end":69,"loc":{"start":{"line":4,"column":5},"end":{"line":4,"column":20},"identifierName":"methodDecorator"},

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-percent-proposal-class-expression-with-decorators/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-percent-proposal-class-expression-with-decorators/output.json
@@ -29,6 +29,7 @@
                 {
                   "type": "Decorator",
                   "start":17,"end":32,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":17}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":18,"end":32,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":17},"identifierName":"classDecorator"},
@@ -53,6 +54,7 @@
                       {
                         "type": "Decorator",
                         "start":53,"end":69,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":20}},
+                        "init": false,
                         "expression": {
                           "type": "Identifier",
                           "start":54,"end":69,"loc":{"start":{"line":4,"column":5},"end":{"line":4,"column":20},"identifierName":"methodDecorator"},

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-class-expression-with-decorators/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/smart-proposal-class-expression-with-decorators/output.json
@@ -36,6 +36,7 @@
                   {
                     "type": "Decorator",
                     "start":17,"end":32,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":17}},
+                    "init": false,
                     "expression": {
                       "type": "Identifier",
                       "start":18,"end":32,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":17},"identifierName":"classDecorator"},
@@ -60,6 +61,7 @@
                         {
                           "type": "Decorator",
                           "start":53,"end":69,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":20}},
+                          "init": false,
                           "expression": {
                             "type": "Identifier",
                             "start":54,"end":69,"loc":{"start":{"line":4,"column":5},"end":{"line":4,"column":20},"identifierName":"methodDecorator"},

--- a/packages/babel-parser/test/fixtures/flow/class-properties/declare-after-decorators/output.json
+++ b/packages/babel-parser/test/fixtures/flow/class-properties/declare-after-decorators/output.json
@@ -27,6 +27,7 @@
                 {
                   "type": "Decorator",
                   "start":12,"end":16,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":6}},
+                  "init": false,
                   "expression": {
                     "type": "Identifier",
                     "start":13,"end":16,"loc":{"start":{"line":2,"column":3},"end":{"line":2,"column":6},"identifierName":"dec"},

--- a/packages/babel-parser/test/fixtures/placeholders/class/decorators/output.json
+++ b/packages/babel-parser/test/fixtures/placeholders/class/decorators/output.json
@@ -14,6 +14,7 @@
           {
             "type": "Decorator",
             "start":0,"end":10,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":10}},
+            "init": false,
             "expression": {
               "type": "Placeholder",
               "start":2,"end":9,"loc":{"start":{"line":1,"column":2},"end":{"line":1,"column":9}},

--- a/packages/babel-parser/test/fixtures/typescript/decorators/type-arguments/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/decorators/type-arguments/output.json
@@ -14,6 +14,7 @@
           {
             "type": "Decorator",
             "start":0,"end":20,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":20}},
+            "init": false,
             "expression": {
               "type": "CallExpression",
               "start":1,"end":20,"loc":{"start":{"line":1,"column":1},"end":{"line":1,"column":20}},

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -1585,6 +1585,7 @@ export interface ImportAttribute extends BaseNode {
 export interface Decorator extends BaseNode {
   type: "Decorator";
   expression: Expression;
+  init?: boolean | null;
 }
 
 export interface DoExpression extends BaseNode {

--- a/packages/babel-types/src/definitions/experimental.ts
+++ b/packages/babel-types/src/definitions/experimental.ts
@@ -51,6 +51,10 @@ defineType("Decorator", {
     expression: {
       validate: assertNodeType("Expression"),
     },
+    init: {
+      validate: assertValueType("boolean"),
+      optional: true,
+    },
   },
 });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

Adds the `@init:` modifier to the decorator plugins. If present, this
adds `init: true` to the decorator node. This currently works in both
plugins, the idea being that we can error for legacy versions of
decorators which do not support `@init:` in the Babel plugin.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13859"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

