### PR TITLE
Extend `hasPlugin` to accept plugin-configuration array pairs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -378,7 +378,7 @@ Note that the code shown in Chrome DevTools is compiled code and therefore diffe
 - After the ESTree PR is accepted, update [ast/spec.md](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md). Note that there are differences between Babel AST and ESTree. In these cases, consistency with current Babel AST outweighs alignment to ESTree. Otherwise it should follow ESTree.
 
 - [ ] Implement parser plugins based on the new AST. The parser plugin name should be the unprefixed slug of the TC39 proposal URL in _camelcase_, i.e. `exportDefaultFrom` from `https://github.com/tc39/proposal-export-default-from`.
-  - [ ] Use the `this.expectPlugin("newSyntax")` check within `@babel/parser` to ensure your new plugin code only runs when that flag is turned on (not default behavior), and a friendly error is thrown if users forget to enable a plugin.
+  - [ ] Use the `this.expectPlugin("pluginName")` check within `@babel/parser` to ensure your new plugin code only runs when that flag is turned on (not default behavior), and a friendly error is thrown if users forget to enable a plugin. You can also supply an array pair to require certain configuration options, e.g., `this.expectPlugin(["pluginName", { configOption: value }])`.
   - [ ] Add failing/passing tests according to spec behavior
   - [ ] Add `@babel/syntax-new-syntax` package. You can copy `packages/babel-plugin-syntax-decimal` and replace `decimal` to `new-syntax`.
   - [ ] Add `@babel/syntax-new-syntax` to `@babel/standalone`.

