### PR TITLE
[babel 8] breaking: bump minimum required Node.js to 14.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,10 +197,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Use Node.js 14.15
+      - name: Use Node.js 14.17
         uses: actions/setup-node@v2-beta
         with:
-          node-version: "14.15" # Node.js 14.15 is the first LTS supported by Babel 8
+          node-version: "14.17" # Node.js 14.17 is the first LTS supported by Babel 8
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,10 +197,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Use Node.js 12
+      - name: Use Node.js 14.15
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 12 # Node.js 12 is the first LTS supported by Babel 8
+          node-version: "14.15" # Node.js 14.15 is the first LTS supported by Babel 8
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/babel.config.js
+++ b/babel.config.js
@@ -62,7 +62,7 @@ module.exports = function (api) {
 
   let transformRuntimeOptions;
 
-  const nodeVersion = bool(process.env.BABEL_8_BREAKING) ? "14.15" : "6.9";
+  const nodeVersion = bool(process.env.BABEL_8_BREAKING) ? "14.17" : "6.9";
   // The vast majority of our src files are modules, but we use
   // unambiguous to keep things simple until we get around to renaming
   // the modules to be more easily distinguished from CommonJS

--- a/babel.config.js
+++ b/babel.config.js
@@ -62,7 +62,7 @@ module.exports = function (api) {
 
   let transformRuntimeOptions;
 
-  const nodeVersion = process.env.BABEL_8_BREAKING ? "14.15" : "6.9";
+  const nodeVersion = bool(process.env.BABEL_8_BREAKING) ? "14.15" : "6.9";
   // The vast majority of our src files are modules, but we use
   // unambiguous to keep things simple until we get around to renaming
   // the modules to be more easily distinguished from CommonJS

--- a/babel.config.js
+++ b/babel.config.js
@@ -62,7 +62,7 @@ module.exports = function (api) {
 
   let transformRuntimeOptions;
 
-  const nodeVersion = "6.9";
+  const nodeVersion = process.env.BABEL_8_BREAKING ? "14.15" : "6.9";
   // The vast majority of our src files are modules, but we use
   // unambiguous to keep things simple until we get around to renaming
   // the modules to be more easily distinguished from CommonJS

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,18 @@
-const supportsESM = parseInt(process.versions.node) >= 12;
+const semver = require("semver");
+const nodeVersion = process.versions.node;
+const supportsESMAndJestLightRunner = semver.satisfies(
+  nodeVersion,
+  // ^12.22 || >=14.17 : Node will throw "t.isIdentifier is not a function" when test is running in worker threads.
+  // ^13.7: `resolve.exports` specifies conditional exports in package.json
+  "^12.22 || ^13.7 || >=14.17"
+);
+//
 const isPublishBundle = process.env.IS_PUBLISH;
 
 module.exports = {
-  runner: supportsESM ? "./test/jest-light-runner" : "jest-runner",
+  runner: supportsESMAndJestLightRunner
+    ? "./test/jest-light-runner"
+    : "jest-runner",
 
   collectCoverageFrom: [
     "packages/*/src/**/*.{js,mjs,ts}",
@@ -12,7 +22,7 @@ module.exports = {
   // The eslint/* packages use ESLint v6, which has dropped support for Node v6.
   // TODO: Remove this process.version check in Babel 8.
   testRegex: `./(packages|codemods${
-    Number(process.versions.node.split(".")[0]) < 10 ? "" : "|eslint"
+    semver.satisfies(nodeVersion, "<10") ? "" : "|eslint"
   })/[^/]+/test/.+\\.m?js$`,
   testPathIgnorePatterns: [
     "/node_modules/",

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,6 @@ const supportsESMAndJestLightRunner = semver.satisfies(
   // ^13.7: `resolve.exports` specifies conditional exports in package.json
   "^12.22 || ^13.7 || >=14.17"
 );
-//
 const isPublishBundle = process.env.IS_PUBLISH;
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "rollup-plugin-dts": "^2.0.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-terser": "^7.0.2",
+    "semver": "^6.3.0",
     "test262-stream": "^1.4.0",
     "through2": "^4.0.0",
     "typescript": "~4.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5876,6 +5876,7 @@ __metadata:
     rollup-plugin-dts: ^2.0.0
     rollup-plugin-node-polyfills: ^0.2.1
     rollup-plugin-terser: ^7.0.2
+    semver: ^6.3.0
     test262-stream: ^1.4.0
     through2: ^4.0.0
     typescript: ~4.5.0


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Bump Babel 8 target to Node.js 14.17
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Y, behind `BABEL_8_BREAKING` flag
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we bump Babel 8 target to Node.js 14.17, the first LTS release of Node.js Ferminum with top level await. It also ensures that when `BABEL_8_BREAKING` is set, Babel is built with `target: { node: "14.17" }`

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14206"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

