### PR TITLE
Use full import specifier path in tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -67,7 +67,10 @@ module.exports = {
         "jest/no-standalone-expect": "off",
         "jest/no-test-callback": "off",
         "jest/valid-describe": "off",
-        "import/extensions": ["error", { json: "always", cjs: "always" }],
+        "import/extensions": [
+          "error",
+          { json: "always", js: "always", cjs: "always", mjs: "always" },
+        ],
       },
     },
     {

--- a/eslint/babel-eslint-plugin-development-internal/test/rules/dry-error-messages.js
+++ b/eslint/babel-eslint-plugin-development-internal/test/rules/dry-error-messages.js
@@ -1,6 +1,6 @@
 import path from "path";
-import rule from "../../src/rules/dry-error-messages";
-import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
+import rule from "../../lib/rules/dry-error-messages.js";
+import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 import { fileURLToPath } from "url";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/eslint/babel-eslint-plugin-development-internal/test/rules/report-error-message-formtat.js
+++ b/eslint/babel-eslint-plugin-development-internal/test/rules/report-error-message-formtat.js
@@ -1,5 +1,5 @@
-import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
-import rule from "../../src/rules/report-error-message-format";
+import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
+import rule from "../../lib/rules/report-error-message-format.js";
 
 const ruleTester = new RuleTester();
 

--- a/eslint/babel-eslint-plugin-development/test/rules/no-deprecated-clone.js
+++ b/eslint/babel-eslint-plugin-development/test/rules/no-deprecated-clone.js
@@ -1,5 +1,5 @@
-import rule from "../../src/rules/no-deprecated-clone";
-import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
+import rule from "../../lib/rules/no-deprecated-clone.js";
+import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 
 const cloneError = "t.clone() is deprecated. Use t.cloneNode() instead.";
 const cloneDeepError =

--- a/eslint/babel-eslint-plugin-development/test/rules/no-undefined-identifier.js
+++ b/eslint/babel-eslint-plugin-development/test/rules/no-undefined-identifier.js
@@ -1,5 +1,5 @@
-import rule from "../../src/rules/no-undefined-identifier";
-import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
+import rule from "../../lib/rules/no-undefined-identifier.js";
+import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 
 const error =
   "Use path.scope.buildUndefinedNode() to create an undefined identifier directly.";

--- a/eslint/babel-eslint-plugin-development/test/rules/plugin-name.js
+++ b/eslint/babel-eslint-plugin-development/test/rules/plugin-name.js
@@ -1,5 +1,5 @@
-import rule from "../../src/rules/plugin-name";
-import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
+import rule from "../../lib/rules/plugin-name.js";
+import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 
 const missingPluginError = "This file does not export a Babel plugin.";
 const missingNameError = "This Babel plugin doesn't have a 'name' property.";

--- a/eslint/babel-eslint-plugin/test/rules/new-cap.js
+++ b/eslint/babel-eslint-plugin/test/rules/new-cap.js
@@ -1,5 +1,5 @@
-import rule from "../../src/rules/new-cap";
-import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
+import rule from "../../lib/rules/new-cap.js";
+import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 
 const ruleTester = new RuleTester();
 ruleTester.run("@babel/new-cap", rule, {

--- a/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
@@ -1,6 +1,6 @@
 import cloneDeep from "clone-deep";
-import rule from "../../src/rules/no-invalid-this";
-import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
+import rule from "../../lib/rules/no-invalid-this.js";
+import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 
 /**
  * A constant value for non strict mode environment.

--- a/eslint/babel-eslint-plugin/test/rules/no-unused-expressions.js
+++ b/eslint/babel-eslint-plugin/test/rules/no-unused-expressions.js
@@ -1,5 +1,5 @@
-import rule from "../../src/rules/no-unused-expressions";
-import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
+import rule from "../../lib/rules/no-unused-expressions.js";
+import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 
 const ruleTester = new RuleTester();
 ruleTester.run("@babel/no-unused-expressions", rule, {

--- a/eslint/babel-eslint-plugin/test/rules/object-curly-spacing.js
+++ b/eslint/babel-eslint-plugin/test/rules/object-curly-spacing.js
@@ -1,5 +1,5 @@
-import rule from "../../src/rules/object-curly-spacing";
-import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
+import rule from "../../lib/rules/object-curly-spacing.js";
+import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 
 const ruleTester = new RuleTester();
 ruleTester.run("@babel/object-curly-spacing", rule, {

--- a/eslint/babel-eslint-plugin/test/rules/semi.js
+++ b/eslint/babel-eslint-plugin/test/rules/semi.js
@@ -1,5 +1,5 @@
-import rule from "../../src/rules/semi";
-import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester";
+import rule from "../../lib/rules/semi.js";
+import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 
 const ruleTester = new RuleTester();
 

--- a/eslint/babel-eslint-tests/test/integration/eslint/verify.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/verify.js
@@ -1,4 +1,4 @@
-import verifyAndAssertMessages from "../../helpers/verifyAndAssertMessages";
+import verifyAndAssertMessages from "../../helpers/verifyAndAssertMessages.js";
 import path from "path";
 import { fileURLToPath } from "url";
 

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -7,7 +7,7 @@ import fs from "fs";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
 
-import { chmod } from "../lib/babel/util";
+import { chmod } from "../lib/babel/util.js";
 
 const require = createRequire(import.meta.url);
 

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import stripAnsi from "strip-ansi";
-import codeFrame, { codeFrameColumns } from "..";
+import codeFrame, { codeFrameColumns } from "../lib/index.js";
 
 describe("@babel/code-frame", function () {
   test("basic usage", function () {

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -1,13 +1,13 @@
-import * as babel from "../lib/index";
+import * as babel from "../lib/index.js";
 import sourceMap from "source-map";
 import path from "path";
-import Plugin from "../lib/config/plugin";
+import Plugin from "../lib/config/plugin.js";
 import generator from "@babel/generator";
 import { fileURLToPath } from "url";
 
-import presetEnv from "../../babel-preset-env";
-import pluginSyntaxFlow from "../../babel-plugin-syntax-flow";
-import pluginFlowStripTypes from "../../babel-plugin-transform-flow-strip-types";
+import presetEnv from "../../babel-preset-env/lib/index.js";
+import pluginSyntaxFlow from "../../babel-plugin-syntax-flow/lib/index.js";
+import pluginFlowStripTypes from "../../babel-plugin-transform-flow-strip-types/lib/index.js";
 
 const cwd = path.dirname(fileURLToPath(import.meta.url));
 

--- a/packages/babel-core/test/assumptions.js
+++ b/packages/babel-core/test/assumptions.js
@@ -1,6 +1,6 @@
 import path from "path";
 import { fileURLToPath } from "url";
-import { loadOptions as loadOptionsOrig, transformSync } from "../lib";
+import { loadOptions as loadOptionsOrig, transformSync } from "../lib/index.js";
 import pluginCommonJS from "@babel/plugin-transform-modules-commonjs";
 
 const cwd = path.dirname(fileURLToPath(import.meta.url));

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -6,7 +6,7 @@ import {
   spawnTransformAsync,
   spawnTransformSync,
   supportsESM,
-} from "./helpers/esm";
+} from "./helpers/esm.js";
 
 const nodeGte8 = (...args) => {
   // "minNodeVersion": "8.0.0" <-- For Ctrl+F when dropping node 6

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -1,6 +1,6 @@
 import path from "path";
 import { fileURLToPath } from "url";
-import * as babel from "..";
+import * as babel from "../lib/index.js";
 
 import {
   spawnTransformAsync,

--- a/packages/babel-core/test/caching-api.js
+++ b/packages/babel-core/test/caching-api.js
@@ -1,6 +1,6 @@
 import gensync from "gensync";
-import { makeStrongCacheSync, makeStrongCache } from "../lib/config/caching";
-import { waitFor } from "../lib/gensync-utils/async";
+import { makeStrongCacheSync, makeStrongCache } from "../lib/config/caching.js";
+import { waitFor } from "../lib/gensync-utils/async.js";
 
 describe("caching API", () => {
   it("should allow permacaching with .forever()", () => {

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -2,12 +2,12 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
-import * as babel from "../lib";
+import * as babel from "../lib/index.js";
 import getTargets from "@babel/helper-compilation-targets";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
-import { isMJS, loadOptionsAsync, skipUnsupportedESM } from "./helpers/esm";
+import { isMJS, loadOptionsAsync, skipUnsupportedESM } from "./helpers/esm.js";
 
 // TODO: In Babel 8, we can directly uses fs.promises which is supported by
 // node 8+

--- a/packages/babel-core/test/config-loading.js
+++ b/packages/babel-core/test/config-loading.js
@@ -1,7 +1,7 @@
 import loadConfigRunner, {
   loadPartialConfig,
   createConfigItem,
-} from "../lib/config";
+} from "../lib/config/index.js";
 import path from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
@@ -38,10 +38,10 @@ describe("@babel/core config loading", () => {
       filename: FILEPATH,
       presets: skipProgrammatic
         ? null
-        : [[require("./fixtures/config-loading/preset3"), {}]],
+        : [[require("./fixtures/config-loading/preset3.js"), {}]],
       plugins: skipProgrammatic
         ? null
-        : [[require("./fixtures/config-loading/plugin6"), {}]],
+        : [[require("./fixtures/config-loading/plugin6.js"), {}]],
     };
   }
 

--- a/packages/babel-core/test/helpers/esm.js
+++ b/packages/babel-core/test/helpers/esm.js
@@ -4,7 +4,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
 
-import * as babel from "../../lib";
+import * as babel from "../../lib/index.js";
 
 const require = createRequire(import.meta.url);
 const dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -1,4 +1,4 @@
-import { loadOptions as loadOptionsOrig } from "../lib";
+import { loadOptions as loadOptionsOrig } from "../lib/index.js";
 import path from "path";
 import { fileURLToPath } from "url";
 

--- a/packages/babel-core/test/parse.js
+++ b/packages/babel-core/test/parse.js
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { parse } from "../lib";
+import { parse } from "../lib/index.js";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
 

--- a/packages/babel-core/test/path.js
+++ b/packages/babel-core/test/path.js
@@ -1,5 +1,5 @@
-import { transform } from "../lib/index";
-import Plugin from "../lib/config/plugin";
+import { transform } from "../lib/index.js";
+import Plugin from "../lib/config/plugin.js";
 import { fileURLToPath } from "url";
 import path from "path";
 

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -1,4 +1,4 @@
-import * as babel from "../lib/index";
+import * as babel from "../lib/index.js";
 import path from "path";
 import { fileURLToPath } from "url";
 

--- a/packages/babel-core/test/targets.js
+++ b/packages/babel-core/test/targets.js
@@ -1,4 +1,4 @@
-import { loadOptions as loadOptionsOrig } from "../lib";
+import { loadOptions as loadOptionsOrig } from "../lib/index.js";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 

--- a/packages/babel-generator/test/arrow-functions.js
+++ b/packages/babel-generator/test/arrow-functions.js
@@ -1,4 +1,4 @@
-import generate from "../lib";
+import generate from "../lib/index.js";
 import { parse } from "@babel/parser";
 
 describe("parameter parentheses", () => {

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1,5 +1,5 @@
-import Printer from "../lib/printer";
-import generate, { CodeGenerator } from "../lib";
+import Printer from "../lib/printer.js";
+import generate, { CodeGenerator } from "../lib/index.js";
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
 import fs from "fs";

--- a/packages/babel-helper-annotate-as-pure/test/index.js
+++ b/packages/babel-helper-annotate-as-pure/test/index.js
@@ -1,4 +1,4 @@
-import annotateAsPure from "../";
+import annotateAsPure from "../lib/index.js";
 
 describe("@babel/helper-annotate-as-pure", () => {
   it("will add leading comment", () => {

--- a/packages/babel-helper-compilation-targets/test/browserslist-extends/browserslist-extends.spec.js
+++ b/packages/babel-helper-compilation-targets/test/browserslist-extends/browserslist-extends.spec.js
@@ -1,6 +1,6 @@
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
-import getTargets from "../../lib";
+import getTargets from "../../lib/index.js";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 

--- a/packages/babel-helper-compilation-targets/test/custom-browserslist-env/custom-browserslist-env.spec.js
+++ b/packages/babel-helper-compilation-targets/test/custom-browserslist-env/custom-browserslist-env.spec.js
@@ -1,4 +1,4 @@
-import getTargets from "../..";
+import getTargets from "../../lib/index.js";
 import { fileURLToPath } from "url";
 import path from "path";
 

--- a/packages/babel-helper-compilation-targets/test/load-browserslist-package-json/load-browserslist-package-json.spec.js
+++ b/packages/babel-helper-compilation-targets/test/load-browserslist-package-json/load-browserslist-package-json.spec.js
@@ -1,4 +1,4 @@
-import getTargets from "../..";
+import getTargets from "../../lib/index.js";
 import { fileURLToPath } from "url";
 import path from "path";
 

--- a/packages/babel-helper-compilation-targets/test/load-browserslistrc/load-browserslistrc.spec.js
+++ b/packages/babel-helper-compilation-targets/test/load-browserslistrc/load-browserslistrc.spec.js
@@ -1,4 +1,4 @@
-import getTargets from "../..";
+import getTargets from "../../lib/index.js";
 import { fileURLToPath } from "url";
 import path from "path";
 

--- a/packages/babel-helper-compilation-targets/test/pretty.spec.js
+++ b/packages/babel-helper-compilation-targets/test/pretty.spec.js
@@ -1,4 +1,4 @@
-import { prettifyTargets, prettifyVersion } from "../lib/pretty";
+import { prettifyTargets, prettifyVersion } from "../lib/pretty.js";
 
 describe("pretty", () => {
   describe("prettifyVersion", () => {

--- a/packages/babel-helper-compilation-targets/test/targets-parser.spec.js
+++ b/packages/babel-helper-compilation-targets/test/targets-parser.spec.js
@@ -1,7 +1,7 @@
 import browserslist from "browserslist";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import getTargets from "..";
+import getTargets from "../lib/index.js";
 
 describe("getTargets", () => {
   it("parses", () => {

--- a/packages/babel-helper-compilation-targets/test/targets-supported.js
+++ b/packages/babel-helper-compilation-targets/test/targets-supported.js
@@ -1,4 +1,4 @@
-import { targetsSupported } from "../lib/filter-items";
+import { targetsSupported } from "../lib/filter-items.js";
 
 describe("targetsSupported", () => {
   const MAX_VERSION = `${Number.MAX_SAFE_INTEGER}.0.0`;

--- a/packages/babel-helper-compilation-targets/test/utils.spec.js
+++ b/packages/babel-helper-compilation-targets/test/utils.spec.js
@@ -1,4 +1,4 @@
-import { semverify } from "../lib/utils";
+import { semverify } from "../lib/utils.js";
 
 describe("utils", () => {
   describe("semverify", () => {

--- a/packages/babel-helper-module-imports/test/index.js
+++ b/packages/babel-helper-module-imports/test/index.js
@@ -2,7 +2,7 @@ import * as babel from "@babel/core";
 import { fileURLToPath } from "url";
 import path from "path";
 
-import { ImportInjector } from "../";
+import { ImportInjector } from "../lib/index.js";
 
 const cwd = path.dirname(fileURLToPath(import.meta.url));
 

--- a/packages/babel-helper-optimise-call-expression/test/index.js
+++ b/packages/babel-helper-optimise-call-expression/test/index.js
@@ -1,7 +1,7 @@
 import { parse } from "@babel/parser";
 import generator from "@babel/generator";
 import * as t from "@babel/types";
-import optimizeCallExpression from "..";
+import optimizeCallExpression from "../lib/index.js";
 
 function transformInput(input, thisIdentifier) {
   const ast = parse(input);

--- a/packages/babel-helper-transform-fixture-test-runner/test/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/test/index.js
@@ -1,4 +1,4 @@
-import { runCodeInTestContext } from "..";
+import { runCodeInTestContext } from "../lib/index.js";
 import { fileURLToPath } from "url";
 
 const filename = fileURLToPath(import.meta.url);

--- a/packages/babel-helper-validator-identifier/test/identifier.spec.js
+++ b/packages/babel-helper-validator-identifier/test/identifier.spec.js
@@ -1,4 +1,4 @@
-import { isIdentifierName } from "..";
+import { isIdentifierName } from "../lib/index.js";
 
 describe("isIdentifierName", function () {
   it("returns false if provided string is empty", function () {

--- a/packages/babel-helper-validator-option/test/find-suggestion.spec.js
+++ b/packages/babel-helper-validator-option/test/find-suggestion.spec.js
@@ -1,4 +1,4 @@
-import { findSuggestion } from "..";
+import { findSuggestion } from "../lib/index.js";
 
 describe("findSuggestion", function () {
   test.each([

--- a/packages/babel-helper-validator-option/test/validator.spec.js
+++ b/packages/babel-helper-validator-option/test/validator.spec.js
@@ -1,4 +1,4 @@
-import { OptionValidator } from "..";
+import { OptionValidator } from "../lib/index.js";
 
 describe("OptionValidator", () => {
   describe("validateTopLevelOptions", () => {

--- a/packages/babel-helpers/test/helpers/define-helper.js
+++ b/packages/babel-helpers/test/helpers/define-helper.js
@@ -1,6 +1,6 @@
 import path from "path";
 import template from "@babel/template";
-import helpers from "../../lib/helpers";
+import helpers from "../../lib/helpers.js";
 
 function getHelperId(dir, name) {
   const testName = path.basename(dir);

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import stripAnsi from "strip-ansi";
-import highlight, { shouldHighlight, getChalk } from "..";
+import highlight, { shouldHighlight, getChalk } from "../lib/index.js";
 
 describe("@babel/highlight", function () {
   function stubColorSupport(supported) {

--- a/packages/babel-parser/test/attachComment-false.js
+++ b/packages/babel-parser/test/attachComment-false.js
@@ -1,6 +1,6 @@
 import path from "path";
-import { runFixtureTestsWithoutExactASTMatch } from "./helpers/runFixtureTests";
-import { parseExpression } from "../lib";
+import { runFixtureTestsWithoutExactASTMatch } from "./helpers/runFixtureTests.js";
+import { parseExpression } from "../lib/index.js";
 import { fileURLToPath } from "url";
 
 runFixtureTestsWithoutExactASTMatch(

--- a/packages/babel-parser/test/error-codes.js
+++ b/packages/babel-parser/test/error-codes.js
@@ -1,4 +1,4 @@
-import { parse } from "../lib";
+import { parse } from "../lib/index.js";
 
 describe("error codes", function () {
   it("raises an error with BABEL_PARSER_SOURCETYPE_MODULE_REQUIRED and reasonCode", function () {

--- a/packages/babel-parser/test/estree-throws.js
+++ b/packages/babel-parser/test/estree-throws.js
@@ -1,6 +1,6 @@
 import path from "path";
-import { runFixtureTestsWithoutExactASTMatch } from "./helpers/runFixtureTests";
-import { parse } from "../lib";
+import { runFixtureTestsWithoutExactASTMatch } from "./helpers/runFixtureTests.js";
+import { parse } from "../lib/index.js";
 import { fileURLToPath } from "url";
 
 runFixtureTestsWithoutExactASTMatch(

--- a/packages/babel-parser/test/expressions.js
+++ b/packages/babel-parser/test/expressions.js
@@ -1,6 +1,6 @@
 import path from "path";
-import { runFixtureTests } from "./helpers/runFixtureTests";
-import { parseExpression } from "../lib";
+import { runFixtureTests } from "./helpers/runFixtureTests.js";
+import { parseExpression } from "../lib/index.js";
 import { fileURLToPath } from "url";
 
 const fixtures = path.join(

--- a/packages/babel-parser/test/index.js
+++ b/packages/babel-parser/test/index.js
@@ -1,6 +1,6 @@
 import path from "path";
-import { runFixtureTests } from "./helpers/runFixtureTests";
-import { parse } from "../lib";
+import { runFixtureTests } from "./helpers/runFixtureTests.js";
+import { parse } from "../lib/index.js";
 import { fileURLToPath } from "url";
 
 const fixtures = path.join(

--- a/packages/babel-parser/test/options.js
+++ b/packages/babel-parser/test/options.js
@@ -1,4 +1,4 @@
-import { parse } from "../lib";
+import { parse } from "../lib/index.js";
 
 describe("options", () => {
   describe("strictMode", () => {

--- a/packages/babel-parser/test/plugin-options.js
+++ b/packages/babel-parser/test/plugin-options.js
@@ -1,4 +1,4 @@
-import { parse } from "../lib";
+import { parse } from "../lib/index.js";
 
 function getParser(code, plugins) {
   return () => parse(code, { plugins, sourceType: "module" });

--- a/packages/babel-parser/test/unit/tokenizer/types.js
+++ b/packages/babel-parser/test/unit/tokenizer/types.js
@@ -1,4 +1,4 @@
-import { tt, tokenOperatorPrecedence } from "../../../src/tokenizer/types";
+import { tt, tokenOperatorPrecedence } from "../../../src/tokenizer/types.js";
 
 describe("token types", () => {
   it("should check if the binOp for relational === in", () => {

--- a/packages/babel-parser/test/unit/util/identifier.js
+++ b/packages/babel-parser/test/unit/util/identifier.js
@@ -1,7 +1,7 @@
 import {
   isKeyword,
   keywordRelationalOperator,
-} from "../../../src/util/identifier";
+} from "../../../src/util/identifier.js";
 
 describe("identifier", () => {
   describe("isKeyword", () => {

--- a/packages/babel-parser/test/unit/util/location.js
+++ b/packages/babel-parser/test/unit/util/location.js
@@ -1,4 +1,4 @@
-import { getLineInfo } from "../../../src/util/location";
+import { getLineInfo } from "../../../src/util/location.js";
 
 describe("getLineInfo", () => {
   const input = "a\nb\nc\nd\ne\nf\ng\nh\ni";

--- a/packages/babel-plugin-proposal-class-static-block/test/plugin-ordering.test.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/plugin-ordering.test.js
@@ -1,5 +1,5 @@
 import * as babel from "@babel/core";
-import proposalClassStaticBlock from "..";
+import proposalClassStaticBlock from "../lib/index.js";
 
 describe("plugin ordering", () => {
   it("should work when @babel/plugin-proposal-class-static-block is after class features plugin", () => {

--- a/packages/babel-plugin-proposal-object-rest-spread/test/hasMoreThanOneBinding.test.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/hasMoreThanOneBinding.test.js
@@ -1,5 +1,5 @@
 import { parse } from "@babel/parser";
-import shouldStoreRHSInTemporaryVariable from "../lib/shouldStoreRHSInTemporaryVariable";
+import shouldStoreRHSInTemporaryVariable from "../lib/shouldStoreRHSInTemporaryVariable.js";
 
 function getFistObjectPattern(program) {
   return parse(program, { sourceType: "module" }).program.body[0]

--- a/packages/babel-plugin-proposal-optional-chaining/test/util.test.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/util.test.js
@@ -1,4 +1,4 @@
-import { willPathCastToBoolean } from "../src/util";
+import { willPathCastToBoolean } from "../src/util.js";
 import { parseSync, traverse } from "@babel/core";
 
 function getPath(input, parserOpts) {

--- a/packages/babel-plugin-syntax-decorators/test/index.js
+++ b/packages/babel-plugin-syntax-decorators/test/index.js
@@ -1,5 +1,5 @@
 import { parse } from "@babel/core";
-import syntaxDecorators from "../lib";
+import syntaxDecorators from "../lib/index.js";
 
 function makeParser(code, options) {
   return () =>

--- a/packages/babel-plugin-transform-modules-amd/test/importInterop-function.js
+++ b/packages/babel-plugin-transform-modules-amd/test/importInterop-function.js
@@ -1,5 +1,5 @@
 import * as babel from "@babel/core";
-import transformAmd from "../lib";
+import transformAmd from "../lib/index.js";
 import externalHelpers from "@babel/plugin-external-helpers";
 
 it("'importInterop' accepts a function", function () {

--- a/packages/babel-plugin-transform-modules-commonjs/test/copied-nodes.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/copied-nodes.js
@@ -2,7 +2,7 @@ import * as babel from "@babel/core";
 import { fileURLToPath } from "url";
 import path from "path";
 
-import transformCommonJS from "..";
+import transformCommonJS from "../lib/index.js";
 
 test("Doesn't use the same object for two different nodes in the AST", function () {
   const code = 'import Foo from "bar"; Foo; Foo;';

--- a/packages/babel-plugin-transform-modules-commonjs/test/esmodule-flag.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/esmodule-flag.js
@@ -3,7 +3,7 @@ import vm from "vm";
 import { fileURLToPath } from "url";
 import path from "path";
 
-import transformCommonJS from "..";
+import transformCommonJS from "../lib/index.js";
 
 test("Re-export doesn't overwrite __esModule flag", function () {
   let code = 'export * from "./dep";';

--- a/packages/babel-plugin-transform-modules-commonjs/test/importInterop-function.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/importInterop-function.js
@@ -1,5 +1,5 @@
 import * as babel from "@babel/core";
-import transformCommonjs from "../lib";
+import transformCommonjs from "../lib/index.js";
 import externalHelpers from "@babel/plugin-external-helpers";
 
 it("'importInterop' accepts a function", function () {

--- a/packages/babel-plugin-transform-modules-umd/test/importInterop-function.js
+++ b/packages/babel-plugin-transform-modules-umd/test/importInterop-function.js
@@ -1,5 +1,5 @@
 import * as babel from "@babel/core";
-import transformUmd from "../lib";
+import transformUmd from "../lib/index.js";
 import externalHelpers from "@babel/plugin-external-helpers";
 
 it("'importInterop' accepts a function", function () {

--- a/packages/babel-plugin-transform-runtime/test/regression.js
+++ b/packages/babel-plugin-transform-runtime/test/regression.js
@@ -3,6 +3,7 @@ import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 
 it("module.exports.default is correctly updated", () => {
+  // eslint-disable-next-line import/extensions
   const typeofHelper = require("@babel/runtime/helpers/typeof");
 
   expect(typeof typeofHelper).toBe("function");

--- a/packages/babel-plugin-transform-typeof-symbol/test/helper.spec.js
+++ b/packages/babel-plugin-transform-typeof-symbol/test/helper.spec.js
@@ -2,7 +2,7 @@ import * as babel from "@babel/core";
 import fs from "fs";
 import { createRequire } from "module";
 
-import transformTypeofSymbol from "..";
+import transformTypeofSymbol from "../lib/index.js";
 
 const require = createRequire(import.meta.url);
 

--- a/packages/babel-preset-env/test/get-option-specific-excludes.spec.js
+++ b/packages/babel-preset-env/test/get-option-specific-excludes.spec.js
@@ -1,4 +1,4 @@
-import getOptionSpecificExcludesFor from "../lib/get-option-specific-excludes";
+import getOptionSpecificExcludesFor from "../lib/get-option-specific-excludes.js";
 
 describe("defaults", () => {
   describe("getOptionSpecificExcludesFor", () => {

--- a/packages/babel-preset-env/test/index.spec.js
+++ b/packages/babel-preset-env/test/index.spec.js
@@ -1,10 +1,11 @@
+// eslint-disable-next-line import/extensions
 import compatData from "@babel/compat-data/plugins";
 
-import * as babelPresetEnv from "../lib/index";
-import removeRegeneratorEntryPlugin from "../lib/polyfills/regenerator";
-import pluginLegacyBabelPolyfill from "../lib/polyfills/babel-polyfill";
-import transformations from "../lib/module-transformations";
-import availablePlugins from "../lib/available-plugins";
+import * as babelPresetEnv from "../lib/index.js";
+import removeRegeneratorEntryPlugin from "../lib/polyfills/regenerator.js";
+import pluginLegacyBabelPolyfill from "../lib/polyfills/babel-polyfill.js";
+import transformations from "../lib/module-transformations.js";
+import availablePlugins from "../lib/available-plugins.js";
 
 import _pluginCoreJS2 from "babel-plugin-polyfill-corejs2";
 import _pluginCoreJS3 from "babel-plugin-polyfill-corejs3";

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -3,7 +3,7 @@ import normalizeOptions, {
   validateModulesOption,
   validateUseBuiltInsOption,
   normalizePluginName,
-} from "../lib/normalize-options";
+} from "../lib/normalize-options.js";
 
 describe("normalize-options", () => {
   describe("normalizeOptions", () => {

--- a/packages/babel-preset-env/test/regressions.js
+++ b/packages/babel-preset-env/test/regressions.js
@@ -1,5 +1,5 @@
 import * as babel7_12 from "@babel/core";
-import env from "..";
+import env from "../lib/index.js";
 import path from "path";
 import { fileURLToPath } from "url";
 

--- a/packages/babel-preset-env/test/top-level-await.js
+++ b/packages/babel-preset-env/test/top-level-await.js
@@ -1,4 +1,4 @@
-import env from "..";
+import env from "../lib/index.js";
 import * as babel from "@babel/core";
 
 describe("supportsTopLevelAwait enables the parser plugin for old parser versions", () => {

--- a/packages/babel-preset-flow/test/normalize-options.spec.js
+++ b/packages/babel-preset-flow/test/normalize-options.spec.js
@@ -1,4 +1,4 @@
-import normalizeOptions from "../src/normalize-options";
+import normalizeOptions from "../lib/normalize-options.js";
 describe("normalize options", () => {
   (process.env.BABEL_8_BREAKING ? describe : describe.skip)("Babel 8", () => {
     it("should throw on unknown options", () => {

--- a/packages/babel-preset-react/test/index.js
+++ b/packages/babel-preset-react/test/index.js
@@ -1,4 +1,4 @@
-import react from "../lib";
+import react from "../lib/index.js";
 
 describe("react preset", () => {
   it("does throw clear error when no options passed for Babel 6", () => {

--- a/packages/babel-preset-react/test/normalize-options.spec.js
+++ b/packages/babel-preset-react/test/normalize-options.spec.js
@@ -1,4 +1,4 @@
-import normalizeOptions from "../src/normalize-options";
+import normalizeOptions from "../src/normalize-options.js";
 describe("normalize options", () => {
   (process.env.BABEL_8_BREAKING ? describe : describe.skip)("Babel 8", () => {
     it("should throw on unknown options", () => {

--- a/packages/babel-preset-typescript/test/normalize-options.spec.js
+++ b/packages/babel-preset-typescript/test/normalize-options.spec.js
@@ -1,4 +1,4 @@
-import normalizeOptions from "../src/normalize-options";
+import normalizeOptions from "../src/normalize-options.js";
 describe("normalize options", () => {
   (process.env.BABEL_8_BREAKING ? describe : describe.skip)("Babel 8", () => {
     it("should throw on unknown options", () => {

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -40,7 +40,7 @@ describe("@babel/register - caching", () => {
     beforeEach(() => {
       // Since lib/cache is a singleton we need to fully reload it
       jest.resetModules();
-      const cache = require("../lib/cache");
+      const cache = require("../lib/cache.js");
 
       load = cache.load;
       get = cache.get;

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -7,7 +7,7 @@ const require = createRequire(import.meta.url);
   () => {
     let Babel;
     beforeAll(() => {
-      Babel = require("../babel");
+      Babel = require("../babel.js");
     });
 
     it("handles the es2015-no-commonjs preset", () => {

--- a/packages/babel-standalone/test/preset-stage-1.test.js
+++ b/packages/babel-standalone/test/preset-stage-1.test.js
@@ -6,7 +6,7 @@ const require = createRequire(import.meta.url);
   () => {
     let Babel;
     beforeAll(() => {
-      Babel = require("../babel");
+      Babel = require("../babel.js");
     });
 
     it("should parser decimal literal", () => {

--- a/packages/babel-template/test/index.js
+++ b/packages/babel-template/test/index.js
@@ -1,5 +1,5 @@
-import generator from "../../babel-generator";
-import template from "../lib";
+import generator from "../../babel-generator/lib/index.js";
+import template from "../lib/index.js";
 import * as t from "@babel/types";
 
 const comments = "// Sum two numbers\nconst add = (a, b) => a + b;";

--- a/packages/babel-traverse/test/ancestry.js
+++ b/packages/babel-traverse/test/ancestry.js
@@ -1,4 +1,4 @@
-import traverse from "../lib";
+import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 
 describe("path/ancestry", function () {

--- a/packages/babel-traverse/test/arrow-transform.js
+++ b/packages/babel-traverse/test/arrow-transform.js
@@ -1,4 +1,4 @@
-import { NodePath } from "../lib";
+import { NodePath } from "../lib/index.js";
 import { parse } from "@babel/parser";
 import generate from "@babel/generator";
 import * as t from "@babel/types";

--- a/packages/babel-traverse/test/conversion.js
+++ b/packages/babel-traverse/test/conversion.js
@@ -1,4 +1,4 @@
-import traverse from "../lib";
+import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 import generate from "@babel/generator";
 import * as t from "@babel/types";

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -1,4 +1,4 @@
-import traverse from "../lib";
+import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 
 function getPath(code) {

--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -1,4 +1,4 @@
-import traverse from "../lib";
+import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
 

--- a/packages/babel-traverse/test/hub.js
+++ b/packages/babel-traverse/test/hub.js
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { Hub } from "../lib";
+import { Hub } from "../lib/index.js";
 
 describe("hub", function () {
   it("default buildError should return TypeError", function () {

--- a/packages/babel-traverse/test/inference.js
+++ b/packages/babel-traverse/test/inference.js
@@ -1,4 +1,4 @@
-import traverse from "../lib";
+import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
 

--- a/packages/babel-traverse/test/introspection.js
+++ b/packages/babel-traverse/test/introspection.js
@@ -1,4 +1,4 @@
-import traverse from "../lib";
+import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 
 function getPath(code, options = { sourceType: "script" }) {

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -1,4 +1,4 @@
-import traverse from "../lib";
+import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 import generate from "@babel/generator";
 import * as t from "@babel/types";

--- a/packages/babel-traverse/test/path/index.js
+++ b/packages/babel-traverse/test/path/index.js
@@ -1,4 +1,4 @@
-import { NodePath } from "../../lib";
+import { NodePath } from "../../lib/index.js";
 
 describe("NodePath", () => {
   describe("setData/getData", () => {

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -1,4 +1,4 @@
-import traverse from "../lib";
+import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 import generate from "@babel/generator";
 

--- a/packages/babel-traverse/test/replacement.js
+++ b/packages/babel-traverse/test/replacement.js
@@ -1,4 +1,4 @@
-import traverse from "../lib";
+import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 import generate from "@babel/generator";
 import * as t from "@babel/types";

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -1,4 +1,4 @@
-import traverse, { NodePath } from "../lib";
+import traverse, { NodePath } from "../lib/index.js";
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
 

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -1,4 +1,4 @@
-import traverse from "../lib";
+import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
 

--- a/packages/babel-types/test/asserts.js
+++ b/packages/babel-types/test/asserts.js
@@ -1,4 +1,4 @@
-import * as t from "../lib";
+import * as t from "../lib/index.js";
 
 describe("asserts", () => {
   const consoleTrace = console.trace;

--- a/packages/babel-types/test/builders/es2015/templateElement.js
+++ b/packages/babel-types/test/builders/es2015/templateElement.js
@@ -1,4 +1,4 @@
-import * as t from "../../..";
+import * as t from "../../../lib/index.js";
 
 describe("builders", function () {
   describe("es2015", function () {

--- a/packages/babel-types/test/builders/experimental/classProperty.js
+++ b/packages/babel-types/test/builders/experimental/classProperty.js
@@ -1,4 +1,4 @@
-import * as t from "../../..";
+import * as t from "../../../lib/index.js";
 
 describe("builders", function () {
   describe("experimental", function () {

--- a/packages/babel-types/test/builders/flow/createTypeAnnotationBasedOnTypeof.js
+++ b/packages/babel-types/test/builders/flow/createTypeAnnotationBasedOnTypeof.js
@@ -1,4 +1,4 @@
-import { createTypeAnnotationBasedOnTypeof } from "../../..";
+import { createTypeAnnotationBasedOnTypeof } from "../../../lib/index.js";
 
 describe("builders", function () {
   describe("flow", function () {

--- a/packages/babel-types/test/builders/flow/declareClass.js
+++ b/packages/babel-types/test/builders/flow/declareClass.js
@@ -1,4 +1,4 @@
-import * as t from "../../..";
+import * as t from "../../../lib/index.js";
 
 describe("builders", function () {
   describe("flow", function () {

--- a/packages/babel-types/test/builders/typescript/tsLiteralType.js
+++ b/packages/babel-types/test/builders/typescript/tsLiteralType.js
@@ -1,4 +1,4 @@
-import * as t from "../../..";
+import * as t from "../../../lib/index.js";
 
 describe("builders", function () {
   describe("typescript", function () {

--- a/packages/babel-types/test/builders/typescript/tsTypeParameter.js
+++ b/packages/babel-types/test/builders/typescript/tsTypeParameter.js
@@ -1,4 +1,4 @@
-import * as t from "../../..";
+import * as t from "../../../lib/index.js";
 
 describe("builders", function () {
   describe("typescript", function () {

--- a/packages/babel-types/test/cloning.js
+++ b/packages/babel-types/test/cloning.js
@@ -1,4 +1,4 @@
-import * as t from "../lib";
+import * as t from "../lib/index.js";
 import { parse } from "@babel/parser";
 
 describe("cloneNode", function () {

--- a/packages/babel-types/test/converters.js
+++ b/packages/babel-types/test/converters.js
@@ -1,4 +1,4 @@
-import * as t from "../lib";
+import * as t from "../lib/index.js";
 import { parse } from "@babel/parser";
 import generate from "@babel/generator";
 

--- a/packages/babel-types/test/fields.js
+++ b/packages/babel-types/test/fields.js
@@ -1,4 +1,4 @@
-import * as t from "../lib";
+import * as t from "../lib/index.js";
 import glob from "glob";
 import path from "path";
 import fs from "fs";

--- a/packages/babel-types/test/misc.js
+++ b/packages/babel-types/test/misc.js
@@ -1,4 +1,4 @@
-import * as t from "../lib";
+import * as t from "../lib/index.js";
 import { parse } from "@babel/parser";
 
 function parseCode(string) {

--- a/packages/babel-types/test/regressions.js
+++ b/packages/babel-types/test/regressions.js
@@ -1,4 +1,4 @@
-import * as t from "../lib";
+import * as t from "../lib/index.js";
 import * as vm from "vm";
 
 describe("regressions", () => {

--- a/packages/babel-types/test/retrievers.js
+++ b/packages/babel-types/test/retrievers.js
@@ -1,4 +1,4 @@
-import * as t from "../lib";
+import * as t from "../lib/index.js";
 import { parse } from "@babel/parser";
 
 function getBody(program) {

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -1,4 +1,4 @@
-import * as t from "../lib";
+import * as t from "../lib/index.js";
 import { parse } from "@babel/parser";
 
 describe("validators", function () {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Since the main blocker for migrating to ESM (https://github.com/babel/babel/pull/13414) is Jest support (Jest reimplements the whole ESM linker, and it has some bugs + Node.js doesn't have a stable API to do it), I'm experimenting with a lightweight approach where I only use _part_ of Jest and run the tests in a native Node.js environment.

I'm starting by only running the tests as ESM (rather than converting them to CJS on-the-fly), but in order to run them natively `import` statements must have the full path.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13938"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

