### PR TITLE
Regenerate monorepo READMEs

### DIFF
--- a/packages/babel-compat-data/README.md
+++ b/packages/babel-compat-data/README.md
@@ -1,0 +1,19 @@
+# @babel/compat-data
+
+> 
+
+See our website [@babel/compat-data](https://babeljs.io/docs/en/babel-compat-data) for more information.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save @babel/compat-data
+```
+
+or using yarn:
+
+```sh
+yarn add @babel/compat-data
+```

--- a/packages/babel-helper-annotate-as-pure/README.md
+++ b/packages/babel-helper-annotate-as-pure/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-annotate-as-pure](https://babeljs.io/docs/en/babe
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-annotate-as-pure
+npm install --save @babel/helper-annotate-as-pure
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-annotate-as-pure --dev
+yarn add @babel/helper-annotate-as-pure
 ```

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/README.md
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-builder-binary-assignment-operator-visitor](https
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-builder-binary-assignment-operator-visitor
+npm install --save @babel/helper-builder-binary-assignment-operator-visitor
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-builder-binary-assignment-operator-visitor --dev
+yarn add @babel/helper-builder-binary-assignment-operator-visitor
 ```

--- a/packages/babel-helper-builder-react-jsx/README.md
+++ b/packages/babel-helper-builder-react-jsx/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-builder-react-jsx](https://babeljs.io/docs/en/bab
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-builder-react-jsx
+npm install --save @babel/helper-builder-react-jsx
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-builder-react-jsx --dev
+yarn add @babel/helper-builder-react-jsx
 ```

--- a/packages/babel-helper-compilation-targets/README.md
+++ b/packages/babel-helper-compilation-targets/README.md
@@ -9,7 +9,7 @@ See our website [@babel/helper-compilation-targets](https://babeljs.io/docs/en/b
 Using npm:
 
 ```sh
-npm install @babel/helper-compilation-targets
+npm install --save @babel/helper-compilation-targets
 ```
 
 or using yarn:

--- a/packages/babel-helper-create-class-features-plugin/README.md
+++ b/packages/babel-helper-create-class-features-plugin/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-create-class-features-plugin](https://babeljs.io/
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-create-class-features-plugin
+npm install --save @babel/helper-create-class-features-plugin
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-create-class-features-plugin --dev
+yarn add @babel/helper-create-class-features-plugin
 ```

--- a/packages/babel-helper-create-regexp-features-plugin/README.md
+++ b/packages/babel-helper-create-regexp-features-plugin/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-create-regexp-features-plugin](https://babeljs.io
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-create-regexp-features-plugin
+npm install --save @babel/helper-create-regexp-features-plugin
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-create-regexp-features-plugin --dev
+yarn add @babel/helper-create-regexp-features-plugin
 ```

--- a/packages/babel-helper-define-map/README.md
+++ b/packages/babel-helper-define-map/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-define-map](https://babeljs.io/docs/en/babel-help
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-define-map
+npm install --save @babel/helper-define-map
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-define-map --dev
+yarn add @babel/helper-define-map
 ```

--- a/packages/babel-helper-explode-assignable-expression/README.md
+++ b/packages/babel-helper-explode-assignable-expression/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-explode-assignable-expression](https://babeljs.io
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-explode-assignable-expression
+npm install --save @babel/helper-explode-assignable-expression
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-explode-assignable-expression --dev
+yarn add @babel/helper-explode-assignable-expression
 ```

--- a/packages/babel-helper-fixtures/README.md
+++ b/packages/babel-helper-fixtures/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-fixtures](https://babeljs.io/docs/en/babel-helper
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-fixtures
+npm install --save @babel/helper-fixtures
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-fixtures --dev
+yarn add @babel/helper-fixtures
 ```

--- a/packages/babel-helper-function-name/README.md
+++ b/packages/babel-helper-function-name/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-function-name](https://babeljs.io/docs/en/babel-h
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-function-name
+npm install --save @babel/helper-function-name
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-function-name --dev
+yarn add @babel/helper-function-name
 ```

--- a/packages/babel-helper-get-function-arity/README.md
+++ b/packages/babel-helper-get-function-arity/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-get-function-arity](https://babeljs.io/docs/en/ba
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-get-function-arity
+npm install --save @babel/helper-get-function-arity
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-get-function-arity --dev
+yarn add @babel/helper-get-function-arity
 ```

--- a/packages/babel-helper-hoist-variables/README.md
+++ b/packages/babel-helper-hoist-variables/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-hoist-variables](https://babeljs.io/docs/en/babel
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-hoist-variables
+npm install --save @babel/helper-hoist-variables
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-hoist-variables --dev
+yarn add @babel/helper-hoist-variables
 ```

--- a/packages/babel-helper-member-expression-to-functions/README.md
+++ b/packages/babel-helper-member-expression-to-functions/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-member-expression-to-functions](https://babeljs.i
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-member-expression-to-functions
+npm install --save @babel/helper-member-expression-to-functions
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-member-expression-to-functions --dev
+yarn add @babel/helper-member-expression-to-functions
 ```

--- a/packages/babel-helper-module-imports/README.md
+++ b/packages/babel-helper-module-imports/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-module-imports](https://babeljs.io/docs/en/babel-
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-module-imports
+npm install --save @babel/helper-module-imports
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-module-imports --dev
+yarn add @babel/helper-module-imports
 ```

--- a/packages/babel-helper-module-transforms/README.md
+++ b/packages/babel-helper-module-transforms/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-module-transforms](https://babeljs.io/docs/en/bab
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-module-transforms
+npm install --save @babel/helper-module-transforms
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-module-transforms --dev
+yarn add @babel/helper-module-transforms
 ```

--- a/packages/babel-helper-optimise-call-expression/README.md
+++ b/packages/babel-helper-optimise-call-expression/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-optimise-call-expression](https://babeljs.io/docs
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-optimise-call-expression
+npm install --save @babel/helper-optimise-call-expression
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-optimise-call-expression --dev
+yarn add @babel/helper-optimise-call-expression
 ```

--- a/packages/babel-helper-plugin-test-runner/README.md
+++ b/packages/babel-helper-plugin-test-runner/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-plugin-test-runner](https://babeljs.io/docs/en/ba
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-plugin-test-runner
+npm install --save @babel/helper-plugin-test-runner
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-plugin-test-runner --dev
+yarn add @babel/helper-plugin-test-runner
 ```

--- a/packages/babel-helper-plugin-utils/README.md
+++ b/packages/babel-helper-plugin-utils/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-plugin-utils](https://babeljs.io/docs/en/babel-he
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-plugin-utils
+npm install --save @babel/helper-plugin-utils
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-plugin-utils --dev
+yarn add @babel/helper-plugin-utils
 ```

--- a/packages/babel-helper-remap-async-to-generator/README.md
+++ b/packages/babel-helper-remap-async-to-generator/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-remap-async-to-generator](https://babeljs.io/docs
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-remap-async-to-generator
+npm install --save @babel/helper-remap-async-to-generator
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-remap-async-to-generator --dev
+yarn add @babel/helper-remap-async-to-generator
 ```

--- a/packages/babel-helper-replace-supers/README.md
+++ b/packages/babel-helper-replace-supers/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-replace-supers](https://babeljs.io/docs/en/babel-
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-replace-supers
+npm install --save @babel/helper-replace-supers
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-replace-supers --dev
+yarn add @babel/helper-replace-supers
 ```

--- a/packages/babel-helper-simple-access/README.md
+++ b/packages/babel-helper-simple-access/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-simple-access](https://babeljs.io/docs/en/babel-h
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-simple-access
+npm install --save @babel/helper-simple-access
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-simple-access --dev
+yarn add @babel/helper-simple-access
 ```

--- a/packages/babel-helper-skip-transparent-expression-wrappers/README.md
+++ b/packages/babel-helper-skip-transparent-expression-wrappers/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-skip-transparent-expression-wrappers](https://bab
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-skip-transparent-expression-wrappers
+npm install --save @babel/helper-skip-transparent-expression-wrappers
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-skip-transparent-expression-wrappers --dev
+yarn add @babel/helper-skip-transparent-expression-wrappers
 ```

--- a/packages/babel-helper-split-export-declaration/README.md
+++ b/packages/babel-helper-split-export-declaration/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-split-export-declaration](https://babeljs.io/docs
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-split-export-declaration
+npm install --save @babel/helper-split-export-declaration
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-split-export-declaration --dev
+yarn add @babel/helper-split-export-declaration
 ```

--- a/packages/babel-helper-transform-fixture-test-runner/README.md
+++ b/packages/babel-helper-transform-fixture-test-runner/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-transform-fixture-test-runner](https://babeljs.io
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-transform-fixture-test-runner
+npm install --save @babel/helper-transform-fixture-test-runner
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-transform-fixture-test-runner --dev
+yarn add @babel/helper-transform-fixture-test-runner
 ```

--- a/packages/babel-helper-validator-identifier/README.md
+++ b/packages/babel-helper-validator-identifier/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-validator-identifier](https://babeljs.io/docs/en/
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-validator-identifier
+npm install --save @babel/helper-validator-identifier
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-validator-identifier --dev
+yarn add @babel/helper-validator-identifier
 ```

--- a/packages/babel-helper-validator-option/README.md
+++ b/packages/babel-helper-validator-option/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-validator-option](https://babeljs.io/docs/en/babe
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-validator-option
+npm install --save @babel/helper-validator-option
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-validator-option --dev
+yarn add @babel/helper-validator-option
 ```

--- a/packages/babel-helper-wrap-function/README.md
+++ b/packages/babel-helper-wrap-function/README.md
@@ -9,11 +9,11 @@ See our website [@babel/helper-wrap-function](https://babeljs.io/docs/en/babel-h
 Using npm:
 
 ```sh
-npm install --save-dev @babel/helper-wrap-function
+npm install --save @babel/helper-wrap-function
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/helper-wrap-function --dev
+yarn add @babel/helper-wrap-function
 ```

--- a/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/README.md
+++ b/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/README.md
@@ -1,6 +1,6 @@
 # @babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression
 
-> Rename destructuring parameter to workaround a [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=220517).
+> Rename destructuring parameter to workaround https://bugs.webkit.org/show_bug.cgi?id=220517
 
 See our website [@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression](https://babeljs.io/docs/en/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression) for more information.
 

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/README.md
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/README.md
@@ -1,6 +1,6 @@
 # @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining
 
-> Transform optional chaining operators to workaround a [v8 bug](https://crbug.com/v8/11558).
+> Transform optional chaining operators to workaround https://crbug.com/v8/11558
 
 See our website [@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining](https://babeljs.io/docs/en/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining) for more information.
 

--- a/packages/babel-plugin-proposal-async-do-expressions/README.md
+++ b/packages/babel-plugin-proposal-async-do-expressions/README.md
@@ -1,6 +1,6 @@
 # @babel/plugin-proposal-async-do-expressions
 
-> Transforms async do expressions to ES2021
+> Transform async do expressions to ES2021
 
 See our website [@babel/plugin-proposal-async-do-expressions](https://babeljs.io/docs/en/babel-plugin-proposal-async-do-expressions) for more information.
 

--- a/packages/babel-plugin-proposal-record-and-tuple/README.md
+++ b/packages/babel-plugin-proposal-record-and-tuple/README.md
@@ -1,0 +1,19 @@
+# @babel/plugin-proposal-record-and-tuple
+
+> A transform for Record and Tuple syntax.
+
+See our website [@babel/plugin-proposal-record-and-tuple](https://babeljs.io/docs/en/babel-plugin-proposal-record-and-tuple) for more information.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @babel/plugin-proposal-record-and-tuple
+```
+
+or using yarn:
+
+```sh
+yarn add @babel/plugin-proposal-record-and-tuple --dev
+```

--- a/packages/babel-plugin-syntax-async-do-expressions/README.md
+++ b/packages/babel-plugin-syntax-async-do-expressions/README.md
@@ -2,7 +2,7 @@
 
 > Allow parsing of async do expressions
 
-See our website [@babel/plugin-syntax-async-do-expressions](https://babel.dev/docs/en/babel-plugin-syntax-async-do-expressions) for more information.
+See our website [@babel/plugin-syntax-async-do-expressions](https://babeljs.io/docs/en/babel-plugin-syntax-async-do-expressions) for more information.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-module-blocks/README.md
+++ b/packages/babel-plugin-syntax-module-blocks/README.md
@@ -1,6 +1,6 @@
 # @babel/plugin-syntax-module-blocks
 
-> Allow parsing of module blocks
+> Allow parsing of JS Module Blocks
 
 See our website [@babel/plugin-syntax-module-blocks](https://babeljs.io/docs/en/babel-plugin-syntax-module-blocks) for more information.
 

--- a/packages/babel-plugin-transform-react-jsx-development/README.md
+++ b/packages/babel-plugin-transform-react-jsx-development/README.md
@@ -1,0 +1,19 @@
+# @babel/plugin-transform-react-jsx-development
+
+> Turn JSX into React function calls in development
+
+See our website [@babel/plugin-transform-react-jsx-development](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx-development) for more information.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @babel/plugin-transform-react-jsx-development
+```
+
+or using yarn:
+
+```sh
+yarn add @babel/plugin-transform-react-jsx-development --dev
+```

--- a/packages/babel-plugin-transform-react-pure-annotations/README.md
+++ b/packages/babel-plugin-transform-react-pure-annotations/README.md
@@ -1,0 +1,19 @@
+# @babel/plugin-transform-react-pure-annotations
+
+> Mark top-level React method calls as pure for tree shaking
+
+See our website [@babel/plugin-transform-react-pure-annotations](https://babeljs.io/docs/en/babel-plugin-transform-react-pure-annotations) for more information.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @babel/plugin-transform-react-pure-annotations
+```
+
+or using yarn:
+
+```sh
+yarn add @babel/plugin-transform-react-pure-annotations --dev
+```

--- a/packages/babel-runtime-corejs2/README.md
+++ b/packages/babel-runtime-corejs2/README.md
@@ -9,11 +9,11 @@ See our website [@babel/runtime-corejs2](https://babeljs.io/docs/en/babel-runtim
 Using npm:
 
 ```sh
-npm install --save-dev @babel/runtime-corejs2
+npm install --save @babel/runtime-corejs2
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/runtime-corejs2 --dev
+yarn add @babel/runtime-corejs2
 ```

--- a/packages/babel-runtime-corejs3/README.md
+++ b/packages/babel-runtime-corejs3/README.md
@@ -9,11 +9,11 @@ See our website [@babel/runtime-corejs3](https://babeljs.io/docs/en/babel-runtim
 Using npm:
 
 ```sh
-npm install --save-dev @babel/runtime-corejs3
+npm install --save @babel/runtime-corejs3
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/runtime-corejs3 --dev
+yarn add @babel/runtime-corejs3
 ```

--- a/packages/babel-runtime/README.md
+++ b/packages/babel-runtime/README.md
@@ -15,5 +15,5 @@ npm install --save @babel/runtime
 or using yarn:
 
 ```sh
-yarn add @babel/runtime 
+yarn add @babel/runtime
 ```

--- a/scripts/generators/readmes.js
+++ b/scripts/generators/readmes.js
@@ -7,7 +7,7 @@
 
 import { join } from "path";
 import { readdirSync, writeFileSync } from "fs";
-import { createRequire } from "url";
+import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
 
@@ -16,7 +16,12 @@ const cwd = process.cwd();
 const packageDir = join(cwd, "packages");
 
 const packages = readdirSync(packageDir);
-const packagesInstalledToDep = ["@babel/runtime"];
+
+const isDep = name =>
+  name.startsWith("@babel/runtime") ||
+  name.startsWith("@babel/helper-") ||
+  name === "@babel/compat-data";
+
 const getWebsiteLink = n => `https://babeljs.io/docs/en/${n}`;
 const getPackageJson = pkg => require(join(packageDir, pkg, "package.json"));
 const getIssueLabelLink = l =>
@@ -24,11 +29,8 @@ const getIssueLabelLink = l =>
     l
   )}%22+is%3Aopen`;
 const getNpmInstall = name =>
-  `npm install ${
-    packagesInstalledToDep.includes(name) ? "--save" : "--save-dev"
-  } ${name}`;
-const getYarnAdd = name =>
-  `yarn add ${name} ${packagesInstalledToDep.includes(name) ? "" : "--dev"}`;
+  `npm install ${isDep(name) ? "--save" : "--save-dev"} ${name}`;
+const getYarnAdd = name => `yarn add ${name}${isDep(name) ? "" : " --dev"}`;
 
 const labels = {
   "babel-preset-flow": getIssueLabelLink("area: flow"),


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We had a script to generate `README.md` files, but we always copy-pasted (rather than using the script) and this lead to different inconsistencies.

I tweaked the script so that it:
- works
- correctly classifies deps vs devDeps

and I regenerated all the non-conforming readmes.