### PR TITLE
[babel 8] Remove `@babel/runtime@<=7.13.0` compat check

### DIFF
--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/options.json
@@ -1,7 +1,7 @@
 {
   "externalHelpers": false,
   "plugins": [
-    "transform-runtime",
+    ["transform-runtime", { "version": "7.100.0" }],
     "transform-template-literals",
     ["transform-modules-commonjs", { "loose": true }]
   ]

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
 
 var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral"));
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/multi-load/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/multi-load/options.json
@@ -2,7 +2,7 @@
   "externalHelpers": false,
   "plugins": [
     ["transform-modules-commonjs", { "loose": true }],
-    "transform-runtime",
+    ["transform-runtime", { "version": "7.100.0" }],
     "./plugin"
   ]
 }

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/multi-load/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/multi-load/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireDefault3 = require("@babel/runtime/helpers/interopRequireDefault");
+var _interopRequireDefault3 = require("@babel/runtime/helpers/interopRequireDefault").default;
 
 exports.__esModule = true;
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/options.json
@@ -1,7 +1,7 @@
 {
   "externalHelpers": false,
   "plugins": [
-    "transform-runtime",
+    ["transform-runtime", { "version": "7.100.0" }],
     "transform-template-literals",
     "transform-modules-commonjs"
   ]

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
 
 var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral"));
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/multi-load/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/multi-load/options.json
@@ -1,4 +1,8 @@
 {
   "externalHelpers": false,
-  "plugins": ["transform-modules-commonjs", "transform-runtime", "./plugin"]
+  "plugins": [
+    "transform-modules-commonjs",
+    ["transform-runtime", { "version": "7.100.0" }],
+    "./plugin"
+  ]
 }

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/multi-load/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/multi-load/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireDefault3 = require("@babel/runtime/helpers/interopRequireDefault");
+var _interopRequireDefault3 = require("@babel/runtime/helpers/interopRequireDefault").default;
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-runtime/src/index.ts
+++ b/packages/babel-plugin-transform-runtime/src/index.ts
@@ -85,12 +85,14 @@ export default declare((api, options, dirname) => {
     throw new Error(`The 'version' option must be a version string.`);
   }
 
-  // In recent @babel/runtime versions, we can use require("helper").default
-  // instead of require("helper") so that it has the same interface as the
-  // ESM helper, and bundlers can better exchange one format for the other.
-  // TODO(Babel 8): Remove this check, it's always true
-  const DUAL_MODE_RUNTIME = "7.13.0";
-  const supportsCJSDefault = hasMinVersion(DUAL_MODE_RUNTIME, runtimeVersion);
+  if (!process.env.BABEL_8_BREAKING) {
+    // In recent @babel/runtime versions, we can use require("helper").default
+    // instead of require("helper") so that it has the same interface as the
+    // ESM helper, and bundlers can better exchange one format for the other.
+    const DUAL_MODE_RUNTIME = "7.13.0";
+    // eslint-disable-next-line no-var
+    var supportsCJSDefault = hasMinVersion(DUAL_MODE_RUNTIME, runtimeVersion);
+  }
 
   function has(obj, key) {
     return Object.prototype.hasOwnProperty.call(obj, key);
@@ -260,8 +262,13 @@ export default declare((api, options, dirname) => {
           cached = t.cloneNode(cached);
         } else {
           cached = addDefault(file.path, source, {
-            importedInterop:
-              isHelper && supportsCJSDefault ? "compiled" : "uncompiled",
+            importedInterop: (
+              process.env.BABEL_8_BREAKING
+                ? isHelper
+                : isHelper && supportsCJSDefault
+            )
+              ? "compiled"
+              : "uncompiled",
             nameHint,
             blockHoist,
           });

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     "transform-classes",
-    ["transform-runtime", { "absoluteRuntime": "./subfolder" }]
+    ["transform-runtime", { "absoluteRuntime": "./subfolder", "version": "7.100.0" }]
   ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/output.js
@@ -1,6 +1,6 @@
-var _createClass = require("<CWD>/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/subfolder/node_modules/@babel/runtime/helpers/createClass.js");
+var _createClass = require("<CWD>/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/subfolder/node_modules/@babel/runtime/helpers/createClass.js").default;
 
-var _classCallCheck = require("<CWD>/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/subfolder/node_modules/@babel/runtime/helpers/classCallCheck.js");
+var _classCallCheck = require("<CWD>/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/subfolder/node_modules/@babel/runtime/helpers/classCallCheck.js").default;
 
 let Foo = /*#__PURE__*/_createClass(function Foo() {
   "use strict";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-use-es-modules/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-use-es-modules/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     "transform-classes",
-    ["transform-runtime", { "absoluteRuntime": true, "useESModules": true }]
+    ["transform-runtime", { "absoluteRuntime": true, "useESModules": true, "version": "7.100.0" }]
   ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-use-es-modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true-use-es-modules/output.js
@@ -1,6 +1,6 @@
-var _createClass = require("<CWD>/packages/babel-runtime/helpers/createClass.js");
+var _createClass = require("<CWD>/packages/babel-runtime/helpers/createClass.js").default;
 
-var _classCallCheck = require("<CWD>/packages/babel-runtime/helpers/classCallCheck.js");
+var _classCallCheck = require("<CWD>/packages/babel-runtime/helpers/classCallCheck.js").default;
 
 let Foo = /*#__PURE__*/_createClass(function Foo() {
   "use strict";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     "transform-classes",
-    ["transform-runtime", { "absoluteRuntime": true }]
+    ["transform-runtime", { "absoluteRuntime": true, "version": "7.100.0" }]
   ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/output.js
@@ -1,6 +1,6 @@
-var _createClass = require("<CWD>/packages/babel-runtime/helpers/createClass.js");
+var _createClass = require("<CWD>/packages/babel-runtime/helpers/createClass.js").default;
 
-var _classCallCheck = require("<CWD>/packages/babel-runtime/helpers/classCallCheck.js");
+var _classCallCheck = require("<CWD>/packages/babel-runtime/helpers/classCallCheck.js").default;
 
 let Foo = /*#__PURE__*/_createClass(function Foo() {
   "use strict";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/dual-babel-runtime/import-compiled-old-runtime/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/dual-babel-runtime/import-compiled-old-runtime/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     "transform-runtime",
     "transform-classes",

--- a/packages/babel-plugin-transform-runtime/test/fixtures/dual-babel-runtime/import-old-runtime/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/dual-babel-runtime/import-old-runtime/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": ["transform-runtime", "transform-classes"]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/dual-babel-runtime/require-old-runtime/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/dual-babel-runtime/require-old-runtime/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": ["transform-runtime", "transform-classes"]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/dual-babel-runtime/useESModules-old-runtime/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/dual-babel-runtime/useESModules-old-runtime/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["transform-runtime", { "useESModules": true }],
     "transform-classes"

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/class/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/class/options.json
@@ -1,3 +1,6 @@
 {
-  "plugins": [["transform-runtime", { "corejs": 2 }], "transform-classes"]
+  "plugins": [
+    ["transform-runtime", { "corejs": 2, "version": "7.100.0" }],
+    "transform-classes"
+  ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/class/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/class/output.js
@@ -1,6 +1,6 @@
-var _createClass = require("@babel/runtime-corejs2/helpers/createClass");
+var _createClass = require("@babel/runtime-corejs2/helpers/createClass").default;
 
-var _classCallCheck = require("@babel/runtime-corejs2/helpers/classCallCheck");
+var _classCallCheck = require("@babel/runtime-corejs2/helpers/classCallCheck").default;
 
 let Foo = /*#__PURE__*/_createClass(function Foo() {
   "use strict";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules-helpers/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules-helpers/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    ["transform-runtime", { "corejs": 2 }],
+    ["transform-runtime", { "corejs": 2, "version": "7.100.0" }],
     "transform-modules-commonjs",
     "transform-classes"
   ]

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules-helpers/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules-helpers/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault");
+var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault").default;
 
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/classCallCheck"));
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    ["transform-runtime", { "corejs": 2 }],
+    ["transform-runtime", { "corejs": 2, "version": "7.100.0" }],
     "transform-modules-commonjs"
   ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules/output.js
@@ -4,7 +4,7 @@ var _Object$defineProperty = require("@babel/runtime-corejs2/core-js/object/defi
 
 var _Object$keys = require("@babel/runtime-corejs2/core-js/object/keys");
 
-var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault");
+var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault").default;
 
 _Object$defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/class/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/class/options.json
@@ -1,3 +1,6 @@
 {
-  "plugins": [["transform-runtime", { "corejs": 3 }], "transform-classes"]
+  "plugins": [
+    ["transform-runtime", { "corejs": 3, "version": "7.100.0" }],
+    "transform-classes"
+  ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/class/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/class/output.js
@@ -1,6 +1,6 @@
-var _createClass = require("@babel/runtime-corejs3/helpers/createClass");
+var _createClass = require("@babel/runtime-corejs3/helpers/createClass").default;
 
-var _classCallCheck = require("@babel/runtime-corejs3/helpers/classCallCheck");
+var _classCallCheck = require("@babel/runtime-corejs3/helpers/classCallCheck").default;
 
 let Foo = /*#__PURE__*/_createClass(function Foo() {
   "use strict";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-helpers/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-helpers/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    ["transform-runtime", { "corejs": 3 }],
+    ["transform-runtime", { "corejs": 3, "version": "7.100.0" }],
     "transform-modules-commonjs",
     "transform-classes"
   ]

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-helpers/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-helpers/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault");
+var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault").default;
 
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime-corejs3/helpers/classCallCheck"));
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-loose/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-loose/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    ["transform-runtime", { "corejs": 3 }],
+    ["transform-runtime", { "corejs": 3, "version": "7.100.0" }],
     ["transform-modules-commonjs", { "loose": true }]
   ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-loose/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-loose/output.js
@@ -6,7 +6,7 @@ var _forEachInstanceProperty = require("@babel/runtime-corejs3/core-js-stable/in
 
 var _Object$keys = require("@babel/runtime-corejs3/core-js-stable/object/keys");
 
-var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault");
+var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault").default;
 
 exports.__esModule = true;
 var _exportNames = {

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    ["transform-runtime", { "corejs": 3 }],
+    ["transform-runtime", { "corejs": 3, "version": "7.100.0" }],
     "transform-modules-commonjs"
   ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules/output.js
@@ -8,7 +8,7 @@ var _forEachInstanceProperty = require("@babel/runtime-corejs3/core-js-stable/in
 
 var _Object$keys = require("@babel/runtime-corejs3/core-js-stable/object/keys");
 
-var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault");
+var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault").default;
 
 _Object$defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/class/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/class/options.json
@@ -1,3 +1,6 @@
 {
-  "plugins": ["transform-runtime", "transform-classes"]
+  "plugins": [
+    ["transform-runtime", { "version": "7.100.0" }],
+    "transform-classes"
+  ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/class/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/class/output.js
@@ -1,6 +1,6 @@
-var _createClass = require("@babel/runtime/helpers/createClass");
+var _createClass = require("@babel/runtime/helpers/createClass").default;
 
-var _classCallCheck = require("@babel/runtime/helpers/classCallCheck");
+var _classCallCheck = require("@babel/runtime/helpers/classCallCheck").default;
 
 let Foo = /*#__PURE__*/_createClass(function Foo() {
   "use strict";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "transform-runtime",
+    ["transform-runtime", { "version": "7.100.0" }],
     "transform-modules-commonjs",
     "transform-classes"
   ]

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
 
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/options.json
@@ -1,3 +1,6 @@
 {
-  "plugins": ["transform-runtime", "transform-modules-commonjs"]
+  "plugins": [
+    ["transform-runtime", { "version": "7.100.0" }],
+    "transform-modules-commonjs"
+  ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/options.json
@@ -4,7 +4,7 @@
     "supportsStaticESM": true
   },
   "plugins": [
-    ["transform-runtime", { "useESModules": "auto" }],
+    ["transform-runtime", { "useESModules": "auto", "version": "7.100.0" }],
     "transform-classes"
   ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/output.js
@@ -1,16 +1,10 @@
-var _createClass = require("@babel/runtime/helpers/createClass");
+var _createClass = require("@babel/runtime/helpers/createClass").default;
 
-var _classCallCheck = require("@babel/runtime/helpers/classCallCheck");
+var _classCallCheck = require("@babel/runtime/helpers/classCallCheck").default;
 
-var _inherits = require("@babel/runtime/helpers/inherits");
+var _inherits = require("@babel/runtime/helpers/inherits").default;
 
-var _possibleConstructorReturn = require("@babel/runtime/helpers/possibleConstructorReturn");
-
-var _getPrototypeOf = require("@babel/runtime/helpers/getPrototypeOf");
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+var _createSuper = require("@babel/runtime/helpers/createSuper").default;
 
 let Foo = /*#__PURE__*/function (_Bar) {
   "use strict";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs/options.json
@@ -4,7 +4,7 @@
     "supportsStaticESM": true
   },
   "plugins": [
-    ["transform-runtime", { "useESModules": true }],
+    ["transform-runtime", { "useESModules": true, "version": "7.100.0" }],
     "transform-classes"
   ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs/output.js
@@ -1,16 +1,10 @@
-var _createClass = require("@babel/runtime/helpers/createClass");
+var _createClass = require("@babel/runtime/helpers/createClass").default;
 
-var _classCallCheck = require("@babel/runtime/helpers/classCallCheck");
+var _classCallCheck = require("@babel/runtime/helpers/classCallCheck").default;
 
-var _inherits = require("@babel/runtime/helpers/inherits");
+var _inherits = require("@babel/runtime/helpers/inherits").default;
 
-var _possibleConstructorReturn = require("@babel/runtime/helpers/possibleConstructorReturn");
-
-var _getPrototypeOf = require("@babel/runtime/helpers/getPrototypeOf");
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+var _createSuper = require("@babel/runtime/helpers/createSuper").default;
 
 let Foo = /*#__PURE__*/function (_Bar) {
   "use strict";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14120"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

