### PR TITLE
Restore class fields transform compat with old `@babel/types`

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -82,7 +82,8 @@ function extractElementDescriptor(
     prop("decorators", takeDecorators(node as Decorable)),
     prop(
       "static",
-      !t.isStaticBlock(node) && node.static && t.booleanLiteral(true),
+      // @ts-expect-error: TS doesn't infer that node is not a StaticBlock
+      !t.isStaticBlock?.(node) && node.static && t.booleanLiteral(true),
     ),
     prop("key", getKey(node)),
   ].filter(Boolean);

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -911,7 +911,8 @@ function replaceThisContext(
     getSuperRef,
     getObjectRef() {
       state.needsClassRef = true;
-      return t.isStaticBlock(path.node) || path.node.static
+      // @ts-expect-error: TS doesn't infer that path.node is not a StaticBlock
+      return t.isStaticBlock?.(path.node) || path.node.static
         ? ref
         : t.memberExpression(ref, t.identifier("prototype"));
     },
@@ -964,7 +965,8 @@ export function buildFieldsInitNodes(
   for (const prop of props) {
     prop.isClassProperty() && ts.assertFieldTransformed(prop);
 
-    const isStatic = !t.isStaticBlock(prop.node) && prop.node.static;
+    // @ts-expect-error: TS doesn't infer that prop.node is not a StaticBlock
+    const isStatic = !t.isStaticBlock?.(prop.node) && prop.node.static;
     const isInstance = !isStatic;
     const isPrivate = prop.isPrivate();
     const isPublic = !isPrivate;

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -242,7 +242,8 @@ export function createClassFeaturePlugin({
             (referenceVisitor, state) => {
               if (isDecorated) return;
               for (const prop of props) {
-                if (t.isStaticBlock(prop.node) || prop.node.static) continue;
+                // @ts-expect-error: TS doesn't infer that prop.node is not a StaticBlock
+                if (t.isStaticBlock?.(prop.node) || prop.node.static) continue;
                 prop.traverse(referenceVisitor, state);
               }
             },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14230
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14231"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

