### PR TITLE
Fix duplicate declaration error on ambient class declarations

### DIFF
--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -705,9 +705,8 @@ export default class Scope {
       for (const declar of declarations) {
         this.registerBinding(path.node.kind, declar);
       }
-    } else if (path.isClassDeclaration() && path.node.declare) {
-      this.registerBinding("class", path);
     } else if (path.isClassDeclaration()) {
+      if (path.node.declare) return;
       this.registerBinding("let", path);
     } else if (path.isImportDeclaration()) {
       const specifiers = path.get("specifiers");

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -705,6 +705,8 @@ export default class Scope {
       for (const declar of declarations) {
         this.registerBinding(path.node.kind, declar);
       }
+    } else if(path.isClassDeclaration() && path.node.declare) {
+      this.registerBinding("class", path);
     } else if (path.isClassDeclaration()) {
       this.registerBinding("let", path);
     } else if (path.isImportDeclaration()) {

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -705,7 +705,7 @@ export default class Scope {
       for (const declar of declarations) {
         this.registerBinding(path.node.kind, declar);
       }
-    } else if(path.isClassDeclaration() && path.node.declare) {
+    } else if (path.isClassDeclaration() && path.node.declare) {
       this.registerBinding("class", path);
     } else if (path.isClassDeclaration()) {
       this.registerBinding("let", path);

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -655,6 +655,18 @@ describe("scope", () => {
       });
     });
 
+    describe('duplicate declaration', () => {
+      it('should not throw error on duplicate class and function declaration', () => {
+        const ast = [
+          t.classDeclaration(t.identifier('A'), t.super(), t.classBody([]), []),
+          t.functionDeclaration(t.identifier('A'), [], t.blockStatement([]))
+        ]
+
+        ast[0].declare = true;
+        expect(() => getPath(ast)).not.toThrowError()
+      })
+    })
+
     describe("global", () => {
       // node1, node2, success
       // every line will run 2 tests `node1;node2;` and `node2;node1;`

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -655,17 +655,17 @@ describe("scope", () => {
       });
     });
 
-    describe('duplicate declaration', () => {
-      it('should not throw error on duplicate class and function declaration', () => {
+    describe("duplicate declaration", () => {
+      it("should not throw error on duplicate class and function declaration", () => {
         const ast = [
-          t.classDeclaration(t.identifier('A'), t.super(), t.classBody([]), []),
-          t.functionDeclaration(t.identifier('A'), [], t.blockStatement([]))
-        ]
+          t.classDeclaration(t.identifier("A"), t.super(), t.classBody([]), []),
+          t.functionDeclaration(t.identifier("A"), [], t.blockStatement([])),
+        ];
 
         ast[0].declare = true;
-        expect(() => getPath(ast)).not.toThrowError()
-      })
-    })
+        expect(() => getPath(ast)).not.toThrowError();
+      });
+    });
 
     describe("global", () => {
       // node1, node2, success


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13735  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Improve the scope handling for `declare class` by adding a check using `path.node.declare` for "declare class".


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14016"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

