### PR TITLE
[babel 8] Remove `@nicolo-ribaudo/chokidar-2` fallback

### DIFF
--- a/packages/babel-cli/src/babel/util.ts
+++ b/packages/babel-cli/src/babel/util.ts
@@ -115,12 +115,12 @@ process.on("uncaughtException", function (err) {
 });
 
 export function requireChokidar(): any {
-  // $FlowIgnore - https://github.com/facebook/flow/issues/6913#issuecomment-662787504
-  const require = createRequire(import /*::("")*/.meta.url);
+  const require = createRequire(import.meta.url);
 
   try {
-    // todo(babel 8): revert `@nicolo-ribaudo/chokidar-2` hack
-    return parseInt(process.versions.node) >= 8
+    return process.env.BABEL_8_BREAKING
+      ? require("chokidar")
+      : parseInt(process.versions.node) >= 8
       ? require("chokidar")
       : require("@nicolo-ribaudo/chokidar-2");
   } catch (err) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We already removed it from `package.json` for Babel 8; this also removes it from the code.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14119"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

