### PR TITLE
Pin `jest-worker` to `27.2.1` in CRA e2e tests

### DIFF
--- a/scripts/integration-tests/e2e-create-react-app.sh
+++ b/scripts/integration-tests/e2e-create-react-app.sh
@@ -57,10 +57,11 @@ node -e "
 "
 
 startLocalRegistry "$PWD"/../../verdaccio-config.yml
-npm install
 
 # Remove these when https://github.com/facebook/jest/pull/12128 is fixed
+npm install --ignore-scripts
 npx npm-force-resolutions
+
 npm install
 
 # Test

--- a/scripts/integration-tests/e2e-create-react-app.sh
+++ b/scripts/integration-tests/e2e-create-react-app.sh
@@ -45,7 +45,22 @@ if [[ "$(node --version)" == v17.* ]]; then
   export NODE_OPTIONS=--openssl-legacy-provider
 fi
 
+# Remove this when https://github.com/facebook/jest/pull/12128 is fixed
+node -e "
+  var pkg = require('./package.json');
+
+  pkg.resolutions = {
+    'jest-worker': '27.3.1'
+  };
+
+  fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2));
+"
+
 startLocalRegistry "$PWD"/../../verdaccio-config.yml
+npm install
+
+# Remove these when https://github.com/facebook/jest/pull/12128 is fixed
+npx npm-force-resolutions
 npm install
 
 # Test


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This should hopefully fix the failing e2e Babel 8 test. I also opened https://github.com/facebook/jest/pull/12128 to fix the regression in Jest (cc @SimenB, in case you missed that PR!), and https://github.com/nodejs/node/issues/41103 to propose completely removing the error.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14040"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

