### PR TITLE
Respect `package.json#exports` when resolving plugins

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -22,6 +22,7 @@ packages/babel-preset-env/test/debug-fixtures
 packages/babel-standalone/babel.js
 packages/babel-standalone/babel.min.js
 packages/babel-parser/test/expressions
+packages/babel-core/src/vendor
 
 eslint/*/lib
 eslint/*/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ package-lock.json
 
 /packages/babel-compat-data/build
 
+/packages/babel-core/src/vendor/*.js
+/packages/babel-core/src/vendor/*.ts
+
 /packages/babel-runtime/helpers/*.js
 !/packages/babel-runtime/helpers/toArray.js
 !/packages/babel-runtime/helpers/iterableToArray.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ package.json
 packages/babel-preset-env/data
 packages/babel-compat-data/data
 packages/babel-compat-data/scripts/data/overlapping-plugins.js
+packages/babel-core/src/vendor
 packages/*/test/fixtures/**/input.*
 packages/*/test/fixtures/**/exec.*
 packages/*/test/fixtures/**/output.*

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "gulp-filter": "^7.0.0",
     "gulp-plumber": "^1.2.1",
     "husky": "^7.0.4",
+    "import-meta-resolve": "^1.1.1",
     "jest": "^27.4.0",
     "jest-worker": "^27.4.0",
     "lint-staged": "^9.2.0",

--- a/packages/babel-core/src/config/files/import-meta-resolve.ts
+++ b/packages/babel-core/src/config/files/import-meta-resolve.ts
@@ -1,0 +1,26 @@
+import { createRequire } from "module";
+import { resolve as polyfill } from "../../vendor/import-meta-resolve";
+
+const require = createRequire(import.meta.url);
+
+let import_;
+try {
+  // Node < 13.3 doesn't support import() syntax.
+  import_ = require("./import").default;
+} catch {}
+
+// import.meta.resolve is only available in ESM, but this file is compiled to CJS.
+// We can extract ir using dynamic import.
+const resolveP = import_
+  ? import_("data:text/javascript,export default import.meta.resolve").then(
+      // Since import.meta.resolve is unstable and only available when
+      // using the --experimental-import-meta-resolve flag, we almost
+      // always use the polyfill for now.
+      m => m.default || polyfill,
+      () => polyfill,
+    )
+  : Promise.resolve(polyfill);
+
+export default function getImportMetaResolve(): Promise<ImportMeta["resolve"]> {
+  return resolveP;
+}

