### PR TITLE
output perf: avoid redundant array copies (plugin-transform-spread)

### DIFF
--- a/benchmark/babel-plugin-transform-spread/array-spread-arguments.mjs
+++ b/benchmark/babel-plugin-transform-spread/array-spread-arguments.mjs
@@ -1,0 +1,15 @@
+import runner from "./runner.mjs";
+
+runner({
+  code: `
+    function arrayOf() {
+      return [...arguments];
+    }
+
+    function work() {
+      return arrayOf("bacon", "egg", "spam");
+    }
+  `,
+  expect: ["bacon", "egg", "spam"],
+  loopCount: 100,
+});

--- a/benchmark/babel-plugin-transform-spread/array-spread-large-array.mjs
+++ b/benchmark/babel-plugin-transform-spread/array-spread-large-array.mjs
@@ -1,0 +1,17 @@
+import runner from "./runner.mjs";
+
+runner({
+  code: `
+    var bar = Array.from({ length: 456000 }, (_, i) => i);
+
+    function foo(a) {
+      return [0, ...a, 1, ...a, 2];
+    }
+
+    function work() {
+      return foo(bar).length;
+    }
+  `,
+  expect: 3 + 2 * 456000,
+  loopCount: 1,
+});

--- a/benchmark/babel-plugin-transform-spread/array-spread-large-set.mjs
+++ b/benchmark/babel-plugin-transform-spread/array-spread-large-set.mjs
@@ -1,0 +1,18 @@
+import runner from "./runner.mjs";
+
+runner({
+  code: `
+    var bar = Array.from({ length: 456000 }, (_, i) => i);
+    var set = new Set(bar);
+
+    function foo(a) {
+      return [0, ...a, 1, ...a, 2];
+    }
+
+    function work() {
+      return foo(set).length;
+    }
+  `,
+  expect: 3 + 2 * 456000,
+  loopCount: 1,
+});

--- a/benchmark/babel-plugin-transform-spread/array-spread-multiple.mjs
+++ b/benchmark/babel-plugin-transform-spread/array-spread-multiple.mjs
@@ -1,0 +1,13 @@
+import runner from "./runner.mjs";
+
+runner({
+  code: `
+    var bar = ["egg", , "spam"];
+
+    function work(a = bar) {
+      return [...a, ...a, ...a];
+    }
+  `,
+  expect: ["egg", void 0, "spam", "egg", void 0, "spam", "egg", void 0, "spam"],
+  loopCount: 100,
+});

--- a/benchmark/babel-plugin-transform-spread/array-spread-small-set.mjs
+++ b/benchmark/babel-plugin-transform-spread/array-spread-small-set.mjs
@@ -1,0 +1,18 @@
+import runner from "./runner.mjs";
+
+runner({
+  code: `
+    var bar = Array.from({ length: 123 }, (_, i) => i);
+    var set = new Set(bar);
+
+    function foo(a) {
+      return [0, ...a, 1, ...a, 2];
+    }
+
+    function work() {
+      return foo(set).length;
+    }
+  `,
+  expect: 3 + 2 * 123,
+  loopCount: 100,
+});

--- a/benchmark/babel-plugin-transform-spread/call-spread-only-arguments.mjs
+++ b/benchmark/babel-plugin-transform-spread/call-spread-only-arguments.mjs
@@ -1,0 +1,19 @@
+import runner from "./runner.mjs";
+
+runner({
+  code: `
+    function foo() {
+      return arguments.length;
+    }
+
+    function bar() {
+      return foo(...arguments);
+    }
+
+    function work() {
+      return bar("bacon", "egg", "spam");
+    }
+  `,
+  expect: 3,
+  loopCount: 100,
+});

--- a/benchmark/babel-plugin-transform-spread/call-spread-sparse-array.mjs
+++ b/benchmark/babel-plugin-transform-spread/call-spread-sparse-array.mjs
@@ -1,0 +1,20 @@
+import runner from "./runner.mjs";
+
+runner({
+  code: `
+    // defer initialization to prevent Babel guessing variable type,
+    // because if it can guess, the plugin emits Array-specific code
+    var bar;
+    bar = new Array(3);
+
+    function foo() {
+      return arguments.length;
+    }
+
+    function work() {
+      return foo(...bar);
+    }
+  `,
+  expect: 3,
+  loopCount: 100,
+});

--- a/benchmark/babel-plugin-transform-spread/call-spread-with-arguments.mjs
+++ b/benchmark/babel-plugin-transform-spread/call-spread-with-arguments.mjs
@@ -1,0 +1,19 @@
+import runner from "./runner.mjs";
+
+runner({
+  code: `
+    function foo() {
+      return arguments.length;
+    }
+
+    function bar() {
+      return foo("ham", "spam", ...arguments, "ham", "spam");
+    }
+
+    function work() {
+      return bar("bacon", "egg", "spam");
+    }
+  `,
+  expect: 7,
+  loopCount: 100,
+});

--- a/benchmark/babel-plugin-transform-spread/run-all.sh
+++ b/benchmark/babel-plugin-transform-spread/run-all.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+# Run all benchmarks in this directory.
+# Pass option -v or --verbose to see the transpiled code under test.
+
+set -eu
+
+SCRIPT_DIR=$(dirname -- "$0")
+cd -- "$SCRIPT_DIR"
+
+for bench in *.mjs
+do
+    yarn node --predictable "$bench" "$@"
+done

--- a/benchmark/babel-plugin-transform-spread/runner.mjs
+++ b/benchmark/babel-plugin-transform-spread/runner.mjs
@@ -1,0 +1,67 @@
+import assert from "assert";
+import path from "path";
+import vm from "vm";
+import Benchmark from "benchmark";
+import chalk from "chalk";
+
+import baseline from "@babel-baseline/core";
+import current from "@babel/core";
+import { report } from "../util.mjs";
+
+const SCRIPT_NAME = path.parse(process.argv[1]).name;
+const VERBOSE = process.argv.some(x => x === "-v" || x === "--verbose");
+
+const suite = new Benchmark.Suite();
+
+export default function runner({ code, expect, loopCount = 1 }) {
+  benchCase({
+    title: `${SCRIPT_NAME} baseline`,
+    babel: baseline,
+    options: {
+      plugins: ["module:@babel-baseline/plugin-transform-spread"],
+    },
+    code,
+    expect,
+    loopCount,
+  });
+
+  benchCase({
+    title: `${SCRIPT_NAME} current`,
+    babel: current,
+    options: {
+      plugins: ["@babel/plugin-transform-spread"],
+    },
+    code,
+    expect,
+    loopCount,
+  });
+
+  suite.on("cycle", report).run();
+}
+
+function benchCase({ title, babel, options, code, expect, loopCount }) {
+  const transpiled = babel.transformSync(code, {
+    babelrc: false,
+    configFile: false,
+    ...options,
+  });
+
+  if (VERBOSE) {
+    console.log(chalk.grey(`// ${title}`));
+    console.log(chalk.cyan(transpiled.code));
+  }
+
+  // prepare VM context with the transpiled code
+  const context = vm.createContext();
+  vm.runInContext(transpiled.code, context);
+  const check = vm.runInContext(`work()`, context);
+  assert.deepEqual(check, expect);
+
+  // compile script that will call function `work` many times
+  // to disperse the effect of startup overhead on benchmarks
+  const loopScript = new vm.Script(`
+    for (let i = ${loopCount}; i--; work());
+  `);
+
+  suite.add(title, () => loopScript.runInContext(context));
+}

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -7,6 +7,7 @@
     "@babel-baseline/generator": "npm:@babel/generator@7.14.5",
     "@babel-baseline/helper-validator-identifier": "npm:@babel/helper-validator-identifier@7.10.4",
     "@babel-baseline/parser": "npm:@babel/parser@7.14.8",
+    "@babel-baseline/plugin-transform-spread": "npm:@babel/plugin-transform-spread@7.16.0",
     "@babel-baseline/traverse": "npm:@babel/traverse@7.15.4",
     "@babel-baseline/types": "npm:@babel/types@7.15.6",
     "@babel/core": "workspace:^",
@@ -17,7 +18,8 @@
     "@babel/preset-flow": "workspace:^",
     "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^",
-    "benchmark": "^2.1.4"
+    "benchmark": "^2.1.4",
+    "chalk": "^4.1.0"
   },
   "version": "7.16.0"
 }

