### PR TITLE
Remove Jest workaround for Babel 8 e2e test

### DIFF
--- a/scripts/integration-tests/e2e-babel.sh
+++ b/scripts/integration-tests/e2e-babel.sh
@@ -32,21 +32,7 @@ startLocalRegistry "$PWD"/scripts/integration-tests/verdaccio-config.yml
 # and not from npm.
 node "$PWD"/scripts/integration-tests/utils/bump-babel-dependencies.js
 
-# Update deps, build and test
-if [ "$BABEL_8_BREAKING" = true ] ; then
-  YARN_ENABLE_IMMUTABLE_INSTALLS=false make -j build-standalone-ci
-
-  # Jest hangs forever in the Babel 8 e2e test when using multiple workers,
-  # but we don't know yet why. Until we figure it out (see
-  # https://github.com/babel/babel/pull/13618) we can use --runInBand.
-  # Additinally, in Babel 8 tests Jest needs to run with ESM support because
-  # @babel/eslint-parser/lib/worker/babel-core.cjs uses dynamic import() to
-  # load @babel/core.
-  NODE_OPTIONS="--experimental-vm-modules" BABEL_ENV=test yarn jest --ci --runInBand
-
-  make -j test-clean
-else
-  YARN_ENABLE_IMMUTABLE_INSTALLS=false make -j test-ci
-fi
+# Build and test
+YARN_ENABLE_IMMUTABLE_INSTALLS=false make -j test-ci
 
 cleanup


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is not needed anymore, because we now use a different Jest runner.

Note that this specific test is failing on `main`, but I don't understand why:
- It doesn't report any failure
- If I SSH into the circleci server and manually run it, everything works fine

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14224"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

