### PR TITLE
fix(babel-parser): DirectiveLiteral contained improperly escaped string values.

### DIFF
--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -156,14 +156,9 @@ export default class StatementParser extends ExpressionParser {
     directive.type = "Directive";
     directive.value = directive.expression;
     delete directive.expression;
-
-    const directiveLiteral = directive.value;
-    const raw = this.input.slice(directiveLiteral.start, directiveLiteral.end);
-    const val = (directiveLiteral.value = raw.slice(1, -1)); // remove quotes
-
-    this.addExtra(directiveLiteral, "raw", raw);
-    this.addExtra(directiveLiteral, "rawValue", val);
-    directiveLiteral.type = "DirectiveLiteral";
+    // We can keep `value` and `extra { raw, rawValue }` from the converted
+    // expression, which was a `StringLiteral`.
+    directive.value.type = "DirectiveLiteral";
     return directive;
   }
 


### PR DESCRIPTION
Closes #13953.

Reviewed by @tolmasky.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #13953 ` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes |
| Major: Breaking Change?  | No |
| Minor: New Feature?      | No |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13954"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

