### PR TITLE
[test runner] Restore `TEST_GREP` support (jest's `-t` parameter)

### DIFF
--- a/test/jest-light-runner/src/index.js
+++ b/test/jest-light-runner/src/index.js
@@ -31,7 +31,7 @@ export default class LightRunner {
    * @param {*} onFailure
    */
   runTests(tests, watcher, onStart, onResult, onFailure) {
-    const { updateSnapshot } = this.#config;
+    const { updateSnapshot, testNamePattern } = this.#config;
 
     return Promise.all(
       tests.map(test => {
@@ -41,7 +41,7 @@ export default class LightRunner {
 
         return piscina
           .run(
-            { test, updateSnapshot, port: mc.port1 },
+            { test, updateSnapshot, testNamePattern, port: mc.port1 },
             { transferList: [mc.port1] }
           )
           .then(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Tested manually running `yarn jest babel-parser/test/index -t placeholders` and `TEST_GREP=placeholders TEST_ONLY=babel-parser make test-only`.

The logic is copied from https://github.com/facebook/jest/blob/3a85065fe5604655e1337ffc1631f9999722c821/packages/jest-circus/src/run.ts#L105 and https://github.com/facebook/jest/blob/e0b33b74b5afd738edc183858b5c34053cfc26dd/packages/jest-circus/src/eventHandler.ts#L237.

Thanks @pzuraq and @tolmasky for noticing that this stopped working! :sweat_smile: 

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14170"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

