### PR TITLE
Disable `test262` CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,38 +171,38 @@ workflows:
   build-standalone:
     jobs:
       - build-standalone
-  test262:
-    jobs:
-      - test262:
-          filters:
-            branches:
-              only:
-                - main
-                - next-8-dev
-                - next-8-rebased
-          context: babel-test262
-  test262-pr:
-    jobs:
-      - approve-test262-run:
-          type: approval
-          filters:
-            branches:
-              ignore:
-                - main
-                - master
-                - next-8-dev
-                - next-8-rebased
-      - test262:
-          requires:
-            - approve-test262-run
-          filters:
-            branches:
-              ignore:
-                - main
-                - master
-                - next-8-dev
-                - next-8-rebased
-          context: babel-test262
+  # test262:
+  #   jobs:
+  #     - test262:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - main
+  #               - next-8-dev
+  #               - next-8-rebased
+  #         context: babel-test262
+  # test262-pr:
+  #   jobs:
+  #     - approve-test262-run:
+  #         type: approval
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - main
+  #               - master
+  #               - next-8-dev
+  #               - next-8-rebased
+  #     - test262:
+  #         requires:
+  #           - approve-test262-run
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - main
+  #               - master
+  #               - next-8-dev
+  #               - next-8-rebased
+  #         context: babel-test262
 
   e2e-breaking:
     jobs:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Until we can run long CircleCI jobs again, this is just unnecessary CO2 consumption and unnecessary ❌s. I think I can try to migrate test262 to GH actions, but it will take a while.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14044"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

