### PR TITLE
Fix derived classes in Chrome <= 36

### DIFF
--- a/packages/babel-helpers/src/helpers.ts
+++ b/packages/babel-helpers/src/helpers.ts
@@ -337,6 +337,7 @@ helpers.inherits = helper("7.0.0-beta.0")`
     }
     // We can't use defineProperty to set the prototype in a single step because it
     // doesn't work in Chrome <= 36. https://github.com/babel/babel/issues/14056
+    // V8 bug: https://bugs.chromium.org/p/v8/issues/detail?id=3334
     subClass.prototype = Object.create(superClass && superClass.prototype, {
       constructor: {
         value: subClass,

--- a/packages/babel-helpers/src/helpers.ts
+++ b/packages/babel-helpers/src/helpers.ts
@@ -335,16 +335,16 @@ helpers.inherits = helper("7.0.0-beta.0")`
     if (typeof superClass !== "function" && superClass !== null) {
       throw new TypeError("Super expression must either be null or a function");
     }
-    Object.defineProperty(subClass, "prototype", {
-      value: Object.create(superClass && superClass.prototype, {
-        constructor: {
-          value: subClass,
-          writable: true,
-          configurable: true
-        }
-      }),
-      writable: false,
+    // We can't use defineProperty to set the prototype in a single step because it
+    // doesn't work in Chrome <= 36. https://github.com/babel/babel/issues/14056
+    subClass.prototype = Object.create(superClass && superClass.prototype, {
+      constructor: {
+        value: subClass,
+        writable: true,
+        configurable: true
+      }
     });
+    Object.defineProperty(subClass, "prototype", { writable: false });
     if (superClass) setPrototypeOf(subClass, superClass);
   }
 `;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14056
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Unfortunately we don't have the infrastructure to run tests in real old browsers, so you can either trust me and @romainmenke that it works or you can download Chrome <= 36 and try it yourself! :sweat_smile: 

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14072"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

