### PR TITLE
Add new method to check if node is null or not

### DIFF
--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -122,6 +122,10 @@ class NodePath<T extends t.Node = t.Node> {
     return val;
   }
 
+  hasNode(): this is NodePath<NonNullable<this["node"]>> {
+    return this.node != null;
+  }
+
   buildCodeFrameError(
     msg: string,
     Error: new () => Error = SyntaxError,

--- a/packages/babel-traverse/test/path/index.js
+++ b/packages/babel-traverse/test/path/index.js
@@ -47,5 +47,20 @@ describe("NodePath", () => {
 
       expect(path.getData(symbol)).toBe(42);
     });
+
+    describe("hasNode", () => {
+      it("returns true if node is null", () => {
+        const path = new NodePath({}, {});
+
+        expect(path.hasNode()).toBe(false);
+      });
+
+      it("returns false if node is not null", () => {
+        const path = new NodePath({}, {});
+        path.node = {};
+
+        expect(path.hasNode()).toBe(true);
+      });
+    });
   });
 });

--- a/packages/babel-traverse/test/path/index.js
+++ b/packages/babel-traverse/test/path/index.js
@@ -49,13 +49,13 @@ describe("NodePath", () => {
     });
 
     describe("hasNode", () => {
-      it("returns true if node is null", () => {
+      it("returns false if node is null", () => {
         const path = new NodePath({}, {});
 
         expect(path.hasNode()).toBe(false);
       });
 
-      it("returns false if node is not null", () => {
+      it("returns true if node is not null", () => {
         const path = new NodePath({}, {});
         path.node = {};
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | y
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | n
| License                  | MIT

While using babel traverse in a typescript project I stumbled upon an annoyance that I wasn't able to really fix in my code, besides defining the types for every single path manually.

The code looks like this:
```ts
function xyz(path: NodePath): void {
  if (path.isArrayExpression()) {
    path.get('elements').map(elementPath => {
      // elementPath: NodePath<Expression | SpreadElement | null>
      if (elementPath.node === null) return;
      otherFunc(elementPath as NodePath<Expression | SpreadElement>); // Have to define that because null is not possible anymore.
    });
  }
}
```

With the introduction of the new method it can be simplified to this, because TS now can figure out itself that node is not null anymore:
```ts
function xyz(path: NodePath): void {
  if (path.isArrayExpression()) {
    path.get('elements').map(elementPath => {
      // elementPath: NodePath<Expression | SpreadElement | null>
      if (!elementPath.hasNode()) return;
      otherFunc(elementPath);
    });
  }
}
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13940"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