--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -13,17 +13,69 @@ function helper(minVersion, source) {
 }
 
 export default Object.freeze({
+  appendArrayLike: helper(
+    "7.16.5",
+    "export default function _appendArrayLike(dest,src,num){var i=0,l=dest.length,n=src.length;for(n>num&&(n=num>0?num:0),dest.length+=n;i<n;)dest[l++]=src[i++];return dest}",
+  ),
   asyncIterator: helper(
     "7.15.9",
     'export default function _asyncIterator(iterable){var method,async,sync,retry=2;for("undefined"!=typeof Symbol&&(async=Symbol.asyncIterator,sync=Symbol.iterator);retry--;){if(async&&null!=(method=iterable[async]))return method.call(iterable);if(sync&&null!=(method=iterable[sync]))return new AsyncFromSyncIterator(method.call(iterable));async="@@asyncIterator",sync="@@iterator"}throw new TypeError("Object is not async iterable")}function AsyncFromSyncIterator(s){function AsyncFromSyncIteratorContinuation(r){if(Object(r)!==r)return Promise.reject(new TypeError(r+" is not an object."));var done=r.done;return Promise.resolve(r.value).then((function(value){return{value:value,done:done}}))}return AsyncFromSyncIterator=function(s){this.s=s,this.n=s.next},AsyncFromSyncIterator.prototype={s:null,n:null,next:function(){return AsyncFromSyncIteratorContinuation(this.n.apply(this.s,arguments))},return:function(value){var ret=this.s.return;return void 0===ret?Promise.resolve({value:value,done:!0}):AsyncFromSyncIteratorContinuation(ret.apply(this.s,arguments))},throw:function(value){var thr=this.s.return;return void 0===thr?Promise.reject(value):AsyncFromSyncIteratorContinuation(thr.apply(this.s,arguments))}},new AsyncFromSyncIterator(s)}',
+  ),
+  concatArrayLike: helper(
+    "7.16.5",
+    "export default function _concatArrayLike(){for(var ai=0,an=arguments.length,dn=0;ai<an;)dn+=arguments[ai++].length;var dest=new Array(dn),di=0;for(ai=0;ai<an;)for(var src=arguments[ai++],si=0,sn=src.length;si<sn;)dest[di++]=src[si++];return dest}",
+  ),
+  getIterator: helper(
+    "7.16.5",
+    'import isObjectType from"isObjectType";export default function _getIterator(o){var m="undefined"!=typeof Symbol&&o[Symbol.iterator]||o["@@iterator"];if(null!=m){if(isObjectType(m=m.call(o)))return m;throw new TypeError("@@iterator method returned a non-object.")}}',
+  ),
+  isArrayLike: helper(
+    "7.16.5",
+    'import isObjectType from"isObjectType";export default function _isArrayLike(x){return isObjectType(x)&&"number"==typeof x.length}',
+  ),
+  isObjectType: helper(
+    "7.16.5",
+    'export default function _isObjectType(x){return"object"==typeof x?null!==x:"function"==typeof x}',
+  ),
+  iteratorClose: helper(
+    "7.16.5",
+    "export default function _iteratorClose(it){null!=it.return&&it.return()}",
+  ),
+  iteratorCloseQuiet: helper(
+    "7.16.5",
+    "export default function _iteratorCloseQuiet(it){try{null!=it.return&&it.return()}catch(e){}}",
   ),
   jsx: helper(
     "7.0.0-beta.0",
     'var REACT_ELEMENT_TYPE;export default function _createRawReactElement(type,props,key,children){REACT_ELEMENT_TYPE||(REACT_ELEMENT_TYPE="function"==typeof Symbol&&Symbol.for&&Symbol.for("react.element")||60103);var defaultProps=type&&type.defaultProps,childrenLength=arguments.length-3;if(props||0===childrenLength||(props={children:void 0}),1===childrenLength)props.children=children;else if(childrenLength>1){for(var childArray=new Array(childrenLength),i=0;i<childrenLength;i++)childArray[i]=arguments[i+3];props.children=childArray}if(props&&defaultProps)for(var propName in defaultProps)void 0===props[propName]&&(props[propName]=defaultProps[propName]);else props||(props=defaultProps||{});return{$$typeof:REACT_ELEMENT_TYPE,type:type,key:void 0===key?null:""+key,ref:null,props:props,_owner:null}}',
   ),
+  maybeAppendIterable: helper(
+    "7.16.5",
+    'import getIterator from"getIterator";import iteratorClose from"iteratorClose";import iteratorCloseQuiet from"iteratorCloseQuiet";export default function _maybeAppendIterable(dest,src,limit){var it=null!=src&&getIterator(src);if(it){for(var s,v,n=0;!(++n>limit||(s=it.next()).done);){v=s.value;try{dest.push(v)}catch(e){throw iteratorCloseQuiet(it),e}}return n>limit&&iteratorClose(it),dest}}',
+  ),
+  maybeAppendUnsupportedIterable: helper(
+    "7.16.5",
+    'import appendArrayLike from"appendArrayLike";export default function _maybeAppendUnsupportedIterable(a,o,n){if("string"==typeof o)return appendArrayLike(a,o,n);if(o){var c=Object.prototype.toString.call(o).slice(8,-1);return"Object"===c&&o.constructor&&(c=o.constructor.name),"Map"===c||"Set"===c?appendArrayLike(a,Array.from(o),n):"Arguments"===c||/^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(c)?appendArrayLike(a,o,n):void 0}}',
+  ),
   objectSpread2: helper(
     "7.5.0",
     'import defineProperty from"defineProperty";function ownKeys(object,enumerableOnly){var keys=Object.keys(object);if(Object.getOwnPropertySymbols){var symbols=Object.getOwnPropertySymbols(object);enumerableOnly&&(symbols=symbols.filter((function(sym){return Object.getOwnPropertyDescriptor(object,sym).enumerable}))),keys.push.apply(keys,symbols)}return keys}export default function _objectSpread2(target){for(var i=1;i<arguments.length;i++){var source=null!=arguments[i]?arguments[i]:{};i%2?ownKeys(Object(source),!0).forEach((function(key){defineProperty(target,key,source[key])})):Object.getOwnPropertyDescriptors?Object.defineProperties(target,Object.getOwnPropertyDescriptors(source)):ownKeys(Object(source)).forEach((function(key){Object.defineProperty(target,key,Object.getOwnPropertyDescriptor(source,key))}))}return target}',
+  ),
+  spreadCoerceToArray: helper(
+    "7.16.5",
+    'import iterableToArray from"iterableToArray";import unsupportedIterableToArray from"unsupportedIterableToArray";import nonIterableSpread from"nonIterableSpread";export default function _spreadCoerceToArray(src){return Array.isArray(src)?src:iterableToArray(src)||unsupportedIterableToArray(src)||nonIterableSpread()}',
+  ),
+  spreadCoerceToArrayLike: helper(
+    "7.16.5",
+    'import isArrayLike from"isArrayLike";import iterableToArray from"iterableToArray";import unsupportedIterableToArray from"unsupportedIterableToArray";import nonIterableSpread from"nonIterableSpread";export default function _spreadCoerceToArrayLike(src){return isArrayLike(src)?src:iterableToArray(src)||unsupportedIterableToArray(src)||nonIterableSpread()}',
+  ),
+  spreadIterableOrArray: helper(
+    "7.16.5",
+    'import appendArrayLike from"appendArrayLike";import maybeAppendIterable from"maybeAppendIterable";import maybeAppendUnsupportedIterable from"maybeAppendUnsupportedIterable";import nonIterableSpread from"nonIterableSpread";export default function _spreadIterableOrArray(dest,src){return Array.isArray(src)?appendArrayLike(dest,src):maybeAppendIterable(dest,src)||maybeAppendUnsupportedIterable(dest,src)||nonIterableSpread()}',
+  ),
+  spreadIterableOrArrayLike: helper(
+    "7.16.5",
+    'import isArrayLike from"isArrayLike";import appendArrayLike from"appendArrayLike";import maybeAppendIterable from"maybeAppendIterable";import maybeAppendUnsupportedIterable from"maybeAppendUnsupportedIterable";import nonIterableSpread from"nonIterableSpread";export default function _spreadIterableOrArrayLike(dest,src){return isArrayLike(src)?appendArrayLike(dest,src):maybeAppendIterable(dest,src)||maybeAppendUnsupportedIterable(dest,src)||nonIterableSpread()}',
   ),
   typeof: helper(
     "7.0.0-beta.0",

--- a/packages/babel-helpers/src/helpers/appendArrayLike.js
+++ b/packages/babel-helpers/src/helpers/appendArrayLike.js
@@ -1,0 +1,22 @@
+/* @minVersion 7.16.5 */
+
+/**
+ * Append at most @p num elements from @p src into @p dest.
+ *
+ * @param {Array}     dest
+ * @param {ArrayLike} src
+ * @param {number}    [num=src.length]
+ * @return {Array}    @p dest
+ */
+export default function _appendArrayLike(dest, src, num) {
+  var i = 0,
+    l = dest.length,
+    n = src.length;
+  if (n > num) n = num > 0 ? num : 0;
+  // inflating destination array length in advance gives the engine a hint
+  // of how much space it will need, but more importantly ensures that the
+  // final length will not overflow 2**32-1 (otherwise throws RangeError)
+  dest.length += n;
+  while (i < n) dest[l++] = src[i++];
+  return dest;
+}

--- a/packages/babel-helpers/src/helpers/concatArrayLike.js
+++ b/packages/babel-helpers/src/helpers/concatArrayLike.js
@@ -1,0 +1,29 @@
+/* @minVersion 7.16.5 */
+
+/**
+ * Concatenate all arguments, which must be array-like objects.
+ *
+ * This helper always returns an array without holes, even if given sparse
+ * array arguments.
+ * It does not use `[Symbol.isConcatSpreadable]` or `[Symbol.iterator]`
+ * properties, only `length` and indices from `0` to `length-1`.
+ */
+export default function _concatArrayLike() {
+  var ai = 0,
+    an = arguments.length,
+    dn = 0;
+  while (ai < an) {
+    dn += arguments[ai++].length;
+  }
+  var dest = new Array(dn),
+    di = 0;
+  for (ai = 0; ai < an; ) {
+    var src = arguments[ai++],
+      si = 0,
+      sn = src.length;
+    while (si < sn) {
+      dest[di++] = src[si++];
+    }
+  }
+  return dest;
+}

--- a/packages/babel-helpers/src/helpers/getIterator.js
+++ b/packages/babel-helpers/src/helpers/getIterator.js
@@ -1,0 +1,15 @@
+/* @minVersion 7.16.5 */
+
+import isObjectType from "isObjectType";
+
+// prettier-ignore
+export default function _getIterator(o) {
+  var m = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"];
+  if (m != null) {
+    // https://tc39.es/ecma262/multipage/abstract-operations.html#sec-getiterator
+    // Step 3. Let iterator be ? Call(method, obj).
+    // Step 4. If Type(iterator) is not Object, throw a TypeError exception.
+    if (isObjectType(m = m.call(o))) return m;
+    throw new TypeError("@@iterator method returned a non-object.");
+  }
+}

--- a/packages/babel-helpers/src/helpers/isArrayLike.js
+++ b/packages/babel-helpers/src/helpers/isArrayLike.js
@@ -1,0 +1,13 @@
+/* @minVersion 7.16.5 */
+
+// Only Objects (in ES Language Type sense, not `typeof` operator) can be
+// array-like. That means Function and String objects are array-like, but
+// string primitives are not, even though they have a `length` property.
+//
+// https://tc39.es/ecma262/multipage/abstract-operations.html#sec-lengthofarraylike
+
+import isObjectType from "isObjectType";
+
+export default function _isArrayLike(x) {
+  return isObjectType(x) && typeof x.length === "number";
+}

--- a/packages/babel-helpers/src/helpers/isObjectType.js
+++ b/packages/babel-helpers/src/helpers/isObjectType.js
@@ -1,0 +1,9 @@
+/* @minVersion 7.16.5 */
+
+// This helper checks ES Language Type, not `typeof` operator result.
+//
+// https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html
+
+export default function _isObjectType(x) {
+  return typeof x === "object" ? x !== null : typeof x === "function";
+}

--- a/packages/babel-helpers/src/helpers/iteratorClose.js
+++ b/packages/babel-helpers/src/helpers/iteratorClose.js
@@ -1,0 +1,5 @@
+/* @minVersion 7.16.5 */
+
+export default function _iteratorClose(it) {
+  if (it.return != null) it.return();
+}

--- a/packages/babel-helpers/src/helpers/iteratorCloseQuiet.js
+++ b/packages/babel-helpers/src/helpers/iteratorCloseQuiet.js
@@ -1,0 +1,9 @@
+/* @minVersion 7.16.5 */
+
+export default function _iteratorCloseQuiet(it) {
+  try {
+    if (it.return != null) it.return();
+  } catch (e) {
+    // swallow exceptions
+  }
+}

--- a/packages/babel-helpers/src/helpers/maybeAppendIterable.js
+++ b/packages/babel-helpers/src/helpers/maybeAppendIterable.js
@@ -1,0 +1,40 @@
+/* @minVersion 7.16.5 */
+
+import getIterator from "getIterator";
+import iteratorClose from "iteratorClose";
+import iteratorCloseQuiet from "iteratorCloseQuiet";
+
+/**
+ * Append elements from iterable @p src into @p dest.
+ *
+ * @param {Array}       dest
+ * @param {any}         src
+ * @param {number}      [limit]
+ * @return {Array}      @p dest if @p src is Iterable
+ * @return {undefined}  otherwise
+ */
+
+export default function _maybeAppendIterable(dest, src, limit) {
+  var it = src != null && getIterator(src);
+  if (it) {
+    var s,
+      v,
+      n = 0;
+    // Argument `limit` is optional, which means it is important to loop
+    // "while not above limit" rather than "while below limit".
+    while (!(++n > limit || (s = it.next()).done)) {
+      v = s.value;
+      // Exceptions from calling `it.next()` or accessing `s.done` or `s.value`
+      // simply propagate without closing the iterator. `it.return()` needs to be
+      // invoked only when appending to `dest` fails, or we stop before `s.done`.
+      try {
+        dest.push(v);
+      } catch (e) {
+        iteratorCloseQuiet(it);
+        throw e;
+      }
+    }
+    if (n > limit) iteratorClose(it);
+    return dest;
+  }
+}

--- a/packages/babel-helpers/src/helpers/maybeAppendUnsupportedIterable.js
+++ b/packages/babel-helpers/src/helpers/maybeAppendUnsupportedIterable.js
@@ -1,0 +1,14 @@
+/* @minVersion 7.16.5 */
+
+import appendArrayLike from "appendArrayLike";
+
+export default function _maybeAppendUnsupportedIterable(a, o, n) {
+  if (typeof o === "string") return appendArrayLike(a, o, n);
+  if (!o) return;
+  var c = Object.prototype.toString.call(o).slice(8, -1);
+  if (c === "Object" && o.constructor) c = o.constructor.name;
+  if (c === "Map" || c === "Set") return appendArrayLike(a, Array.from(o), n);
+  if (c === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(c)) {
+    return appendArrayLike(a, o, n);
+  }
+}

--- a/packages/babel-helpers/src/helpers/spreadCoerceToArray.js
+++ b/packages/babel-helpers/src/helpers/spreadCoerceToArray.js
@@ -1,0 +1,13 @@
+/* @minVersion 7.16.5 */
+
+import iterableToArray from "iterableToArray";
+import unsupportedIterableToArray from "unsupportedIterableToArray";
+import nonIterableSpread from "nonIterableSpread";
+
+export default function _spreadCoerceToArray(src) {
+  return Array.isArray(src)
+    ? src
+    : iterableToArray(src) ||
+        unsupportedIterableToArray(src) ||
+        nonIterableSpread();
+}

--- a/packages/babel-helpers/src/helpers/spreadCoerceToArrayLike.js
+++ b/packages/babel-helpers/src/helpers/spreadCoerceToArrayLike.js
@@ -1,0 +1,14 @@
+/* @minVersion 7.16.5 */
+
+import isArrayLike from "isArrayLike";
+import iterableToArray from "iterableToArray";
+import unsupportedIterableToArray from "unsupportedIterableToArray";
+import nonIterableSpread from "nonIterableSpread";
+
+export default function _spreadCoerceToArrayLike(src) {
+  return isArrayLike(src)
+    ? src
+    : iterableToArray(src) ||
+        unsupportedIterableToArray(src) ||
+        nonIterableSpread();
+}

--- a/packages/babel-helpers/src/helpers/spreadIterableOrArray.js
+++ b/packages/babel-helpers/src/helpers/spreadIterableOrArray.js
@@ -1,0 +1,21 @@
+/* @minVersion 7.16.5 */
+
+import appendArrayLike from "appendArrayLike";
+import maybeAppendIterable from "maybeAppendIterable";
+import maybeAppendUnsupportedIterable from "maybeAppendUnsupportedIterable";
+import nonIterableSpread from "nonIterableSpread";
+
+/**
+ * Append all elements from @p src into @p dest.
+ *
+ * @param {Array}           dest
+ * @param {Array|Iterable}  src
+ * @return {Array}          @p dest
+ */
+export default function _spreadIterableOrArray(dest, src) {
+  return Array.isArray(src)
+    ? appendArrayLike(dest, src)
+    : maybeAppendIterable(dest, src) ||
+        maybeAppendUnsupportedIterable(dest, src) ||
+        nonIterableSpread();
+}

--- a/packages/babel-helpers/src/helpers/spreadIterableOrArrayLike.js
+++ b/packages/babel-helpers/src/helpers/spreadIterableOrArrayLike.js
@@ -1,0 +1,22 @@
+/* @minVersion 7.16.5 */
+
+import isArrayLike from "isArrayLike";
+import appendArrayLike from "appendArrayLike";
+import maybeAppendIterable from "maybeAppendIterable";
+import maybeAppendUnsupportedIterable from "maybeAppendUnsupportedIterable";
+import nonIterableSpread from "nonIterableSpread";
+
+/**
+ * Append all elements from @p src into @p dest.
+ *
+ * @param {Array}               dest
+ * @param {ArrayLike|Iterable}  src
+ * @return {Array}              @p dest
+ */
+export default function _spreadIterableOrArrayLike(dest, src) {
+  return isArrayLike(src)
+    ? appendArrayLike(dest, src)
+    : maybeAppendIterable(dest, src) ||
+        maybeAppendUnsupportedIterable(dest, src) ||
+        nonIterableSpread();
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
@@ -17,7 +17,7 @@ var Test = function Test() {
         args[_key] = arguments[_key];
       }
 
-      _this = _super.call.apply(_super, [this].concat(args));
+      _this = _super.call.apply(_super, babelHelpers.appendArrayLike([this], args));
       babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "a", function () {
         return babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Other.prototype)), "test", _thisSuper);
       });

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/function-call-spread/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/function-call-spread/output.js
@@ -1,6 +1,6 @@
 var _a, _a2, _a3, _a4, _a4$b;
 
