### PR TITLE
Always print directives with double quotes when minified

### DIFF
--- a/packages/babel-generator/src/generators/base.ts
+++ b/packages/babel-generator/src/generators/base.ts
@@ -58,7 +58,7 @@ const unescapedDoubleQuoteRE = /(?:^|[^\\])(?:\\\\)*"/;
 
 export function DirectiveLiteral(this: Printer, node: t.DirectiveLiteral) {
   const raw = this.getPossibleRaw(node);
-  if (raw != null) {
+  if (!this.format.minified && raw != null) {
     this.token(raw);
     return;
   }

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -548,6 +548,20 @@ describe("programmatic generation", function () {
         generate(directive);
       }).toThrow();
     });
+
+    it("preserves single quotes if not minified", function () {
+      const directive = parse("'use strict';").program.directives[0];
+      const output = generate(directive).code;
+
+      expect(output).toBe("'use strict';");
+    });
+
+    it("converts single quotes to double quotes if minified", function () {
+      const directive = parse("'use strict';").program.directives[0];
+      const output = generate(directive, { minified: true }).code;
+
+      expect(output).toBe('"use strict";');
+    });
   });
 
   describe("typescript generate parentheses if necessary", function () {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | n/a
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

@babel/generator outputs all strings with double quotes when `minified` option is enabled - presumably because it gzips better with consistent quotes.

This PR makes generator do the same for directives.

```js
generate( parse("'use strict';").program.directives[0], { minified: true } ).code
```

Result before: `'use strict';`
Result after: `"use strict";`


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14094"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

