### PR TITLE
Skip class fields transform when not necessary for private methods

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/field-reinitialization/private-field/options.json
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/field-reinitialization/private-field/options.json
@@ -1,6 +1,6 @@
 {
   "presets": [["env", { "shippedProposals": true }]],
   "targets": {
-    "chrome": "75"
+    "chrome": "70"
   }
 }

--- a/packages/babel-preset-env/src/plugins-compat-data.ts
+++ b/packages/babel-preset-env/src/plugins-compat-data.ts
@@ -17,7 +17,4 @@ for (const plugin of Object.keys(bugfixPlugins)) {
   }
 }
 
-pluginsFiltered["proposal-class-properties"] =
-  pluginsFiltered["proposal-private-methods"];
-
 export { pluginsFiltered as plugins, bugfixPluginsFiltered as pluginsBugfixes };

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
@@ -18,7 +18,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung }
   proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung }
-  proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
   proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
@@ -18,7 +18,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung }
   proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung }
-  proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
   proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { edge < 94 }
   proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 84 }
+  proposal-class-properties { edge < 79 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { edge < 94 }
   proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 84 }
+  proposal-class-properties { edge < 79 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { edge < 94 }
   proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 84 }
+  proposal-class-properties { edge < 79 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { edge < 94 }
   proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 84 }
+  proposal-class-properties { edge < 79 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { edge < 94 }
   proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 84 }
+  proposal-class-properties { edge < 79 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { edge < 94 }
   proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 84 }
+  proposal-class-properties { edge < 79 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { edge < 94 }
   proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 84 }
+  proposal-class-properties { edge < 79 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { edge < 94 }
   proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 84 }
+  proposal-class-properties { edge < 79 }
   proposal-private-methods { edge < 84 }
   proposal-numeric-separator { edge < 79 }
   proposal-logical-assignment-operators { edge < 85 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { safari }
   proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 15 }
+  proposal-class-properties { safari < 14.1 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }
   proposal-logical-assignment-operators { safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { safari }
   proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 15 }
+  proposal-class-properties { safari < 14.1 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }
   proposal-logical-assignment-operators { safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { safari }
   proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 15 }
+  proposal-class-properties { safari < 14.1 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }
   proposal-logical-assignment-operators { safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { safari }
   proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 15 }
+  proposal-class-properties { safari < 14.1 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }
   proposal-logical-assignment-operators { safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -18,7 +18,7 @@ Using modules transform: false
 Using plugins:
   proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung }
   proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung }
-  proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
   proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -18,7 +18,7 @@ Using modules transform: false
 Using plugins:
   proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung }
   proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung }
-  proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
   proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }

--- a/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -18,7 +18,7 @@ Using modules transform: false
 Using plugins:
   proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung }
   proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung }
-  proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
   proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -18,7 +18,7 @@ Using modules transform: false
 Using plugins:
   proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung }
   proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung }
-  proposal-class-properties { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
   proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
   proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
   proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
@@ -17,7 +17,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ios, opera < 80, safari, samsung }
   proposal-private-property-in-object { firefox < 90, ios < 15, safari < 15, samsung }
-  proposal-class-properties { firefox < 90, ios < 15, safari < 15 }
+  proposal-class-properties { firefox < 90, ios < 15, safari < 14.1 }
   proposal-private-methods { firefox < 90, ios < 15, safari < 15 }
   proposal-numeric-separator { ios < 13 }
   proposal-logical-assignment-operators { firefox < 79, ios < 14, safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
@@ -18,7 +18,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, opera < 80, safari, samsung }
   proposal-private-property-in-object { firefox < 90, ie, ios < 15, safari < 15, samsung }
