### PR TITLE
Skip ESLint 8 tests on publish

### DIFF
--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -98,6 +98,11 @@ describe("Babel and Espree", () => {
     }
 
     if (eslintVersion !== 7) {
+      if (process.env.IS_PUBLISH) {
+        console.warn("Skipping ESLint 8 test because using a release build.");
+        return;
+      }
+
       // ESLint 8
       const espreeAST = espree8.parse(code, {
         ...espreeOptions,
@@ -459,7 +464,9 @@ describe("Babel and Espree", () => {
     });
   }
 
-  it("private identifier (token) - ESLint 8", () => {
+  const itNotPublish = process.env.IS_PUBLISH ? it.skip : it;
+
+  itNotPublish("private identifier (token) - ESLint 8", () => {
     const code = "class A { #x }";
     const babylonAST = parseForESLint8(code, {
       eslintVisitorKeys: true,
@@ -561,7 +568,7 @@ describe("Babel and Espree", () => {
     ).toMatchObject(staticKw);
   });
 
-  it("static (token) - ESLint 8", () => {
+  itNotPublish("static (token) - ESLint 8", () => {
     const code = `
       class A {
         static m() {}
@@ -650,7 +657,7 @@ describe("Babel and Espree", () => {
     });
   }
 
-  it("pipeline # topic token - ESLint 8", () => {
+  itNotPublish("pipeline # topic token - ESLint 8", () => {
     const code = `
       x |> #
       y |> #[0]


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When publishing, ESLint 8 tests fail because we cannot use [this compile-time plugin](https://github.com/babel/babel/blob/b1dca958018c02d88f416645ea8a88ca53174251/babel.config.js#L673) to override the version check. It causes problems when releasing, for example https://github.com/babel/babel/runs/4052183772?check_suite_focus=true.

I tested this locally using `make prepublish`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13898"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