-(_a = a) === null || _a === void 0 ? void 0 : _a.apply(void 0, babelHelpers.toConsumableArray(args));
-(_a2 = a) === null || _a2 === void 0 ? void 0 : _a2.b.apply(_a2, babelHelpers.toConsumableArray(args));
-(_a3 = a) === null || _a3 === void 0 ? void 0 : _a3.b.apply(_a3, babelHelpers.toConsumableArray(args)).c;
-(_a4 = a) === null || _a4 === void 0 ? void 0 : (_a4$b = _a4.b.apply(_a4, babelHelpers.toConsumableArray(args))).c.apply(_a4$b, babelHelpers.toConsumableArray(args));
+(_a = a) === null || _a === void 0 ? void 0 : _a.apply(void 0, babelHelpers.spreadCoerceToArray(args));
+(_a2 = a) === null || _a2 === void 0 ? void 0 : _a2.b.apply(_a2, babelHelpers.spreadCoerceToArray(args));
+(_a3 = a) === null || _a3 === void 0 ? void 0 : _a3.b.apply(_a3, babelHelpers.spreadCoerceToArray(args)).c;
+(_a4 = a) === null || _a4 === void 0 ? void 0 : (_a4$b = _a4.b.apply(_a4, babelHelpers.spreadCoerceToArray(args))).c.apply(_a4$b, babelHelpers.spreadCoerceToArray(args));