--- a/packages/babel-core/src/config/files/import-meta-resolve.ts
+++ b/packages/babel-core/src/config/files/import-meta-resolve.ts
@@ -11,15 +11,31 @@ try {
 
 // import.meta.resolve is only available in ESM, but this file is compiled to CJS.
 // We can extract ir using dynamic import.
-const resolveP = import_
-  ? import_("data:text/javascript,export default import.meta.resolve").then(
-      // Since import.meta.resolve is unstable and only available when
-      // using the --experimental-import-meta-resolve flag, we almost
-      // always use the polyfill for now.
-      m => m.default || polyfill,
-      () => polyfill,
-    )
-  : Promise.resolve(polyfill);
+const resolveP =
+  import_ &&
+  // Due to a Node.js/V8 bug (https://github.com/nodejs/node/issues/35889), we cannot
+  // use dynamic import when running in the default Jest environment because it
+  // uses vm.SourceTextModule.
+  // Jest defines globalThis["jest-symbol-do-not-touch"] in
+  // https://github.com/facebook/jest/blob/11d79ec096a25851124356095d60352f6ca2824e/packages/jest-util/src/installCommonGlobals.ts#L49
+  // which is called by
+  // https://github.com/facebook/jest/blob/11d79ec096a25851124356095d60352f6ca2824e/packages/jest-environment-node/src/index.ts#L85
+  //
+  // Note that our Jest runner doesn't have this problem, because it runs ESM in the default
+  // Node.js context rather than using the `vm` module.
+  //
+  // When V8 fixes this bug, we can remove this check. We usually don't have package-specific hacks,
+  // but Jest is a big Babel consumer widely used in the community and they cannot workaround
+  // this problem on their side.
+  !Object.hasOwnProperty.call(global, "jest-symbol-do-not-touch")
+    ? import_("data:text/javascript,export default import.meta.resolve").then(
+        // Since import.meta.resolve is unstable and only available when
+        // using the --experimental-import-meta-resolve flag, we almost
+        // always use the polyfill for now.
+        m => m.default || polyfill,
+        () => polyfill,
+      )
+    : Promise.resolve(polyfill);
 
 export default function getImportMetaResolve(): Promise<ImportMeta["resolve"]> {
   return resolveP;

--- a/packages/babel-core/src/config/files/index.ts
+++ b/packages/babel-core/src/config/files/index.ts
@@ -21,9 +21,10 @@ export type {
   RelativeConfig,
   FilePackageData,
 } from "./types";
-export {
-  resolvePlugin,
-  resolvePreset,
-  loadPlugin,
-  loadPreset,
-} from "./plugins";
+export { loadPlugin, loadPreset } from "./plugins";
+
+import gensync from "gensync";
+import * as plugins from "./plugins";
+
+export const resolvePlugin = gensync(plugins.resolvePlugin).sync;
+export const resolvePreset = gensync(plugins.resolvePreset).sync;

--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -12,6 +12,8 @@ try {
   import_ = require("./import").default;
 } catch {}
 
+export const supportsESM = !!import_;
+
 export default function* loadCjsOrMjsDefault(
   filepath: string,
   asyncError: string,

--- a/packages/babel-core/src/config/files/plugins.ts
+++ b/packages/babel-core/src/config/files/plugins.ts
@@ -4,9 +4,12 @@
 
 import buildDebug from "debug";
 import path from "path";
-import type { Handler } from "gensync";
-import loadCjsOrMjsDefault from "./module-types";
+import gensync, { type Gensync, type Handler } from "gensync";
 import { isAsync } from "../../gensync-utils/async";
+import loadCjsOrMjsDefault, { supportsESM } from "./module-types";
+import { fileURLToPath, pathToFileURL } from "url";
+
+import getImportMetaResolve from "./import-meta-resolve";
 
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
@@ -24,22 +27,19 @@ const OTHER_PRESET_ORG_RE =
   /^(@(?!babel\/)[^/]+\/)(?![^/]*babel-preset(?:-|\/|$)|[^/]+\/)/;
 const OTHER_ORG_DEFAULT_RE = /^(@(?!babel$)[^/]+)$/;
 
-export function resolvePlugin(name: string, dirname: string): string | null {
-  return resolveStandardizedName("plugin", name, dirname);
+export function* resolvePlugin(name: string, dirname: string): Handler<string> {
+  return yield* resolveStandardizedName("plugin", name, dirname);
 }
 
-export function resolvePreset(name: string, dirname: string): string | null {
-  return resolveStandardizedName("preset", name, dirname);
+export function* resolvePreset(name: string, dirname: string): Handler<string> {
+  return yield* resolveStandardizedName("preset", name, dirname);
 }
 
 export function* loadPlugin(
   name: string,
   dirname: string,
 ): Handler<{ filepath: string; value: unknown }> {
-  const filepath = resolvePlugin(name, dirname);
-  if (!filepath) {
-    throw new Error(`Plugin ${name} not found relative to ${dirname}`);
-  }
+  const filepath = yield* resolvePlugin(name, dirname);
 
   const value = yield* requireModule("plugin", filepath);
   debug("Loaded plugin %o from %o.", name, dirname);
@@ -51,10 +51,7 @@ export function* loadPreset(
   name: string,
   dirname: string,
 ): Handler<{ filepath: string; value: unknown }> {
-  const filepath = resolvePreset(name, dirname);
-  if (!filepath) {
-    throw new Error(`Preset ${name} not found relative to ${dirname}`);
-  }
+  const filepath = yield* resolvePreset(name, dirname);
 
   const value = yield* requireModule("preset", filepath);
 
@@ -93,62 +90,111 @@ function standardizeName(type: "plugin" | "preset", name: string) {
   );
 }
 
-function resolveStandardizedName(
+type Result<T> = { error: Error; value: null } | { error: null; value: T };
+
+function* resolveAlternativesHelper(
   type: "plugin" | "preset",
   name: string,
-  dirname: string = process.cwd(),
-) {
+): Iterator<string, string, Result<string>> {
   const standardizedName = standardizeName(type, name);
+  const { error, value } = yield standardizedName;
+  if (!error) return value;
 
+  // @ts-ignore
+  if (error.code !== "MODULE_NOT_FOUND") throw error;
+
+  if (standardizedName !== name && !(yield name).error) {
+    error.message += `\n- If you want to resolve "${name}", use "module:${name}"`;
+  }
+
+  if (!(yield standardizeName(type, "@babel/" + name)).error) {
+    error.message += `\n- Did you mean "@babel/${name}"?`;
+  }
+
+  const oppositeType = type === "preset" ? "plugin" : "preset";
+  if (!(yield standardizeName(oppositeType, name)).error) {
+    error.message += `\n- Did you accidentally pass a ${oppositeType} as a ${type}?`;
+  }
+
+  throw error;
+}
+
+function tryRequireResolve(
+  id: Parameters<RequireResolve>[0],
+  { paths: [dirname] }: Parameters<RequireResolve>[1],
+): Result<string> {
   try {
-    return require.resolve(standardizedName, {
-      paths: [dirname],
-    });
-  } catch (e) {
-    if (e.code !== "MODULE_NOT_FOUND") throw e;
-
-    if (standardizedName !== name) {
-      let resolvedOriginal = false;
-      try {
-        require.resolve(name, {
-          paths: [dirname],
-        });
-        resolvedOriginal = true;
-      } catch {}
-
-      if (resolvedOriginal) {
-        e.message += `\n- If you want to resolve "${name}", use "module:${name}"`;
-      }
-    }
-
-    let resolvedBabel = false;
-    try {
-      require.resolve(standardizeName(type, "@babel/" + name), {
-        paths: [dirname],
-      });
-      resolvedBabel = true;
-    } catch {}
-
-    if (resolvedBabel) {
-      e.message += `\n- Did you mean "@babel/${name}"?`;
-    }
-
-    let resolvedOppositeType = false;
-    const oppositeType = type === "preset" ? "plugin" : "preset";
-    try {
-      require.resolve(standardizeName(oppositeType, name), {
-        paths: [dirname],
-      });
-      resolvedOppositeType = true;
-    } catch {}
-
-    if (resolvedOppositeType) {
-      e.message += `\n- Did you accidentally pass a ${oppositeType} as a ${type}?`;
-    }
-
-    throw e;
+    return { error: null, value: require.resolve(id, { paths: [dirname] }) };
+  } catch (error) {
+    return { error, value: null };
   }
 }
+
+async function tryImportMetaResolve(
+  id: Parameters<ImportMeta["resolve"]>[0],
+  options: Parameters<ImportMeta["resolve"]>[1],
+): Promise<Result<string>> {
+  const importMetaResolve = await getImportMetaResolve();
+  try {
+    return { error: null, value: await importMetaResolve(id, options) };
+  } catch (error) {
+    return { error, value: null };
+  }
+}
+
+function resolveStandardizedNameForRequrie(
+  type: "plugin" | "preset",
+  name: string,
+  dirname: string,
+) {
+  const it = resolveAlternativesHelper(type, name);
+  let res = it.next();
+  while (!res.done) {
+    res = it.next(tryRequireResolve(res.value, { paths: [dirname] }));
+  }
+  return res.value;
+}
+async function resolveStandardizedNameForImport(
+  type: "plugin" | "preset",
+  name: string,
+  dirname: string,
+) {
+  const parentUrl = pathToFileURL(
+    path.join(dirname, "./babel-virtual-resolve-base.js"),
+  ).href;
+
+  const it = resolveAlternativesHelper(type, name);
+  let res = it.next();
+  while (!res.done) {
+    res = it.next(await tryImportMetaResolve(res.value, parentUrl));
+  }
+  return fileURLToPath(res.value);
+}
+
+const resolveStandardizedName: Gensync<
+  (type: "plugin" | "preset", name: string, dirname?: string) => string
+> = gensync({
+  sync(type, name, dirname = process.cwd()) {
+    return resolveStandardizedNameForRequrie(type, name, dirname);
+  },
+  async async(type, name, dirname = process.cwd()) {
+    if (!supportsESM) {
+      return resolveStandardizedNameForRequrie(type, name, dirname);
+    }
+
+    try {
+      return await resolveStandardizedNameForImport(type, name, dirname);
+    } catch (e) {
+      try {
+        return resolveStandardizedNameForRequrie(type, name, dirname);
+      } catch (e2) {
+        if (e.type === "MODULE_NOT_FOUND") throw e;
+        if (e2.type === "MODULE_NOT_FOUND") throw e2;
+        throw e;
+      }
+    }
+  },
+});
 
 if (!process.env.BABEL_8_BREAKING) {
   // eslint-disable-next-line no-var

--- a/packages/babel-core/src/vendor/import-meta-resolve.d.ts
+++ b/packages/babel-core/src/vendor/import-meta-resolve.d.ts
@@ -1,0 +1,1 @@
+export function resolve(specifier: stirng, parent: string): Promise<string>;

--- a/packages/babel-core/test/fixtures/resolution/pkg-exports/node_modules/babel-plugin-dual/import.mjs
+++ b/packages/babel-core/test/fixtures/resolution/pkg-exports/node_modules/babel-plugin-dual/import.mjs
@@ -1,0 +1,9 @@
+export default function ({ types: t }) {
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("ESM"));
+      },
+    },
+  };
+}

--- a/packages/babel-core/test/fixtures/resolution/pkg-exports/node_modules/babel-plugin-dual/package.json
+++ b/packages/babel-core/test/fixtures/resolution/pkg-exports/node_modules/babel-plugin-dual/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "babel-plugin-dual",
+  "exports": {
+    "import": "./import.mjs",
+    "require": "./require.cjs"
+  }
+}

--- a/packages/babel-core/test/fixtures/resolution/pkg-exports/node_modules/babel-plugin-dual/require.cjs
+++ b/packages/babel-core/test/fixtures/resolution/pkg-exports/node_modules/babel-plugin-dual/require.cjs
@@ -1,0 +1,9 @@
+module.exports = function ({ types: t }) {
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("CJS"));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -463,4 +463,30 @@ describe("addon resolution", function () {
       });
     }).toThrow(/Cannot (?:find|resolve) module 'babel-plugin-foo'/);
   });
