### PR TITLE
fix: check preceding line break before exclamation

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2832,7 +2832,11 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       kind: "var" | "let" | "const",
     ): void {
       super.parseVarId(decl, kind);
-      if (decl.id.type === "Identifier" && this.eat(tt.bang)) {
+      if (
+        decl.id.type === "Identifier" &&
+        !this.hasPrecedingLineBreak() &&
+        this.eat(tt.bang)
+      ) {
         decl.definite = true;
       }
 

--- a/packages/babel-parser/test/fixtures/typescript/variable-declarator/definite-asi/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/variable-declarator/definite-asi/input.ts
@@ -1,0 +1,2 @@
+let x
+!function() {};

--- a/packages/babel-parser/test/fixtures/typescript/variable-declarator/definite-asi/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/variable-declarator/definite-asi/output.json
@@ -1,0 +1,54 @@
+{
+  "type": "File",
+  "start":0,"end":21,"loc":{"start":{"line":1,"column":0},"end":{"line":2,"column":15}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":21,"loc":{"start":{"line":1,"column":0},"end":{"line":2,"column":15}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":5,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":5}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":4,"end":5,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":5}},
+            "id": {
+              "type": "Identifier",
+              "start":4,"end":5,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":5},"identifierName":"x"},
+              "name": "x"
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "ExpressionStatement",
+        "start":6,"end":21,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":15}},
+        "expression": {
+          "type": "UnaryExpression",
+          "start":6,"end":20,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":14}},
+          "operator": "!",
+          "prefix": true,
+          "argument": {
+            "type": "FunctionExpression",
+            "start":7,"end":20,"loc":{"start":{"line":2,"column":1},"end":{"line":2,"column":14}},
+            "id": null,
+            "generator": false,
+            "async": false,
+            "params": [],
+            "body": {
+              "type": "BlockStatement",
+              "start":18,"end":20,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":14}},
+              "body": [],
+              "directives": []
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14045
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The variable declaration disallows preceding line breaks before exclamation marks. See also https://github.com/microsoft/TypeScript/blob/67872a50d071ced53c1be6a8c03c9c3610584b4c/src/compiler/parser.ts#L6567

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14049"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

