### PR TITLE
fix: update UnexpectedPrivateField error message

### DIFF
--- a/packages/babel-parser/src/parser/error-message.js
+++ b/packages/babel-parser/src/parser/error-message.js
@@ -213,8 +213,7 @@ export const ErrorMessages = makeErrorTemplates(
       "`new.target` can only be used in functions or class properties.",
     UnexpectedNumericSeparator:
       "A numeric separator is only allowed between two digits.",
-    UnexpectedPrivateField:
-      "Private names can only be used as the name of a class element (i.e. class C { #p = 42; #m() {} } )\n or a property of member expression (i.e. this.#p).",
+    UnexpectedPrivateField: "Unexpected private name.",
     UnexpectedReservedWord: "Unexpected reserved word '%0'.",
     UnexpectedSuper: "'super' is only allowed in object methods and classes.",
     UnexpectedToken: "Unexpected token '%0'.",

--- a/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-destructuring-arguments/output.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-destructuring-arguments/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":46,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
   "errors": [
-    "SyntaxError: Private names can only be used as the name of a class element (i.e. class C { #p = 42; #m() {} } )\n or a property of member expression (i.e. this.#p). (3:11)"
+    "SyntaxError: Unexpected private name. (3:11)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-destructuring/output.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-destructuring/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":59,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":1}},
   "errors": [
-    "SyntaxError: Private names can only be used as the name of a class element (i.e. class C { #p = 42; #m() {} } )\n or a property of member expression (i.e. this.#p). (4:12)"
+    "SyntaxError: Unexpected private name. (4:12)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-object-method/output.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-object-method/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: Private names can only be used as the name of a class element (i.e. class C { #p = 42; #m() {} } )\n or a property of member expression (i.e. this.#p). (2:11)"
+    "SyntaxError: Unexpected private name. (2:11)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-object-property/output.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-object-property/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":32,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: Private names can only be used as the name of a class element (i.e. class C { #p = 42; #m() {} } )\n or a property of member expression (i.e. this.#p). (2:11)"
+    "SyntaxError: Unexpected private name. (2:11)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-ts-type-literal/output.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-ts-type-literal/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":28,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":1}},
   "errors": [
-    "SyntaxError: Private names can only be used as the name of a class element (i.e. class C { #p = 42; #m() {} } )\n or a property of member expression (i.e. this.#p). (2:3)"
+    "SyntaxError: Unexpected private name. (2:3)"
   ],
   "program": {
     "type": "Program",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/pull/13931#discussion_r748787830
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Update the error message of "UnexpectedPrivateField" since it does not cover the private brand checks: `#p in obj`. In #13931, a private name can also appear in the key of an object pattern. At this time we think listing all the available private names position can be daunting, so in this PR we only point out the error itself.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13975"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

