### PR TITLE
Bring back deferred `require()` calls in `core` and `cli`

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -73,6 +73,12 @@ module.exports = function (api) {
     "eslint/*/test",
   ];
 
+  const lazyRequireSources = [
+    "./packages/babel-cli",
+    "./packages/babel-core",
+    "./packages/babel-preset-env/src/available-plugins.js",
+  ];
+
   switch (env) {
     // Configs used during bundling builds.
     case "standalone":
@@ -192,20 +198,6 @@ module.exports = function (api) {
         plugins: ["babel-plugin-transform-charcodes"],
       },
       convertESM && {
-        test: [
-          "./packages/babel-cli",
-          "./packages/babel-core",
-          "./packages/babel-preset-env/src/available-plugins.js",
-        ].map(normalize),
-        plugins: [
-          // Explicitly use the lazy version of CommonJS modules.
-          [
-            "@babel/transform-modules-commonjs",
-            { importInterop: importInteropSrc, lazy: true },
-          ],
-        ],
-      },
-      convertESM && {
         test: ["./packages/babel-node/src"].map(normalize),
         // Used to conditionally import kexec
         plugins: ["@babel/plugin-proposal-dynamic-import"],
@@ -216,7 +208,18 @@ module.exports = function (api) {
         plugins: [transformNamedBabelTypesImportToDestructuring],
       },
       convertESM && {
+        test: lazyRequireSources.map(normalize),
+        plugins: [
+          // Explicitly use the lazy version of CommonJS modules.
+          [
+            "@babel/transform-modules-commonjs",
+            { importInterop: importInteropSrc, lazy: true },
+          ],
+        ],
+      },
+      convertESM && {
         test: sources.map(normalize),
+        exclude: lazyRequireSources.map(normalize),
         plugins: [
           [
             "@babel/transform-modules-commonjs",

--- a/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/test/util.skip-bundled.js
+++ b/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/test/util.skip-bundled.js
@@ -1,5 +1,6 @@
-import { parseSync, traverse } from "@babel/core";
 import { shouldTransform } from "../lib/util.js";
+import babel from "@babel/core";
+const { parseSync, traverse } = babel;
 
 function getPath(input, parserOpts = {}) {
   let targetPath;

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/util.skip-bundled.js
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/util.skip-bundled.js
@@ -1,5 +1,6 @@
-import { parseSync, traverse } from "@babel/core";
 import { shouldTransform } from "../lib/util.js";
+import babel from "@babel/core";
+const { parseSync, traverse } = babel;
 
 function getPath(input, parserOpts = {}) {
   let targetPath;

--- a/packages/babel-plugin-proposal-optional-chaining/test/util.skip-bundled.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/util.skip-bundled.js
@@ -1,5 +1,6 @@
 import { willPathCastToBoolean } from "../lib/util.js";
-import { parseSync, traverse } from "@babel/core";
+import babel from "@babel/core";
+const { parseSync, traverse } = babel;
 
 function getPath(input, parserOpts) {
   let targetPath;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `e2e-breaking` failure on `main`
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

https://github.com/babel/babel/pull/13966 accidentally introduced a performance regression by removing lazy requires from `@babel/core` and `@babel/cli`, because the first `@babel/transform-modules-commonjs` configuration was overwritten by the second one.
Rather than just reordering them I added an explicit `exclude`, so that it's more robust.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14028"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

