### PR TITLE
[babel 8] Align `allow*` parser options with ESLint behavior

### DIFF
--- a/eslint/babel-eslint-parser/README.md
+++ b/eslint/babel-eslint-parser/README.md
@@ -51,6 +51,7 @@ Additional configuration options can be set in your ESLint configuration under t
 
 - `requireConfigFile` (default `true`) can be set to `false` to allow @babel/eslint-parser to run on files that do not have a Babel configuration associated with them. This can be useful for linting files that are not transformed by Babel (such as tooling configuration files), though we recommend using the default parser via [glob-based configuration](https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-based-on-glob-patterns). Note: @babel/eslint-parser will not parse any experimental syntax when no configuration file is found.
 - `sourceType` can be set to `"module"`(default) or `"script"` if your code isn't using ECMAScript modules.
+<!-- TODO(Babel 8): Remove this -->
 - `allowImportExportEverywhere` (default `false`) can be set to `true` to allow import and export declarations to appear anywhere a statement is allowed if your build environment supports that. Otherwise import and export declarations can only appear at a program's top level.
 - `ecmaFeatures.globalReturn` (default `false`) allow return statements in the global scope when used with `sourceType: "script"`.
 - `babelOptions` is an object containing Babel configuration [options](https://babeljs.io/docs/en/options) that are passed to Babel's parser at runtime. For cases where users might not want to use a Babel configuration file or are running Babel through another tool (such as Webpack with `babel-loader`).
@@ -97,13 +98,13 @@ This configuration is useful for monorepo, when you are running ESLint on every 
 
 ```js
 module.exports = {
-  "parser": "@babel/eslint-parser",
-  "parserOptions": {
-    "babelOptions": {
-      "rootMode": "upward"
-    }
-  }
-}
+  parser: "@babel/eslint-parser",
+  parserOptions: {
+    babelOptions: {
+      rootMode: "upward",
+    },
+  },
+};
 ```
 
 ### Run

--- a/eslint/babel-eslint-parser/src/analyze-scope.cjs
+++ b/eslint/babel-eslint-parser/src/analyze-scope.cjs
@@ -340,8 +340,7 @@ module.exports = function analyzeScope(ast, parserOptions, client) {
     directive: false,
     nodejsScope:
       ast.sourceType === "script" &&
-      (parserOptions.ecmaFeatures &&
-        parserOptions.ecmaFeatures.globalReturn) === true,
+      parserOptions.ecmaFeatures?.globalReturn === true,
     impliedStrict: false,
     sourceType: ast.sourceType,
     ecmaVersion: parserOptions.ecmaVersion,

--- a/eslint/babel-eslint-parser/src/configuration.cjs
+++ b/eslint/babel-eslint-parser/src/configuration.cjs
@@ -4,7 +4,6 @@ exports.normalizeESLintConfig = function (options) {
     // ESLint sets ecmaVersion: undefined when ecmaVersion is not set in the config.
     ecmaVersion = 2020,
     sourceType = "module",
-    allowImportExportEverywhere = false,
     requireConfigFile = true,
     ...otherOptions
   } = options;
@@ -13,7 +12,6 @@ exports.normalizeESLintConfig = function (options) {
     babelOptions: { cwd: process.cwd(), ...babelOptions },
     ecmaVersion: ecmaVersion === "latest" ? 1e8 : ecmaVersion,
     sourceType,
-    allowImportExportEverywhere,
     requireConfigFile,
     ...otherOptions,
   };

--- a/eslint/babel-eslint-parser/src/worker/configuration.cjs
+++ b/eslint/babel-eslint-parser/src/worker/configuration.cjs
@@ -26,9 +26,16 @@ function normalizeParserOptions(options) {
     filename: options.filePath,
     ...options.babelOptions,
     parserOpts: {
-      allowImportExportEverywhere: options.allowImportExportEverywhere,
-      allowReturnOutsideFunction: true,
-      allowSuperOutsideMethod: true,
+      ...(process.env.BABEL_8_BREAKING
+        ? {}
+        : {
+            allowImportExportEverywhere:
+              options.allowImportExportEverywhere ?? false,
+            allowSuperOutsideMethod: true,
+          }),
+      allowReturnOutsideFunction:
+        options.ecmaFeatures?.globalReturn ??
+        (process.env.BABEL_8_BREAKING ? false : true),
       ...options.babelOptions.parserOpts,
       plugins: getParserPlugins(options.babelOptions),
       // skip comment attaching for parsing performance

--- a/eslint/babel-eslint-tests/test/integration/eslint/verify.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/verify.js
@@ -45,9 +45,10 @@ describe("verify", () => {
   });
 
   it("super keyword in class (issue #10)", () => {
-    verifyAndAssertMessages("class Foo { constructor() { super() } }", {
-      "no-undef": 1,
-    });
+    verifyAndAssertMessages(
+      "class Foo extends class {} { constructor() { super() } }",
+      { "no-undef": 1 },
+    );
   });
 
   it("Rest parameter in destructuring assignment (issue #11)", () => {
@@ -1549,7 +1550,9 @@ describe("verify", () => {
     );
   });
 
-  it("allowImportExportEverywhere option (#327)", () => {
+  const babel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
+
+  babel7("allowImportExportEverywhere option (#327)", () => {
     verifyAndAssertMessages(
       `
         if (true) { import Foo from 'foo'; }
@@ -1565,6 +1568,29 @@ describe("verify", () => {
           ecmaVersion: 6,
           sourceType: "module",
           allowImportExportEverywhere: true,
+        },
+      },
+    );
+  });
+
+  it("allowImportExportEverywhere @babel/parser option (#327)", () => {
+    verifyAndAssertMessages(
+      `
+        if (true) { import Foo from 'foo'; }
+        function foo() { import Bar from 'bar'; }
+        switch (a) { case 1: import FooBar from 'foobar'; }
+      `,
+      {},
+      [],
+      "module",
+      {
+        env: {},
+        parserOptions: {
+          ecmaVersion: 6,
+          sourceType: "module",
+          babelOptions: {
+            parserOpts: { allowImportExportEverywhere: true },
+          },
         },
       },
     );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/13903
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

- The `@babel/eslint-parser` `allowImportExportEverywhere` option is removed; users can pass it to `babelOptions.parserOpts`.
- `allowSuperOutsideMethod` is disabled.
- `allowReturnOutsideFunction` is inferred from `ecmaFeatures.globalReturn`. We already use it [in other places](https://github.com/babel/babel/blob/885e1e02f55073d005df6f5972dff168ec191da6/eslint/babel-eslint-parser/src/analyze-scope.cjs#L343-L344)

I added different non-babel-8 tests to validate the _current_ behavior.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13921"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