--- a/packages/babel-plugin-transform-classes/test/fixtures/assumption-constantSuper/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/assumption-constantSuper/accessing-super-class/output.js
@@ -6,7 +6,7 @@ var Test = /*#__PURE__*/function (_Foo) {
   var _super = babelHelpers.createSuper(Test);
 
   function Test() {
-    var _Foo$prototype$test;
+    var _sprd, _sprd2, _Foo$prototype$test;
 
     var _this;
 
@@ -17,11 +17,11 @@ var Test = /*#__PURE__*/function (_Foo) {
     _Foo.prototype.test.call(babelHelpers.assertThisInitialized(_this));
 
     _this = _super.apply(this, arguments);
-    _this = _super.call.apply(_super, [this, "test"].concat(Array.prototype.slice.call(arguments)));
+    _this = _super.call.apply(_super, ((_sprd = [this, "test"]).push.apply(_sprd, arguments), _sprd));
 
     _Foo.prototype.test.apply(babelHelpers.assertThisInitialized(_this), arguments);
 
-    (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, [babelHelpers.assertThisInitialized(_this), "test"].concat(Array.prototype.slice.call(arguments)));
+    (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, ((_sprd2 = [babelHelpers.assertThisInitialized(_this), "test"]).push.apply(_sprd2, arguments), _sprd2));
 
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
@@ -4,7 +4,7 @@ var Test = /*#__PURE__*/function (_Foo) {
   babelHelpers.inheritsLoose(Test, _Foo);
 
   function Test() {
-    var _Foo$prototype$test;
+    var _sprd, _sprd2, _Foo$prototype$test;
 
     var _this;
 
@@ -14,11 +14,11 @@ var Test = /*#__PURE__*/function (_Foo) {
     _Foo.prototype.test.call(babelHelpers.assertThisInitialized(_this));
 
     _this = _Foo.apply(this, arguments) || this;
-    _this = _Foo.call.apply(_Foo, [this, "test"].concat(Array.prototype.slice.call(arguments))) || this;
+    _this = _Foo.call.apply(_Foo, ((_sprd = [this, "test"]).push.apply(_sprd, arguments), _sprd)) || this;
 
     _Foo.prototype.test.apply(babelHelpers.assertThisInitialized(_this), arguments);
 
-    (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, [babelHelpers.assertThisInitialized(_this), "test"].concat(Array.prototype.slice.call(arguments)));
+    (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, ((_sprd2 = [babelHelpers.assertThisInitialized(_this), "test"]).push.apply(_sprd2, arguments), _sprd2));
 
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
@@ -6,7 +6,7 @@ var Test = /*#__PURE__*/function (_Foo) {
   var _super = babelHelpers.createSuper(Test);
 
   function Test() {
-    var _babelHelpers$get;
+    var _sprd, _sprd2, _babelHelpers$get;
 
     var _thisSuper, _thisSuper2, _thisSuper3, _this;
 
@@ -15,10 +15,10 @@ var Test = /*#__PURE__*/function (_Foo) {
     _this = _super.call(this);
     babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper).call(_thisSuper);
     _this = _super.apply(this, arguments);
-    _this = _super.call.apply(_super, [this, "test"].concat(Array.prototype.slice.call(arguments)));
+    _this = _super.call.apply(_super, ((_sprd = [this, "test"]).push.apply(_sprd, arguments), _sprd));
     babelHelpers.get((_thisSuper2 = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper2).apply(_thisSuper2, arguments);
 
-    (_babelHelpers$get = babelHelpers.get((_thisSuper3 = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper3)).call.apply(_babelHelpers$get, [_thisSuper3, "test"].concat(Array.prototype.slice.call(arguments)));
+    (_babelHelpers$get = babelHelpers.get((_thisSuper3 = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper3)).call.apply(_babelHelpers$get, ((_sprd2 = [_thisSuper3, "test"]).push.apply(_sprd2, arguments), _sprd2));
 
     return _this;
   }
@@ -26,22 +26,22 @@ var Test = /*#__PURE__*/function (_Foo) {
   babelHelpers.createClass(Test, [{
     key: "test",
     value: function test() {
-      var _babelHelpers$get2;
+      var _sprd3, _babelHelpers$get2;
 
       babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", this).call(this);
       babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", this).apply(this, arguments);
 
-      (_babelHelpers$get2 = babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", this)).call.apply(_babelHelpers$get2, [this, "test"].concat(Array.prototype.slice.call(arguments)));
+      (_babelHelpers$get2 = babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", this)).call.apply(_babelHelpers$get2, ((_sprd3 = [this, "test"]).push.apply(_sprd3, arguments), _sprd3));
     }
   }], [{
     key: "foo",
     value: function foo() {
-      var _babelHelpers$get3;
+      var _sprd4, _babelHelpers$get3;
 
       babelHelpers.get(babelHelpers.getPrototypeOf(Test), "foo", this).call(this);
       babelHelpers.get(babelHelpers.getPrototypeOf(Test), "foo", this).apply(this, arguments);
 
-      (_babelHelpers$get3 = babelHelpers.get(babelHelpers.getPrototypeOf(Test), "foo", this)).call.apply(_babelHelpers$get3, [this, "test"].concat(Array.prototype.slice.call(arguments)));
+      (_babelHelpers$get3 = babelHelpers.get(babelHelpers.getPrototypeOf(Test), "foo", this)).call.apply(_babelHelpers$get3, ((_sprd4 = [this, "test"]).push.apply(_sprd4, arguments), _sprd4));
     }
   }]);
   return Test;

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/array-unpack-optimisation/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/array-unpack-optimisation/output.js
@@ -21,7 +21,7 @@ var _ref4 = [a[1], a[0]];
 a[0] = _ref4[0];
 a[1] = _ref4[1];
 
-var _ref5 = [].concat(babelHelpers.toConsumableArray(foo), [bar]),
+var _ref5 = babelHelpers.concatArrayLike(babelHelpers.spreadCoerceToArray(foo), [bar]),
     a = _ref5[0],
     b = _ref5[1];
 

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-spread-optimisation/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-spread-optimisation/output.js
@@ -17,7 +17,7 @@ function foo() {
     b[_key2] = arguments[_key2];
   }
 
-  foo.apply(void 0, [1].concat(b));
+  foo.apply(void 0, babelHelpers.appendArrayLike([1], b));
 }
 
 function foo() {

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -21,7 +21,7 @@ var App = /*#__PURE__*/function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    _this = _super.call.apply(_super, [this].concat(args));
+    _this = _super.call.apply(_super, babelHelpers.appendArrayLike([this], args));
     babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "exportType", '');
     return _this;
   }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/regression/12863/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/regression/12863/output.mjs
@@ -5,7 +5,8 @@ import _inherits from "@babel/runtime-corejs3/helpers/inherits";
 import _possibleConstructorReturn from "@babel/runtime-corejs3/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime-corejs3/helpers/getPrototypeOf";
 import _defineProperty from "@babel/runtime-corejs3/helpers/defineProperty";
-import _concatInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/concat";
+
+function _appendArrayLike(dest, src, num) { var i = 0, l = dest.length, n = src.length; for (n > num && (n = num > 0 ? num : 0), dest.length += n; i < n;) dest[l++] = src[i++]; return dest; }
 
 function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = _Reflect$construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
 
@@ -17,13 +18,11 @@ let B = /*#__PURE__*/function (_A) {
   var _super = _createSuper(B);
 
   function B(...args) {
-    var _context;
-
     var _this;
 
     _classCallCheck(this, B);
 
-    _this = _super.call.apply(_super, _concatInstanceProperty(_context = [this]).call(_context, args));
+    _this = _super.call.apply(_super, _appendArrayLike([this], args));
 
     _defineProperty(_assertThisInitialized(_this), "b", 8);
 

--- a/packages/babel-plugin-transform-spread/test/fixtures/allowArrayLike/simple/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/allowArrayLike/simple/output.js
@@ -1,1 +1,1 @@
-var arr = ["a"].concat(babelHelpers.maybeArrayLike(babelHelpers.toConsumableArray, p2), ["e"]);
+var arr = babelHelpers.concatArrayLike(["a"], babelHelpers.spreadCoerceToArrayLike(p2), ["e"]);

--- a/packages/babel-plugin-transform-spread/test/fixtures/assumption-arrayLikeIsIterable/simple/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/assumption-arrayLikeIsIterable/simple/output.js
@@ -1,1 +1,1 @@
-var arr = ["a"].concat(babelHelpers.maybeArrayLike(babelHelpers.toConsumableArray, p2), ["e"]);
+var arr = babelHelpers.concatArrayLike(["a"], babelHelpers.spreadCoerceToArrayLike(p2), ["e"]);

--- a/packages/babel-plugin-transform-spread/test/fixtures/assumption-iterableIsArray/arguments/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/assumption-iterableIsArray/arguments/output.js
@@ -1,5 +1,7 @@
 function foo() {
+  var _sprd;
+
   // We know for sure that 'arguments' is _not_ an array, so we
   // can ignore the assumption in this case.
-  return Array.prototype.slice.call(arguments);
+  return (_sprd = []).push.apply(_sprd, arguments), _sprd;
 }

--- a/packages/babel-plugin-transform-spread/test/fixtures/assumption-iterableIsArray/array-literals/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/assumption-iterableIsArray/array-literals/output.js
@@ -1,1 +1,1 @@
-var lyrics = ["head", "and", "toes"].concat(parts);
+var lyrics = babelHelpers.concatArrayLike(["head", "and", "toes"], parts);

--- a/packages/babel-plugin-transform-spread/test/fixtures/assumption-iterableIsArray/function-call/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/assumption-iterableIsArray/function-call/output.js
@@ -1,1 +1,1 @@
-lyrics(["head", "and", "toes"].concat(parts));
+lyrics(babelHelpers.concatArrayLike(["head", "and", "toes"], parts));

--- a/packages/babel-plugin-transform-spread/test/fixtures/assumption-iterableIsArray/sparse-array/exec.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/assumption-iterableIsArray/sparse-array/exec.js
@@ -1,0 +1,3 @@
+const a = new Array(1); // sparse, has 1 hole
+const b = [48, ...a, 50]; // must not have hole
+expect(b).toStrictEqual([48, undefined, 50]);

--- a/packages/babel-plugin-transform-spread/test/fixtures/call-context/flow-type-cast/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/call-context/flow-type-cast/output.js
@@ -1,3 +1,3 @@
 var _a;
 
-((_a = a).b: any).apply(_a, babelHelpers.toConsumableArray(args));
+((_a = a).b: any).apply(_a, babelHelpers.spreadCoerceToArray(args));

--- a/packages/babel-plugin-transform-spread/test/fixtures/call-context/parenthesized-expressions/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/call-context/parenthesized-expressions/output.js
@@ -1,3 +1,3 @@
 var _a;
 
-((_a = a).b).apply(_a, babelHelpers.toConsumableArray(args));
+((_a = a).b).apply(_a, babelHelpers.spreadCoerceToArray(args));

--- a/packages/babel-plugin-transform-spread/test/fixtures/call-context/ts-type-cast/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/call-context/ts-type-cast/output.js
@@ -1,3 +1,3 @@
 var _a;
 
-(<any> (_a = a).b).apply(_a, babelHelpers.toConsumableArray(args));
+(<any> (_a = a).b).apply(_a, babelHelpers.spreadCoerceToArray(args));

--- a/packages/babel-plugin-transform-spread/test/fixtures/regression/10416/output.mjs
+++ b/packages/babel-plugin-transform-spread/test/fixtures/regression/10416/output.mjs
@@ -1,5 +1,5 @@
 const E_ARR = [];
 export default function () {
   const someVar = E_ARR;
-  return babelHelpers.toConsumableArray(someVar);
+  return babelHelpers.spreadIterableOrArray([], someVar);
 }

--- a/packages/babel-plugin-transform-spread/test/fixtures/regression/11400/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/regression/11400/output.js
@@ -1,3 +1,3 @@
 var _dog;
 
-(_dog = dog).bark.apply(_dog, babelHelpers.toConsumableArray(args));
+(_dog = dog).bark.apply(_dog, babelHelpers.spreadCoerceToArray(args));

--- a/packages/babel-plugin-transform-spread/test/fixtures/regression/6647/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/regression/6647/output.js
@@ -2,4 +2,4 @@
 
 var _a = babelHelpers.interopRequireDefault(require("a"));
 
-_a.default.preview.apply(_a.default, babelHelpers.toConsumableArray(c));
+_a.default.preview.apply(_a.default, babelHelpers.spreadCoerceToArray(c));

--- a/packages/babel-plugin-transform-spread/test/fixtures/regression/issue-8907/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/regression/issue-8907/output.js
@@ -4,4 +4,4 @@ arr.concat = () => {
   throw new Error('Should not be called');
 };
 
-const x = [].concat(arr);
+const x = babelHelpers.concatArrayLike(arr);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/arguments-array/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/arguments-array/output.js
@@ -1,5 +1,7 @@
 function foo() {
-  return bar(Array.prototype.slice.call(arguments));
+  var _sprd;
+
+  return bar(((_sprd = []).push.apply(_sprd, arguments), _sprd));
 }
 
 function bar(one, two, three) {

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/arguments-concat/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/arguments-concat/output.js
@@ -1,5 +1,7 @@
 function foo() {
-  return bar.apply(void 0, ["test"].concat(Array.prototype.slice.call(arguments)));
+  var _sprd;
+
+  return bar.apply(void 0, ((_sprd = ["test"]).push.apply(_sprd, arguments), _sprd));
 }
 
 function bar(one, two, three) {

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literal-first/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literal-first/output.js
@@ -1,1 +1,1 @@
-var lyrics = [].concat(babelHelpers.toConsumableArray(parts), ["head", "and", "toes"]);
+var lyrics = babelHelpers.concatArrayLike(babelHelpers.spreadCoerceToArray(parts), ["head", "and", "toes"]);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literal-middle/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literal-middle/output.js
@@ -1,1 +1,1 @@
-var a = [b].concat(babelHelpers.toConsumableArray(c), [d]);
+var a = babelHelpers.concatArrayLike([b], babelHelpers.spreadCoerceToArray(c), [d]);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literal-multiple/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literal-multiple/output.js
@@ -1,1 +1,1 @@
-var a = [b].concat(babelHelpers.toConsumableArray(c), [d, e], babelHelpers.toConsumableArray(f));
+var a = babelHelpers.concatArrayLike([b], babelHelpers.spreadCoerceToArray(c), [d, e], babelHelpers.spreadCoerceToArray(f));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literal-with-hole/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literal-with-hole/output.js
@@ -1,1 +1,1 @@
-var arr = ['a',, 'b'].concat(babelHelpers.toConsumableArray(c));
+var arr = babelHelpers.spreadIterableOrArray(['a',, 'b'], c);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literals/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literals/output.js
@@ -1,1 +1,1 @@
-var lyrics = ["head", "and", "toes"].concat(babelHelpers.toConsumableArray(parts));
+var lyrics = babelHelpers.concatArrayLike(["head", "and", "toes"], babelHelpers.spreadCoerceToArray(parts));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/array-symbol-unsupported/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/array-symbol-unsupported/output.js
@@ -3,4 +3,4 @@ var a = (() => [2, 3])(); // !!! In order to run this test, this shouldn't be op
 // and exec.js
 
 
-[1].concat(babelHelpers.toConsumableArray(a));
+babelHelpers.concatArrayLike([1], babelHelpers.spreadCoerceToArray(a));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-computed-method-call-multiple-args/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-computed-method-call-multiple-args/output.js
@@ -1,3 +1,3 @@
 var _obj;
 
-(_obj = obj)[method].apply(_obj, [foo, bar].concat(babelHelpers.toConsumableArray(args)));
+(_obj = obj)[method].apply(_obj, babelHelpers.spreadIterableOrArray([foo, bar], args));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-computed-method-call-single-arg/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-computed-method-call-single-arg/output.js
@@ -1,3 +1,3 @@
 var _obj;
 
-(_obj = obj)[method].apply(_obj, babelHelpers.toConsumableArray(args));
+(_obj = obj)[method].apply(_obj, babelHelpers.spreadCoerceToArray(args));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-method-call-multiple-args/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-method-call-multiple-args/output.js
@@ -1,5 +1,5 @@
 var _foob, _foob$test;
 
-(_foob = foob).add.apply(_foob, [foo, bar].concat(babelHelpers.toConsumableArray(numbers)));
+(_foob = foob).add.apply(_foob, babelHelpers.spreadIterableOrArray([foo, bar], numbers));
 
-(_foob$test = foob.test).add.apply(_foob$test, [foo, bar].concat(babelHelpers.toConsumableArray(numbers)));
+(_foob$test = foob.test).add.apply(_foob$test, babelHelpers.spreadIterableOrArray([foo, bar], numbers));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-method-call-single-arg/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-method-call-single-arg/output.js
@@ -1,5 +1,5 @@
 var _foob, _foob$test;
 
-(_foob = foob).add.apply(_foob, babelHelpers.toConsumableArray(numbers));
+(_foob = foob).add.apply(_foob, babelHelpers.spreadCoerceToArray(numbers));
 
-(_foob$test = foob.test).add.apply(_foob$test, babelHelpers.toConsumableArray(numbers));
+(_foob$test = foob.test).add.apply(_foob$test, babelHelpers.spreadCoerceToArray(numbers));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-method-call-super-multiple-args/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-method-call-super-multiple-args/output.js
@@ -1,6 +1,6 @@
 class Foo {
   bar() {
-    super.bar.apply(this, [arg1, arg2].concat(babelHelpers.toConsumableArray(args)));
+    super.bar.apply(this, babelHelpers.spreadIterableOrArray([arg1, arg2], args));
   }
 
 }

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-method-call-super-single-arg/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/contexted-method-call-super-single-arg/output.js
@@ -1,6 +1,6 @@
 class Foo {
   bar() {
-    super.bar.apply(this, babelHelpers.toConsumableArray(args));
+    super.bar.apply(this, babelHelpers.spreadCoerceToArray(args));
   }
 
 }

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/known-rest/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/known-rest/output.js
@@ -3,5 +3,5 @@ function foo() {
     bar[_key] = arguments[_key];
   }
 
-  return [].concat(bar);
+  return babelHelpers.concatArrayLike(bar);
 }

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-array-literal-babel-7/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-array-literal-babel-7/output.js
@@ -1,2 +1,2 @@
-f.apply(void 0, [1, 2, 3]);
-f.apply(void 0, babelHelpers.arrayWithoutHoles([1,, 3]));
+f(1, 2, 3);
+f(1, void 0, 3);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-array-literal/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-array-literal/output.js
@@ -1,2 +1,2 @@
-f.apply(void 0, [1, 2, 3]);
-f.apply(void 0, babelHelpers.arrayLikeToArray([1,, 3]));
+f(1, 2, 3);
+f(1, void 0, 3);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-first/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-first/output.js
@@ -1,1 +1,3 @@
-add.apply(void 0, babelHelpers.toConsumableArray(numbers).concat([foo, bar]));
+var _sprd;
+
+add.apply(void 0, ((_sprd = babelHelpers.spreadIterableOrArray([], numbers)).push(foo, bar), _sprd));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-middle/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-middle/output.js
@@ -1,1 +1,3 @@
-add.apply(void 0, [foo].concat(babelHelpers.toConsumableArray(numbers), [bar]));
+var _sprd;
+
+add.apply(void 0, ((_sprd = babelHelpers.spreadIterableOrArray([foo], numbers)).push(bar), _sprd));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-multiple-args/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-multiple-args/output.js
@@ -1,1 +1,1 @@
-add.apply(void 0, [foo, bar].concat(babelHelpers.toConsumableArray(numbers)));
+add.apply(void 0, babelHelpers.spreadIterableOrArray([foo, bar], numbers));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-multiple/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-multiple/output.js
@@ -1,1 +1,3 @@
-add.apply(void 0, [foo].concat(babelHelpers.toConsumableArray(numbers), [bar, what], babelHelpers.toConsumableArray(test)));
+var _sprd;
+
+add.apply(void 0, ((_sprd = babelHelpers.spreadIterableOrArray([foo], numbers)).push(bar, what), babelHelpers.spreadIterableOrArray(_sprd, test)));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-single-arg/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/method-call-single-arg/output.js
@@ -1,1 +1,1 @@
-add.apply(void 0, babelHelpers.toConsumableArray(numbers));
+add.apply(void 0, babelHelpers.spreadCoerceToArray(numbers));

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/nested-array-with-hole-babel-7/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/nested-array-with-hole-babel-7/output.js
@@ -1,2 +1,2 @@
-var a = babelHelpers.arrayWithoutHoles(['a',, 'b']);
-var b = ['a'].concat(babelHelpers.arrayWithoutHoles(['b',, 'c']));
+var a = ['a', void 0, 'b'];
+var b = ['a', 'b', void 0, 'c'];

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/nested-array-with-hole/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/nested-array-with-hole/output.js
@@ -1,2 +1,2 @@
-var a = babelHelpers.arrayLikeToArray(['a',, 'b']);
-var b = ['a'].concat(babelHelpers.arrayLikeToArray(['b',, 'c']));
+var a = ['a', void 0, 'b'];
+var b = ['a', 'b', void 0, 'c'];

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/new-expression-babel-7/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/new-expression-babel-7/output.js
@@ -1,3 +1,3 @@
-babelHelpers.construct(Numbers, babelHelpers.toConsumableArray(nums));
-babelHelpers.construct(Numbers, [1].concat(babelHelpers.toConsumableArray(nums)));
-babelHelpers.construct(Numbers, babelHelpers.arrayWithoutHoles([1,, 3]));
+babelHelpers.construct(Numbers, babelHelpers.spreadCoerceToArray(nums));
+babelHelpers.construct(Numbers, babelHelpers.spreadIterableOrArray([1], nums));
+babelHelpers.construct(Numbers, [1, void 0, 3]);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/new-expression/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/new-expression/output.js
@@ -1,3 +1,3 @@
-babelHelpers.construct(Numbers, babelHelpers.toConsumableArray(nums));
-babelHelpers.construct(Numbers, [1].concat(babelHelpers.toConsumableArray(nums)));
-babelHelpers.construct(Numbers, babelHelpers.arrayLikeToArray([1,, 3]));
+babelHelpers.construct(Numbers, babelHelpers.spreadCoerceToArray(nums));
+babelHelpers.construct(Numbers, babelHelpers.spreadIterableOrArray([1], nums));
+babelHelpers.construct(Numbers, [1, void 0, 3]);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/non-iterable/exec.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/non-iterable/exec.js
@@ -1,6 +1,6 @@
 var o = {};
 
-expect(() => [...undefined]).toThrow(/undefined is not iterable|property 'Symbol\(Symbol\.iterator\)' of undefined/);
+expect(() => [...undefined]).toThrow(/spread non-iterable/);
 
 expect(() => [...o]).toThrow(/spread non-iterable/);
 

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/single/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/single/output.js
@@ -1,1 +1,1 @@
-babelHelpers.toConsumableArray(foo);
+babelHelpers.spreadIterableOrArray([], foo);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-after/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-after/output.js
@@ -7,7 +7,7 @@ let A = /*#__PURE__*/function (_B) {
 
   function A() {
     babelHelpers.classCallCheck(this, A);
-    return _super.call.apply(_super, [this].concat(babelHelpers.toConsumableArray(foo)));
+    return _super.call.apply(_super, babelHelpers.spreadIterableOrArray([this], foo));
   }
 
   return A;

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-before/output.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/super-classes-plugin-before/output.js
@@ -7,7 +7,7 @@ let A = /*#__PURE__*/function (_B) {
 
   function A() {
     babelHelpers.classCallCheck(this, A);
-    return _super.call.apply(_super, [this].concat(babelHelpers.toConsumableArray(foo)));
+    return _super.call.apply(_super, babelHelpers.spreadIterableOrArray([this], foo));
   }
 
   return A;

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/spread-super-firefox-40/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/spread-super-firefox-40/output.js
@@ -7,7 +7,7 @@ var A = /*#__PURE__*/function (_B) {
 
   function A(args) {
     babelHelpers.classCallCheck(this, A);
-    return _super.call.apply(_super, [this].concat(babelHelpers.toConsumableArray(args)));
+    return _super.call.apply(_super, babelHelpers.spreadIterableOrArray([this], args));
   }
 
   return A;

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -18,6 +18,15 @@
     "regenerator-runtime": "^0.13.4"
   },
   "exports": {
+    "./helpers/appendArrayLike": [
+      {
+        "node": "./helpers/appendArrayLike.js",
+        "import": "./helpers/esm/appendArrayLike.js",
+        "default": "./helpers/appendArrayLike.js"
+      },
+      "./helpers/appendArrayLike.js"
+    ],
+    "./helpers/esm/appendArrayLike": "./helpers/esm/appendArrayLike.js",
     "./helpers/asyncIterator": [
       {
         "node": "./helpers/asyncIterator.js",
@@ -27,6 +36,60 @@
       "./helpers/asyncIterator.js"
     ],
     "./helpers/esm/asyncIterator": "./helpers/esm/asyncIterator.js",
+    "./helpers/concatArrayLike": [
+      {
+        "node": "./helpers/concatArrayLike.js",
+        "import": "./helpers/esm/concatArrayLike.js",
+        "default": "./helpers/concatArrayLike.js"
+      },
+      "./helpers/concatArrayLike.js"
+    ],
+    "./helpers/esm/concatArrayLike": "./helpers/esm/concatArrayLike.js",
+    "./helpers/getIterator": [
+      {
+        "node": "./helpers/getIterator.js",
+        "import": "./helpers/esm/getIterator.js",
+        "default": "./helpers/getIterator.js"
+      },
+      "./helpers/getIterator.js"
+    ],
+    "./helpers/esm/getIterator": "./helpers/esm/getIterator.js",
+    "./helpers/isArrayLike": [
+      {
+        "node": "./helpers/isArrayLike.js",
+        "import": "./helpers/esm/isArrayLike.js",
+        "default": "./helpers/isArrayLike.js"
+      },
+      "./helpers/isArrayLike.js"
+    ],
+    "./helpers/esm/isArrayLike": "./helpers/esm/isArrayLike.js",
+    "./helpers/isObjectType": [
+      {
+        "node": "./helpers/isObjectType.js",
+        "import": "./helpers/esm/isObjectType.js",
+        "default": "./helpers/isObjectType.js"
+      },
+      "./helpers/isObjectType.js"
+    ],
+    "./helpers/esm/isObjectType": "./helpers/esm/isObjectType.js",
+    "./helpers/iteratorClose": [
+      {
+        "node": "./helpers/iteratorClose.js",
+        "import": "./helpers/esm/iteratorClose.js",
+        "default": "./helpers/iteratorClose.js"
+      },
+      "./helpers/iteratorClose.js"
+    ],
+    "./helpers/esm/iteratorClose": "./helpers/esm/iteratorClose.js",
+    "./helpers/iteratorCloseQuiet": [
+      {
+        "node": "./helpers/iteratorCloseQuiet.js",
+        "import": "./helpers/esm/iteratorCloseQuiet.js",
+        "default": "./helpers/iteratorCloseQuiet.js"
+      },
+      "./helpers/iteratorCloseQuiet.js"
+    ],
+    "./helpers/esm/iteratorCloseQuiet": "./helpers/esm/iteratorCloseQuiet.js",
     "./helpers/jsx": [
       {
         "node": "./helpers/jsx.js",
@@ -36,6 +99,24 @@
       "./helpers/jsx.js"
     ],
     "./helpers/esm/jsx": "./helpers/esm/jsx.js",
+    "./helpers/maybeAppendIterable": [
+      {
+        "node": "./helpers/maybeAppendIterable.js",
+        "import": "./helpers/esm/maybeAppendIterable.js",
+        "default": "./helpers/maybeAppendIterable.js"
+      },
+      "./helpers/maybeAppendIterable.js"
+    ],
+    "./helpers/esm/maybeAppendIterable": "./helpers/esm/maybeAppendIterable.js",
+    "./helpers/maybeAppendUnsupportedIterable": [
+      {
+        "node": "./helpers/maybeAppendUnsupportedIterable.js",
+        "import": "./helpers/esm/maybeAppendUnsupportedIterable.js",
+        "default": "./helpers/maybeAppendUnsupportedIterable.js"
+      },
+      "./helpers/maybeAppendUnsupportedIterable.js"
+    ],
+    "./helpers/esm/maybeAppendUnsupportedIterable": "./helpers/esm/maybeAppendUnsupportedIterable.js",
     "./helpers/objectSpread2": [
       {
         "node": "./helpers/objectSpread2.js",
@@ -45,6 +126,42 @@
       "./helpers/objectSpread2.js"
     ],
     "./helpers/esm/objectSpread2": "./helpers/esm/objectSpread2.js",
+    "./helpers/spreadCoerceToArray": [
+      {
+        "node": "./helpers/spreadCoerceToArray.js",
+        "import": "./helpers/esm/spreadCoerceToArray.js",
+        "default": "./helpers/spreadCoerceToArray.js"
+      },
+      "./helpers/spreadCoerceToArray.js"
+    ],
+    "./helpers/esm/spreadCoerceToArray": "./helpers/esm/spreadCoerceToArray.js",
+    "./helpers/spreadCoerceToArrayLike": [
+      {
+        "node": "./helpers/spreadCoerceToArrayLike.js",
+        "import": "./helpers/esm/spreadCoerceToArrayLike.js",
+        "default": "./helpers/spreadCoerceToArrayLike.js"
+      },
+      "./helpers/spreadCoerceToArrayLike.js"
+    ],
+    "./helpers/esm/spreadCoerceToArrayLike": "./helpers/esm/spreadCoerceToArrayLike.js",
+    "./helpers/spreadIterableOrArray": [
+      {
+        "node": "./helpers/spreadIterableOrArray.js",
+        "import": "./helpers/esm/spreadIterableOrArray.js",
+        "default": "./helpers/spreadIterableOrArray.js"
+      },
+      "./helpers/spreadIterableOrArray.js"
+    ],
+    "./helpers/esm/spreadIterableOrArray": "./helpers/esm/spreadIterableOrArray.js",
+    "./helpers/spreadIterableOrArrayLike": [
+      {
+        "node": "./helpers/spreadIterableOrArrayLike.js",
+        "import": "./helpers/esm/spreadIterableOrArrayLike.js",
+        "default": "./helpers/spreadIterableOrArrayLike.js"
+      },
+      "./helpers/spreadIterableOrArrayLike.js"
+    ],
+    "./helpers/esm/spreadIterableOrArrayLike": "./helpers/esm/spreadIterableOrArrayLike.js",
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof.js",

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -17,6 +17,15 @@
     "regenerator-runtime": "^0.13.4"
   },
   "exports": {
+    "./helpers/appendArrayLike": [
+      {
+        "node": "./helpers/appendArrayLike.js",
+        "import": "./helpers/esm/appendArrayLike.js",
+        "default": "./helpers/appendArrayLike.js"
+      },
+      "./helpers/appendArrayLike.js"
+    ],
+    "./helpers/esm/appendArrayLike": "./helpers/esm/appendArrayLike.js",
     "./helpers/asyncIterator": [
       {
         "node": "./helpers/asyncIterator.js",
@@ -26,6 +35,60 @@
       "./helpers/asyncIterator.js"
     ],
     "./helpers/esm/asyncIterator": "./helpers/esm/asyncIterator.js",
+    "./helpers/concatArrayLike": [
+      {
+        "node": "./helpers/concatArrayLike.js",
+        "import": "./helpers/esm/concatArrayLike.js",
+        "default": "./helpers/concatArrayLike.js"
+      },
+      "./helpers/concatArrayLike.js"
+    ],
+    "./helpers/esm/concatArrayLike": "./helpers/esm/concatArrayLike.js",
+    "./helpers/getIterator": [
+      {
+        "node": "./helpers/getIterator.js",
+        "import": "./helpers/esm/getIterator.js",
+        "default": "./helpers/getIterator.js"
+      },
+      "./helpers/getIterator.js"
+    ],
+    "./helpers/esm/getIterator": "./helpers/esm/getIterator.js",
+    "./helpers/isArrayLike": [
+      {
+        "node": "./helpers/isArrayLike.js",
+        "import": "./helpers/esm/isArrayLike.js",
+        "default": "./helpers/isArrayLike.js"
+      },
+      "./helpers/isArrayLike.js"
+    ],
+    "./helpers/esm/isArrayLike": "./helpers/esm/isArrayLike.js",
+    "./helpers/isObjectType": [
+      {
+        "node": "./helpers/isObjectType.js",
+        "import": "./helpers/esm/isObjectType.js",
+        "default": "./helpers/isObjectType.js"
+      },
+      "./helpers/isObjectType.js"
+    ],
+    "./helpers/esm/isObjectType": "./helpers/esm/isObjectType.js",
+    "./helpers/iteratorClose": [
+      {
+        "node": "./helpers/iteratorClose.js",
+        "import": "./helpers/esm/iteratorClose.js",
+        "default": "./helpers/iteratorClose.js"
+      },
+      "./helpers/iteratorClose.js"
+    ],
+    "./helpers/esm/iteratorClose": "./helpers/esm/iteratorClose.js",
+    "./helpers/iteratorCloseQuiet": [
+      {
+        "node": "./helpers/iteratorCloseQuiet.js",
+        "import": "./helpers/esm/iteratorCloseQuiet.js",
+        "default": "./helpers/iteratorCloseQuiet.js"
+      },
+      "./helpers/iteratorCloseQuiet.js"
+    ],
+    "./helpers/esm/iteratorCloseQuiet": "./helpers/esm/iteratorCloseQuiet.js",
     "./helpers/jsx": [
       {
         "node": "./helpers/jsx.js",
@@ -35,6 +98,24 @@
       "./helpers/jsx.js"
     ],
     "./helpers/esm/jsx": "./helpers/esm/jsx.js",
+    "./helpers/maybeAppendIterable": [
+      {
+        "node": "./helpers/maybeAppendIterable.js",
+        "import": "./helpers/esm/maybeAppendIterable.js",
+        "default": "./helpers/maybeAppendIterable.js"
+      },
+      "./helpers/maybeAppendIterable.js"
+    ],
+    "./helpers/esm/maybeAppendIterable": "./helpers/esm/maybeAppendIterable.js",
+    "./helpers/maybeAppendUnsupportedIterable": [
+      {
+        "node": "./helpers/maybeAppendUnsupportedIterable.js",
+        "import": "./helpers/esm/maybeAppendUnsupportedIterable.js",
+        "default": "./helpers/maybeAppendUnsupportedIterable.js"
+      },
+      "./helpers/maybeAppendUnsupportedIterable.js"
+    ],
+    "./helpers/esm/maybeAppendUnsupportedIterable": "./helpers/esm/maybeAppendUnsupportedIterable.js",
     "./helpers/objectSpread2": [
       {
         "node": "./helpers/objectSpread2.js",
@@ -44,6 +125,42 @@
       "./helpers/objectSpread2.js"
     ],
     "./helpers/esm/objectSpread2": "./helpers/esm/objectSpread2.js",
+    "./helpers/spreadCoerceToArray": [
+      {
+        "node": "./helpers/spreadCoerceToArray.js",
+        "import": "./helpers/esm/spreadCoerceToArray.js",
+        "default": "./helpers/spreadCoerceToArray.js"
+      },
+      "./helpers/spreadCoerceToArray.js"
+    ],
+    "./helpers/esm/spreadCoerceToArray": "./helpers/esm/spreadCoerceToArray.js",
+    "./helpers/spreadCoerceToArrayLike": [
+      {
+        "node": "./helpers/spreadCoerceToArrayLike.js",
+        "import": "./helpers/esm/spreadCoerceToArrayLike.js",
+        "default": "./helpers/spreadCoerceToArrayLike.js"
+      },
+      "./helpers/spreadCoerceToArrayLike.js"
+    ],
+    "./helpers/esm/spreadCoerceToArrayLike": "./helpers/esm/spreadCoerceToArrayLike.js",
+    "./helpers/spreadIterableOrArray": [
+      {
+        "node": "./helpers/spreadIterableOrArray.js",
+        "import": "./helpers/esm/spreadIterableOrArray.js",
+        "default": "./helpers/spreadIterableOrArray.js"
+      },
+      "./helpers/spreadIterableOrArray.js"
+    ],
+    "./helpers/esm/spreadIterableOrArray": "./helpers/esm/spreadIterableOrArray.js",
+    "./helpers/spreadIterableOrArrayLike": [
+      {
+        "node": "./helpers/spreadIterableOrArrayLike.js",
+        "import": "./helpers/esm/spreadIterableOrArrayLike.js",
+        "default": "./helpers/spreadIterableOrArrayLike.js"
+      },
+      "./helpers/spreadIterableOrArrayLike.js"
+    ],
+    "./helpers/esm/spreadIterableOrArrayLike": "./helpers/esm/spreadIterableOrArrayLike.js",
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof.js",

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -17,6 +17,15 @@
     "regenerator-runtime": "^0.13.4"
   },
   "exports": {
+    "./helpers/appendArrayLike": [
+      {
+        "node": "./helpers/appendArrayLike.js",
+        "import": "./helpers/esm/appendArrayLike.js",
+        "default": "./helpers/appendArrayLike.js"
+      },
+      "./helpers/appendArrayLike.js"
+    ],
+    "./helpers/esm/appendArrayLike": "./helpers/esm/appendArrayLike.js",
     "./helpers/asyncIterator": [
       {
         "node": "./helpers/asyncIterator.js",
@@ -26,6 +35,60 @@
       "./helpers/asyncIterator.js"
     ],
     "./helpers/esm/asyncIterator": "./helpers/esm/asyncIterator.js",
+    "./helpers/concatArrayLike": [
+      {
+        "node": "./helpers/concatArrayLike.js",
+        "import": "./helpers/esm/concatArrayLike.js",
+        "default": "./helpers/concatArrayLike.js"
+      },
+      "./helpers/concatArrayLike.js"
+    ],
+    "./helpers/esm/concatArrayLike": "./helpers/esm/concatArrayLike.js",
+    "./helpers/getIterator": [
+      {
+        "node": "./helpers/getIterator.js",
+        "import": "./helpers/esm/getIterator.js",
+        "default": "./helpers/getIterator.js"
+      },
+      "./helpers/getIterator.js"
+    ],
+    "./helpers/esm/getIterator": "./helpers/esm/getIterator.js",
+    "./helpers/isArrayLike": [
+      {
+        "node": "./helpers/isArrayLike.js",
+        "import": "./helpers/esm/isArrayLike.js",
+        "default": "./helpers/isArrayLike.js"
+      },
+      "./helpers/isArrayLike.js"
+    ],
+    "./helpers/esm/isArrayLike": "./helpers/esm/isArrayLike.js",
+    "./helpers/isObjectType": [
+      {
+        "node": "./helpers/isObjectType.js",
+        "import": "./helpers/esm/isObjectType.js",
+        "default": "./helpers/isObjectType.js"
+      },
+      "./helpers/isObjectType.js"
+    ],
+    "./helpers/esm/isObjectType": "./helpers/esm/isObjectType.js",
+    "./helpers/iteratorClose": [
+      {
+        "node": "./helpers/iteratorClose.js",
+        "import": "./helpers/esm/iteratorClose.js",
+        "default": "./helpers/iteratorClose.js"
+      },
+      "./helpers/iteratorClose.js"
+    ],
+    "./helpers/esm/iteratorClose": "./helpers/esm/iteratorClose.js",
+    "./helpers/iteratorCloseQuiet": [
+      {
+        "node": "./helpers/iteratorCloseQuiet.js",
+        "import": "./helpers/esm/iteratorCloseQuiet.js",
+        "default": "./helpers/iteratorCloseQuiet.js"
+      },
+      "./helpers/iteratorCloseQuiet.js"
+    ],
+    "./helpers/esm/iteratorCloseQuiet": "./helpers/esm/iteratorCloseQuiet.js",
     "./helpers/jsx": [
       {
         "node": "./helpers/jsx.js",
@@ -35,6 +98,24 @@
       "./helpers/jsx.js"
     ],
     "./helpers/esm/jsx": "./helpers/esm/jsx.js",
+    "./helpers/maybeAppendIterable": [
+      {
+        "node": "./helpers/maybeAppendIterable.js",
+        "import": "./helpers/esm/maybeAppendIterable.js",
+        "default": "./helpers/maybeAppendIterable.js"
+      },
+      "./helpers/maybeAppendIterable.js"
+    ],
+    "./helpers/esm/maybeAppendIterable": "./helpers/esm/maybeAppendIterable.js",
+    "./helpers/maybeAppendUnsupportedIterable": [
+      {
+        "node": "./helpers/maybeAppendUnsupportedIterable.js",
+        "import": "./helpers/esm/maybeAppendUnsupportedIterable.js",
+        "default": "./helpers/maybeAppendUnsupportedIterable.js"
+      },
+      "./helpers/maybeAppendUnsupportedIterable.js"
+    ],
+    "./helpers/esm/maybeAppendUnsupportedIterable": "./helpers/esm/maybeAppendUnsupportedIterable.js",
     "./helpers/objectSpread2": [
       {
         "node": "./helpers/objectSpread2.js",
@@ -44,6 +125,42 @@
       "./helpers/objectSpread2.js"
     ],
     "./helpers/esm/objectSpread2": "./helpers/esm/objectSpread2.js",
+    "./helpers/spreadCoerceToArray": [
+      {
+        "node": "./helpers/spreadCoerceToArray.js",
+        "import": "./helpers/esm/spreadCoerceToArray.js",
+        "default": "./helpers/spreadCoerceToArray.js"
+      },
+      "./helpers/spreadCoerceToArray.js"
+    ],
+    "./helpers/esm/spreadCoerceToArray": "./helpers/esm/spreadCoerceToArray.js",
+    "./helpers/spreadCoerceToArrayLike": [
+      {
+        "node": "./helpers/spreadCoerceToArrayLike.js",
+        "import": "./helpers/esm/spreadCoerceToArrayLike.js",
+        "default": "./helpers/spreadCoerceToArrayLike.js"
+      },
+      "./helpers/spreadCoerceToArrayLike.js"
+    ],
+    "./helpers/esm/spreadCoerceToArrayLike": "./helpers/esm/spreadCoerceToArrayLike.js",
+    "./helpers/spreadIterableOrArray": [
+      {
+        "node": "./helpers/spreadIterableOrArray.js",
+        "import": "./helpers/esm/spreadIterableOrArray.js",
+        "default": "./helpers/spreadIterableOrArray.js"
+      },
+      "./helpers/spreadIterableOrArray.js"
+    ],
+    "./helpers/esm/spreadIterableOrArray": "./helpers/esm/spreadIterableOrArray.js",
+    "./helpers/spreadIterableOrArrayLike": [
+      {
+        "node": "./helpers/spreadIterableOrArrayLike.js",
+        "import": "./helpers/esm/spreadIterableOrArrayLike.js",
+        "default": "./helpers/spreadIterableOrArrayLike.js"
+      },
+      "./helpers/spreadIterableOrArrayLike.js"
+    ],
+    "./helpers/esm/spreadIterableOrArrayLike": "./helpers/esm/spreadIterableOrArrayLike.js",
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,6 +55,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel-baseline/plugin-transform-spread@npm:@babel/plugin-transform-spread@7.16.0, @babel/plugin-transform-spread@npm:^7.16.0":
+  version: 7.16.0
+  resolution: "@babel/plugin-transform-spread@npm:7.16.0"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.16.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: c295ef5e329fc31bd78e0aac3d6d848475a26e40cffff207dfd450416a25478bedb03402a0cc569bc5b7d3e92c22bff8a7cf76f1a9d896070e3cdeae1aee0316
+  languageName: node
+  linkType: hard
+
 "@babel-baseline/traverse@npm:@babel/traverse@7.15.4":
   version: 7.15.4
   resolution: "@babel/traverse@npm:7.15.4"
@@ -139,6 +151,7 @@ __metadata:
     "@babel-baseline/generator": "npm:@babel/generator@7.14.5"
     "@babel-baseline/helper-validator-identifier": "npm:@babel/helper-validator-identifier@7.10.4"
     "@babel-baseline/parser": "npm:@babel/parser@7.14.8"
+    "@babel-baseline/plugin-transform-spread": "npm:@babel/plugin-transform-spread@7.16.0"
     "@babel-baseline/traverse": "npm:@babel/traverse@7.15.4"
     "@babel-baseline/types": "npm:@babel/types@7.15.6"
     "@babel/core": "workspace:^"
@@ -150,6 +163,7 @@ __metadata:
     "@babel/traverse": "workspace:^"
     "@babel/types": "workspace:^"
     benchmark: ^2.1.4
+    chalk: ^4.1.0
   languageName: unknown
   linkType: soft
 
@@ -3008,18 +3022,6 @@ __metadata:
     "@babel/core": ^7.0.0-0
   languageName: unknown
   linkType: soft
-
-"@babel/plugin-transform-spread@npm:^7.16.0":
-  version: 7.16.0
-  resolution: "@babel/plugin-transform-spread@npm:7.16.0"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.14.5
-    "@babel/helper-skip-transparent-expression-wrappers": ^7.16.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: c295ef5e329fc31bd78e0aac3d6d848475a26e40cffff207dfd450416a25478bedb03402a0cc569bc5b7d3e92c22bff8a7cf76f1a9d896070e3cdeae1aee0316
-  languageName: node
-  linkType: hard
 
 "@babel/plugin-transform-spread@workspace:^, @babel/plugin-transform-spread@workspace:packages/babel-plugin-transform-spread":
   version: 0.0.0-use.local


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13861 
| Patch: Bug Fix?          | :heavy_check_mark: 
| Major: Breaking Change?  |
| Minor: New Feature?      | some new helpers, do those count?
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | only internal, in benchmark devdeps
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

### 1. bug fix: spreading sparse array variable
An accidental side effect of this revamp is that it fixes #13861. (test included)

### 2. perf: spreading `arguments`
Previously `Array.p.slice` was used to convert `[...arguments]` to array, but `Array.p.push` works faster.

```
array-spread-arguments baseline: 16_773 ops/sec ±0.41% (0.06ms)
array-spread-arguments current: 33_122 ops/sec ±0.33% (0.03ms)
```
<details>
<summary>benchmark transform</summary>

```js
// array-spread-arguments baseline
function arrayOf() {
  return Array.prototype.slice.call(arguments);
}

function work() {
  return arrayOf("bacon", "egg", "spam");
}
```
```js
// array-spread-arguments current
function arrayOf() {
  var _sprd;

  return (_sprd = []).push.apply(_sprd, arguments), _sprd;
}

function work() {
  return arrayOf("bacon", "egg", "spam");
}
```
</details>


### 3. perf: spreading single array in call
A call such as `foo(...bar)` was transformed into `foo.apply(void 0, _toConsumableArray(bar))`.
`_toConsumableArray` returns a copy without holes. But if `bar` is already an array, there is no need to make a copy, even if it is sparse: `foo.apply` does not respect holes. At first I simply replaced `_toConsumableArray` with `_toArray`, but that helper was written for destructuring and gives a misleading error message when `bar` is not iterable. So I ended up adding a new helper.

```
call-spread-sparse-array baseline: 7_221 ops/sec ±0.52% (0.138ms)
call-spread-sparse-array current: 12_735 ops/sec ±0.33% (0.079ms)
```

<details>
<summary>benchmark transform</summary>

```js
// call-spread-sparse-array baseline
function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }

function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }

function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }

function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }

function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }

function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }

// defer initialization to prevent Babel guessing variable type,
// because if it can guess, the plugin emits Array-specific code
var bar;
bar = new Array(3);

function foo() {
  return arguments.length;
}

function work() {
  return foo.apply(void 0, _toConsumableArray(bar));
}
```
```js
// call-spread-sparse-array current
function _spreadCoerceToArray(src) { return Array.isArray(src) ? src : _iterableToArray(src) || _unsupportedIterableToArray(src) || _nonIterableSpread(); }

function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }

function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }

function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }

function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }

// defer initialization to prevent Babel guessing variable type,
// because if it can guess, the plugin emits Array-specific code
var bar;
bar = new Array(3);

function foo() {
  return arguments.length;
}

function work() {
  return foo.apply(void 0, _spreadCoerceToArray(bar));
}
```
</details>

### 4. perf: calls with multiple arguments and spread
Previously calls like `foo("ham", "spam", ...arguments, "ham", "spam");` were transformed such that each spread element was copied to a new array, and then all the chunks `concat`enated and `apply`ed. Assuming function calls usually get only a few arguments (even after spread), I think it makes more sense to accumulate them incrementally into a single temporary array; that is use a sequence of `temp.push` and `append(temp, iterable)` (new helper) calls.

```
call-spread-with-arguments baseline: 9_219 ops/sec ±1.86% (0.108ms)
call-spread-with-arguments current: 21_542 ops/sec ±0.44% (0.046ms)
```

<details>
<summary>benchmark transform</summary>

```js
// call-spread-with-arguments baseline
function foo() {
  return arguments.length;
}

function bar() {
  return foo.apply(void 0, ["ham", "spam"].concat(Array.prototype.slice.call(arguments), ["ham", "spam"]));
}

function work() {
  return bar("bacon", "egg", "spam");
}
```
```js
// call-spread-with-arguments current
function foo() {
  return arguments.length;
}

function bar() {
  var _sprd;

  return foo.apply(void 0, ((_sprd = ["ham", "spam"]).push.apply(_sprd, arguments), _sprd.push("ham", "spam"), _sprd));
}

function work() {
  return bar("bacon", "egg", "spam");
}
```
</details>

### 5. arrays with multiple spread elements
Previously, in array expression like `[x, ...a, y, ...b]` both `a` and `b` were each copied into their own array without holes, and all the pieces then concatenated. However, if there are no holes in the outer array expression, we don't need to copy `a` and `b` separately if they are already arrays, but instead use a `concat`-like helper that fills holes.

```
array-spread-multiple baseline: 3_042 ops/sec ±0.52% (0.329ms)
array-spread-multiple current: 5_618 ops/sec ±0.26% (0.178ms)
```

<details>
<summary>benchmark transform</summary>

```js
// array-spread-multiple baseline
function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }

function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }

function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }

function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }

function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }

function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }

var bar = ["egg",, "spam"];

function work(a = bar) {
  return [].concat(_toConsumableArray(a), _toConsumableArray(a), _toConsumableArray(a));
}
```
```js
// array-spread-multiple current
function _concatArrayLike() { for (var ai = 0, an = arguments.length, dn = 0; ai < an;) dn += arguments[ai++].length; var dest = new Array(dn), di = 0; for (ai = 0; ai < an;) for (var src = arguments[ai++], si = 0, sn = src.length; si < sn;) dest[di++] = src[si++]; return dest; }

function _spreadCoerceToArray(src) { return Array.isArray(src) ? src : _iterableToArray(src) || _unsupportedIterableToArray(src) || _nonIterableSpread(); }

function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }

function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }

function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }

function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }

var bar = ["egg",, "spam"];

function work(a = bar) {
  return _concatArrayLike(_spreadCoerceToArray(a), _spreadCoerceToArray(a), _spreadCoerceToArray(a));
}
```
</details>

```
array-spread-large-array baseline: 101 ops/sec ±1.39% (9.915ms)
array-spread-large-array current: 188 ops/sec ±0.32% (5.326ms)
```

<details>
<summary>benchmark transform</summary>

```js
// array-spread-large-array baseline
function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }

function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }

function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }

function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }

function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }

function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }

var bar = Array.from({
  length: 456000
}, (_, i) => i);

function foo(a) {
  return [0].concat(_toConsumableArray(a), [1], _toConsumableArray(a), [2]);
}

function work() {
  return foo(bar).length;
}
```
```js
// array-spread-large-array current
function _concatArrayLike() { for (var ai = 0, an = arguments.length, dn = 0; ai < an;) dn += arguments[ai++].length; var dest = new Array(dn), di = 0; for (ai = 0; ai < an;) for (var src = arguments[ai++], si = 0, sn = src.length; si < sn;) dest[di++] = src[si++]; return dest; }

function _spreadCoerceToArray(src) { return Array.isArray(src) ? src : _iterableToArray(src) || _unsupportedIterableToArray(src) || _nonIterableSpread(); }

function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }

function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }

function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }

function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }

var bar = Array.from({
  length: 456000
}, (_, i) => i);

function foo(a) {
  return _concatArrayLike([0], _spreadCoerceToArray(a), [1], _spreadCoerceToArray(a), [2]);
}

function work() {
  return foo(bar).length;
}
```
</details>

There's a caveat, though. If none of the spread elements are arrays, the new transform does the same amount of work as the old one — copy each iterable into an array, and then concatenate those — but the old transform uses built-in `concat`, whereas the new transform uses `concatArrayLike` helper, which is inevitably slower.

```
array-spread-large-set baseline: 93.68 ops/sec ±1.29% (11ms)
array-spread-large-set current: 86.81 ops/sec ±0.37% (12ms)
```

<details>
<summary>benchmark transform</summary>

```js
// array-spread-large-set baseline
function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }

function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }

function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }

function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }

function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }

function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }

var bar = Array.from({
  length: 456000
}, (_, i) => i);
var set = new Set(bar);

function foo(a) {
  return [0].concat(_toConsumableArray(a), [1], _toConsumableArray(a), [2]);
}

function work() {
  return foo(set).length;
}
```
```js
// array-spread-large-set current
function _concatArrayLike() { for (var ai = 0, an = arguments.length, dn = 0; ai < an;) dn += arguments[ai++].length; var dest = new Array(dn), di = 0; for (ai = 0; ai < an;) for (var src = arguments[ai++], si = 0, sn = src.length; si < sn;) dest[di++] = src[si++]; return dest; }

function _spreadCoerceToArray(src) { return Array.isArray(src) ? src : _iterableToArray(src) || _unsupportedIterableToArray(src) || _nonIterableSpread(); }

function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }

function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }

function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }

function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }

var bar = Array.from({
  length: 456000
}, (_, i) => i);
var set = new Set(bar);

function foo(a) {
  return _concatArrayLike([0], _spreadCoerceToArray(a), [1], _spreadCoerceToArray(a), [2]);
}

function work() {
  return foo(set).length;
}
```
</details>

```
array-spread-small-set baseline: 2_212 ops/sec ±0.52% (0.452ms)
array-spread-small-set current: 2_183 ops/sec ±0.8% (0.458ms)
```

<details>
<summary>benchmark transform</summary>

```js
// array-spread-small-set baseline
function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }

function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }

function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }

function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }

function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }

function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }

var bar = Array.from({
  length: 123
}, (_, i) => i);
var set = new Set(bar);

function foo(a) {
  return [0].concat(_toConsumableArray(a), [1], _toConsumableArray(a), [2]);
}

function work() {
  return foo(set).length;
}
```
```js
// array-spread-small-set current
function _concatArrayLike() { for (var ai = 0, an = arguments.length, dn = 0; ai < an;) dn += arguments[ai++].length; var dest = new Array(dn), di = 0; for (ai = 0; ai < an;) for (var src = arguments[ai++], si = 0, sn = src.length; si < sn;) dest[di++] = src[si++]; return dest; }

function _spreadCoerceToArray(src) { return Array.isArray(src) ? src : _iterableToArray(src) || _unsupportedIterableToArray(src) || _nonIterableSpread(); }

function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }

function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }

function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }

function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }

var bar = Array.from({
  length: 123
}, (_, i) => i);
var set = new Set(bar);

function foo(a) {
  return _concatArrayLike([0], _spreadCoerceToArray(a), [1], _spreadCoerceToArray(a), [2]);
}

function work() {
  return foo(set).length;
}
```
</details>

### 6. potential follow-up changes, not included in this PR

Helper `toConsumableArray` is made obsolete (and consequently `arrayWithoutHoles` as well). It is still referenced from a now-unused code path in `babel-traverse: Scope.toArray()` but it's no longer invoked from `babel-plugin-transform-spread`. I guess these can be removed in Babel 8.

Helper `iterableToArrayLimit(o, n)` could delegate to new helper `maybeAppendIterable([], o, n)`.
Helper `unsupportedIterableToArray(o, n)` could delegate to new helper `maybeAppendUnsupportedIterable([], o, n)`.
