### PR TITLE
Don't use ESM for `require`d files in `@babel/helpers` tests

### DIFF
--- a/packages/babel-helpers/test/fixtures/dependencies/basic/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/basic/plugin.js
@@ -1,4 +1,4 @@
-const defineHelper = require("../../../helpers/define-helper").default;
+const defineHelper = require("../../../helpers/define-helper.cjs");
 
 const dependency = defineHelper(__dirname, "dependency", `
   export default function fn() {}

--- a/packages/babel-helpers/test/fixtures/dependencies/deep/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/deep/plugin.js
@@ -1,4 +1,4 @@
-const defineHelper = require("../../../helpers/define-helper").default;
+const defineHelper = require("../../../helpers/define-helper.cjs");
 
 const dependencyDeep = defineHelper(__dirname, "dependencyDeep", `
   export default function fn() {}

--- a/packages/babel-helpers/test/fixtures/dependencies/missing/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/missing/plugin.js
@@ -1,4 +1,4 @@
-const defineHelper = require("../../../helpers/define-helper").default;
+const defineHelper = require("../../../helpers/define-helper.cjs");
 
 const main = defineHelper(__dirname, "main", `
   import dep from "(!!!)%-..a,4892 missing";

--- a/packages/babel-helpers/test/fixtures/dependencies/multiple/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/multiple/plugin.js
@@ -1,4 +1,4 @@
-const defineHelper = require("../../../helpers/define-helper").default;
+const defineHelper = require("../../../helpers/define-helper.cjs");
 
 const dependency1 = defineHelper(__dirname, "dependency1", `
   export default function fn() { 0; }

--- a/packages/babel-helpers/test/fixtures/dependencies/rename-binding-equal/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/rename-binding-equal/plugin.js
@@ -1,4 +1,4 @@
-const defineHelper = require("../../../helpers/define-helper").default;
+const defineHelper = require("../../../helpers/define-helper.cjs");
 
 const dependency = defineHelper(__dirname, "dependency", `
   let foo = "dependency";

--- a/packages/babel-helpers/test/fixtures/dependencies/rename-deep-global/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/rename-deep-global/plugin.js
@@ -1,4 +1,4 @@
-const defineHelper = require("../../../helpers/define-helper").default;
+const defineHelper = require("../../../helpers/define-helper.cjs");
 
 const dependency = defineHelper(__dirname, "dependency", `
   export default function fn() {

--- a/packages/babel-helpers/test/fixtures/dependencies/reuse-dependency/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/reuse-dependency/plugin.js
@@ -1,4 +1,4 @@
-const defineHelper = require("../../../helpers/define-helper").default;
+const defineHelper = require("../../../helpers/define-helper.cjs");
 
 const dependency = defineHelper(__dirname, "dependency", `
   export default function fn() { 0; }

--- a/packages/babel-helpers/test/fixtures/dependencies/variable-same-name-dependency/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/variable-same-name-dependency/plugin.js
@@ -1,4 +1,4 @@
-const defineHelper = require("../../../helpers/define-helper").default;
+const defineHelper = require("../../../helpers/define-helper.cjs");
 
 const dependency = defineHelper(__dirname, "dependency", `
   export default function fn() {}

--- a/packages/babel-helpers/test/fixtures/regression/9496/plugin.js
+++ b/packages/babel-helpers/test/fixtures/regression/9496/plugin.js
@@ -1,4 +1,4 @@
-const defineHelper = require("../../../helpers/define-helper").default;
+const defineHelper = require("../../../helpers/define-helper.cjs");
 
 const main = defineHelper(__dirname, "main", `
   export default function helper() {}

--- a/packages/babel-helpers/test/helpers/define-helper.cjs
+++ b/packages/babel-helpers/test/helpers/define-helper.cjs
@@ -1,17 +1,14 @@
-import path from "path";
-import template from "@babel/template";
-import helpers from "../../lib/helpers.js";
+const path = require("path");
+// eslint-disable-next-line import/no-extraneous-dependencies
+const template = require("@babel/template").default;
+const helpers = require("../../lib/helpers.js").default;
 
 function getHelperId(dir, name) {
   const testName = path.basename(dir);
   return `_$_${testName}_${name}`;
 }
 
-export default function defineHelper(
-  dir: string,
-  name: string,
-  code: string,
-): string {
+module.exports = function defineHelper(dir, name, code) {
   const id = getHelperId(dir, name);
   if (id in helpers) {
     throw new Error(`The ${id} helper is already defined.`);
@@ -23,4 +20,4 @@ export default function defineHelper(
     },
   });
   return id;
-}
+};


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is yet another piece extracted from #13966. You cannot `require()` an ESM file, so this PR aligns what we do with what we could do if we ran on native ESM.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/13996"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

