### PR TITLE
fix: Enforce newer version of pirates due to compatibility issues with esm

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -21,7 +21,7 @@
     "clone-deep": "^4.0.1",
     "find-cache-dir": "condition:BABEL_8_BREAKING ? ^3.3.1 : ^2.0.0",
     "make-dir": "condition:BABEL_8_BREAKING ? : ^2.1.0",
-    "pirates": "^4.0.0",
+    "pirates": "^4.0.5",
     "source-map-support": "^0.5.16"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3499,7 +3499,7 @@ __metadata:
     clone-deep: ^4.0.1
     find-cache-dir: "condition:BABEL_8_BREAKING ? ^3.3.1 : ^2.0.0"
     make-dir: "condition:BABEL_8_BREAKING ? : ^2.1.0"
-    pirates: ^4.0.0
+    pirates: ^4.0.5
     source-map-support: ^0.5.16
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -12051,13 +12051,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-modules-regexp@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "node-modules-regexp@npm:1.0.0"
-  checksum: 99541903536c5ce552786f0fca7f06b88df595e62e423c21fa86a1674ee2363dad1f7482d1bec20b4bd9fa5f262f88e6e5cb788fc56411113f2fe2e97783a3a7
-  languageName: node
-  linkType: hard
-
 "node-releases@npm:^2.0.1":
   version: 2.0.1
   resolution: "node-releases@npm:2.0.1"
@@ -12799,12 +12792,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.0, pirates@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "pirates@npm:4.0.1"
-  dependencies:
-    node-modules-regexp: ^1.0.0
-  checksum: 091e232aac19f0049a681838fa9fcb4af824b5b1eb0e9325aa07b9d13245bfe3e4fa57a7766b9fdcd19cb89f2c15c688b46023be3047cb288023a0c079d3b2a3
+"pirates@npm:^4.0.0, pirates@npm:^4.0.1, pirates@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "pirates@npm:4.0.5"
+  checksum: c9994e61b85260bec6c4fc0307016340d9b0c4f4b6550a957afaaff0c9b1ad58fbbea5cfcf083860a25cb27a375442e2b0edf52e2e1e40e69934e08dcc52d227
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT


This issue danez/pirates#90 was preventing the use of `@babel/register` with `esm` (https://www.npmjs.com/package/esm) 
The bug was introduced in 4.0.2 and fixed in 4.0.5.

I think it would be best to enforce the latest version to avoid more people running into this.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14195"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

