### PR TITLE
Update compat data (specifically for rhino 1.7.14)

### DIFF
--- a/packages/babel-compat-data/data/corejs2-built-ins.json
+++ b/packages/babel-compat-data/data/corejs2-built-ins.json
@@ -628,6 +628,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "2",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.number.is-finite": {
@@ -713,6 +714,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "2",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.number.parse-int": {
@@ -724,6 +726,7 @@
     "node": "0.12",
     "ios": "9",
     "samsung": "2",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.object.assign": {
@@ -813,6 +816,7 @@
     "node": "7",
     "ios": "10.3",
     "samsung": "6",
+    "rhino": "1.7.14",
     "electron": "1.4"
   },
   "es6.object.freeze": {
@@ -1014,6 +1018,7 @@
     "node": "7",
     "ios": "10.3",
     "samsung": "6",
+    "rhino": "1.7.14",
     "electron": "1.4"
   },
   "es6.promise": {
@@ -1304,6 +1309,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.big": {
@@ -1317,6 +1323,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.blink": {
@@ -1330,6 +1337,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.bold": {
@@ -1343,6 +1351,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.code-point-at": {
@@ -1380,6 +1389,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.fontcolor": {
@@ -1393,6 +1403,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.fontsize": {
@@ -1406,6 +1417,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.from-code-point": {
@@ -1443,6 +1455,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.iterator": {
@@ -1468,6 +1481,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es7.string.pad-start": {
@@ -1503,6 +1517,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "3.4",
+    "rhino": "1.7.14",
     "electron": "0.21"
   },
   "es6.string.repeat": {
@@ -1528,6 +1543,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.starts-with": {
@@ -1553,6 +1569,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.sub": {
@@ -1566,6 +1583,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.sup": {
@@ -1579,6 +1597,7 @@
     "ios": "7",
     "phantom": "2",
     "samsung": "1",
+    "rhino": "1.7.14",
     "electron": "0.20"
   },
   "es6.string.trim": {

--- a/packages/babel-compat-data/data/plugin-bugfixes.json
+++ b/packages/babel-compat-data/data/plugin-bugfixes.json
@@ -108,7 +108,6 @@
     "firefox": "2",
     "node": "6",
     "samsung": "5",
-    "rhino": "1.7.13",
     "electron": "0.37"
   },
   "transform-template-literals": {
@@ -131,6 +130,7 @@
     "node": "4",
     "ios": "13",
     "samsung": "3.4",
+    "rhino": "1.7.14",
     "electron": "0.21"
   },
   "proposal-optional-chaining": {

--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -47,6 +47,7 @@
     "node": "12.5",
     "ios": "13",
     "samsung": "11",
+    "rhino": "1.7.14",
     "electron": "6.0"
   },
   "proposal-logical-assignment-operators": {
@@ -90,6 +91,7 @@
     "node": "10",
     "ios": "12",
     "samsung": "9",
+    "rhino": "1.7.14",
     "electron": "3.0"
   },
   "proposal-optional-catch-binding": {
@@ -187,6 +189,7 @@
     "node": "7",
     "ios": "10.3",
     "samsung": "6",
+    "rhino": "1.7.14",
     "electron": "1.3"
   },
   "transform-template-literals": {
@@ -277,6 +280,7 @@
     "node": "4",
     "ios": "9",
     "samsung": "4",
+    "rhino": "1.7.14",
     "electron": "0.27"
   },
   "transform-duplicate-keys": {

--- a/packages/babel-compat-data/scripts/data/plugin-features.js
+++ b/packages/babel-compat-data/scripts/data/plugin-features.js
@@ -157,7 +157,9 @@ const es2022 = {
     "Ergonomic brand checks for private fields",
   "proposal-class-properties": {
     features: [
-      "static class fields",
+      "static class fields / public static class fields",
+      "static class fields / private static class fields",
+      "static class fields / computed static class fields",
       "instance class fields, public instance class fields",
       "instance class fields, private instance class fields basic support",
       "instance class fields, computed instance class fields",

--- a/packages/babel-compat-data/scripts/download-compat-table.sh
+++ b/packages/babel-compat-data/scripts/download-compat-table.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-COMPAT_TABLE_COMMIT=bddf2b204ffc959f738355517257f6f389b12584
+COMPAT_TABLE_COMMIT=11c7e1d81049dd0fd765156ba86d61ed8e909a49
 GIT_HEAD=build/compat-table/.git/HEAD
 
 if [ -d "build/compat-table" ]; then


### PR DESCRIPTION


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | 
| Tests Added + Pass?      | No
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This is a first attempt at updating compat data, in this case specifically to support rhino 1.7.14. Per discussion over at https://github.com/mozilla/rhino/pull/1164 with @nicolo-ribaudo, I updated the fixtures as well with `make build-compat-data && make bootstrap && OVERWRITE=true yarn jest`. Unfortunately, this seems to have triggered a number of unrelated changes to the fixture `stdout` files and caused one of the fixture tests to fail:

```
 FAIL  packages/babel-preset-env/test/fixtures.js (12.192 s)
babel-preset-env/shipped proposals > new class features chrome 94
        SyntaxError: /Users/phulin/Documents/Projects/kol/babel/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-chrome-94/input.js: Static class blocks are not enabled. Please add `@babel/plugin-proposal-class-static-block` to your configuration.
        > 1 | class A {
            | ^
          2 |   #foo;
          3 |
          4 |   static {
```

Curious for any advice you all have as to how to resolve these. I'm sure I'm doing something wrong here.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14208"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

