### PR TITLE
Use Node.js interop when importing `lib` in `test`

### DIFF
--- a/eslint/babel-eslint-plugin-development-internal/test/rules/dry-error-messages.js
+++ b/eslint/babel-eslint-plugin-development-internal/test/rules/dry-error-messages.js
@@ -12,7 +12,7 @@ const MODULE_PARENT_DIR = path.resolve(dirname, "test/errorsModule.js");
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("dry-error-messages", rule, {
+ruleTester.run("dry-error-messages", rule.default, {
   valid: [
     // Ignores malformed `this.raise` invocations.
     {

--- a/eslint/babel-eslint-plugin-development-internal/test/rules/report-error-message-formtat.js
+++ b/eslint/babel-eslint-plugin-development-internal/test/rules/report-error-message-formtat.js
@@ -3,7 +3,7 @@ import rule from "../../lib/rules/report-error-message-format.js";
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("report-error-message-format", rule, {
+ruleTester.run("report-error-message-format", rule.default, {
   valid: [
     "makeErrorTemplates({});",
     'makeErrorTemplates({ ThisIsAnError: "This is an error." });',

--- a/eslint/babel-eslint-plugin-development/test/rules/no-deprecated-clone.js
+++ b/eslint/babel-eslint-plugin-development/test/rules/no-deprecated-clone.js
@@ -9,7 +9,7 @@ const ruleTester = new RuleTester({
   parserOptions: { sourceType: "module" },
 });
 
-ruleTester.run("no-deprecated-clone", rule, {
+ruleTester.run("no-deprecated-clone", rule.default, {
   valid: [
     `_.clone(obj)`,
     `_.cloneDeep(obj)`,

--- a/eslint/babel-eslint-plugin-development/test/rules/no-undefined-identifier.js
+++ b/eslint/babel-eslint-plugin-development/test/rules/no-undefined-identifier.js
@@ -8,7 +8,7 @@ const ruleTester = new RuleTester({
   parserOptions: { sourceType: "module" },
 });
 
-ruleTester.run("no-undefined-identifier", rule, {
+ruleTester.run("no-undefined-identifier", rule.default, {
   valid: [
     `_.identifier("undefined")`,
     `_.Identifier("undefined")`,

--- a/eslint/babel-eslint-plugin-development/test/rules/plugin-name.js
+++ b/eslint/babel-eslint-plugin-development/test/rules/plugin-name.js
@@ -6,7 +6,7 @@ const missingNameError = "This Babel plugin doesn't have a 'name' property.";
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("plugin-name", rule, {
+ruleTester.run("plugin-name", rule.default, {
   valid: [
     `export default function () { return { name: "test-plugin" } }`,
     `import { declare } from "@babel/helper-plugin-utils"; declare(() => { return { name: "test-plugin" } })`,

--- a/eslint/babel-eslint-plugin/test/rules/new-cap.js
+++ b/eslint/babel-eslint-plugin/test/rules/new-cap.js
@@ -2,7 +2,7 @@ import rule from "../../lib/rules/new-cap.js";
 import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 
 const ruleTester = new RuleTester();
-ruleTester.run("@babel/new-cap", rule, {
+ruleTester.run("@babel/new-cap", rule.default, {
   valid: [
     {
       code: "@MyDecorator(123) class MyClass{}",

--- a/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
+++ b/eslint/babel-eslint-plugin/test/rules/no-invalid-this.js
@@ -165,7 +165,7 @@ const patterns = [
 ];
 
 const ruleTester = new RuleTester();
-ruleTester.run("@babel/no-invalid-this", rule, {
+ruleTester.run("@babel/no-invalid-this", rule.default, {
   valid: extractPatterns(patterns, "valid"),
   invalid: extractPatterns(patterns, "invalid"),
 });

--- a/eslint/babel-eslint-plugin/test/rules/no-unused-expressions.js
+++ b/eslint/babel-eslint-plugin/test/rules/no-unused-expressions.js
@@ -2,7 +2,7 @@ import rule from "../../lib/rules/no-unused-expressions.js";
 import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 
 const ruleTester = new RuleTester();
-ruleTester.run("@babel/no-unused-expressions", rule, {
+ruleTester.run("@babel/no-unused-expressions", rule.default, {
   valid: [
     "let a = do { if (foo) { foo.bar; } }",
     "let a = do { foo; }",

--- a/eslint/babel-eslint-plugin/test/rules/object-curly-spacing.js
+++ b/eslint/babel-eslint-plugin/test/rules/object-curly-spacing.js
@@ -2,7 +2,7 @@ import rule from "../../lib/rules/object-curly-spacing.js";
 import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.js";
 
 const ruleTester = new RuleTester();
-ruleTester.run("@babel/object-curly-spacing", rule, {
+ruleTester.run("@babel/object-curly-spacing", rule.default, {
   valid: ['export x from "mod";'],
   invalid: [],
 });

--- a/eslint/babel-eslint-plugin/test/rules/semi.js
+++ b/eslint/babel-eslint-plugin/test/rules/semi.js
@@ -3,7 +3,7 @@ import RuleTester from "../../../babel-eslint-shared-fixtures/utils/RuleTester.j
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("semi", rule, {
+ruleTester.run("semi", rule.default, {
   valid: [
     "class Foo { bar = 'example'; }",
     "class Foo { #bar = 'example'; }",

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -1,6 +1,8 @@
 import chalk from "chalk";
 import stripAnsi from "strip-ansi";
-import codeFrame, { codeFrameColumns } from "../lib/index.js";
+
+import _codeFrame, { codeFrameColumns } from "../lib/index.js";
+const codeFrame = _codeFrame.default;
 
 describe("@babel/code-frame", function () {
   test("basic usage", function () {

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -1,9 +1,11 @@
-import * as babel from "../lib/index.js";
+import babel from "../lib/index.js";
 import sourceMap from "source-map";
 import path from "path";
-import Plugin from "../lib/config/plugin.js";
 import generator from "@babel/generator";
 import { fileURLToPath } from "url";
+
+import _Plugin from "../lib/config/plugin.js";
+const Plugin = _Plugin.default;
 
 import presetEnv from "../../babel-preset-env/lib/index.js";
 import pluginSyntaxFlow from "../../babel-plugin-syntax-flow/lib/index.js";

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -2,8 +2,10 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
-import * as babel from "../lib/index.js";
-import getTargets from "@babel/helper-compilation-targets";
+import babel from "../lib/index.js";
+
+import _getTargets from "@babel/helper-compilation-targets";
+const getTargets = _getTargets.default;
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/packages/babel-core/test/config-loading.js
+++ b/packages/babel-core/test/config-loading.js
@@ -1,4 +1,4 @@
-import loadConfigRunner, {
+import _loadConfigRunner, {
   loadPartialConfig,
   createConfigItem,
 } from "../lib/config/index.js";
@@ -8,7 +8,7 @@ import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
 
-const loadConfig = loadConfigRunner.sync;
+const loadConfig = _loadConfigRunner.default.sync;
 
 describe("@babel/core config loading", () => {
   const FILEPATH = path.join(

--- a/packages/babel-core/test/evaluation.js
+++ b/packages/babel-core/test/evaluation.js
@@ -1,5 +1,7 @@
-import traverse from "@babel/traverse";
 import { parse } from "@babel/parser";
+
+import _traverse from "@babel/traverse";
+const traverse = _traverse.default;
 
 describe("evaluation", function () {
   function addTest(code, type, value, notConfident) {

--- a/packages/babel-core/test/path.js
+++ b/packages/babel-core/test/path.js
@@ -1,7 +1,9 @@
 import { transform } from "../lib/index.js";
-import Plugin from "../lib/config/plugin.js";
 import { fileURLToPath } from "url";
 import path from "path";
+
+import _Plugin from "../lib/config/plugin.js";
+const Plugin = _Plugin.default;
 
 const cwd = path.dirname(fileURLToPath(import.meta.url));
 

--- a/packages/babel-core/test/plugins.js
+++ b/packages/babel-core/test/plugins.js
@@ -2,7 +2,7 @@ import runner from "@babel/helper-transform-fixture-test-runner";
 import { fileURLToPath } from "url";
 import path from "path";
 
-runner(
+runner.default(
   path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures/plugins"),
   "plugins",
 );

--- a/packages/babel-core/test/transformation.js
+++ b/packages/babel-core/test/transformation.js
@@ -2,7 +2,7 @@ import runner from "@babel/helper-transform-fixture-test-runner";
 import { fileURLToPath } from "url";
 import path from "path";
 
-runner(
+runner.default(
   path.join(
     path.dirname(fileURLToPath(import.meta.url)),
     "/fixtures/transformation",

--- a/packages/babel-generator/test/arrow-functions.js
+++ b/packages/babel-generator/test/arrow-functions.js
@@ -1,5 +1,7 @@
-import generate from "../lib/index.js";
 import { parse } from "@babel/parser";
+
+import _generate from "../lib/index.js";
+const generate = _generate.default;
 
 describe("parameter parentheses", () => {
   // Common source text for several snapshot tests

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1,5 +1,3 @@
-import Printer from "../lib/printer.js";
-import generate, { CodeGenerator } from "../lib/index.js";
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
 import fs from "fs";
@@ -7,6 +5,11 @@ import path from "path";
 import fixtures from "@babel/helper-fixtures";
 import sourcemap from "source-map";
 import { fileURLToPath } from "url";
+
+import _Printer from "../lib/printer.js";
+import _generate, { CodeGenerator } from "../lib/index.js";
+const Printer = _Printer.default;
+const generate = _generate.default;
 
 describe("generation", function () {
   it("completeness", function () {
@@ -795,7 +798,7 @@ describe("CodeGenerator", function () {
   });
 });
 
-const suites = fixtures(
+const suites = fixtures.default(
   path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures"),
 );
 

--- a/packages/babel-helper-annotate-as-pure/test/index.js
+++ b/packages/babel-helper-annotate-as-pure/test/index.js
@@ -1,4 +1,5 @@
-import annotateAsPure from "../lib/index.js";
+import _annotateAsPure from "../lib/index.js";
+const annotateAsPure = _annotateAsPure.default;
 
 describe("@babel/helper-annotate-as-pure", () => {
   it("will add leading comment", () => {

--- a/packages/babel-helper-compilation-targets/test/browserslist-extends/browserslist-extends.spec.js
+++ b/packages/babel-helper-compilation-targets/test/browserslist-extends/browserslist-extends.spec.js
@@ -1,6 +1,8 @@
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
-import getTargets from "../../lib/index.js";
+
+import _getTargets from "../../lib/index.js";
+const getTargets = _getTargets.default;
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 

--- a/packages/babel-helper-compilation-targets/test/custom-browserslist-env/custom-browserslist-env.spec.js
+++ b/packages/babel-helper-compilation-targets/test/custom-browserslist-env/custom-browserslist-env.spec.js
@@ -1,6 +1,8 @@
-import getTargets from "../../lib/index.js";
 import { fileURLToPath } from "url";
 import path from "path";
+
+import _getTargets from "../../lib/index.js";
+const getTargets = _getTargets.default;
 
 it("allows custom browserslist env", () => {
   const actual = getTargets(

--- a/packages/babel-helper-compilation-targets/test/load-browserslist-package-json/load-browserslist-package-json.spec.js
+++ b/packages/babel-helper-compilation-targets/test/load-browserslist-package-json/load-browserslist-package-json.spec.js
@@ -1,6 +1,8 @@
-import getTargets from "../../lib/index.js";
 import { fileURLToPath } from "url";
 import path from "path";
+
+import _getTargets from "../../lib/index.js";
+const getTargets = _getTargets.default;
 
 const oldCwd = process.cwd();
 

--- a/packages/babel-helper-compilation-targets/test/load-browserslistrc/load-browserslistrc.spec.js
+++ b/packages/babel-helper-compilation-targets/test/load-browserslistrc/load-browserslistrc.spec.js
@@ -1,6 +1,8 @@
-import getTargets from "../../lib/index.js";
 import { fileURLToPath } from "url";
 import path from "path";
+
+import _getTargets from "../../lib/index.js";
+const getTargets = _getTargets.default;
 
 const oldCwd = process.cwd();
 

--- a/packages/babel-helper-compilation-targets/test/targets-parser.spec.js
+++ b/packages/babel-helper-compilation-targets/test/targets-parser.spec.js
@@ -1,7 +1,9 @@
 import browserslist from "browserslist";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import getTargets from "../lib/index.js";
+
+import _getTargets from "../lib/index.js";
+const getTargets = _getTargets.default;
 
 describe("getTargets", () => {
   it("parses", () => {

--- a/packages/babel-helper-optimise-call-expression/test/index.js
+++ b/packages/babel-helper-optimise-call-expression/test/index.js
@@ -1,7 +1,10 @@
 import { parse } from "@babel/parser";
-import generator from "@babel/generator";
 import * as t from "@babel/types";
-import optimizeCallExpression from "../lib/index.js";
+
+import _generator from "@babel/generator";
+import _optimizeCallExpression from "../lib/index.js";
+const generator = _generator.default;
+const optimizeCallExpression = _optimizeCallExpression.default;
 
 function transformInput(input, thisIdentifier) {
   const ast = parse(input);

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -1,6 +1,8 @@
 import chalk from "chalk";
 import stripAnsi from "strip-ansi";
-import highlight, { shouldHighlight, getChalk } from "../lib/index.js";
+
+import _highlight, { shouldHighlight, getChalk } from "../lib/index.js";
+const highlight = _highlight.default;
 
 describe("@babel/highlight", function () {
   function stubColorSupport(supported) {

--- a/packages/babel-plugin-proposal-object-rest-spread/test/hasMoreThanOneBinding.test.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/hasMoreThanOneBinding.test.js
@@ -1,5 +1,8 @@
 import { parse } from "@babel/parser";
-import shouldStoreRHSInTemporaryVariable from "../lib/shouldStoreRHSInTemporaryVariable.js";
+
+import _shouldStoreRHSInTemporaryVariable from "../lib/shouldStoreRHSInTemporaryVariable.js";
+const shouldStoreRHSInTemporaryVariable =
+  _shouldStoreRHSInTemporaryVariable.default;
 
 function getFistObjectPattern(program) {
   return parse(program, { sourceType: "module" }).program.body[0]

--- a/packages/babel-preset-env/test/get-option-specific-excludes.spec.js
+++ b/packages/babel-preset-env/test/get-option-specific-excludes.spec.js
@@ -1,4 +1,5 @@
-import getOptionSpecificExcludesFor from "../lib/get-option-specific-excludes.js";
+import _getOptionSpecificExcludesFor from "../lib/get-option-specific-excludes.js";
+const getOptionSpecificExcludesFor = _getOptionSpecificExcludesFor.default;
 
 describe("defaults", () => {
   describe("getOptionSpecificExcludesFor", () => {

--- a/packages/babel-preset-env/test/index.spec.js
+++ b/packages/babel-preset-env/test/index.spec.js
@@ -1,11 +1,16 @@
 // eslint-disable-next-line import/extensions
 import compatData from "@babel/compat-data/plugins";
 
-import * as babelPresetEnv from "../lib/index.js";
-import removeRegeneratorEntryPlugin from "../lib/polyfills/regenerator.js";
-import pluginLegacyBabelPolyfill from "../lib/polyfills/babel-polyfill.js";
-import transformations from "../lib/module-transformations.js";
-import availablePlugins from "../lib/available-plugins.js";
+import babelPresetEnv from "../lib/index.js";
+
+import _removeRegeneratorEntryPlugin from "../lib/polyfills/regenerator.js";
+import _pluginLegacyBabelPolyfill from "../lib/polyfills/babel-polyfill.js";
+import _transformations from "../lib/module-transformations.js";
+import _availablePlugins from "../lib/available-plugins.js";
+const removeRegeneratorEntryPlugin = _removeRegeneratorEntryPlugin.default;
+const pluginLegacyBabelPolyfill = _pluginLegacyBabelPolyfill.default;
+const transformations = _transformations.default;
+const availablePlugins = _availablePlugins.default;
 
 import _pluginCoreJS2 from "babel-plugin-polyfill-corejs2";
 import _pluginCoreJS3 from "babel-plugin-polyfill-corejs3";

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -1,9 +1,10 @@
-import normalizeOptions, {
+import _normalizeOptions, {
   checkDuplicateIncludeExcludes,
   validateModulesOption,
   validateUseBuiltInsOption,
   normalizePluginName,
 } from "../lib/normalize-options.js";
+const normalizeOptions = _normalizeOptions.default;
 
 describe("normalize-options", () => {
   describe("normalizeOptions", () => {

--- a/packages/babel-preset-flow/test/normalize-options.spec.js
+++ b/packages/babel-preset-flow/test/normalize-options.spec.js
@@ -1,4 +1,6 @@
-import normalizeOptions from "../lib/normalize-options.js";
+import _normalizeOptions from "../lib/normalize-options.js";
+const normalizeOptions = _normalizeOptions.default;
+
 describe("normalize options", () => {
   (process.env.BABEL_8_BREAKING ? describe : describe.skip)("Babel 8", () => {
     it("should throw on unknown options", () => {

--- a/packages/babel-preset-react/test/index.js
+++ b/packages/babel-preset-react/test/index.js
@@ -1,16 +1,17 @@
-import react from "../lib/index.js";
+import _reactPreset from "../lib/index.js";
+const reactPreset = _reactPreset.default;
 
 describe("react preset", () => {
   it("does throw clear error when no options passed for Babel 6", () => {
     expect(() => {
-      react({ version: "6.5.0" });
+      reactPreset({ version: "6.5.0" });
     }).toThrow(Error, /Requires Babel "\^7.0.0-0"/);
   });
   (process.env.BABEL_8_BREAKING ? it : it.skip)(
     "throws when unknown option is passed",
     () => {
       expect(() => {
-        react({ assertVersion() {} }, { runtine: true });
+        reactPreset({ assertVersion() {} }, { runtine: true });
       }).toThrowErrorMatchingInlineSnapshot(`
         "@babel/preset-react: 'runtine' is not a valid top-level option.
         - Did you mean 'runtime'?"
@@ -21,7 +22,7 @@ describe("react preset", () => {
     "throws when option is of incorrect type",
     () => {
       expect(() => {
-        react({ assertVersion() {} }, { runtime: true });
+        reactPreset({ assertVersion() {} }, { runtime: true });
       }).toThrowErrorMatchingInlineSnapshot(
         `"@babel/preset-react: 'runtime' option must be a string."`,
       );

--- a/packages/babel-preset-react/test/normalize-options.skip-bundled.js
+++ b/packages/babel-preset-react/test/normalize-options.skip-bundled.js
@@ -1,4 +1,5 @@
-import normalizeOptions from "../lib/normalize-options.js";
+import _normalizeOptions from "../lib/normalize-options.js";
+const normalizeOptions = _normalizeOptions.default;
 
 describe("normalize options", () => {
   (process.env.BABEL_8_BREAKING ? describe : describe.skip)("Babel 8", () => {

--- a/packages/babel-preset-typescript/test/normalize-options.skip-bundled.js
+++ b/packages/babel-preset-typescript/test/normalize-options.skip-bundled.js
@@ -1,4 +1,5 @@
-import normalizeOptions from "../lib/normalize-options.js";
+import _normalizeOptions from "../lib/normalize-options.js";
+const normalizeOptions = _normalizeOptions.default;
 
 describe("normalize options", () => {
   (process.env.BABEL_8_BREAKING ? describe : describe.skip)("Babel 8", () => {

--- a/packages/babel-template/test/index.js
+++ b/packages/babel-template/test/index.js
@@ -1,6 +1,9 @@
-import generator from "../../babel-generator/lib/index.js";
-import template from "../lib/index.js";
 import * as t from "@babel/types";
+
+import _generator from "../../babel-generator/lib/index.js";
+import _template from "../lib/index.js";
+const generator = _generator.default;
+const template = _template.default;
 
 const comments = "// Sum two numbers\nconst add = (a, b) => a + b;";
 

--- a/packages/babel-traverse/test/ancestry.js
+++ b/packages/babel-traverse/test/ancestry.js
@@ -1,5 +1,7 @@
-import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
+
+import _traverse from "../lib/index.js";
+const traverse = _traverse.default;
 
 describe("path/ancestry", function () {
   describe("isAncestor", function () {

--- a/packages/babel-traverse/test/arrow-transform.js
+++ b/packages/babel-traverse/test/arrow-transform.js
@@ -1,7 +1,9 @@
 import { NodePath } from "../lib/index.js";
 import { parse } from "@babel/parser";
-import generate from "@babel/generator";
 import * as t from "@babel/types";
+
+import _generate from "@babel/generator";
+const generate = _generate.default;
 
 function assertConversion(
   input,

--- a/packages/babel-traverse/test/conversion.js
+++ b/packages/babel-traverse/test/conversion.js
@@ -1,7 +1,10 @@
-import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
-import generate from "@babel/generator";
 import * as t from "@babel/types";
+
+import _traverse from "../lib/index.js";
+import _generate from "@babel/generator";
+const traverse = _traverse.default;
+const generate = _generate.default;
 
 function getPath(code) {
   const ast = parse(code);

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -1,5 +1,7 @@
-import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
+
+import _traverse from "../lib/index.js";
+const traverse = _traverse.default;
 
 function getPath(code) {
   const ast = parse(code);

--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -1,6 +1,8 @@
-import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
+
+import _traverse from "../lib/index.js";
+const traverse = _traverse.default;
 
 describe("path/family", function () {
   describe("getBindingIdentifiers", function () {

--- a/packages/babel-traverse/test/inference.js
+++ b/packages/babel-traverse/test/inference.js
@@ -1,6 +1,8 @@
-import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
+
+import _traverse from "../lib/index.js";
+const traverse = _traverse.default;
 
 function getPath(code) {
   const ast = parse(code, { plugins: ["flow"] });

--- a/packages/babel-traverse/test/introspection.js
+++ b/packages/babel-traverse/test/introspection.js
@@ -1,5 +1,7 @@
-import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
+
+import _traverse from "../lib/index.js";
+const traverse = _traverse.default;
 
 function getPath(code, options = { sourceType: "script" }) {
   const ast = parse(code, options);

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -1,7 +1,10 @@
-import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
-import generate from "@babel/generator";
 import * as t from "@babel/types";
+
+import _traverse from "../lib/index.js";
+import _generate from "@babel/generator";
+const traverse = _traverse.default;
+const generate = _generate.default;
 
 function getPath(code, parserOpts) {
   const ast = parse(code, parserOpts);

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -1,6 +1,9 @@
-import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
-import generate from "@babel/generator";
+
+import _traverse from "../lib/index.js";
+import _generate from "@babel/generator";
+const traverse = _traverse.default;
+const generate = _generate.default;
 
 function getPath(code) {
   const ast = parse(code);

--- a/packages/babel-traverse/test/replacement.js
+++ b/packages/babel-traverse/test/replacement.js
@@ -1,7 +1,10 @@
-import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
-import generate from "@babel/generator";
 import * as t from "@babel/types";
+
+import _traverse from "../lib/index.js";
+import _generate from "@babel/generator";
+const traverse = _traverse.default;
+const generate = _generate.default;
 
 describe("path/replacement", function () {
   describe("replaceWith", function () {

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -1,6 +1,8 @@
-import traverse, { NodePath } from "../lib/index.js";
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
+
+import _traverse, { NodePath } from "../lib/index.js";
+const traverse = _traverse.default;
 
 function getPath(code, options): NodePath<t.Program> {
   const ast =

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -1,6 +1,8 @@
-import traverse from "../lib/index.js";
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
+
+import _traverse from "../lib/index.js";
+const traverse = _traverse.default;
 
 describe("traverse", function () {
   const code = `

--- a/packages/babel-types/test/converters.js
+++ b/packages/babel-types/test/converters.js
@@ -1,6 +1,8 @@
 import * as t from "../lib/index.js";
 import { parse } from "@babel/parser";
-import generate from "@babel/generator";
+
+import _generate from "@babel/generator";
+const generate = _generate.default;
 
 function parseCode(string) {
   return parse(string, {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is another piece extracted from #13966. We where using the compiled import interop when importing `lib` files from the `ŧest` folder, to simulate an ESM-ESM interaction. However, the tests can be migrated to native ESM sooner than `lib`, so we cannot have this abstraction.

This PR aligns the tests with the same behavior they would have if run as native ESM.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13995"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

