### PR TITLE
Fix traverse scope tests

### DIFF
--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -763,7 +763,7 @@ describe("scope", () => {
       });
       it("in function declaration", () => {
         const functionDeclaration = getPath("function f() { var foo; }").get(
-          "body.0.expression",
+          "body.0",
         );
         expect(functionDeclaration.scope.hasOwnBinding("foo")).toBe(true);
       });
@@ -851,7 +851,7 @@ describe("scope", () => {
       });
       it("in function declaration", () => {
         const functionDeclaration = getPath("function f() { let foo; }").get(
-          "body.0.expression",
+          "body.0",
         );
         expect(functionDeclaration.scope.hasOwnBinding("foo")).toBe(true);
       });


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | n/a
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

A couple of the tests for scope in `@babel/traverse` were incorrect.

`getPath("function f() { var foo; }").get("body.0.expression")` refers to a path which doesn't exist.

These tests were still passing, but surprisingly so!

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14202"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