+
+  const nodeGte12 = parseInt(process.versions.node, 10) >= 12 ? it : it.skip;
+
+  nodeGte12("should respect package.json#exports", async function () {
+    process.chdir("pkg-exports");
+
+    expect(
+      babel.transformSync("", {
+        filename: "filename.js",
+        babelrc: false,
+        configFile: false,
+        plugins: ["babel-plugin-dual"],
+      }).code,
+    ).toBe(`"CJS"`);
+
+    expect(
+      (
+        await babel.transformAsync("", {
+          filename: "filename.js",
+          babelrc: false,
+          configFile: false,
+          plugins: ["babel-plugin-dual"],
+        })
+      ).code,
+    ).toBe(`"ESM"`);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5866,6 +5866,7 @@ __metadata:
     gulp-filter: ^7.0.0
     gulp-plumber: ^1.2.1
     husky: ^7.0.4
+    import-meta-resolve: ^1.1.1
     jest: ^27.4.0
     jest-worker: ^27.4.0
     lint-staged: ^9.2.0
@@ -6278,6 +6279,15 @@ __metadata:
   version: 3.0.0
   resolution: "builtin-status-codes@npm:3.0.0"
   checksum: 1119429cf4b0d57bf76b248ad6f529167d343156ebbcc4d4e4ad600484f6bc63002595cbb61b67ad03ce55cd1d3c4711c03bbf198bf24653b8392420482f3773
+  languageName: node
+  linkType: hard
+
+"builtins@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "builtins@npm:4.0.0"
+  dependencies:
+    semver: ^7.0.0
+  checksum: 3c8b3b96ed88dd8e21286a3590292862ad62a59085bbcd77a4470848fed0f59fcd67f366afdf9ca8d7e77abce7ccf336bf662c12ead949294aa03bc563a57a1c
   languageName: node
   linkType: hard
 
@@ -9624,6 +9634,15 @@ fsevents@^1.2.7:
   bin:
     import-local-fixture: fixtures/cli.js
   checksum: c74d9f9484c878cda1de3434613c7ff72d5dadcf20e5482542232d7c2575b713ff88701d6675fcf09a3684cb23fb407c8b333b9cbc59438712723d058d8e976c
+  languageName: node
+  linkType: hard
+
+"import-meta-resolve@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "import-meta-resolve@npm:1.1.1"
+  dependencies:
+    builtins: ^4.0.0
+  checksum: 2024161e169c45ed25a9f51d984a432a9cc342c35737f9410266bab237ca2f756c1f80c15e2297df83c92f585743d5105291f2ad24094a513f804c6023ea1472
   languageName: node
   linkType: hard
 
@@ -13813,7 +13832,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.5":
+"semver@npm:^7.0.0, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.5":
   version: 7.3.5
   resolution: "semver@npm:7.3.5"
   dependencies:


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I had a demo code like this:
```js
await babel.transformAsync(input, {
  configFile: false,
  plugins: [
    ["babel-plugin-polyfill-corejs3", {
      "method": "usage-pure"
    }],
  ],
})
```
and I noticed that it resolved to the CJS version of `babel-plugin-polyfill-corejs3`, even if `@babel/core` internally uses `import()` to load it.

This PR fixes that, by using the correct resolution algorithm for ESM. I used `require.resolve` for CJS and https://github.com/wooorm/import-meta-resolve for ESM (which is an exact copy of the experimental `import.meta.resolve` Node.js API).

Unfortunately that package is published as ESM, so we cannot directly depend on it. I added a gulp task to add it as a (`.gitignore`d) file in our `src` folder, so that we can then compile it to CJS.

<details>
<summary>The vendored file has this MIT license + copyright (inlined in a comment)</summary>

```
/*
(The MIT License)

Copyright (c) 2021 Titus Wormer <mailto:tituswormer@gmail.com>

Permission is hereby granted, free of charge, to any person obtaining
a copy of this software and associated documentation files (the
'Software'), to deal in the Software without restriction, including
without limitation the rights to use, copy, modify, merge, publish,
distribute, sublicense, and/or sell copies of the Software, and to
permit persons to whom the Software is furnished to do so, subject to
the following conditions:

The above copyright notice and this permission notice shall be
included in all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

---

This is a derivative work based on:
<https://github.com/nodejs/node>.
Which is licensed:

"""
Copyright Node.js contributors. All rights reserved.

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to
deal in the Software without restriction, including without limitation the
rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
sell copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in
all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
IN THE SOFTWARE.
"""

This license applies to parts of Node.js originating from the
https://github.com/joyent/node repository:

"""
Copyright Joyent, Inc. and other Node contributors. All rights reserved.
Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to
deal in the Software without restriction, including without limitation the
rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
sell copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in
all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
IN THE SOFTWARE.
"""
*/
</details>

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14110"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

