### PR TITLE
fix: forward stop signal to parent path

### DIFF
--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -77,22 +77,33 @@ traverse.cheap = function (node, enter) {
   return traverseFast(node, enter);
 };
 
+/**
+ * Traverse the children of given node
+ * @param {Node} node
+ * @param {TraverseOptions} opts The traverse options used to create a new traversal context
+ * @param {scope} scope A traversal scope used to create a new traversal context. When opts.noScope is true, scope should not be provided
+ * @param {any} state A user data storage provided as the second callback argument for traversal visitors
+ * @param {NodePath} path A NodePath of given node
+ * @param {string[]} skipKeys A list of key names that should be skipped during traversal. The skipKeys are applied to every descendants
+ *
+ * @note This function does not visit the given `node`.
+ */
 traverse.node = function (
   node: t.Node,
   opts: TraverseOptions,
   scope?: Scope,
   state?: any,
-  parentPath?: NodePath,
-  skipKeys?,
+  path?: NodePath,
+  skipKeys?: string[],
 ) {
   const keys = VISITOR_KEYS[node.type];
   if (!keys) return;
 
-  const context = new TraversalContext(scope, opts, state, parentPath);
+  const context = new TraversalContext(scope, opts, state, path);
   for (const key of keys) {
     if (skipKeys && skipKeys[key]) continue;
     if (context.visit(node, key)) {
-      parentPath?.stop();
+      path?.stop();
       return;
     }
   }

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -91,7 +91,10 @@ traverse.node = function (
   const context = new TraversalContext(scope, opts, state, parentPath);
   for (const key of keys) {
     if (skipKeys && skipKeys[key]) continue;
-    if (context.visit(node, key)) return;
+    if (context.visit(node, key)) {
+      parentPath?.stop();
+      return;
+    }
   }
 };
 

--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -1,6 +1,6 @@
 // This file contains methods responsible for maintaining a TraversalContext.
 
-import traverse from "../index";
+import { traverseNode } from "../traverse-node";
 import { SHOULD_SKIP, SHOULD_STOP } from "./index";
 import type TraversalContext from "../context";
 import type NodePath from "./index";
@@ -95,7 +95,7 @@ export function visit(this: NodePath): boolean {
   restoreContext(this, currentContext);
 
   this.debug("Recursing into...");
-  traverse.node(
+  this.shouldStop = traverseNode(
     this.node,
     this.opts,
     this.scope,

--- a/packages/babel-traverse/src/traverse-node.ts
+++ b/packages/babel-traverse/src/traverse-node.ts
@@ -1,6 +1,8 @@
 import TraversalContext from "./context";
 import type { TraverseOptions } from "./index";
 import type NodePath from "./path";
+import type Scope from "./scope";
+import type * as t from "@babel/types";
 import { VISITOR_KEYS } from "@babel/types";
 
 /**

--- a/packages/babel-traverse/src/traverse-node.ts
+++ b/packages/babel-traverse/src/traverse-node.ts
@@ -1,0 +1,38 @@
+import TraversalContext from "./context";
+import type { TraverseOptions } from "./index";
+import type NodePath from "./path";
+import { VISITOR_KEYS } from "@babel/types";
+
+/**
+ * Traverse the children of given node
+ * @param {Node} node
+ * @param {TraverseOptions} opts The traverse options used to create a new traversal context
+ * @param {scope} scope A traversal scope used to create a new traversal context. When opts.noScope is true, scope should not be provided
+ * @param {any} state A user data storage provided as the second callback argument for traversal visitors
+ * @param {NodePath} path A NodePath of given node
+ * @param {string[]} skipKeys A list of key names that should be skipped during traversal. The skipKeys are applied to every descendants
+ * @returns {boolean} Whether the traversal stops early
+
+ * @note This function does not visit the given `node`.
+ */
+export function traverseNode(
+  node: t.Node,
+  opts: TraverseOptions,
+  scope?: Scope,
+  state?: any,
+  path?: NodePath,
+  skipKeys?: string[],
+): boolean {
+  const keys = VISITOR_KEYS[node.type];
+  if (!keys) return false;
+
+  const context = new TraversalContext(scope, opts, state, path);
+  for (const key of keys) {
+    if (skipKeys && skipKeys[key]) continue;
+    if (context.visit(node, key)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -277,4 +277,20 @@ describe("traverse", function () {
       expect(blockStatementVisitedCounter).toBe(1);
     });
   });
+  describe("path.stop()", () => {
+    it("should stop the traversal when a grand child is stopped", () => {
+      const ast = parse("f;g;");
+
+      let visitedCounter = 0;
+      traverse(ast, {
+        noScope: true,
+        Identifier(path) {
+          visitedCounter += 1;
+          path.stop();
+        },
+      });
+
+      expect(visitedCounter).toBe(1);
+    });
+  });
 });

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -313,5 +313,28 @@ describe("traverse", function () {
 
       expect(visitedCounter).toBe(2);
     });
+
+    it("should not affect root traversal", () => {
+      const ast = parse("f;g;");
+
+      let visitedCounter = 0;
+      let programShouldStop;
+      traverse(ast, {
+        noScope: true,
+        Program(path) {
+          path.traverse({
+            noScope: true,
+            Identifier(path) {
+              visitedCounter += 1;
+              path.stop();
+            },
+          });
+          programShouldStop = path.shouldStop;
+        },
+      });
+
+      expect(visitedCounter).toBe(1);
+      expect(programShouldStop).toBe(false);
+    });
   });
 });

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -292,5 +292,26 @@ describe("traverse", function () {
 
       expect(visitedCounter).toBe(1);
     });
+
+    it("can be reverted in the exit listener of the parent whose child is stopped", () => {
+      const ast = parse("f;g;");
+
+      let visitedCounter = 0;
+      traverse(ast, {
+        noScope: true,
+        Identifier(path) {
+          visitedCounter += 1;
+          path.stop();
+        },
+        ExpressionStatement: {
+          exit(path) {
+            path.shouldStop = false;
+            path.shouldSkip = false;
+          },
+        },
+      });
+
+      expect(visitedCounter).toBe(2);
+    });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14099 
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we extract `traverse.node` into a new routine `traverseNode` that returns whether the traversal stops early. Because `traverse.node` is an API, `traverse.node` now calls `traverseNode` but returns `undefined` conditionally. `path.visit()` now calls `traverseNode` and set `.shouldStop` accordingly when the traversal is requested to stop.

For example,

```js
f;g;
```

has AST
```
Program - ExpressionStatement (f;) - Identifier (f)
        - ExpressionStatement (g;) - Identifier (g)
```

when an Identifier visitor requests to stop by calling `path.stop()`, the signal is not forwarded to `ExpressionStatement[]` queue visitor because we simply called `traverse.node()` which lost track of whether the traversal stopped gracefully, so the root traversal continues to `g;`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14105"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

