### PR TITLE
maintain estree string literal shape when cloned

### DIFF
--- a/packages/babel-parser/src/parser/node.js
+++ b/packages/babel-parser/src/parser/node.js
@@ -79,12 +79,17 @@ export function cloneStringLiteral(node: any): any {
     return clonePlaceholder(node);
   }
   const cloned = Object.create(NodePrototype);
-  cloned.type = "StringLiteral";
+  cloned.type = type;
   cloned.start = start;
   cloned.end = end;
   cloned.loc = loc;
   cloned.range = range;
-  cloned.extra = extra;
+  if (node.raw !== undefined) {
+    // estree set node.raw instead of node.extra
+    cloned.raw = node.raw;
+  } else {
+    cloned.extra = extra;
+  }
   cloned.value = node.value;
   return cloned;
 }

--- a/packages/babel-parser/test/fixtures/estree/module-string-names/mixed/options.json
+++ b/packages/babel-parser/test/fixtures/estree/module-string-names/mixed/options.json
@@ -1,3 +1,0 @@
-{
-  "sourceType": "module"
-}

--- a/packages/babel-parser/test/fixtures/estree/module-string-names/options.json
+++ b/packages/babel-parser/test/fixtures/estree/module-string-names/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["flow", "jsx", "estree"]
+}

--- a/packages/babel-parser/test/fixtures/estree/module-string-names/shorthand/input.js
+++ b/packages/babel-parser/test/fixtures/estree/module-string-names/shorthand/input.js
@@ -1,0 +1,1 @@
+export { "foo" } from "module-a";

--- a/packages/babel-parser/test/fixtures/estree/module-string-names/shorthand/output.json
+++ b/packages/babel-parser/test/fixtures/estree/module-string-names/shorthand/output.json
@@ -1,0 +1,42 @@
+{
+  "type": "File",
+  "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":33}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":33}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":33}},
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start":9,"end":14,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":14}},
+            "local": {
+              "type": "Literal",
+              "start":9,"end":14,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":14}},
+              "value": "foo",
+              "raw": "\"foo\""
+            },
+            "exported": {
+              "type": "Literal",
+              "start":9,"end":14,"loc":{"start":{"line":1,"column":9},"end":{"line":1,"column":14}},
+              "raw": "\"foo\"",
+              "value": "foo"
+            }
+          }
+        ],
+        "source": {
+          "type": "Literal",
+          "start":22,"end":32,"loc":{"start":{"line":1,"column":22},"end":{"line":1,"column":32}},
+          "value": "module-a",
+          "raw": "\"module-a\""
+        },
+        "declaration": null,
+        "exportKind": "value"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14037
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Override `cloneStringLiteral` to maintain ESTree string literal shape.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14039"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

