### PR TITLE
Fix the transform of `super.foo--`/`super[foo]--` (and prefix)

### DIFF
--- a/packages/babel-traverse/src/path/conversion.ts
+++ b/packages/babel-traverse/src/path/conversion.ts
@@ -485,7 +485,12 @@ function standardizeSuperProperty(superProp) {
           computedKey ? identifier(computedKey.name) : superProp.node.property,
           superProp.node.computed,
         ),
-        binaryExpression("+", identifier(tmp.name), numericLiteral(1)),
+        binaryExpression(
+          // map `++` to `+`, and `--` to `-`
+          superProp.parentPath.node.operator[0] as "+" | "-",
+          identifier(tmp.name),
+          numericLiteral(1),
+        ),
       ),
     ];
 

--- a/packages/babel-traverse/test/arrow-transform.js
+++ b/packages/babel-traverse/test/arrow-transform.js
@@ -518,7 +518,7 @@ describe("arrow function conversion", () => {
     );
   });
 
-  it("should convert super.prop prefix update", () => {
+  it("should convert `++super.prop` prefix update", () => {
     assertConversion(
       `
       () => {
@@ -542,7 +542,31 @@ describe("arrow function conversion", () => {
     );
   });
 
-  it("should convert super[prop] prefix update", () => {
+  it("should convert `--super.prop` prefix update", () => {
+    assertConversion(
+      `
+      () => {
+        --super.foo;
+      };
+      --super.foo;
+      () => --super.foo;
+    `,
+      `
+      var _superprop_getFoo = () => super.foo,
+          _superprop_setFoo = _value => super.foo = _value;
+
+      (function () {
+        var _tmp;
+
+        _tmp = _superprop_getFoo(), _superprop_setFoo(_tmp - 1);
+      });
+      --super.foo;
+      () => --super.foo;
+    `,
+    );
+  });
+
+  it("should convert `++super[prop]` prefix update", () => {
     assertConversion(
       `
       () => {
@@ -566,7 +590,31 @@ describe("arrow function conversion", () => {
     );
   });
 
-  it("should convert super.prop suffix update", () => {
+  it("should convert `--super[prop]` prefix update", () => {
+    assertConversion(
+      `
+      () => {
+        --super[foo];
+      };
+      --super[foo];
+      () => --super[foo];
+    `,
+      `
+      var _superprop_get = _prop2 => super[_prop2],
+          _superprop_set = (_prop3, _value) => super[_prop3] = _value;
+
+      (function () {
+        var _tmp, _prop;
+
+        _tmp = _superprop_get(_prop = foo), _superprop_set(_prop, _tmp - 1);
+      });
+      --super[foo];
+      () => --super[foo];
+    `,
+    );
+  });
+
+  it("should convert `super.prop++` suffix update", () => {
     assertConversion(
       `
       () => {
@@ -590,7 +638,31 @@ describe("arrow function conversion", () => {
     );
   });
 
-  it("should convert super[prop] suffix update", () => {
+  it("should convert `super.prop--` suffix update", () => {
+    assertConversion(
+      `
+      () => {
+        super.foo--;
+      };
+      super.foo--;
+      () => super.foo--;
+    `,
+      `
+      var _superprop_getFoo = () => super.foo,
+          _superprop_setFoo = _value => super.foo = _value;
+
+      (function () {
+        var _tmp;
+
+        _tmp = _superprop_getFoo(), _superprop_setFoo(_tmp - 1), _tmp;
+      });
+      super.foo--;
+      () => super.foo--;
+    `,
+    );
+  });
+
+  it("should convert `super[prop]++` suffix update", () => {
     assertConversion(
       `
       () => {
@@ -610,6 +682,30 @@ describe("arrow function conversion", () => {
       });
       super[foo]++;
       () => super[foo]++;
+    `,
+    );
+  });
+
+  it("should convert `super[prop]--` suffix update", () => {
+    assertConversion(
+      `
+      () => {
+        super[foo]--;
+      };
+      super[foo]--;
+      () => super[foo]--;
+    `,
+      `
+      var _superprop_get = _prop2 => super[_prop2],
+          _superprop_set = (_prop3, _value) => super[_prop3] = _value;
+
+      (function () {
+        var _tmp, _prop;
+
+        _tmp = _superprop_get(_prop = foo), _superprop_set(_prop, _tmp - 1), _tmp;
+      });
+      super[foo]--;
+      () => super[foo]--;
     `,
     );
   });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14161
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14162"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

