### PR TITLE
Eager `t.*` access in `shouldStoreRHSInTemporaryVariable`

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/src/shouldStoreRHSInTemporaryVariable.ts
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/shouldStoreRHSInTemporaryVariable.ts
@@ -1,6 +1,6 @@
 import { types as t } from "@babel/core";
 
-const { isObjectProperty } = t;
+const { isObjectProperty, isArrayPattern, isObjectPattern, isAssignmentPattern, isRestElement, isIdentifier, LVal } = t;
 /**
  * This is a helper function to determine if we should create an intermediate variable
  * such that the RHS of an assignment is not duplicated.
@@ -8,12 +8,12 @@ const { isObjectProperty } = t;
  * See https://github.com/babel/babel/pull/13711#issuecomment-914388382 for discussion
  * on further optimizations.
  */
-export default function shouldStoreRHSInTemporaryVariable(node: t.LVal) {
-  if (t.isArrayPattern(node)) {
+export default function shouldStoreRHSInTemporaryVariable(node: LVal) {
+  if (isArrayPattern(node)) {
     const nonNullElements = node.elements.filter(element => element !== null);
     if (nonNullElements.length > 1) return true;
     else return shouldStoreRHSInTemporaryVariable(nonNullElements[0]);
-  } else if (t.isObjectPattern(node)) {
+  } else if (isObjectPattern(node)) {
     const { properties } = node;
     if (properties.length > 1) return true;
     else if (properties.length === 0) return false;
@@ -21,15 +21,15 @@ export default function shouldStoreRHSInTemporaryVariable(node: t.LVal) {
       const firstProperty = properties[0];
       if (isObjectProperty(firstProperty)) {
         // the value of the property must be an LVal
-        return shouldStoreRHSInTemporaryVariable(firstProperty.value as t.LVal);
+        return shouldStoreRHSInTemporaryVariable(firstProperty.value as LVal);
       } else {
         return shouldStoreRHSInTemporaryVariable(firstProperty);
       }
     }
-  } else if (t.isAssignmentPattern(node)) {
+  } else if (isAssignmentPattern(node)) {
     return shouldStoreRHSInTemporaryVariable(node.left);
-  } else if (t.isRestElement(node)) {
-    if (t.isIdentifier(node.argument)) return true;
+  } else if (isRestElement(node)) {
+    if (isIdentifier(node.argument)) return true;
     return shouldStoreRHSInTemporaryVariable(node.argument);
   } else {
     // node is Identifier or MemberExpression

--- a/packages/babel-plugin-proposal-object-rest-spread/src/shouldStoreRHSInTemporaryVariable.ts
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/shouldStoreRHSInTemporaryVariable.ts
@@ -1,6 +1,13 @@
 import { types as t } from "@babel/core";
 
-const { isObjectProperty, isArrayPattern, isObjectPattern, isAssignmentPattern, isRestElement, isIdentifier } = t;
+const {
+  isObjectProperty,
+  isArrayPattern,
+  isObjectPattern,
+  isAssignmentPattern,
+  isRestElement,
+  isIdentifier
+} = t;
 /**
  * This is a helper function to determine if we should create an intermediate variable
  * such that the RHS of an assignment is not duplicated.

--- a/packages/babel-plugin-proposal-object-rest-spread/src/shouldStoreRHSInTemporaryVariable.ts
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/shouldStoreRHSInTemporaryVariable.ts
@@ -1,6 +1,6 @@
 import { types as t } from "@babel/core";
 
-const { isObjectProperty, isArrayPattern, isObjectPattern, isAssignmentPattern, isRestElement, isIdentifier, LVal } = t;
+const { isObjectProperty, isArrayPattern, isObjectPattern, isAssignmentPattern, isRestElement, isIdentifier } = t;
 /**
  * This is a helper function to determine if we should create an intermediate variable
  * such that the RHS of an assignment is not duplicated.
@@ -8,7 +8,7 @@ const { isObjectProperty, isArrayPattern, isObjectPattern, isAssignmentPattern, 
  * See https://github.com/babel/babel/pull/13711#issuecomment-914388382 for discussion
  * on further optimizations.
  */
-export default function shouldStoreRHSInTemporaryVariable(node: LVal) {
+export default function shouldStoreRHSInTemporaryVariable(node: t.LVal) {
   if (isArrayPattern(node)) {
     const nonNullElements = node.elements.filter(element => element !== null);
     if (nonNullElements.length > 1) return true;
@@ -21,7 +21,7 @@ export default function shouldStoreRHSInTemporaryVariable(node: LVal) {
       const firstProperty = properties[0];
       if (isObjectProperty(firstProperty)) {
         // the value of the property must be an LVal
-        return shouldStoreRHSInTemporaryVariable(firstProperty.value as LVal);
+        return shouldStoreRHSInTemporaryVariable(firstProperty.value as t.LVal);
       } else {
         return shouldStoreRHSInTemporaryVariable(firstProperty);
       }

--- a/packages/babel-plugin-proposal-object-rest-spread/src/shouldStoreRHSInTemporaryVariable.ts
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/shouldStoreRHSInTemporaryVariable.ts
@@ -6,7 +6,7 @@ const {
   isObjectPattern,
   isAssignmentPattern,
   isRestElement,
-  isIdentifier
+  isIdentifier,
 } = t;
 /**
  * This is a helper function to determine if we should create an intermediate variable


### PR DESCRIPTION
use more deconstruction.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14191"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

