### PR TITLE
chore: run tscheck on babel 8 breaking test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
           BABEL_8_BREAKING: true
           STRIP_BABEL_8_FLAG: true
       - name: Lint
-        run: make lint
+        run: make -j tscheck flowcheck-ci lint-ci
         env:
           BABEL_ENV: test
           BABEL_8_BREAKING: true


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Run tscheck on Babel 8 breaking tests
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Currently we only run `eslint` on the Babel 8 build. In this PR we also enable `tscheck`. I will mark the PR ready to review when CI is green.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14190"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

