### PR TITLE
Allow `$schema` property in json config files

### DIFF
--- a/packages/babel-core/src/config/files/configuration.ts
+++ b/packages/babel-core/src/config/files/configuration.ts
@@ -263,8 +263,6 @@ const readConfigJSON5 = makeStaticFileCache((filepath, content): ConfigFile => {
     throw err;
   }
 
-  delete options["$schema"];
-
   if (!options) throw new Error(`${filepath}: No config detected`);
 
   if (typeof options !== "object") {
@@ -273,6 +271,8 @@ const readConfigJSON5 = makeStaticFileCache((filepath, content): ConfigFile => {
   if (Array.isArray(options)) {
     throw new Error(`${filepath}: Expected config object but found array`);
   }
+
+  delete options["$schema"];
 
   return {
     filepath,

--- a/packages/babel-core/src/config/files/configuration.ts
+++ b/packages/babel-core/src/config/files/configuration.ts
@@ -263,6 +263,8 @@ const readConfigJSON5 = makeStaticFileCache((filepath, content): ConfigFile => {
     throw err;
   }
 
+  delete options["$schema"];
+
   if (!options) throw new Error(`${filepath}: No config detected`);
 
   if (typeof options !== "object") {

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -1343,5 +1343,19 @@ describe("buildConfigChain", function () {
         });
       }).toThrow(/Preset \/\* your preset \*\/ requires a filename/);
     });
+
+    it("should not throw error on $schema property in json config files", () => {
+      const filename = fixture(
+        "config-files",
+        "babel-config-json-$schema-property",
+        "babel.config.json",
+      );
+      expect(() => {
+        babel.loadPartialConfig({
+          filename,
+          cwd: path.dirname(filename),
+        });
+      }).not.toThrow();
+    });
   });
 });

--- a/packages/babel-core/test/fixtures/config/config-files/babel-config-json-$schema-property/babel.config.json
+++ b/packages/babel-core/test/fixtures/config/config-files/babel-config-json-$schema-property/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://json.schemastore.org/babelrc"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14038  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

$schema property will be deleted from json config files, while file is being read.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14067"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

