### PR TITLE
Remove Babel 6 from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,9 @@ currently being supported with security updates.
 | Version  | Supported          |
 | -------- | ------------------ |
 | 7.x      | :white_check_mark: |
-| 6.26.x   | :white_check_mark: |
-| < 6.26.0 | :x:                |
+| 6.x      | :x:                |
+
+Note that for each supported major version, we will only provide security fixes for the last minor version. This means that if, for example, the last released version is 7.16.4 we will only release security fixes as 7.16.5 and not for 7.15.x or older.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

At this point, Babel 7 has been released for so long that we can officially stop supporting Babel 6 (and in practice we haven't has Babel 6 releases for a while).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14223"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

