### PR TITLE
add benchmarks for `babel-types` builders

### DIFF
--- a/benchmark/babel-types/builders/memberExpression.mjs
+++ b/benchmark/babel-types/builders/memberExpression.mjs
@@ -1,0 +1,23 @@
+import Benchmark from "benchmark";
+import baseline from "@babel-baseline/types";
+import current from "@babel/types";
+import { report } from "../../util.mjs";
+
+const suite = new Benchmark.Suite();
+
+function benchCases(implementations) {
+  const funcName = "memberExpression";
+  for (const version in implementations) {
+    const t = implementations[version];
+    const func = t[funcName];
+    const idObj = t.identifier("obj");
+    const idProp = t.identifier("prop");
+    suite.add(`${version} ${funcName} builder`, () => {
+      func(idObj, idProp, /*computed?*/ false, /*optional? missing*/);
+    });
+  }
+}
+
+benchCases({ baseline, current });
+
+suite.on("cycle", report).run();

--- a/benchmark/babel-types/builders/stringLiteral.mjs
+++ b/benchmark/babel-types/builders/stringLiteral.mjs
@@ -1,0 +1,21 @@
+import Benchmark from "benchmark";
+import baseline from "@babel-baseline/types";
+import current from "@babel/types";
+import { report } from "../../util.mjs";
+
+const suite = new Benchmark.Suite();
+
+function benchCases(implementations) {
+  const funcName = "stringLiteral";
+  for (const version in implementations) {
+    const t = implementations[version];
+    const func = t[funcName];
+    suite.add(`${version} ${funcName} builder`, () => {
+      func("bar");
+    });
+  }
+}
+
+benchCases({ baseline, current });
+
+suite.on("cycle", report).run();

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -8,6 +8,7 @@
     "@babel-baseline/helper-validator-identifier": "npm:@babel/helper-validator-identifier@7.10.4",
     "@babel-baseline/parser": "npm:@babel/parser@7.14.8",
     "@babel-baseline/traverse": "npm:@babel/traverse@7.15.4",
+    "@babel-baseline/types": "npm:@babel/types@7.15.6",
     "@babel/core": "workspace:*",
     "@babel/generator": "workspace:*",
     "@babel/helper-validator-identifier": "workspace:*",
@@ -15,6 +16,7 @@
     "@babel/preset-env": "workspace:*",
     "@babel/preset-flow": "workspace:*",
     "@babel/traverse": "workspace:*",
+    "@babel/types": "workspace:*",
     "benchmark": "^2.1.4"
   },
   "version": "7.15.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,6 +72,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel-baseline/types@npm:@babel/types@7.15.6, @babel/types@npm:^7.0.0, @babel/types@npm:^7.12.7, @babel/types@npm:^7.14.5, @babel/types@npm:^7.15.0, @babel/types@npm:^7.15.4, @babel/types@npm:^7.15.6, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
+  version: 7.15.6
+  resolution: "@babel/types@npm:7.15.6"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.14.9
+    to-fast-properties: ^2.0.0
+  checksum: 37f497dde10d238b5eb184efab83b415a86611e3d73dc0434de0cfb851b20ee606a3b7e1525e5b2d522fac1248d0345fea0468006f246262511b80cd3ed2419f
+  languageName: node
+  linkType: hard
+
 "@babel-internal/runtime-integration-rollup@workspace:test/runtime-integration/rollup":
   version: 0.0.0-use.local
   resolution: "@babel-internal/runtime-integration-rollup@workspace:test/runtime-integration/rollup"
@@ -130,6 +140,7 @@ __metadata:
     "@babel-baseline/helper-validator-identifier": "npm:@babel/helper-validator-identifier@7.10.4"
     "@babel-baseline/parser": "npm:@babel/parser@7.14.8"
     "@babel-baseline/traverse": "npm:@babel/traverse@7.15.4"
+    "@babel-baseline/types": "npm:@babel/types@7.15.6"
     "@babel/core": "workspace:*"
     "@babel/generator": "workspace:*"
     "@babel/helper-validator-identifier": "workspace:*"
@@ -137,6 +148,7 @@ __metadata:
     "@babel/preset-env": "workspace:*"
     "@babel/preset-flow": "workspace:*"
     "@babel/traverse": "workspace:*"
+    "@babel/types": "workspace:*"
     benchmark: ^2.1.4
   languageName: unknown
   linkType: soft
@@ -3599,16 +3611,6 @@ __metadata:
     globals: "condition:BABEL_8_BREAKING ? ^13.5.0 : ^11.1.0"
   languageName: unknown
   linkType: soft
-
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.7, @babel/types@npm:^7.14.5, @babel/types@npm:^7.15.0, @babel/types@npm:^7.15.4, @babel/types@npm:^7.15.6, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
-  version: 7.15.6
-  resolution: "@babel/types@npm:7.15.6"
-  dependencies:
-    "@babel/helper-validator-identifier": ^7.14.9
-    to-fast-properties: ^2.0.0
-  checksum: 37f497dde10d238b5eb184efab83b415a86611e3d73dc0434de0cfb851b20ee606a3b7e1525e5b2d522fac1248d0345fea0468006f246262511b80cd3ed2419f
-  languageName: node
-  linkType: hard
 
 "@babel/types@workspace:*, @babel/types@workspace:^7.14.9, @babel/types@workspace:^7.15.4, @babel/types@workspace:^7.15.6, @babel/types@workspace:packages/babel-types":
   version: 0.0.0-use.local


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | benchmark (devdeps) :heavy_plus_sign: @babel/types
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Should've probably included those with #13843 
I also added one for `memberExpression` to see how something less trivial than `stringLiteral` compares.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13874"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

