### PR TITLE
Fix: default rest argument array elements as undefined

### DIFF
--- a/packages/babel-plugin-transform-parameters/src/rest.ts
+++ b/packages/babel-plugin-transform-parameters/src/rest.ts
@@ -1,12 +1,8 @@
 import { template, types as t } from "@babel/core";
 
 const buildRest = template(`
-  for (var LEN = ARGUMENTS.length,
-           ARRAY = new Array(ARRAY_LEN),
-           KEY = START;
-       KEY < LEN;
-       KEY++) {
-    ARRAY[ARRAY_KEY] = ARGUMENTS[KEY];
+  for (var ARGS = ARGUMENTS, LEN = ARGS.length, ARRAY = new Array(ARRAY_LEN), KEY = START; KEY < LEN; KEY++) {
+    ARRAY[ARRAY_KEY] = ARGS[KEY];
   }
 `);
 
@@ -334,7 +330,10 @@ export default function convertFunctionRest(path) {
     arrLen = t.identifier(len.name);
   }
 
+  const args = scope.generateUidIdentifier("args");
+
   const loop = buildRest({
+    ARGS: args,
     ARGUMENTS: argsId,
     ARRAY_KEY: arrKey,
     ARRAY_LEN: arrLen,

--- a/packages/babel-plugin-transform-parameters/test/fixtures/assumption-ignoreFunctionLength/destructuring-rest/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/assumption-ignoreFunctionLength/destructuring-rest/output.js
@@ -7,8 +7,8 @@ function t(x, _ref) {
   var a = _ref.a,
       b = _ref.b;
 
-  for (var _len = arguments.length, args = new Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-    args[_key - 2] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, args = new Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+    args[_key - 2] = _args[_key];
   }
 
   console.log(x, a, b, args);

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-arguments/exec.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-arguments/exec.js
@@ -1,0 +1,4 @@
+function func(...arguments) {
+    return arguments;
+}
+expect(func(1, 2, 3)).toStrictEqual([1, 2, 3])

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-arguments/input.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-arguments/input.js
@@ -1,0 +1,4 @@
+function func(...arguments) {
+    console.log(arguments); // [1, 2, 3]
+}
+func(1, 2, 3);

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-arguments/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-arguments/output.js
@@ -1,0 +1,9 @@
+function func() {
+  for (var _args = arguments, _len = _args.length, arguments = new Array(_len), _key = 0; _key < _len; _key++) {
+    arguments[_key] = _args[_key];
+  }
+
+  console.log(arguments); // [1, 2, 3]
+}
+
+func(1, 2, 3);

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-rest/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-rest/output.js
@@ -17,8 +17,8 @@ rest2(undefined, 2);
 function rest3() {
   var b = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : a;
 
-  for (var _len = arguments.length, a = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-    a[_key - 1] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, a = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    a[_key - 1] = _args[_key];
   }
 
   expect(a).toHaveLength(1);

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/destructuring-rest/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/destructuring-rest/output.js
@@ -6,8 +6,8 @@ function t() {
       a = _ref.a,
       b = _ref.b;
 
-  for (var _len = arguments.length, args = new Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-    args[_key - 2] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, args = new Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+    args[_key - 2] = _args[_key];
   }
 
   console.log(x, a, b, args);

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/regression-4333/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/regression-4333/output.js
@@ -1,8 +1,8 @@
 var args = 'bar';
 
 function foo() {
-  for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
-    args[_key] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+    args[_key] = _args[_key];
   }
 
   return args;

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/regression-4634/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/regression-4634/output.js
@@ -1,6 +1,6 @@
 let oneOf = function () {
-  for (var _len = arguments.length, nodes = new Array(_len), _key = 0; _key < _len; _key++) {
-    nodes[_key] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, nodes = new Array(_len), _key = 0; _key < _len; _key++) {
+    nodes[_key] = _args[_key];
   }
 
   if (nodes.length === 1) {

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-arguments-deoptimisation/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-arguments-deoptimisation/output.js
@@ -1,6 +1,6 @@
 function x() {
-  for (var _len = arguments.length, rest = new Array(_len), _key = 0; _key < _len; _key++) {
-    rest[_key] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, rest = new Array(_len), _key = 0; _key < _len; _key++) {
+    rest[_key] = _args[_key];
   }
 
   arguments;

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-arrow-functions/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-arrow-functions/output.js
@@ -24,8 +24,8 @@ var somefun = function () {
 };
 
 function demo1() {
-  for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
-    args[_key] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+    args[_key] = _args[_key];
   }
 
   return function (i) {
@@ -36,8 +36,8 @@ function demo1() {
 var x = function () {
   if (noNeedToWork) return 0;
 
-  for (var _len2 = arguments.length, rest = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
-    rest[_key2] = arguments[_key2];
+  for (var _args2 = arguments, _len2 = _args2.length, rest = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+    rest[_key2] = _args2[_key2];
   }
 
   return rest;
@@ -46,8 +46,8 @@ var x = function () {
 var innerclassproperties = function () {
   var _class, _temp;
 
-  for (var _len3 = arguments.length, args = new Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
-    args[_key3] = arguments[_key3];
+  for (var _args3 = arguments, _len3 = _args3.length, args = new Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
+    args[_key3] = _args3[_key3];
   }
 
   return _temp = _class = function _class() {

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-async-arrow-functions/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-async-arrow-functions/output.js
@@ -13,8 +13,8 @@ var x = /*#__PURE__*/function () {
   var _ref2 = babelHelpers.asyncToGenerator(function* () {
     if (noNeedToWork) return 0;
 
-    for (var _len = arguments.length, rest = new Array(_len), _key = 0; _key < _len; _key++) {
-      rest[_key] = arguments[_key];
+    for (var _args = arguments, _len = _args.length, rest = new Array(_len), _key = 0; _key < _len; _key++) {
+      rest[_key] = _args[_key];
     }
 
     return rest;

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-binding-deoptimisation/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-binding-deoptimisation/output.js
@@ -1,6 +1,6 @@
 var deepAssign = function () {
-  for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
-    args[_key] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+    args[_key] = _args[_key];
   }
 
   return args = [];

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-deepest-common-ancestor-earliest-child/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-deepest-common-ancestor-earliest-child/output.js
@@ -2,8 +2,8 @@
 function r() {
   if (noNeedToWork) return 0;
 
-  for (var _len = arguments.length, rest = new Array(_len), _key = 0; _key < _len; _key++) {
-    rest[_key] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, rest = new Array(_len), _key = 0; _key < _len; _key++) {
+    rest[_key] = _args[_key];
   }
 
   return rest;
@@ -13,8 +13,8 @@ function r() {
 function r() {
   if (noNeedToWork) return 0;
 
-  for (var _len2 = arguments.length, rest = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
-    rest[_key2] = arguments[_key2];
+  for (var _args2 = arguments, _len2 = _args2.length, rest = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+    rest[_key2] = _args2[_key2];
   }
 
   rest;
@@ -25,8 +25,8 @@ function r() {
 function r() {
   if (noNeedToWork) return 0;
 
-  for (var _len3 = arguments.length, rest = new Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
-    rest[_key3] = arguments[_key3];
+  for (var _args3 = arguments, _len3 = _args3.length, rest = new Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
+    rest[_key3] = _args3[_key3];
   }
 
   if (true) {
@@ -39,8 +39,8 @@ function r() {
 
 function r() {
   if (true) {
-    for (var _len4 = arguments.length, rest = new Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
-      rest[_key4] = arguments[_key4];
+    for (var _args4 = arguments, _len4 = _args4.length, rest = new Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
+      rest[_key4] = _args4[_key4];
     }
 
     if (true) {
@@ -55,8 +55,8 @@ function r() {
 function r() {
   if (noNeedToWork) return 0;
 
-  for (var _len5 = arguments.length, rest = new Array(_len5), _key5 = 0; _key5 < _len5; _key5++) {
-    rest[_key5] = arguments[_key5];
+  for (var _args5 = arguments, _len5 = _args5.length, rest = new Array(_len5), _key5 = 0; _key5 < _len5; _key5++) {
+    rest[_key5] = _args5[_key5];
   }
 
   if (lol) rest;
@@ -65,8 +65,8 @@ function r() {
 
 
 function a() {
-  for (var _len6 = arguments.length, args = new Array(_len6), _key6 = 0; _key6 < _len6; _key6++) {
-    args[_key6] = arguments[_key6];
+  for (var _args6 = arguments, _len6 = _args6.length, args = new Array(_len6), _key6 = 0; _key6 < _len6; _key6++) {
+    args[_key6] = _args6[_key6];
   }
 
   return function () {
@@ -78,8 +78,8 @@ function a() {
 
 
 function runQueue(queue) {
-  for (var _len7 = arguments.length, args = new Array(_len7 > 1 ? _len7 - 1 : 0), _key7 = 1; _key7 < _len7; _key7++) {
-    args[_key7 - 1] = arguments[_key7];
+  for (var _args7 = arguments, _len7 = _args7.length, args = new Array(_len7 > 1 ? _len7 - 1 : 0), _key7 = 1; _key7 < _len7; _key7++) {
+    args[_key7 - 1] = _args7[_key7];
   }
 
   for (var i = 0; i < queue.length; i++) {
@@ -90,8 +90,8 @@ function runQueue(queue) {
 
 function runQueue(queue) {
   if (foo) {
-    for (var _len8 = arguments.length, args = new Array(_len8 > 1 ? _len8 - 1 : 0), _key8 = 1; _key8 < _len8; _key8++) {
-      args[_key8 - 1] = arguments[_key8];
+    for (var _args8 = arguments, _len8 = _args8.length, args = new Array(_len8 > 1 ? _len8 - 1 : 0), _key8 = 1; _key8 < _len8; _key8++) {
+      args[_key8 - 1] = _args8[_key8];
     }
 
     for (var i = 0; i < queue.length; i++) {
@@ -103,8 +103,8 @@ function runQueue(queue) {
 function r() {
   if (noNeedToWork) return 0;
 
-  for (var _len9 = arguments.length, rest = new Array(_len9), _key9 = 0; _key9 < _len9; _key9++) {
-    rest[_key9] = arguments[_key9];
+  for (var _args9 = arguments, _len9 = _args9.length, rest = new Array(_len9), _key9 = 0; _key9 < _len9; _key9++) {
+    rest[_key9] = _args9[_key9];
   }
 
   var _x = x;

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-length/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-length/output.js
@@ -6,8 +6,8 @@ var t = function (f) {
 };
 
 function t(f) {
-  for (var _len = arguments.length, items = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-    items[_key - 1] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, items = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    items[_key - 1] = _args[_key];
   }
 
   items;

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/output.js
@@ -1,6 +1,6 @@
 var x = function (foo) {
-  for (var _len = arguments.length, bar = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-    bar[_key - 1] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, bar = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    bar[_key - 1] = _args[_key];
   }
 
   console.log(bar);
@@ -13,8 +13,8 @@ var y = function (foo) {
 };
 
 var b = function (x, y) {
-  for (var _len2 = arguments.length, args = new Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
-    args[_key2 - 2] = arguments[_key2];
+  for (var _args2 = arguments, _len2 = _args2.length, args = new Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+    args[_key2 - 2] = _args2[_key2];
   }
 
   console.log(args[0]);
@@ -23,8 +23,8 @@ var b = function (x, y) {
 };
 
 var z = function (foo) {
-  for (var _len3 = arguments.length, bar = new Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
-    bar[_key3 - 1] = arguments[_key3];
+  for (var _args3 = arguments, _len3 = _args3.length, bar = new Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
+    bar[_key3 - 1] = _args3[_key3];
   }
 
   var x = function () {
@@ -33,8 +33,8 @@ var z = function (foo) {
 };
 
 var a = function (foo) {
-  for (var _len4 = arguments.length, bar = new Array(_len4 > 1 ? _len4 - 1 : 0), _key4 = 1; _key4 < _len4; _key4++) {
-    bar[_key4 - 1] = arguments[_key4];
+  for (var _args4 = arguments, _len4 = _args4.length, bar = new Array(_len4 > 1 ? _len4 - 1 : 0), _key4 = 1; _key4 < _len4; _key4++) {
+    bar[_key4 - 1] = _args4[_key4];
   }
 
   return bar.join(",");
@@ -43,16 +43,16 @@ var a = function (foo) {
 var b = function (foo) {
   var join = "join";
 
-  for (var _len5 = arguments.length, bar = new Array(_len5 > 1 ? _len5 - 1 : 0), _key5 = 1; _key5 < _len5; _key5++) {
-    bar[_key5 - 1] = arguments[_key5];
+  for (var _args5 = arguments, _len5 = _args5.length, bar = new Array(_len5 > 1 ? _len5 - 1 : 0), _key5 = 1; _key5 < _len5; _key5++) {
+    bar[_key5 - 1] = _args5[_key5];
   }
 
   return bar[join];
 };
 
 var b = function () {
-  for (var _len6 = arguments.length, bar = new Array(_len6), _key6 = 0; _key6 < _len6; _key6++) {
-    bar[_key6] = arguments[_key6];
+  for (var _args6 = arguments, _len6 = _args6.length, bar = new Array(_len6), _key6 = 0; _key6 < _len6; _key6++) {
+    bar[_key6] = _args6[_key6];
   }
 
   return bar.len;
@@ -67,16 +67,16 @@ var b = function (foo, baz) {
 };
 
 function x() {
-  for (var _len7 = arguments.length, rest = new Array(_len7), _key7 = 0; _key7 < _len7; _key7++) {
-    rest[_key7] = arguments[_key7];
+  for (var _args7 = arguments, _len7 = _args7.length, rest = new Array(_len7), _key7 = 0; _key7 < _len7; _key7++) {
+    rest[_key7] = _args7[_key7];
   }
 
   rest[0] = 0;
 }
 
 function swap() {
-  for (var _len8 = arguments.length, rest = new Array(_len8), _key8 = 0; _key8 < _len8; _key8++) {
-    rest[_key8] = arguments[_key8];
+  for (var _args8 = arguments, _len8 = _args8.length, rest = new Array(_len8), _key8 = 0; _key8 < _len8; _key8++) {
+    rest[_key8] = _args8[_key8];
   }
 
   var _ref = [rest[1], rest[0]];
@@ -85,8 +85,8 @@ function swap() {
 }
 
 function forIn() {
-  for (var _len9 = arguments.length, rest = new Array(_len9), _key9 = 0; _key9 < _len9; _key9++) {
-    rest[_key9] = arguments[_key9];
+  for (var _args9 = arguments, _len9 = _args9.length, rest = new Array(_len9), _key9 = 0; _key9 < _len9; _key9++) {
+    rest[_key9] = _args9[_key9];
   }
 
   for (rest[0] in this) {
@@ -95,40 +95,40 @@ function forIn() {
 }
 
 function inc() {
-  for (var _len10 = arguments.length, rest = new Array(_len10), _key10 = 0; _key10 < _len10; _key10++) {
-    rest[_key10] = arguments[_key10];
+  for (var _args10 = arguments, _len10 = _args10.length, rest = new Array(_len10), _key10 = 0; _key10 < _len10; _key10++) {
+    rest[_key10] = _args10[_key10];
   }
 
   ++rest[0];
 }
 
 function dec() {
-  for (var _len11 = arguments.length, rest = new Array(_len11), _key11 = 0; _key11 < _len11; _key11++) {
-    rest[_key11] = arguments[_key11];
+  for (var _args11 = arguments, _len11 = _args11.length, rest = new Array(_len11), _key11 = 0; _key11 < _len11; _key11++) {
+    rest[_key11] = _args11[_key11];
   }
 
   --rest[0];
 }
 
 function del() {
-  for (var _len12 = arguments.length, rest = new Array(_len12), _key12 = 0; _key12 < _len12; _key12++) {
-    rest[_key12] = arguments[_key12];
+  for (var _args12 = arguments, _len12 = _args12.length, rest = new Array(_len12), _key12 = 0; _key12 < _len12; _key12++) {
+    rest[_key12] = _args12[_key12];
   }
 
   delete rest[0];
 }
 
 function method() {
-  for (var _len13 = arguments.length, rest = new Array(_len13), _key13 = 0; _key13 < _len13; _key13++) {
-    rest[_key13] = arguments[_key13];
+  for (var _args13 = arguments, _len13 = _args13.length, rest = new Array(_len13), _key13 = 0; _key13 < _len13; _key13++) {
+    rest[_key13] = _args13[_key13];
   }
 
   rest[0]();
 }
 
 function newExp() {
-  for (var _len14 = arguments.length, rest = new Array(_len14), _key14 = 0; _key14 < _len14; _key14++) {
-    rest[_key14] = arguments[_key14];
+  for (var _args14 = arguments, _len14 = _args14.length, rest = new Array(_len14), _key14 = 0; _key14 < _len14; _key14++) {
+    rest[_key14] = _args14[_key14];
   }
 
   new rest[0]();
@@ -137,8 +137,8 @@ function newExp() {
 
 
 function arrayDestructure() {
-  for (var _len15 = arguments.length, rest = new Array(_len15), _key15 = 0; _key15 < _len15; _key15++) {
-    rest[_key15] = arguments[_key15];
+  for (var _args15 = arguments, _len15 = _args15.length, rest = new Array(_len15), _key15 = 0; _key15 < _len15; _key15++) {
+    rest[_key15] = _args15[_key15];
   }
 
   var _x = x;
@@ -149,8 +149,8 @@ function arrayDestructure() {
 }
 
 function forOf() {
-  for (var _len16 = arguments.length, rest = new Array(_len16), _key16 = 0; _key16 < _len16; _key16++) {
-    rest[_key16] = arguments[_key16];
+  for (var _args16 = arguments, _len16 = _args16.length, rest = new Array(_len16), _key16 = 0; _key16 < _len16; _key16++) {
+    rest[_key16] = _args16[_key16];
   }
 
   var _iterator = babelHelpers.createForOfIteratorHelper(this),
@@ -169,16 +169,16 @@ function forOf() {
 }
 
 function postfixIncrement() {
-  for (var _len17 = arguments.length, rest = new Array(_len17), _key17 = 0; _key17 < _len17; _key17++) {
-    rest[_key17] = arguments[_key17];
+  for (var _args17 = arguments, _len17 = _args17.length, rest = new Array(_len17), _key17 = 0; _key17 < _len17; _key17++) {
+    rest[_key17] = _args17[_key17];
   }
 
   rest[0]++;
 }
 
 function postfixDecrement() {
-  for (var _len18 = arguments.length, rest = new Array(_len18), _key18 = 0; _key18 < _len18; _key18++) {
-    rest[_key18] = arguments[_key18];
+  for (var _args18 = arguments, _len18 = _args18.length, rest = new Array(_len18), _key18 = 0; _key18 < _len18; _key18++) {
+    rest[_key18] = _args18[_key18];
   }
 
   rest[0]--;

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-nested-iife/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-nested-iife/output.js
@@ -15,8 +15,8 @@ function broken(x) {
       return Foo;
     }(Bar);
 
-    for (var _len = arguments.length, foo = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-      foo[_key - 1] = arguments[_key];
+    for (var _args = arguments, _len = _args.length, foo = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      foo[_key - 1] = _args[_key];
     }
 
     return hello.apply(void 0, foo);

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-patterns/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-patterns/output.js
@@ -1,6 +1,6 @@
 function foo() {
-  for (var _len = arguments.length, _ref = new Array(_len), _key = 0; _key < _len; _key++) {
-    _ref[_key] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, _ref = new Array(_len), _key = 0; _key < _len; _key++) {
+    _ref[_key] = _args[_key];
   }
 
   var a = _ref[0];

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-spread-optimisation/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-spread-optimisation/output.js
@@ -5,24 +5,24 @@ function foo() {
 
 
 function foo(a) {
-  for (var _len = arguments.length, b = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-    b[_key - 1] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, b = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    b[_key - 1] = _args[_key];
   }
 
   foo.apply(void 0, b);
 }
 
 function foo() {
-  for (var _len2 = arguments.length, b = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
-    b[_key2] = arguments[_key2];
+  for (var _args2 = arguments, _len2 = _args2.length, b = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+    b[_key2] = _args2[_key2];
   }
 
   foo.apply(void 0, [1].concat(b));
 }
 
 function foo() {
-  for (var _len3 = arguments.length, args = new Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
-    args[_key3] = arguments[_key3];
+  for (var _args3 = arguments, _len3 = _args3.length, args = new Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
+    args[_key3] = _args3[_key3];
   }
 
   args.pop();

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-ts-this-parameter/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-ts-this-parameter/output.js
@@ -3,8 +3,8 @@ function u(this: Foo) {
 }
 
 function v(this: Foo, event: string) {
-  for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-    args[_key - 1] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    args[_key - 1] = _args[_key];
   }
 
   args;

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-var _args = babelHelpers.interopRequireDefault(require("utils/url/args"));
+var _args2 = babelHelpers.interopRequireDefault(require("utils/url/args"));
 
 var App = /*#__PURE__*/function (_Component) {
   babelHelpers.inherits(App, _Component);
@@ -17,8 +17,8 @@ var App = /*#__PURE__*/function (_Component) {
 
     babelHelpers.classCallCheck(this, App);
 
-    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
-      args[_key] = arguments[_key];
+    for (var _args = arguments, _len = _args.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = _args[_key];
     }
 
     _this = _super.call.apply(_super, [this].concat(args));
@@ -29,7 +29,7 @@ var App = /*#__PURE__*/function (_Component) {
   babelHelpers.createClass(App, [{
     key: "componentDidMount",
     value: function componentDidMount() {
-      this.exportType = _args["default"].get('type', window.location.href);
+      this.exportType = _args2["default"].get('type', window.location.href);
     }
   }]);
   return App;

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-simple/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-simple/output.js
@@ -1,8 +1,8 @@
 const a = 'bar';
 
 function foo() {
-  for (var _len = arguments.length, a = new Array(_len), _key = 0; _key < _len; _key++) {
-    a[_key] = arguments[_key];
+  for (var _args = arguments, _len = _args.length, a = new Array(_len), _key = 0; _key < _len; _key++) {
+    a[_key] = _args[_key];
   }
 
   return a;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13992 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Default rest argument array elements won't be undefined anymore, It will give the correct output as required from the arguments with rest, Because now we first memoize the arguments and then bind the arguments to some other array.