### PR TITLE
Avoid dynamic import when it's not needed

### DIFF
--- a/packages/babel-core/src/config/files/import-meta-resolve.ts
+++ b/packages/babel-core/src/config/files/import-meta-resolve.ts
@@ -10,33 +10,38 @@ try {
 } catch {}
 
 // import.meta.resolve is only available in ESM, but this file is compiled to CJS.
-// We can extract ir using dynamic import.
-const resolveP =
+// We can extract it using dynamic import.
+const importMetaResolveP: Promise<ImportMeta["resolve"]> =
   import_ &&
   // Due to a Node.js/V8 bug (https://github.com/nodejs/node/issues/35889), we cannot
-  // use dynamic import when running in the default Jest environment because it
-  // uses vm.SourceTextModule.
-  // Jest defines globalThis["jest-symbol-do-not-touch"] in
-  // https://github.com/facebook/jest/blob/11d79ec096a25851124356095d60352f6ca2824e/packages/jest-util/src/installCommonGlobals.ts#L49
-  // which is called by
-  // https://github.com/facebook/jest/blob/11d79ec096a25851124356095d60352f6ca2824e/packages/jest-environment-node/src/index.ts#L85
+  // use always dynamic import because it segfaults when running in a Node.js `vm` context,
+  // which is used by the default Jest environment and by webpack-cli.
   //
-  // Note that our Jest runner doesn't have this problem, because it runs ESM in the default
-  // Node.js context rather than using the `vm` module.
+  // However, import.meta.resolve is experimental and only enabled when Node.js is run
+  // with the `--experimental-import-meta-resolve` flag: we can avoid calling import()
+  // when that flag is not enabled, so that the default behavior never segfaults.
   //
-  // When V8 fixes this bug, we can remove this check. We usually don't have package-specific hacks,
-  // but Jest is a big Babel consumer widely used in the community and they cannot workaround
-  // this problem on their side.
-  !Object.hasOwnProperty.call(global, "jest-symbol-do-not-touch")
+  // Hopefully, before Node.js unflags import.meta.resolve, either:
+  // - we will move to ESM, so that we have direct access to import.meta.resolve, or
+  // - the V8 bug will be fixed so that we can safely use dynamic import by default.
+  //
+  // I (@nicolo-ribaudo) am really anoyed by this bug, because there is no known
+  // work-around other than "don't use dynamic import if you are running in a `vm` context",
+  // but there is no reliable way to detect it (you cannot try/catch segfaults).
+  //
+  // This is the only place where we *need* to use dynamic import because we need to access
+  // an ES module. All the other places will first try using require() and *then*, if
+  // it throws because it's a module, will fallback to import().
+  process.execArgv.includes("--experimental-import-meta-resolve")
     ? import_("data:text/javascript,export default import.meta.resolve").then(
-        // Since import.meta.resolve is unstable and only available when
-        // using the --experimental-import-meta-resolve flag, we almost
-        // always use the polyfill for now.
         m => m.default || polyfill,
         () => polyfill,
       )
     : Promise.resolve(polyfill);
 
-export default function getImportMetaResolve(): Promise<ImportMeta["resolve"]> {
-  return resolveP;
+export default async function resolve(
+  specifier: Parameters<ImportMeta["resolve"]>[0],
+  parent?: Parameters<ImportMeta["resolve"]>[1],
+): ReturnType<ImportMeta["resolve"]> {
+  return (await importMetaResolveP)(specifier, parent);
 }

--- a/packages/babel-core/src/config/files/plugins.ts
+++ b/packages/babel-core/src/config/files/plugins.ts
@@ -9,7 +9,7 @@ import { isAsync } from "../../gensync-utils/async";
 import loadCjsOrMjsDefault, { supportsESM } from "./module-types";
 import { fileURLToPath, pathToFileURL } from "url";
 
-import getImportMetaResolve from "./import-meta-resolve";
+import importMetaResolve from "./import-meta-resolve";
 
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
@@ -134,7 +134,6 @@ async function tryImportMetaResolve(
   id: Parameters<ImportMeta["resolve"]>[0],
   options: Parameters<ImportMeta["resolve"]>[1],
 ): Promise<Result<string>> {
-  const importMetaResolve = await getImportMetaResolve();
   try {
     return { error: null, value: await importMetaResolve(id, options) };
   } catch (error) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14186 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This fixes https://github.com/babel/babel/issues/14186. It's *the* annoying segfault; the one that affects Babel/Webpack/Jest but V8 doesn't fix. In https://github.com/babel/babel/pull/14110 I added a workaround just for Jest, but since it also affects other projects this PR replaces the Jest workaround with another one. It will still crash in some cases, but only when using the `--experimental-import-meta-resolve` experimental flag with Jest or Webpack (hopefully no one relies on this combination, but otherwise there is not much that we can do other than :+1: the Node.js issue and the V8 bug).

@jlowcs Could you also try replacing line 26 of https://unpkg.com/browse/@babel/core@7.16.10/lib/config/files/import-meta-resolve.js with the following code, trigger a few CI runs, and see if it still works (it's a better fix from the one I already asked you to verify, because it doesn't affect the current Babel behavior other than avoiding crashes):
```js
const resolveP = import_ && process.execArgv.includes("--experimental-import-meta-resolve")
    ? import_("data:text/javascript,export default import.meta.resolve").then(m => m.default || _importMetaResolve.resolve, () => _importMetaResolve.resolve)
    : Promise.resolve(_importMetaResolve.resolve);
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14192"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

