### PR TITLE
Remove usage of `--openssl-legacy-provider` in e2e tests

### DIFF
--- a/scripts/integration-tests/e2e-create-react-app.sh
+++ b/scripts/integration-tests/e2e-create-react-app.sh
@@ -40,11 +40,6 @@ do
   (cd "$d"; node "$bump_deps")
 done
 
-if [[ "$(node --version)" == v17.* ]]; then
-  # Remove this when https://github.com/webpack/webpack/issues/14532 is fixed
-  export NODE_OPTIONS=--openssl-legacy-provider
-fi
-
 startLocalRegistry "$PWD"/../../verdaccio-config.yml
 npm install
 

--- a/scripts/integration-tests/e2e-vue-cli.sh
+++ b/scripts/integration-tests/e2e-vue-cli.sh
@@ -30,11 +30,6 @@ node "$PWD"/../../utils/bump-babel-dependencies.js
 yarn lerna exec -- node "$PWD"/../../utils/bump-babel-dependencies.js
 yarn install --ignore-engines # Remove --ignore-engines when vue-cli upgrades their lockfile to eslint-import-resolver-webpack@0.13.2
 
-if [[ "$(node --version)" == v17.* ]]; then
-  # Remove this when https://github.com/webpack/webpack/issues/14532 is fixed
-  export NODE_OPTIONS=--openssl-legacy-provider
-fi
-
 # Test
 CI=true yarn test -p babel,babel-preset-app
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Maybe this works; the linked webpack bug has been fixed.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14031"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

