### PR TITLE
Import the correct `./typeof.js` helper in `@babel/runtime`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,27 +28,33 @@ package-lock.json
 /packages/babel-runtime/helpers/*.js
 !/packages/babel-runtime/helpers/toArray.js
 !/packages/babel-runtime/helpers/iterableToArray.js
+!/packages/babel-runtime/helpers/possibleConstructorReturn.js
 !/packages/babel-runtime/helpers/temporalRef.js
 !/packages/babel-runtime/helpers/typeof.js
 /packages/babel-runtime/helpers/esm/*.js
 !/packages/babel-runtime/helpers/esm/toArray.js
 !/packages/babel-runtime/helpers/esm/iterableToArray.js
+!/packages/babel-runtime/helpers/esm/possibleConstructorReturn.js
 !/packages/babel-runtime/helpers/esm/temporalRef.js
 
 /packages/babel-runtime-corejs2/helpers/*.js
 !/packages/babel-runtime-corejs2/helpers/toArray.js
 !/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+!/packages/babel-runtime-corejs2/helpers/possibleConstructorReturn.js
 !/packages/babel-runtime-corejs2/helpers/temporalRef.js
 !/packages/babel-runtime-corejs2/helpers/typeof.js
 /packages/babel-runtime-corejs2/helpers/esm/*.js
 !/packages/babel-runtime-corejs2/helpers/esm/toArray.js
 !/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+!/packages/babel-runtime-corejs2/helpers/esm/possibleConstructorReturn.js
 !/packages/babel-runtime-corejs2/helpers/esm/temporalRef.js
 /packages/babel-runtime-corejs2/core-js/**/*.js
 !/packages/babel-runtime-corejs2/core-js/map.js
 
 /packages/babel-runtime-corejs3/helpers/*.js
+!/packages/babel-runtime-corejs3/helpers/possibleConstructorReturn.js
 /packages/babel-runtime-corejs3/helpers/esm/*.js
+!/packages/babel-runtime-corejs3/helpers/esm/possibleConstructorReturn.js
 /packages/babel-runtime-corejs3/core-js/**/*.js
 /packages/babel-runtime-corejs3/core-js-stable/**/*.js
 

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -259,15 +259,23 @@ function buildHelper(
 
 function buildRuntimeRewritePlugin(runtimeName, helperName) {
   /**
-   * rewrite helpers imports to runtime imports
+   * Rewrite helper imports to load the adequate module format version
    * @example
    * adjustImportPath(ast`"setPrototypeOf"`)
-   * // returns ast`"@babel/runtime/helpers/esm/setPrototypeOf"`
-   * @param {*} node The string literal contains import path
+   * // returns ast`"./setPrototypeOf"`
+   * @example
+   * adjustImportPath(ast`"@babel/runtime/helpers/typeof"`)
+   * // returns ast`"./typeof"`
+   * @param {*} node The string literal that contains the import path
    */
   function adjustImportPath(node) {
-    if (helpers.list.includes(node.value)) {
-      node.value = `./${node.value}.js`;
+    const helpersPath = path.join(runtimeName, "helpers");
+    const helper = node.value.startsWith(helpersPath)
+      ? path.basename(node.value)
+      : node.value;
+
+    if (helpers.list.includes(helper)) {
+      node.value = `./${helper}.js`;
     }
   }
 

--- a/packages/babel-runtime-corejs2/helpers/esm/possibleConstructorReturn.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/possibleConstructorReturn.js
@@ -1,0 +1,11 @@
+import _typeof from "./typeof.js";
+import assertThisInitialized from "./assertThisInitialized.js";
+export default function _possibleConstructorReturn(self, call) {
+  if (call && (_typeof(call) === "object" || typeof call === "function")) {
+    return call;
+  } else if (call !== void 0) {
+    throw new TypeError("Derived constructors may only return object or undefined");
+  }
+
+  return assertThisInitialized(self);
+}

--- a/packages/babel-runtime-corejs2/helpers/possibleConstructorReturn.js
+++ b/packages/babel-runtime-corejs2/helpers/possibleConstructorReturn.js
@@ -1,0 +1,15 @@
+var _typeof = require("./typeof.js")["default"];
+
+var assertThisInitialized = require("./assertThisInitialized.js");
+
+function _possibleConstructorReturn(self, call) {
+  if (call && (_typeof(call) === "object" || typeof call === "function")) {
+    return call;
+  } else if (call !== void 0) {
+    throw new TypeError("Derived constructors may only return object or undefined");
+  }
+
+  return assertThisInitialized(self);
+}
+
+module.exports = _possibleConstructorReturn, module.exports.__esModule = true, module.exports["default"] = module.exports;

--- a/packages/babel-runtime-corejs3/helpers/esm/possibleConstructorReturn.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/possibleConstructorReturn.js
@@ -1,0 +1,11 @@
+import _typeof from "./typeof.js";
+import assertThisInitialized from "./assertThisInitialized.js";
+export default function _possibleConstructorReturn(self, call) {
+  if (call && (_typeof(call) === "object" || typeof call === "function")) {
+    return call;
+  } else if (call !== void 0) {
+    throw new TypeError("Derived constructors may only return object or undefined");
+  }
+
+  return assertThisInitialized(self);
+}

--- a/packages/babel-runtime-corejs3/helpers/possibleConstructorReturn.js
+++ b/packages/babel-runtime-corejs3/helpers/possibleConstructorReturn.js
@@ -1,0 +1,15 @@
+var _typeof = require("./typeof.js")["default"];
+
+var assertThisInitialized = require("./assertThisInitialized.js");
+
+function _possibleConstructorReturn(self, call) {
+  if (call && (_typeof(call) === "object" || typeof call === "function")) {
+    return call;
+  } else if (call !== void 0) {
+    throw new TypeError("Derived constructors may only return object or undefined");
+  }
+
+  return assertThisInitialized(self);
+}
+
+module.exports = _possibleConstructorReturn, module.exports.__esModule = true, module.exports["default"] = module.exports;

--- a/packages/babel-runtime/helpers/esm/possibleConstructorReturn.js
+++ b/packages/babel-runtime/helpers/esm/possibleConstructorReturn.js
@@ -1,0 +1,11 @@
+import _typeof from "./typeof.js";
+import assertThisInitialized from "./assertThisInitialized.js";
+export default function _possibleConstructorReturn(self, call) {
+  if (call && (_typeof(call) === "object" || typeof call === "function")) {
+    return call;
+  } else if (call !== void 0) {
+    throw new TypeError("Derived constructors may only return object or undefined");
+  }
+
+  return assertThisInitialized(self);
+}

--- a/packages/babel-runtime/helpers/possibleConstructorReturn.js
+++ b/packages/babel-runtime/helpers/possibleConstructorReturn.js
@@ -1,0 +1,15 @@
+var _typeof = require("./typeof.js")["default"];
+
+var assertThisInitialized = require("./assertThisInitialized.js");
+
+function _possibleConstructorReturn(self, call) {
+  if (call && (_typeof(call) === "object" || typeof call === "function")) {
+    return call;
+  } else if (call !== void 0) {
+    throw new TypeError("Derived constructors may only return object or undefined");
+  }
+
+  return assertThisInitialized(self);
+}
+
+module.exports = _possibleConstructorReturn, module.exports.__esModule = true, module.exports["default"] = module.exports;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes [#13786](https://github.com/babel/babel/issues/13786)
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | No
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

**Context**

When a helper depends on another helper which is not explicitly imported (see code snippet below), the `babel-plugin-transform-runtime` will inject the helper at the top but it will not inject it in the proper module format version.

Let's take the `possibleConstructorReturn` as an example. The helper itself does not "explicitly" depend on `typeof`:
https://github.com/babel/babel/blob/89cab4311ce6dea0090d5819a721a1269765d6ec/packages/babel-helpers/src/helpers.ts#L618-L630

When building `possibleConstructorReturn` ([build-dist#247](https://github.com/babel/babel/blob/89cab4311ce6dea0090d5819a721a1269765d6ec/packages/babel-plugin-transform-runtime/scripts/build-dist.js#L246-L249)) the `babel-plugin-transform-runtime` plugin will run over it and inject the unimported `typeof` at the very top as follows:

```diff
+ import _typeof from "@babel/runtime/helpers/typeof";
import assertThisInitialized from "./assertThisInitialized.js";
```

The issue is that the injected module format is CJS instead of being picked up by the context. The desired output should be the following:

```diff
- import _typeof from "@babel/runtime/helpers/typeof";
+ import _typeof from "./typeof.js";
import assertThisInitialized from "./assertThisInitialized.js";
```

**The solution**
To fix the issue I updated the [adjustImportPath](https://github.com/babel/babel/blob/89cab4311ce6dea0090d5819a721a1269765d6ec/packages/babel-plugin-transform-runtime/scripts/build-dist.js#L268) function to rewrite the imports generated from the `babel-plugin-transform-runtime` as relative path imports.

I realize that this PR is just patching the problem rather than making the transform runtime plugin import the proper module format in the first place. Doing that, however, would require us to do some rethinking of the build-dist file, which considering the issue was marked as "good first issue", I deemed it was out of scope. Let me know if I should proceed otherwise.

**Testing**
~Guidance on testing the `build-dist` file is appreciated.~
Updated: Commited the helper generated code to avoid regressions.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14081"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

