### PR TITLE
fix: use file extension for absolute helper imports in `@babel/plugin-transform-runtime`

### DIFF
--- a/packages/babel-plugin-transform-runtime/src/index.ts
+++ b/packages/babel-plugin-transform-runtime/src/index.ts
@@ -165,7 +165,7 @@ export default declare((api, options, dirname) => {
     };
   }
 
-  const corejsExt = absoluteRuntime ? ".js" : "";
+  const ext = absoluteRuntime ? ".js" : "";
 
   return {
     name: "transform-runtime",
@@ -178,7 +178,7 @@ export default declare((api, options, dirname) => {
             [pluginsCompat]: {
               runtimeVersion,
               useBabelRuntime: modulePath,
-              ext: corejsExt,
+              ext,
             },
           },
           createRegeneratorPlugin({
@@ -193,7 +193,7 @@ export default declare((api, options, dirname) => {
             method: "usage-pure",
             version: 3,
             proposals,
-            [pluginsCompat]: { useBabelRuntime: modulePath, ext: corejsExt },
+            [pluginsCompat]: { useBabelRuntime: modulePath, ext },
           },
           createRegeneratorPlugin({
             method: "usage-pure",
@@ -233,7 +233,7 @@ export default declare((api, options, dirname) => {
             : "helpers";
 
         return addDefaultImport(
-          `${modulePath}/${helpersDir}/${name}`,
+          `${modulePath}/${helpersDir}/${name}${ext}`,
           name,
           blockHoist,
           true,

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/output.js
@@ -1,4 +1,4 @@
-var _classCallCheck = require("<CWD>/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/subfolder/node_modules/@babel/runtime/helpers/classCallCheck");
+var _classCallCheck = require("<CWD>/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/subfolder/node_modules/@babel/runtime/helpers/classCallCheck.js");
 
 let Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/output.js
@@ -1,4 +1,4 @@
-var _classCallCheck = require("<CWD>/packages/babel-runtime/helpers/classCallCheck");
+var _classCallCheck = require("<CWD>/packages/babel-runtime/helpers/classCallCheck.js");
 
 let Foo = function Foo() {
   "use strict";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Note when "absoluteRuntime" is false (the default), `@babel/plugin-transform-runtime` will inserts imports like `@babel/runtime/helpers/esm/classCallCheck`, while when it is true, it inserts imports to absolute paths like `/Users/you/project/.yarn/cache/@babel-runtime-npm-7.16.0-2f490bebb5-bfbca3ec52.zip/node_modules/@babel/runtime/helpers/esm/classCallCheck`.

When using babel to transpile files in an ESM package (aka package.json has `"module": true`), the latter type fails for me using yarn 3.0.2 and webpack 5.62.1.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13945"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

