### PR TITLE
Support flow function type annotation with no parent

### DIFF
--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -321,9 +321,10 @@ export function FunctionTypeAnnotation(
 
   // this node type is overloaded, not sure why but it makes it EXTREMELY annoying
   if (
-    parent.type === "ObjectTypeCallProperty" ||
-    parent.type === "DeclareFunction" ||
-    (parent.type === "ObjectTypeProperty" && parent.method)
+    parent &&
+    (parent.type === "ObjectTypeCallProperty" ||
+      parent.type === "DeclareFunction" ||
+      (parent.type === "ObjectTypeProperty" && parent.method))
   ) {
     this.token(":");
   } else {

--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -290,7 +290,7 @@ export function ExistsTypeAnnotation(this: Printer) {
 export function FunctionTypeAnnotation(
   this: Printer,
   node: t.FunctionTypeAnnotation,
-  parent: any,
+  parent: t.Node | void,
 ) {
   this.print(node.typeParameters, node);
   this.token("(");

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -497,6 +497,17 @@ describe("programmatic generation", function () {
     expect(output).toBe("interface A {}");
   });
 
+  it("flow function type annotation with no parent", () => {
+    const functionTypeAnnotation = t.functionTypeAnnotation(
+      null,
+      [],
+      null,
+      t.voidTypeAnnotation(),
+    );
+    const output = generate(functionTypeAnnotation).code;
+    expect(output).toBe("() => void");
+  });
+
   describe("directives", function () {
     it("preserves escapes", function () {
       const directive = t.directive(


### PR DESCRIPTION
I have a use case where I want to generate code for a FunctionTypeAnnotation node, and the node has no parent. When the node is passed into the FunctionTypeAnnotation handler, it assumes a parent exists.
I've added a check for the parent so that we don't try to read `.type` off of an undefined parent.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14014"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

