### PR TITLE
test: add prettier e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,14 @@ jobs:
           at: /tmp/verdaccio-workspace
       - run: BABEL_8_BREAKING=true ./scripts/integration-tests/e2e-jest.sh
 
+  e2e-breaking-prettier:
+    executor: node-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/verdaccio-workspace
+      - run: BABEL_8_BREAKING=true ./scripts/integration-tests/e2e-prettier.sh
+
 workflows:
   version: 2
   build-standalone:
@@ -243,5 +251,8 @@ workflows:
           requires:
             - publish-verdaccio-babel-8-breaking
       - e2e-breaking-jest:
+          requires:
+            - publish-verdaccio-babel-8-breaking
+      - e2e-breaking-prettier:
           requires:
             - publish-verdaccio-babel-8-breaking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,7 @@ jobs:
           - vue-cli
           - jest
           - react-native
+          - prettier
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -45,6 +45,6 @@ if [ "$BABEL_8_BREAKING" = true ] ; then
 fi
 
 # Only run js,jsx,misc format tests
-yarn test "tests/format/{js,jsx,misc}" --update-snapshot
+yarn test "tests/format/(jsx?|misc)" --update-snapshot
 
 cleanup

--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -44,7 +44,7 @@ if [ "$BABEL_8_BREAKING" = true ] ; then
   sed -i 's/allowDeclareFields: true,\?/\/* allowDeclareFields: true *\//g' babel.config.js
 fi
 
-# Only run js and jsx format tests
-yarn test "tests/format/jsx?"
+# Only run js,jsx,misc format tests
+yarn test "tests/format/{js,jsx,misc}" --update-snapshot
 
 cleanup

--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -15,16 +15,12 @@ source utils/cleanup.sh
 set -x
 
 # Clone prettier
-git clone --depth=1 https://github.com/prettier/prettier /tmp/prettier
-cd /tmp/prettier || exit
+git clone --depth=1 https://github.com/prettier/prettier tmp/prettier
+cd tmp/prettier || exit
 
 # Update @babel/* dependencies
 bump_deps="$root/utils/bump-babel-dependencies.js"
 node "$bump_deps"
-for d in ./packages/*/
-do
-  (cd "$d"; node "$bump_deps")
-done
 
 #==============================================================================#
 #                                 ENVIRONMENT                                  #
@@ -38,11 +34,6 @@ yarn --version
 
 startLocalRegistry "$root"/verdaccio-config.yml
 yarn install
-
-if [ "$BABEL_8_BREAKING" = true ] ; then
-  # This option is removed in Babel 8
-  sed -i 's/allowDeclareFields: true,\?/\/* allowDeclareFields: true *\//g' babel.config.js
-fi
 
 # Only run js,jsx,misc format tests
 yarn test "tests/format/(jsx?|misc)" --update-snapshot

--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+#==============================================================================#
+#                                  SETUP                                       #
+#==============================================================================#
+
+# Start in scripts/integration-tests/ even if run from root directory
+cd "$(dirname "$0")" || exit
+root="$PWD"
+
+source utils/local-registry.sh
+source utils/cleanup.sh
+
+# Echo every command being executed
+set -x
+
+# Clone prettier
+git clone --depth=1 https://github.com/prettier/prettier /tmp/prettier
+cd /tmp/prettier || exit
+
+# Update @babel/* dependencies
+bump_deps="$root/utils/bump-babel-dependencies.js"
+node "$bump_deps"
+for d in ./packages/*/
+do
+  (cd "$d"; node "$bump_deps")
+done
+
+#==============================================================================#
+#                                 ENVIRONMENT                                  #
+#==============================================================================#
+node -v
+yarn --version
+
+#==============================================================================#
+#                                   TEST                                       #
+#==============================================================================#
+
+startLocalRegistry "$root"/verdaccio-config.yml
+yarn install
+
+if [ "$BABEL_8_BREAKING" = true ] ; then
+  # This option is removed in Babel 8
+  sed -i 's/allowDeclareFields: true,\?/\/* allowDeclareFields: true *\//g' babel.config.js
+fi
+
+# Only run js and jsx format tests
+yarn test "tests/format/jsx?"
+
+cleanup

--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -32,10 +32,13 @@ yarn --version
 #                                   TEST                                       #
 #==============================================================================#
 
+# Don't use Yarn 2
+export YARN_IGNORE_PATH=1
+
 startLocalRegistry "$root"/verdaccio-config.yml
 yarn install
 
 # Only run js,jsx,misc format tests
-yarn test "tests/format/(jsx?|misc)" --update-snapshot
+yarn test "tests/format/(jsx?|misc)/" --update-snapshot
 
 cleanup

--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -39,6 +39,7 @@ startLocalRegistry "$root"/verdaccio-config.yml
 yarn install
 
 # Only run js,jsx,misc format tests
-yarn test "tests/format/(jsx?|misc)/" --update-snapshot
+# Without --runInBand CircleCI hangs.
+yarn test "tests/format/(jsx?|misc)/" --update-snapshot --runInBand
 
 cleanup


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Added prettier e2e test, which takes around 4mins on GitHub workflows.

For CI performance, only `jsx` and `js` format tests are executed. 

@fisker Please let me know if I miss any other tests related to the prettier-parser-babel.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14058"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