--- a/packages/babel-parser/src/parser/base.js
+++ b/packages/babel-parser/src/parser/base.js
@@ -31,12 +31,31 @@ export default class BaseParser {
   declare input: string;
   declare length: number;
 
-  hasPlugin(name: string): boolean {
-    return this.plugins.has(name);
+  // This method accepts either a string (plugin name) or an array pair
+  // (plugin name and options object). If an options object is given,
+  // then each value is non-recursively checked for identity with that
+  // plugin’s actual option value.
+  hasPlugin(pluginConfig: PluginConfig): boolean {
+    if (typeof pluginConfig === "string") {
+      return this.plugins.has(pluginConfig);
+    } else {
+      const [pluginName, pluginOptions] = pluginConfig;
+      if (!this.hasPlugin(pluginName)) {
+        return false;
+      }
+      const actualOptions = this.plugins.get(pluginName);
+      for (const key of Object.keys(pluginOptions)) {
+        if (actualOptions?.[key] !== pluginOptions[key]) {
+          return false;
+        }
+      }
+      return true;
+    }
   }
 
   getPluginOption(plugin: string, name: string) {
-    // $FlowIssue
-    if (this.hasPlugin(plugin)) return this.plugins.get(plugin)[name];
+    return this.plugins.get(plugin)?.[name];
   }
 }
+
+export type PluginConfig = string | [string, { [string]: any }];

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -448,7 +448,7 @@ export default class ExpressionParser extends LValParser {
 
         if (
           op === tt.pipeline &&
-          this.getPluginOption("pipelineOperator", "proposal") === "minimal"
+          this.hasPlugin(["pipelineOperator", { proposal: "minimal" }])
         ) {
           if (this.state.type === tt._await && this.prodParam.hasAwait) {
             throw this.raise(
@@ -1429,11 +1429,12 @@ export default class ExpressionParser extends LValParser {
   ): boolean {
     switch (pipeProposal) {
       case "hack": {
-        const pluginTopicToken = this.getPluginOption(
+        return this.hasPlugin([
           "pipelineOperator",
-          "topicToken",
-        );
-        return tokenLabelName(tokenType) === pluginTopicToken;
+          {
+            topicToken: tokenLabelName(tokenType),
+          },
+        ]);
       }
       case "smart":
         return tokenType === tt.hash;
@@ -2742,7 +2743,7 @@ export default class ExpressionParser extends LValParser {
   // of the infix operator `|>`.
 
   checkPipelineAtInfixOperator(left: N.Expression, leftStartPos: number) {
-    if (this.getPluginOption("pipelineOperator", "proposal") === "smart") {
+    if (this.hasPlugin(["pipelineOperator", { proposal: "smart" }])) {
       if (left.type === "SequenceExpression") {
         // Ensure that the pipeline head is not a comma-delimited
         // sequence expression.
@@ -2843,8 +2844,7 @@ export default class ExpressionParser extends LValParser {
   // had before the function was called.
 
   withSmartMixTopicForbiddingContext<T>(callback: () => T): T {
-    const proposal = this.getPluginOption("pipelineOperator", "proposal");
-    if (proposal === "smart") {
+    if (this.hasPlugin(["pipelineOperator", { proposal: "smart" }])) {
       // Reset the parser’s topic context only if the smart-mix pipe proposal is active.
       const outerContextTopicState = this.state.topicContext;
       this.state.topicContext = {

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -21,6 +21,7 @@ import ProductionParameterHandler, {
 } from "../util/production-parameter";
 import { Errors, type ErrorTemplate, ErrorCodes } from "./error";
 import type { ParsingError } from "./error";
+import type { PluginConfig } from "./base";
 /*::
 import type ScopeHandler from "../util/scope";
 */
@@ -175,26 +176,38 @@ export default class UtilParser extends Tokenizer {
     /* eslint-enable @babel/development-internal/dry-error-messages */
   }
 
-  expectPlugin(name: string, pos?: ?number): true {
-    if (!this.hasPlugin(name)) {
+  getPluginNamesFromConfigs(pluginConfigs: Array<PluginConfig>): Array<string> {
+    return pluginConfigs.map(c => {
+      if (typeof c === "string") {
+        return c;
+      } else {
+        return c[0];
+      }
+    });
+  }
+
+  expectPlugin(pluginConfig: PluginConfig, pos?: ?number): true {
+    if (!this.hasPlugin(pluginConfig)) {
       throw this.raiseWithData(
         pos != null ? pos : this.state.start,
-        { missingPlugin: [name] },
-        `This experimental syntax requires enabling the parser plugin: '${name}'`,
+        { missingPlugin: this.getPluginNamesFromConfigs([pluginConfig]) },
+        `This experimental syntax requires enabling the parser plugin: ${JSON.stringify(
+          pluginConfig,
+        )}.`,
       );
     }
 
     return true;
   }
 
-  expectOnePlugin(names: Array<string>, pos?: ?number): void {
-    if (!names.some(n => this.hasPlugin(n))) {
+  expectOnePlugin(pluginConfigs: Array<PluginConfig>, pos?: ?number): void {
+    if (!pluginConfigs.some(c => this.hasPlugin(c))) {
       throw this.raiseWithData(
         pos != null ? pos : this.state.start,
-        { missingPlugin: names },
-        `This experimental syntax requires enabling one of the following parser plugin(s): '${names.join(
-          ", ",
-        )}'`,
+        { missingPlugin: this.getPluginNamesFromConfigs(pluginConfigs) },
+        `This experimental syntax requires enabling one of the following parser plugin(s): ${pluginConfigs
+          .map(c => JSON.stringify(c))
+          .join(", ")}.`,
       );
     }
   }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-default-token/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-default-token/options.json
@@ -1,4 +1,3 @@
 {
-  "sourceType": "module",
   "throws": "Unexpected token (1:18)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-default/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-default/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'exportDefaultFrom' (1:7)"
+  "sourceType": "module",
+  "throws": "This experimental syntax requires enabling the parser plugin: \"exportDefaultFrom\". (1:7)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/async-do-expressions-with-do-expressions/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/async-do-expressions-with-do-expressions/options.json
@@ -1,5 +1,5 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'asyncDoExpressions' (1:7)",
+  "throws": "This experimental syntax requires enabling the parser plugin: \"asyncDoExpressions\". (1:7)",
   "plugins": [
     "doExpressions"
   ]

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/async-do-expressions/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/async-do-expressions/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'doExpressions' (1:7)",
+  "throws": "This experimental syntax requires enabling the parser plugin: \"doExpressions\". (1:7)",
   "plugins": []
 }

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/decimal/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/decimal/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'decimal' (1:2)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"decimal\". (1:2)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/decorators/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/decorators/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'decorators-legacy, decorators' (1:0)",
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"decorators-legacy\", \"decorators\". (1:0)",
   "plugins": []
 }

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/do-expressions/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/do-expressions/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'doExpressions' (1:1)",
+  "throws": "This experimental syntax requires enabling the parser plugin: \"doExpressions\". (1:1)",
   "plugins": []
 }

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/export-default/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/export-default/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'exportDefaultFrom' (1:7)",
+  "throws": "This experimental syntax requires enabling the parser plugin: \"exportDefaultFrom\". (1:7)",
   "plugins": []
 }

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/import-assertions-dynamic/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/import-assertions-dynamic/options.json
@@ -1,5 +1,5 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'importAssertions' (1:24)",
+  "throws": "This experimental syntax requires enabling the parser plugin: \"importAssertions\". (1:24)",
   "sourceType": "module",
   "plugins": []
 }

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/import-assertions/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/import-assertions/options.json
@@ -1,5 +1,5 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'importAssertions' (1:27)",
+  "throws": "This experimental syntax requires enabling the parser plugin: \"importAssertions\". (1:27)",
   "sourceType": "module",
   "plugins": []
 }

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/module-attributes/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/module-attributes/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'moduleAttributes' (1:27)",
+  "throws": "This experimental syntax requires enabling the parser plugin: \"moduleAttributes\". (1:27)",
   "BABEL_8_BREAKING": false
 }

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/module-blocks/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/module-blocks/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'moduleBlocks' (1:18)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"moduleBlocks\". (1:18)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/export-decorated-class-without-plugin/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/export-decorated-class-without-plugin/options.json
@@ -1,5 +1,5 @@
 {
+  "plugins": null,
   "sourceType": "module",
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'decorators, decorators-legacy' (1:7)",
-  "plugins": null
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"decorators\", \"decorators-legacy\". (1:7)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/function-sent/disabled-function-keyword-declaration/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/function-sent/disabled-function-keyword-declaration/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'functionSent' (2:11)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"functionSent\". (2:11)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/function-sent/disabled-function-keyword-expression/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/function-sent/disabled-function-keyword-expression/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'functionSent' (2:12)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"functionSent\". (2:12)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/function-sent/disabled-inside-generator/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/function-sent/disabled-inside-generator/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'functionSent' (2:18)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"functionSent\". (2:18)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/import-assertions/without-plugin/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-assertions/without-plugin/options.json
@@ -1,4 +1,5 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'importAssertions' (1:27)",
-  "plugins": []
+  "plugins": [],
+  "sourceType": "module",
+  "throws": "This experimental syntax requires enabling the parser plugin: \"importAssertions\". (1:27)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/module-attributes/without-plugin/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/module-attributes/without-plugin/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'moduleAttributes' (1:27)",
+  "throws": "This experimental syntax requires enabling the parser plugin: \"moduleAttributes\". (1:27)",
   "plugins": []
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/no-plugin-pipe/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/no-plugin-pipe/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'pipelineOperator' (1:2)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"pipelineOperator\". (1:2)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/record-and-tuple/not-enabled-hash/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/record-and-tuple/not-enabled-hash/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'recordAndTuple' (1:0)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"recordAndTuple\". (1:0)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/throw-expression/not-enabled/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/throw-expression/not-enabled/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'throwExpressions' (2:3)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"throwExpressions\". (2:3)"
 }

--- a/packages/babel-parser/test/fixtures/flow/expect-plugin/export-interface/options.json
+++ b/packages/babel-parser/test/fixtures/flow/expect-plugin/export-interface/options.json
@@ -3,5 +3,5 @@
   "plugins": [
     "jsx"
   ],
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (1:7)"
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"flow\", \"typescript\". (1:7)"
 }

--- a/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type-named/options.json
+++ b/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type-named/options.json
@@ -3,5 +3,5 @@
   "plugins": [
     "jsx"
   ],
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (2:7)"
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"flow\", \"typescript\". (2:7)"
 }

--- a/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type/options.json
+++ b/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type/options.json
@@ -3,5 +3,5 @@
   "plugins": [
     "jsx"
   ],
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (1:7)"
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"flow\", \"typescript\". (1:7)"
 }

--- a/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-fragment/options.json
+++ b/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-fragment/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'jsx, flow, typescript' (3:4)",
-  "plugins": []
+  "plugins": [],
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"jsx\", \"flow\", \"typescript\". (3:4)"
 }

--- a/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-jsx-expression/options.json
+++ b/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-jsx-expression/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": [],
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'jsx, flow, typescript' (1:0)"
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"jsx\", \"flow\", \"typescript\". (1:0)"
 }

--- a/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-type-param/options.json
+++ b/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-type-param/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": [],
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'jsx, flow, typescript' (1:0)"
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"jsx\", \"flow\", \"typescript\". (1:0)"
 }

--- a/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin-non-BMP-identifier/options.json
+++ b/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin-non-BMP-identifier/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'jsx, flow, typescript' (1:0)",
-  "plugins": []
+  "plugins": [],
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"jsx\", \"flow\", \"typescript\". (1:0)"
 }

--- a/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin/options.json
+++ b/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'jsx, flow, typescript' (1:0)",
-  "plugins": []
+  "plugins": [],
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"jsx\", \"flow\", \"typescript\". (1:0)"
 }

--- a/packages/babel-parser/test/fixtures/placeholders/export/default-default-from/options.json
+++ b/packages/babel-parser/test/fixtures/placeholders/export/default-default-from/options.json
@@ -1,5 +1,7 @@
 {
-  "plugins": ["placeholders"],
+  "plugins": [
+    "placeholders"
+  ],
   "sourceType": "module",
-  "throws": "This experimental syntax requires enabling the parser plugin: 'exportDefaultFrom' (1:7)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"exportDefaultFrom\". (1:7)"
 }

--- a/packages/babel-parser/test/fixtures/placeholders/export/default-named-from-2/options.json
+++ b/packages/babel-parser/test/fixtures/placeholders/export/default-named-from-2/options.json
@@ -1,5 +1,7 @@
 {
-  "plugins": ["placeholders"],
+  "plugins": [
+    "placeholders"
+  ],
   "sourceType": "module",
-  "throws": "This experimental syntax requires enabling the parser plugin: 'exportDefaultFrom' (1:16)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"exportDefaultFrom\". (1:16)"
 }

--- a/packages/babel-parser/test/fixtures/placeholders/export/default-named-from-3/options.json
+++ b/packages/babel-parser/test/fixtures/placeholders/export/default-named-from-3/options.json
@@ -1,5 +1,7 @@
 {
-  "plugins": ["placeholders"],
+  "plugins": [
+    "placeholders"
+  ],
   "sourceType": "module",
-  "throws": "This experimental syntax requires enabling the parser plugin: 'exportDefaultFrom' (1:16)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"exportDefaultFrom\". (1:16)"
 }

--- a/packages/babel-parser/test/fixtures/placeholders/export/default-named-from/options.json
+++ b/packages/babel-parser/test/fixtures/placeholders/export/default-named-from/options.json
@@ -1,5 +1,7 @@
 {
-  "plugins": ["placeholders"],
+  "plugins": [
+    "placeholders"
+  ],
   "sourceType": "module",
-  "throws": "This experimental syntax requires enabling the parser plugin: 'exportDefaultFrom' (1:7)"
+  "throws": "This experimental syntax requires enabling the parser plugin: \"exportDefaultFrom\". (1:7)"
 }

--- a/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-interface/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-interface/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (1:7)"
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"flow\", \"typescript\". (1:7)"
 }

--- a/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type-named/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type-named/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (2:7)"
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"flow\", \"typescript\". (2:7)"
 }

--- a/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/expect-plugin/export-type/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'flow, typescript' (1:7)"
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): \"flow\", \"typescript\". (1:7)"
 }

--- a/scripts/parser-tests/test262/index.js
+++ b/scripts/parser-tests/test262/index.js
@@ -153,6 +153,7 @@ const ignoredFeatures = [
 const ignoredTests = ["built-ins/RegExp/", "language/literals/regexp/"];
 
 const featuresToPlugins = {
+  __proto__: null,
   "import-assertions": "importAssertions",
 };
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | Not needed
| Any Dependency Changes?  | No
| License                  | MIT

This also allows expectPlugin and expectOnePlugin to give better error messages. For example:
> This experimental syntax requires enabling the parser plugin "pipelineOperator".
> This experimental syntax requires enabling the parser plugin ["pipelineOperator", {proposal: "hack", topicToken: "^^"}].

See https://github.com/babel/babel/pull/13973#discussion_r751812878. 
CC: @JLHwung.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13982"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

