### PR TITLE
Fix binding access for plugin-transform-typescript

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -305,9 +305,8 @@ export default declare((api: ConfigAPI, opts: Options): Plugin => {
                   // just bail if there is no binding, since chances are good that if
                   // the import statement was injected then it wasn't a typescript type
                   // import anyway.
-                  if (!importsToRemove.has(binding.path)) {
+                  if (binding && !importsToRemove.has(binding.path)) {
                     if (
-                      binding &&
                       isImportTypeOnly({
                         binding,
                         programPath: path,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  --
| Patch: Bug Fix?          | Yes, fixes #13901 
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | --
| Any Dependency Changes?  | No
| License                  | MIT

## Description of changes

The `binding` may be `undefined` at the changed place, and it works well before this [commit change](https://github.com/babel/babel/commit/d5ba35586754da12ae406f6012b24d7f02ac17a6#diff-91c2ed700fa9ad8ea2099c04fc8c26bacf24429582cd9e5ef31c3404ddb9e609R308) (< v7.16.0), it will cause `Cannot read property 'path' of undefined` error.

refer: https://github.com/umijs/father/issues/418 https://github.com/cnpm/bug-versions/pull/154


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13900"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

