### PR TITLE
Add `assertions` to `ExportNamedDeclaration` without `from`

### DIFF
--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1824,8 +1824,8 @@ export default class StatementParser extends ExpressionParser {
 
     if (isFromRequired || hasSpecifiers || hasDeclaration) {
       this.checkExport(node, true, false, !!node.source);
-      if (this.hasPlugin("importAssertions")) {
-        node.assertions ??= [];
+      if (this.hasPlugin("importAssertions") && node.assertions == null) {
+        node.assertions = [];
       }
       return this.finishNode(node, "ExportNamedDeclaration");
     }

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1824,6 +1824,9 @@ export default class StatementParser extends ExpressionParser {
 
     if (isFromRequired || hasSpecifiers || hasDeclaration) {
       this.checkExport(node, true, false, !!node.source);
+      if (this.hasPlugin("importAssertions") && node.assertions == null) {
+        node.assertions = [];
+      }
       return this.finishNode(node, "ExportNamedDeclaration");
     }
 

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1824,9 +1824,6 @@ export default class StatementParser extends ExpressionParser {
 
     if (isFromRequired || hasSpecifiers || hasDeclaration) {
       this.checkExport(node, true, false, !!node.source);
-      if (this.hasPlugin("importAssertions") && node.assertions == null) {
-        node.assertions = [];
-      }
       return this.finishNode(node, "ExportNamedDeclaration");
     }
 
@@ -1886,6 +1883,9 @@ export default class StatementParser extends ExpressionParser {
 
       node.source = null;
       node.declaration = null;
+      if (this.hasPlugin("importAssertions")) {
+        node.assertions = [];
+      }
 
       return true;
     }
@@ -1896,6 +1896,9 @@ export default class StatementParser extends ExpressionParser {
     if (this.shouldParseExportDeclaration()) {
       node.specifiers = [];
       node.source = null;
+      if (this.hasPlugin("importAssertions")) {
+        node.assertions = [];
+      }
       node.declaration = this.parseExportDeclaration(node);
       return true;
     }
@@ -2008,12 +2011,8 @@ export default class StatementParser extends ExpressionParser {
       if (assertions) {
         node.assertions = assertions;
       }
-    } else {
-      if (expect) {
-        this.unexpected();
-      } else {
-        node.source = null;
-      }
+    } else if (expect) {
+      this.unexpected();
     }
 
     this.semicolon();

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1824,8 +1824,8 @@ export default class StatementParser extends ExpressionParser {
 
     if (isFromRequired || hasSpecifiers || hasDeclaration) {
       this.checkExport(node, true, false, !!node.source);
-      if (this.hasPlugin("importAssertions") && node.assertions == null) {
-        node.assertions = [];
+      if (this.hasPlugin("importAssertions")) {
+        node.assertions ??= [];
       }
       return this.finishNode(node, "ExportNamedDeclaration");
     }

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/invalid-export-without-from/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/invalid-export-without-from/output.json
@@ -56,7 +56,8 @@
           }
         ],
         "source": null,
-        "declaration": null
+        "declaration": null,
+        "assertions": []
       },
       {
         "type": "ExpressionStatement",

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-class/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-class/input.js
@@ -1,0 +1,1 @@
+export class Foo {}

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-class/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-class/output.json
@@ -1,0 +1,35 @@
+{
+  "type": "File",
+  "start":0,"end":19,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":19}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":19,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":19}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start":0,"end":19,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":19}},
+        "specifiers": [],
+        "source": null,
+        "declaration": {
+          "type": "ClassDeclaration",
+          "start":7,"end":19,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":19}},
+          "id": {
+            "type": "Identifier",
+            "start":13,"end":16,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":16},"identifierName":"Foo"},
+            "name": "Foo"
+          },
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "start":17,"end":19,"loc":{"start":{"line":1,"column":17},"end":{"line":1,"column":19}},
+            "body": []
+          }
+        },
+        "assertions": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-function/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-function/input.js
@@ -1,0 +1,1 @@
+export function foo() {}

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-function/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-function/output.json
@@ -1,0 +1,38 @@
+{
+  "type": "File",
+  "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":24}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":24}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start":0,"end":24,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":24}},
+        "specifiers": [],
+        "source": null,
+        "declaration": {
+          "type": "FunctionDeclaration",
+          "start":7,"end":24,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":24}},
+          "id": {
+            "type": "Identifier",
+            "start":16,"end":19,"loc":{"start":{"line":1,"column":16},"end":{"line":1,"column":19},"identifierName":"foo"},
+            "name": "foo"
+          },
+          "generator": false,
+          "async": false,
+          "params": [],
+          "body": {
+            "type": "BlockStatement",
+            "start":22,"end":24,"loc":{"start":{"line":1,"column":22},"end":{"line":1,"column":24}},
+            "body": [],
+            "directives": []
+          }
+        },
+        "assertions": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-variable/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-variable/input.js
@@ -1,0 +1,1 @@
+export const foo = "";

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-variable/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-variable/output.json
@@ -1,0 +1,45 @@
+{
+  "type": "File",
+  "start":0,"end":22,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":22}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":22,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":22}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start":0,"end":22,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":22}},
+        "specifiers": [],
+        "source": null,
+        "declaration": {
+          "type": "VariableDeclaration",
+          "start":7,"end":22,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":22}},
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "start":13,"end":21,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":21}},
+              "id": {
+                "type": "Identifier",
+                "start":13,"end":16,"loc":{"start":{"line":1,"column":13},"end":{"line":1,"column":16},"identifierName":"foo"},
+                "name": "foo"
+              },
+              "init": {
+                "type": "StringLiteral",
+                "start":19,"end":21,"loc":{"start":{"line":1,"column":19},"end":{"line":1,"column":21}},
+                "extra": {
+                  "rawValue": "",
+                  "raw": "\"\""
+                },
+                "value": ""
+              }
+            }
+          ],
+          "kind": "const"
+        },
+        "assertions": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-without-from/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-without-from/input.js
@@ -1,0 +1,3 @@
+const foo = "";
+
+export { foo };

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-without-from/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/valid-export-without-from/output.json
@@ -1,0 +1,61 @@
+{
+  "type": "File",
+  "start":0,"end":32,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":15}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":32,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":15}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":15,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":15}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":6,"end":14,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":14}},
+            "id": {
+              "type": "Identifier",
+              "start":6,"end":9,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":9},"identifierName":"foo"},
+              "name": "foo"
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start":12,"end":14,"loc":{"start":{"line":1,"column":12},"end":{"line":1,"column":14}},
+              "extra": {
+                "rawValue": "",
+                "raw": "\"\""
+              },
+              "value": ""
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start":17,"end":32,"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":15}},
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start":26,"end":29,"loc":{"start":{"line":3,"column":9},"end":{"line":3,"column":12}},
+            "local": {
+              "type": "Identifier",
+              "start":26,"end":29,"loc":{"start":{"line":3,"column":9},"end":{"line":3,"column":12},"identifierName":"foo"},
+              "name": "foo"
+            },
+            "exported": {
+              "type": "Identifier",
+              "start":26,"end":29,"loc":{"start":{"line":3,"column":9},"end":{"line":3,"column":12},"identifierName":"foo"},
+              "name": "foo"
+            }
+          }
+        ],
+        "source": null,
+        "declaration": null,
+        "assertions": []
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

Add `assertions` to `ExportNamedDeclaration` without `from` when `importAssertions` is enabled.

According to [estree spec](https://github.com/estree/estree/blob/master/stage3/import-assertions.md#exportnameddeclaration):

> assertions must be an empty array when source is null.

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13957"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

