### PR TITLE
Avoid infinite loop when highlighting an empty input

### DIFF
--- a/packages/babel-highlight/src/index.ts
+++ b/packages/babel-highlight/src/index.ts
@@ -262,6 +262,7 @@ export function getChalk(options: Options) {
  * Highlight `code`.
  */
 export default function highlight(code: string, options: Options = {}): string {
+  if (!code) return code;
   if (shouldHighlight(options)) {
     const chalk = getChalk(options);
     const defs = getDefs(chalk);

--- a/packages/babel-highlight/src/index.ts
+++ b/packages/babel-highlight/src/index.ts
@@ -262,8 +262,7 @@ export function getChalk(options: Options) {
  * Highlight `code`.
  */
 export default function highlight(code: string, options: Options = {}): string {
-  if (!code) return code;
-  if (shouldHighlight(options)) {
+  if (code !== "" && shouldHighlight(options)) {
     const chalk = getChalk(options);
     const defs = getDefs(chalk);
     return highlightTokens(defs, code);


### PR DESCRIPTION
fix(highlight): When text is an empty string, highlight will die cycle

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14166
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14165"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

