### PR TITLE
Fix handling of `this`&co in computed keys in arrows transform

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@babel/helper-annotate-as-pure": "workspace:^",
+    "@babel/helper-environment-visitor": "workspace:^",
     "@babel/helper-function-name": "workspace:^",
     "@babel/helper-member-expression-to-functions": "workspace:^",
     "@babel/helper-optimise-call-expression": "workspace:^",

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -850,7 +850,11 @@ function buildPrivateMethodDeclaration(
   );
 }
 
-const thisContextVisitor = traverse.visitors.merge([
+const thisContextVisitor = traverse.visitors.merge<{
+  classRef: t.Identifier;
+  needsClassRef: boolean;
+  innerBinding: t.Identifier;
+}>([
   {
     ThisExpression(path, state) {
       state.needsClassRef = true;

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -1,9 +1,8 @@
 import { template, traverse, types as t } from "@babel/core";
 import type { File } from "@babel/core";
 import type { NodePath, Visitor, Scope } from "@babel/traverse";
-import ReplaceSupers, {
-  environmentVisitor,
-} from "@babel/helper-replace-supers";
+import ReplaceSupers from "@babel/helper-replace-supers";
+import environmentVisitor from "@babel/helper-environment-visitor";
 import memberExpressionToFunctions from "@babel/helper-member-expression-to-functions";
 import type {
   Handler,

--- a/packages/babel-helper-create-class-features-plugin/src/misc.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/misc.ts
@@ -3,7 +3,7 @@ import type { File } from "@babel/core";
 import type { NodePath, Scope, Visitor, Binding } from "@babel/traverse";
 import environmentVisitor from "@babel/helper-environment-visitor";
 
-const findBareSupers = traverse.visitors.merge([
+const findBareSupers = traverse.visitors.merge<NodePath<t.CallExpression>[]>([
   {
     Super(path: NodePath<t.Super>) {
       const { node, parentPath } = path;

--- a/packages/babel-helper-create-class-features-plugin/src/misc.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/misc.ts
@@ -1,7 +1,7 @@
 import { template, traverse, types as t } from "@babel/core";
 import type { File } from "@babel/core";
 import type { NodePath, Scope, Visitor, Binding } from "@babel/traverse";
-import { environmentVisitor } from "@babel/helper-replace-supers";
+import environmentVisitor from "@babel/helper-environment-visitor";
 
 const findBareSupers = traverse.visitors.merge([
   {

--- a/packages/babel-helper-environment-visitor/.npmignore
+++ b/packages/babel-helper-environment-visitor/.npmignore
@@ -1,0 +1,3 @@
+src
+test
+*.log

--- a/packages/babel-helper-environment-visitor/README.md
+++ b/packages/babel-helper-environment-visitor/README.md
@@ -1,0 +1,19 @@
+# @babel/helper-replace-supers
+
+> Helper function to replace supers
+
+See our website [@babel/helper-replace-supers](https://babeljs.io/docs/en/babel-helper-replace-supers) for more information.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @babel/helper-replace-supers
+```
+
+or using yarn:
+
+```sh
+yarn add @babel/helper-replace-supers --dev
+```

--- a/packages/babel-helper-environment-visitor/README.md
+++ b/packages/babel-helper-environment-visitor/README.md
@@ -1,19 +1,19 @@
-# @babel/helper-replace-supers
+# @babel/helper-environment-visitor
 
-> Helper function to replace supers
+> Helper visitor to only visit nodes in the current 'this' context
 
-See our website [@babel/helper-replace-supers](https://babeljs.io/docs/en/babel-helper-replace-supers) for more information.
+See our website [@babel/helper-environment-visitor](https://babeljs.io/docs/en/babel-helper-environment-visitor) for more information.
 
 ## Install
 
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-replace-supers
+npm install --save-dev @babel/helper-environment-visitor
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-replace-supers --dev
+yarn add @babel/helper-environment-visitor --dev
 ```

--- a/packages/babel-helper-environment-visitor/package.json
+++ b/packages/babel-helper-environment-visitor/package.json
@@ -13,6 +13,9 @@
     "access": "public"
   },
   "main": "./lib/index.js",
+  "exports": {
+    ".": "./lib/index.js"
+  },
   "dependencies": {
     "@babel/types": "workspace:^"
   },

--- a/packages/babel-helper-environment-visitor/package.json
+++ b/packages/babel-helper-environment-visitor/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@babel/helper-environment-visitor",
+  "version": "7.16.0",
+  "description": "Helper visitor to only visit nodes in the current 'this' context",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/babel/babel.git",
+    "directory": "packages/babel-helper-environment-visitor"
+  },
+  "homepage": "https://babel.dev/docs/en/next/babel-helper-environment-visitor",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./lib/index.js",
+  "dependencies": {
+    "@babel/types": "workspace:^"
+  },
+  "devDependencies": {
+    "@babel/traverse": "workspace:^"
+  },
+  "engines": {
+    "node": ">=6.9.0"
+  },
+  "author": "The Babel Team (https://babel.dev/team)"
+}

--- a/packages/babel-helper-environment-visitor/src/index.ts
+++ b/packages/babel-helper-environment-visitor/src/index.ts
@@ -1,0 +1,45 @@
+import type { NodePath } from "@babel/traverse";
+import { VISITOR_KEYS, staticBlock } from "@babel/types";
+import type * as t from "@babel/types";
+
+// TODO (Babel 8): Don't export this function.
+export function skipAllButComputedKey(
+  path: NodePath<t.Method | t.ClassProperty | t.ClassPrivateProperty>,
+) {
+  // If the path isn't computed, just skip everything.
+  // @ts-expect-error todo(flow->ts) check node type before cheking the property
+  if (!path.node.computed) {
+    path.skip();
+    return;
+  }
+
+  // So it's got a computed key. Make sure to skip every other key the
+  // traversal would visit.
+  const keys = VISITOR_KEYS[path.type];
+  for (const key of keys) {
+    if (key !== "key") path.skipKey(key);
+  }
+}
+
+const skipKey = process.env.BABEL_8_BREAKING
+  ? "StaticBlock|ClassPrivateProperty|TypeAnnotation"
+  : `${staticBlock ? "StaticBlock|" : ""}ClassPrivateProperty|TypeAnnotation`;
+
+// environmentVisitor should be used when traversing the whole class and not for specific class elements/methods.
+// For perf reasons, the environmentVisitor might be traversed with `{ noScope: true }`, which means `path.scope` is undefined.
+// Avoid using `path.scope` here
+export default {
+  [skipKey]: path => path.skip(),
+
+  Function(path: NodePath<t.Function>) {
+    // Methods will be handled by the Method visit
+    if (path.isMethod()) return;
+    // Arrow functions inherit their parent's environment
+    if (path.isArrowFunctionExpression()) return;
+    path.skip();
+  },
+
+  "Method|ClassProperty"(path: NodePath<t.Method | t.ClassProperty>) {
+    skipAllButComputedKey(path);
+  },
+};

--- a/packages/babel-helper-environment-visitor/src/index.ts
+++ b/packages/babel-helper-environment-visitor/src/index.ts
@@ -4,10 +4,9 @@ import type * as t from "@babel/types";
 
 // TODO (Babel 8): Don't export this function.
 export function skipAllButComputedKey(
-  path: NodePath<t.Method | t.ClassProperty | t.ClassPrivateProperty>,
+  path: NodePath<t.Method | t.ClassProperty>,
 ) {
   // If the path isn't computed, just skip everything.
-  // @ts-expect-error todo(flow->ts) check node type before cheking the property
   if (!path.node.computed) {
     path.skip();
     return;
@@ -21,23 +20,17 @@ export function skipAllButComputedKey(
   }
 }
 
+// Methods are handled by the Method visitor; arrows are not skipped because they inherit the context.
 const skipKey = process.env.BABEL_8_BREAKING
-  ? "StaticBlock|ClassPrivateProperty|TypeAnnotation"
-  : `${staticBlock ? "StaticBlock|" : ""}ClassPrivateProperty|TypeAnnotation`;
+  ? "StaticBlock|ClassPrivateProperty|TypeAnnotation|FunctionDeclaration|FunctionExpression"
+  : (staticBlock ? "StaticBlock|" : "") +
+    "ClassPrivateProperty|TypeAnnotation|FunctionDeclaration|FunctionExpression";
 
 // environmentVisitor should be used when traversing the whole class and not for specific class elements/methods.
 // For perf reasons, the environmentVisitor might be traversed with `{ noScope: true }`, which means `path.scope` is undefined.
 // Avoid using `path.scope` here
 export default {
   [skipKey]: path => path.skip(),
-
-  Function(path: NodePath<t.Function>) {
-    // Methods will be handled by the Method visit
-    if (path.isMethod()) return;
-    // Arrow functions inherit their parent's environment
-    if (path.isArrowFunctionExpression()) return;
-    path.skip();
-  },
 
   "Method|ClassProperty"(path: NodePath<t.Method | t.ClassProperty>) {
     skipAllButComputedKey(path);

--- a/packages/babel-helper-member-expression-to-functions/src/index.ts
+++ b/packages/babel-helper-member-expression-to-functions/src/index.ts
@@ -538,7 +538,7 @@ export interface HandlerState<State = {}> extends Handler<State> {
   handle(
     this: HandlerState<State> & State,
     member: Member,
-    noDocumentAll: boolean,
+    noDocumentAll?: boolean,
   ): void;
   memoiser: AssignmentMemoiser;
 }

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -15,8 +15,8 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
+    "@babel/helper-environment-visitor": "workspace:^",
     "@babel/helper-module-imports": "workspace:^",
-    "@babel/helper-replace-supers": "workspace:^",
     "@babel/helper-simple-access": "workspace:^",
     "@babel/helper-split-export-declaration": "workspace:^",
     "@babel/helper-validator-identifier": "workspace:^",

--- a/packages/babel-helper-module-transforms/src/rewrite-this.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-this.ts
@@ -1,4 +1,4 @@
-import { environmentVisitor } from "@babel/helper-replace-supers";
+import environmentVisitor from "@babel/helper-environment-visitor";
 import traverse from "@babel/traverse";
 import { numericLiteral, unaryExpression } from "@babel/types";
 import type * as t from "@babel/types";

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -14,6 +14,7 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
+    "@babel/helper-environment-visitor": "workspace:^",
     "@babel/helper-member-expression-to-functions": "workspace:^",
     "@babel/helper-optimise-call-expression": "workspace:^",
     "@babel/traverse": "workspace:^",

--- a/packages/babel-helper-replace-supers/src/index.ts
+++ b/packages/babel-helper-replace-supers/src/index.ts
@@ -1,6 +1,7 @@
 import type { HubInterface, NodePath, Scope } from "@babel/traverse";
 import traverse from "@babel/traverse";
 import memberExpressionToFunctions from "@babel/helper-member-expression-to-functions";
+import type { HandlerState } from "@babel/helper-member-expression-to-functions";
 import optimiseCall from "@babel/helper-optimise-call-expression";
 import environmentVisitor from "@babel/helper-environment-visitor";
 import {
@@ -43,7 +44,9 @@ function getPrototypeOfExpression(objectRef, isStatic, file, isPrivateMethod) {
   return callExpression(file.addHelper("getPrototypeOf"), [targetRef]);
 }
 
-const visitor = traverse.visitors.merge([
+const visitor = traverse.visitors.merge<
+  HandlerState<ReplaceState> & ReplaceState
+>([
   environmentVisitor,
   {
     Super(path, state) {

--- a/packages/babel-helper-replace-supers/src/index.ts
+++ b/packages/babel-helper-replace-supers/src/index.ts
@@ -2,8 +2,8 @@ import type { HubInterface, NodePath, Scope } from "@babel/traverse";
 import traverse from "@babel/traverse";
 import memberExpressionToFunctions from "@babel/helper-member-expression-to-functions";
 import optimiseCall from "@babel/helper-optimise-call-expression";
+import environmentVisitor from "@babel/helper-environment-visitor";
 import {
-  VISITOR_KEYS,
   assignmentExpression,
   booleanLiteral,
   callExpression,
@@ -11,11 +11,16 @@ import {
   identifier,
   memberExpression,
   sequenceExpression,
-  staticBlock,
   stringLiteral,
   thisExpression,
 } from "@babel/types";
 import type * as t from "@babel/types";
+
+// TODO (Babel 8): Don't export this.
+export {
+  default as environmentVisitor,
+  skipAllButComputedKey,
+} from "@babel/helper-environment-visitor";
 
 /**
  * Creates an expression which result is the proto of objectRef.
@@ -37,48 +42,6 @@ function getPrototypeOfExpression(objectRef, isStatic, file, isPrivateMethod) {
 
   return callExpression(file.addHelper("getPrototypeOf"), [targetRef]);
 }
-
-export function skipAllButComputedKey(
-  path: NodePath<t.Method | t.ClassProperty | t.ClassPrivateProperty>,
-) {
-  // If the path isn't computed, just skip everything.
-  // @ts-expect-error todo(flow->ts) check node type before cheking the property
-  if (!path.node.computed) {
-    path.skip();
-    return;
-  }
-
-  // So it's got a computed key. Make sure to skip every other key the
-  // traversal would visit.
-  const keys = VISITOR_KEYS[path.type];
-  for (const key of keys) {
-    if (key !== "key") path.skipKey(key);
-  }
-}
-
-// environmentVisitor should be used when traversing the whole class and not for specific class elements/methods.
-// For perf reasons, the environmentVisitor will be traversed with `{ noScope: true }`, which means `path.scope` is undefined.
-// Avoid using `path.scope` here
-export const environmentVisitor = {
-  // todo (Babel 8): remove StaticBlock brand checks
-  [`${staticBlock ? "StaticBlock|" : ""}ClassPrivateProperty|TypeAnnotation`](
-    path: NodePath,
-  ) {
-    path.skip();
-  },
-
-  Function(path: NodePath) {
-    // Methods will be handled by the Method visit
-    if (path.isMethod()) return;
-    // Arrow functions inherit their parent's environment
-    if (path.isArrowFunctionExpression()) return;
-    path.skip();
-  },
-
-  "Method|ClassProperty"(path: NodePath<t.Method | t.ClassProperty>) {
-    skipAllButComputedKey(path);
-  },
-};
 
 const visitor = traverse.visitors.merge([
   environmentVisitor,

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -15,6 +15,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/helper-annotate-as-pure": "workspace:^",
+    "@babel/helper-environment-visitor": "workspace:^",
     "@babel/helper-function-name": "workspace:^",
     "@babel/helper-optimise-call-expression": "workspace:^",
     "@babel/helper-plugin-utils": "workspace:^",

--- a/packages/babel-plugin-transform-classes/src/transformClass.ts
+++ b/packages/babel-plugin-transform-classes/src/transformClass.ts
@@ -1,8 +1,7 @@
 import type { NodePath, Visitor } from "@babel/traverse";
 import nameFunction from "@babel/helper-function-name";
-import ReplaceSupers, {
-  environmentVisitor,
-} from "@babel/helper-replace-supers";
+import ReplaceSupers from "@babel/helper-replace-supers";
+import environmentVisitor from "@babel/helper-environment-visitor";
 import optimiseCall from "@babel/helper-optimise-call-expression";
 import { traverse, template, types as t } from "@babel/core";
 import annotateAsPure from "@babel/helper-annotate-as-pure";

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@babel/code-frame": "workspace:^",
     "@babel/generator": "workspace:^",
+    "@babel/helper-environment-visitor": "workspace:^",
     "@babel/helper-function-name": "workspace:^",
     "@babel/helper-hoist-variables": "workspace:^",
     "@babel/helper-split-export-declaration": "workspace:^",

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -1,5 +1,6 @@
 import * as virtualTypes from "./path/lib/virtual-types";
 import { DEPRECATED_KEYS, FLIPPED_ALIAS_KEYS, TYPES } from "@babel/types";
+import type { Visitor } from "./types";
 
 /**
  * explode() will take a visitor object with all of the various shorthands
@@ -175,6 +176,7 @@ function validateVisitorMethods(path, val) {
   }
 }
 
+export function merge<State>(visitors: Visitor<State>[]): Visitor<State>;
 export function merge(
   visitors: any[],
   states: any[] = [],

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -178,6 +178,11 @@ function validateVisitorMethods(path, val) {
 
 export function merge<State>(visitors: Visitor<State>[]): Visitor<State>;
 export function merge(
+  visitors: Visitor<unknown>[],
+  states?: any[],
+  wrapper?: Function | null,
+): Visitor<unknown>;
+export function merge(
   visitors: any[],
   states: any[] = [],
   wrapper?: Function | null,

--- a/packages/babel-traverse/test/arrow-transform.js
+++ b/packages/babel-traverse/test/arrow-transform.js
@@ -71,6 +71,30 @@ describe("arrow function conversion", () => {
     );
   });
 
+  it("should convert super calls in constructors used in computed method keys", () => {
+    assertConversion(
+      `
+      () => ({
+        [super()]: 123,
+        get [super() + "1"]() {},
+        [super()]() {},
+      });
+    `,
+      `
+      var _supercall = (..._args) => super(..._args);
+
+      (function () {
+        return {
+          [_supercall()]: 123,
+          get [_supercall() + "1"]() {},
+          [_supercall()]() {},
+        };
+      });
+    `,
+      { methodName: "constructor", extend: true },
+    );
+  });
+
   it("should convert super calls and this references in constructors", () => {
     assertConversion(
       `
@@ -122,6 +146,32 @@ describe("arrow function conversion", () => {
       this;
       () => (super(), _this = this);
       () => this;
+    `,
+      { methodName: "constructor", extend: true },
+    );
+  });
+
+  it("should convert this references in constructors with super() used in computed method keys", () => {
+    assertConversion(
+      `
+      () => this;
+
+      ({
+        [super()]: 123,
+        get [super() + "1"]() {},
+        [super()]() {},
+      });
+    `,
+      `
+      var _this;
+
+      (function () { return _this; });
+
+      ({
+        [(super(), _this = this)]: 123,
+        get [(super(), _this = this) + "1"]() {},
+        [(super(), _this = this)]() {},
+      });
     `,
       { methodName: "constructor", extend: true },
     );
@@ -269,6 +319,29 @@ describe("arrow function conversion", () => {
       });
       <this.this this="" />;
       () => <this.this this="" />;
+    `,
+    );
+  });
+
+  it("should convert this references used in computed method keys", () => {
+    assertConversion(
+      `
+      () => ({
+        [this]: 123,
+        get [this + "1"]() {},
+        [this]() {},
+      });
+    `,
+      `
+      var _this = this;
+
+      (function () {
+        return {
+          [_this]: 123,
+          get [_this + "1"]() {},
+          [_this]() {},
+        };
+      });
     `,
     );
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "./packages/babel-helper-create-class-features-plugin/src/**/*.ts",
     "./packages/babel-helper-create-regexp-features-plugin/src/**/*.ts",
     "./packages/babel-helper-define-map/src/**/*.ts",
+    "./packages/babel-helper-environment-visitor/src/**/*.ts",
     "./packages/babel-helper-explode-assignable-expression/src/**/*.ts",
     "./packages/babel-helper-fixtures/src/**/*.ts",
     "./packages/babel-helper-function-name/src/**/*.ts",
@@ -176,6 +177,9 @@
       ],
       "@babel/helper-define-map": [
         "./packages/babel-helper-define-map/src"
+      ],
+      "@babel/helper-environment-visitor": [
+        "./packages/babel-helper-environment-visitor/src"
       ],
       "@babel/helper-explode-assignable-expression": [
         "./packages/babel-helper-explode-assignable-expression/src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3679,6 +3679,7 @@ __metadata:
   dependencies:
     "@babel/code-frame": "workspace:^"
     "@babel/generator": "workspace:^"
+    "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-function-name": "workspace:^"
     "@babel/helper-hoist-variables": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,6 +546,7 @@ __metadata:
   dependencies:
     "@babel/core": "workspace:^"
     "@babel/helper-annotate-as-pure": "workspace:^"
+    "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-function-name": "workspace:^"
     "@babel/helper-member-expression-to-functions": "workspace:^"
     "@babel/helper-optimise-call-expression": "workspace:^"
@@ -610,6 +611,15 @@ __metadata:
   checksum: 372378ac4235c4fe135f1cd6d0f63697e7cb3ef63a884eb14f4b439984846bcaec0b7a32cf8df6756a21557ae3ebb3c2ee18d9a191260705a583333e5e60df7c
   languageName: node
   linkType: hard
+
+"@babel/helper-environment-visitor@workspace:^, @babel/helper-environment-visitor@workspace:packages/babel-helper-environment-visitor":
+  version: 0.0.0-use.local
+  resolution: "@babel/helper-environment-visitor@workspace:packages/babel-helper-environment-visitor"
+  dependencies:
+    "@babel/traverse": "workspace:^"
+    "@babel/types": "workspace:^"
+  languageName: unknown
+  linkType: soft
 
 "@babel/helper-explode-assignable-expression@npm:^7.16.0":
   version: 7.16.0
@@ -735,8 +745,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-module-transforms@workspace:packages/babel-helper-module-transforms"
   dependencies:
+    "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-module-imports": "workspace:^"
-    "@babel/helper-replace-supers": "workspace:^"
     "@babel/helper-simple-access": "workspace:^"
     "@babel/helper-split-export-declaration": "workspace:^"
     "@babel/helper-validator-identifier": "workspace:^"
@@ -849,6 +859,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-replace-supers@workspace:packages/babel-helper-replace-supers"
   dependencies:
+    "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-member-expression-to-functions": "workspace:^"
     "@babel/helper-optimise-call-expression": "workspace:^"
     "@babel/traverse": "workspace:^"
@@ -2193,6 +2204,7 @@ __metadata:
   dependencies:
     "@babel/core": "workspace:^"
     "@babel/helper-annotate-as-pure": "workspace:^"
+    "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-function-name": "workspace:^"
     "@babel/helper-optimise-call-expression": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13981
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I had to extract `environmentVisitor` to a new package to avoid circular deps between `@babel/traverse` and `@babell/helper-replace-supers`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14005"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

