### PR TITLE
Normalize absolute paths on Windows

### DIFF
--- a/packages/babel-plugin-transform-runtime/src/get-runtime-path/index.ts
+++ b/packages/babel-plugin-transform-runtime/src/get-runtime-path/index.ts
@@ -34,5 +34,5 @@ function resolveAbsoluteRuntime(moduleName: string, dirname: string) {
 }
 
 export function resolveFSPath(path) {
-  return require.resolve(path);
+  return require.resolve(path).replace(/\\/g, "/");
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/windows/absoluteRuntime/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/windows/absoluteRuntime/output.js
@@ -1,4 +1,4 @@
-var _asyncToGenerator = require("<CWD>\\packages\\babel-runtime\\helpers\\asyncToGenerator.js");
+var _asyncToGenerator = require("<CWD>/packages/babel-runtime/helpers/asyncToGenerator.js");
 
 function test() {
   return _test.apply(this, arguments);


### PR DESCRIPTION
| Q | A
|---|---
| Fixed Issues?            | Fixes #14185 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

Normalized file path, which otherwise causes issues in @rollup/plugin-babel, see issue at  https://github.com/rollup/plugins/issues/1089 and PR (incl. discussions) at https://github.com/rollup/plugins/pull/1090


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14187"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

