### PR TITLE
disable immutable yarn install during e2e-jest test

### DIFF
--- a/scripts/integration-tests/e2e-jest.sh
+++ b/scripts/integration-tests/e2e-jest.sh
@@ -38,7 +38,8 @@ python --version
 #==============================================================================#
 
 startLocalRegistry "$root"/verdaccio-config.yml
-yarn install
+# yarn.lock will be modified by @babel/* bumps
+yarn install --no-immutable
 yarn dedupe '@babel/*'
 
 if [ "$BABEL_8_BREAKING" = true ] ; then


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fix recent jest e2e test failure because jest migrates to Yarn 3 (nice!)
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`yarn install` will infer `--immutable` when it is executed in a CI environment. However in the e2e test we are bumping `@babel/*` deps so the lock file will be inevitably modified during install.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14262"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