-  proposal-class-properties { firefox < 90, ie, ios < 15, safari < 15 }
+  proposal-class-properties { firefox < 90, ie, ios < 15, safari < 14.1 }
   proposal-private-methods { firefox < 90, ie, ios < 15, safari < 15 }
   proposal-numeric-separator { ie, ios < 13 }
   proposal-logical-assignment-operators { firefox < 79, ie, ios < 14, safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
@@ -17,7 +17,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { firefox < 93, ios, opera < 80, safari, samsung }
   proposal-private-property-in-object { ios < 15, safari < 15, samsung }
-  proposal-class-properties { ios < 15, safari < 15 }
+  proposal-class-properties { ios < 15 }
   proposal-private-methods { ios < 15, safari < 15 }
   syntax-numeric-separator
   syntax-nullish-coalescing-operator

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { electron }
   proposal-private-property-in-object { electron < 13.0 }
-  proposal-class-properties { electron < 10.0 }
+  proposal-class-properties { electron < 6.0 }
   proposal-private-methods { electron < 10.0 }
   proposal-numeric-separator { electron < 6.0 }
   proposal-logical-assignment-operators { electron < 10.0 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: false
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { node < 16.11 }
   proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 14.6 }
+  proposal-class-properties { node < 12 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }
   proposal-logical-assignment-operators { node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
@@ -15,7 +15,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
   proposal-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-class-properties { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
+  proposal-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
   proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
   proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
   proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
@@ -13,7 +13,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, electron, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, electron < 10.0, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
   proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { electron }
   proposal-private-property-in-object { electron < 13.0 }
-  proposal-class-properties { electron < 10.0 }
+  proposal-class-properties { electron < 6.0 }
   proposal-private-methods { electron < 10.0 }
   proposal-numeric-separator { electron < 6.0 }
   proposal-logical-assignment-operators { electron < 10.0 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: false
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { node < 16.11 }
   proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 14.6 }
+  proposal-class-properties { node < 12 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }
   proposal-logical-assignment-operators { node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
@@ -15,7 +15,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
   proposal-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-class-properties { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
+  proposal-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
   proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
   proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
   proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { samsung }
   proposal-private-property-in-object { samsung }
-  proposal-class-properties { samsung < 14 }
+  proposal-class-properties { samsung < 11 }
   proposal-private-methods { samsung < 14 }
   proposal-numeric-separator { samsung < 11 }
   proposal-logical-assignment-operators { samsung < 14 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
@@ -13,7 +13,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, electron, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, electron < 10.0, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
   proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { node < 16.11 }
   proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 14.6 }
+  proposal-class-properties { node < 12 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }
   proposal-logical-assignment-operators { node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: false
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
@@ -11,7 +11,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { firefox < 93, node < 16.11 }
   proposal-private-property-in-object { firefox < 90, node < 16.9 }
-  proposal-class-properties { firefox < 90, node < 14.6 }
+  proposal-class-properties { firefox < 90, node < 12 }
   proposal-private-methods { firefox < 90, node < 14.6 }
   proposal-numeric-separator { firefox < 70, node < 12.5 }
   proposal-logical-assignment-operators { firefox < 79, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  syntax-class-properties
   proposal-private-methods { chrome < 84 }
   syntax-numeric-separator
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  syntax-class-properties
   proposal-private-methods { chrome < 84 }
   syntax-numeric-separator
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -17,7 +17,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ios, opera < 80, safari, samsung }
   proposal-private-property-in-object { firefox < 90, ios < 15, safari < 15, samsung }
-  proposal-class-properties { firefox < 90, ios < 15, safari < 15 }
+  proposal-class-properties { firefox < 90, ios < 15, safari < 14.1 }
   proposal-private-methods { firefox < 90, ios < 15, safari < 15 }
   proposal-numeric-separator { ios < 13 }
   proposal-logical-assignment-operators { firefox < 79, ios < 14, safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -18,7 +18,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, opera < 80, safari, samsung }
   proposal-private-property-in-object { firefox < 90, ie, ios < 15, safari < 15, samsung }
-  proposal-class-properties { firefox < 90, ie, ios < 15, safari < 15 }
+  proposal-class-properties { firefox < 90, ie, ios < 15, safari < 14.1 }
   proposal-private-methods { firefox < 90, ie, ios < 15, safari < 15 }
   proposal-numeric-separator { ie, ios < 13 }
   proposal-logical-assignment-operators { firefox < 79, ie, ios < 14, safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -17,7 +17,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { firefox < 93, ios, opera < 80, safari, samsung }
   proposal-private-property-in-object { ios < 15, safari < 15, samsung }
-  proposal-class-properties { ios < 15, safari < 15 }
+  proposal-class-properties { ios < 15 }
   proposal-private-methods { ios < 15, safari < 15 }
   syntax-numeric-separator
   syntax-nullish-coalescing-operator

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { electron }
   proposal-private-property-in-object { electron < 13.0 }
-  proposal-class-properties { electron < 10.0 }
+  proposal-class-properties { electron < 6.0 }
   proposal-private-methods { electron < 10.0 }
   proposal-numeric-separator { electron < 6.0 }
   proposal-logical-assignment-operators { electron < 10.0 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: false
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { node < 16.11 }
   proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 14.6 }
+  proposal-class-properties { node < 12 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }
   proposal-logical-assignment-operators { node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -15,7 +15,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
   proposal-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-class-properties { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
+  proposal-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
   proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
   proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
   proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -13,7 +13,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, electron, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, electron < 10.0, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
   proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { electron }
   proposal-private-property-in-object { electron < 13.0 }
-  proposal-class-properties { electron < 10.0 }
+  proposal-class-properties { electron < 6.0 }
   proposal-private-methods { electron < 10.0 }
   proposal-numeric-separator { electron < 6.0 }
   proposal-logical-assignment-operators { electron < 10.0 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: false
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { node < 16.11 }
   proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 14.6 }
+  proposal-class-properties { node < 12 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }
   proposal-logical-assignment-operators { node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
@@ -15,7 +15,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
   proposal-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-class-properties { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
+  proposal-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
   proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
   proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
   proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { samsung }
   proposal-private-property-in-object { samsung }
-  proposal-class-properties { samsung < 14 }
+  proposal-class-properties { samsung < 11 }
   proposal-private-methods { samsung < 14 }
   proposal-numeric-separator { samsung < 11 }
   proposal-logical-assignment-operators { samsung < 14 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -13,7 +13,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, electron, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, electron < 10.0, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
   proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { node < 16.11 }
   proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 14.6 }
+  proposal-class-properties { node < 12 }
   proposal-private-methods { node < 14.6 }
   proposal-numeric-separator { node < 12.5 }
   proposal-logical-assignment-operators { node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: false
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, ie, node < 16.11 }
   proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 84, ie, node < 14.6 }
+  proposal-class-properties { chrome < 74, ie, node < 12 }
   proposal-private-methods { chrome < 84, ie, node < 14.6 }
   proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
   proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
@@ -11,7 +11,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { firefox < 93, node < 16.11 }
   proposal-private-property-in-object { firefox < 90, node < 16.9 }
-  proposal-class-properties { firefox < 90, node < 14.6 }
+  proposal-class-properties { firefox < 90, node < 12 }
   proposal-private-methods { firefox < 90, node < 14.6 }
   proposal-numeric-separator { firefox < 70, node < 12.5 }
   proposal-logical-assignment-operators { firefox < 79, node < 15 }

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  syntax-class-properties
   proposal-private-methods { chrome < 84 }
   syntax-numeric-separator
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  syntax-class-properties
   proposal-private-methods { chrome < 84 }
   syntax-numeric-separator
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94 }
   proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 84 }
+  proposal-class-properties { chrome < 74 }
   proposal-private-methods { chrome < 84 }
   proposal-numeric-separator { chrome < 75 }
   proposal-logical-assignment-operators { chrome < 85 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
@@ -12,7 +12,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { chrome < 94, firefox < 93, ie }
   proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 84, firefox < 90, ie }
+  proposal-class-properties { chrome < 74, firefox < 90, ie }
   proposal-private-methods { chrome < 84, firefox < 90, ie }
   proposal-numeric-separator { chrome < 75, firefox < 70, ie }
   proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/input.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/input.js
@@ -1,0 +1,10 @@
+class A {
+  #x;
+}
+
+class B {
+  #x;
+  #y() {
+    this.#x;
+  }
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/options.json
@@ -1,5 +1,5 @@
 {
-  "BABEL_8_BREAKING": true,
+  "BABEL_8_BREAKING": false,
   "validateLogs": true,
   "targets": "node 12.0",
   "presets": [

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/output.js
@@ -1,0 +1,22 @@
+class A {
+  #x;
+}
+
+var _x = /*#__PURE__*/new WeakMap();
+
+var _y = /*#__PURE__*/new WeakSet();
+
+class B {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _y);
+    babelHelpers.classPrivateFieldInitSpec(this, _x, {
+      writable: true,
+      value: void 0
+    });
+  }
+
+}
+
+function _y2() {
+  babelHelpers.classPrivateFieldGet(this, _x);
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/stdout.txt
@@ -15,7 +15,7 @@ Using plugins:
   proposal-numeric-separator { node < 12.5 }
   proposal-logical-assignment-operators { node < 15 }
   proposal-nullish-coalescing-operator { node < 14 }
-  proposal-optional-chaining { node < 14 }
+  proposal-optional-chaining { node < 16.9 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/input.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/input.js
@@ -1,0 +1,10 @@
+class A {
+  #x;
+}
+
+class B {
+  #x;
+  #y() {
+    this.#x;
+  }
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/options.json
@@ -1,0 +1,7 @@
+{
+  "validateLogs": true,
+  "targets": "node 12",
+  "presets": [
+    ["env", { "debug": true }]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/output.js
@@ -1,0 +1,22 @@
+class A {
+  #x;
+}
+
+var _x = /*#__PURE__*/new WeakMap();
+
+var _y = /*#__PURE__*/new WeakSet();
+
+class B {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _y);
+    babelHelpers.classPrivateFieldInitSpec(this, _x, {
+      writable: true,
+      value: void 0
+    });
+  }
+
+}
+
+function _y2() {
+  babelHelpers.classPrivateFieldGet(this, _x);
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/stdout.txt
@@ -15,7 +15,7 @@ Using plugins:
   syntax-numeric-separator
   proposal-logical-assignment-operators { node < 15 }
   proposal-nullish-coalescing-operator { node < 14 }
-  proposal-optional-chaining { node < 16.9 }
+  proposal-optional-chaining { node < 14 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/stdout.txt
@@ -1,0 +1,27 @@
+@babel/preset-env: `DEBUG` option
+
+Using targets:
+{
+  "node": "12.22"
+}
+
+Using modules transform: auto
+
+Using plugins:
+  proposal-class-static-block { node < 16.11 }
+  proposal-private-property-in-object { node < 16.9 }
+  syntax-class-properties
+  proposal-private-methods { node < 14.6 }
+  syntax-numeric-separator
+  proposal-logical-assignment-operators { node < 15 }
+  proposal-nullish-coalescing-operator { node < 14 }
+  proposal-optional-chaining { node < 16.9 }
+  syntax-json-strings
+  syntax-optional-catch-binding
+  syntax-async-generators
+  syntax-object-rest-spread
+  proposal-export-namespace-from { node < 13.2 }
+  transform-modules-commonjs
+  proposal-dynamic-import
+
+Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { safari }
   proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 15 }
+  proposal-class-properties { safari < 14.1 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }
   proposal-logical-assignment-operators { safari < 14 }

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
@@ -10,7 +10,7 @@ Using modules transform: auto
 Using plugins:
   proposal-class-static-block { safari }
   proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 15 }
+  proposal-class-properties { safari < 14.1 }
   proposal-private-methods { safari < 15 }
   proposal-numeric-separator { safari < 13 }
   proposal-logical-assignment-operators { safari < 14 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14167
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR simply relaxes an error in the `helper-create-class-features-plugin` helper, so that it doesn't throw when a class only has fields (and not private methods or other features) and the class fields transform is not enabled.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14169"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

