### PR TITLE
Restore `@babel/register` compat with `@babel/core@7.5.x`

### DIFF
--- a/packages/babel-register/src/worker/transform.js
+++ b/packages/babel-register/src/worker/transform.js
@@ -78,7 +78,7 @@ exports.transform = async function (input, filename) {
 
 if (!process.env.BABEL_8_BREAKING) {
   exports.transformSync = function (input, filename) {
-    const opts = babel.loadOptionsSync({
+    const opts = babel.loadOptions({
       // sourceRoot can be overwritten
       sourceRoot: path.dirname(filename) + path.sep,
       ...cloneDeep(transformOpts),


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14131 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`loadOptionsSync` is not available in every Babel 7 version.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14136"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

