### PR TITLE
jsx-development: do not emit `this` within ts module block

### DIFF
--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/within-ts-module-block/input.ts
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/within-ts-module-block/input.ts
@@ -1,0 +1,5 @@
+export namespace Namespaced {
+	export const Component = () => (
+		<div>Hello, world!</div>
+	);
+}

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/within-ts-module-block/options.json
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/within-ts-module-block/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "transform-react-jsx-development",
+    ["syntax-typescript", { "isTSX": true }]
+  ],
+  "sourceType": "module",
+  "os": ["linux", "darwin"]
+}

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/within-ts-module-block/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/within-ts-module-block/output.mjs
@@ -1,0 +1,11 @@
+var _jsxFileName = "<CWD>/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/within-ts-module-block/input.ts";
+import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
+export namespace Namespaced {
+  export const Component = () => /*#__PURE__*/_jsxDEV("div", {
+    children: "Hello, world!"
+  }, void 0, false, {
+    fileName: _jsxFileName,
+    lineNumber: 3,
+    columnNumber: 3
+  }, void 0);
+}

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/within-ts-module-block/input.ts
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/within-ts-module-block/input.ts
@@ -1,0 +1,5 @@
+export namespace Namespaced {
+	export const Component = () => (
+		<div>Hello, world!</div>
+	);
+}

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/within-ts-module-block/options.json
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/within-ts-module-block/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "transform-react-jsx-development",
+    ["syntax-typescript", { "isTSX": true }]
+  ],
+  "sourceType": "module",
+  "os": ["win32"]
+}

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/within-ts-module-block/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/within-ts-module-block/output.mjs
@@ -1,0 +1,11 @@
+var _jsxFileName = "<CWD>\\packages\\babel-plugin-transform-react-jsx-development\\test\\fixtures\\windows\\within-ts-module-block\\input.ts";
+import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
+export namespace Namespaced {
+  export const Component = () => /*#__PURE__*/_jsxDEV("div", {
+    children: "Hello, world!"
+  }, void 0, false, {
+    fileName: _jsxFileName,
+    lineNumber: 3,
+    columnNumber: 3
+  }, void 0);
+}

--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
@@ -2,15 +2,13 @@ import jsx from "@babel/plugin-syntax-jsx";
 import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 import type { PluginPass } from "@babel/core";
-import type { NodePath, Visitor } from "@babel/traverse";
+import type { NodePath, Scope, Visitor } from "@babel/traverse";
 import { addNamed, addNamespace, isModule } from "@babel/helper-module-imports";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 import type {
-  ArrowFunctionExpression,
   CallExpression,
   Class,
   Expression,
-  FunctionParent,
   Identifier,
   JSXAttribute,
   JSXElement,
@@ -21,8 +19,6 @@ import type {
   ObjectExpression,
   Program,
 } from "@babel/types";
-
-type Diff<T, U> = T extends U ? never : T;
 
 const DEFAULT = {
   importSource: "react",
@@ -116,7 +112,7 @@ export default function createPlugin({ name, development }) {
     const injectMetaPropertiesVisitor: Visitor<PluginPass> = {
       JSXOpeningElement(path, state) {
         const attributes = [];
-        if (isThisAllowed(path)) {
+        if (isThisAllowed(path.scope)) {
           attributes.push(
             t.jsxAttribute(
               t.jsxIdentifier("__self"),
@@ -295,52 +291,36 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
       } as Visitor<PluginPass>,
     };
 
-    // Finds the closest parent function that provides `this`. Specifically, this looks for
-    // the first parent function that isn't an arrow function.
-    //
-    // Derived from `Scope#getFunctionParent`
-    function getThisFunctionParent(
-      path: NodePath,
-    ): NodePath<Diff<FunctionParent, ArrowFunctionExpression>> | null {
-      let scope = path.scope;
-      do {
-        if (
-          scope.path.isFunctionParent() &&
-          !scope.path.isArrowFunctionExpression()
-        ) {
-          // @ts-expect-error ts can not infer scope.path is Diff<FunctionParent, ArrowFunctionExpression>
-          return scope.path;
-        }
-      } while ((scope = scope.parent));
-      return null;
-    }
-
     // Returns whether the class has specified a superclass.
     function isDerivedClass(classPath: NodePath<Class>) {
       return classPath.node.superClass !== null;
     }
 
-    // Returns whether `this` is allowed at given path.
-    function isThisAllowed(path: NodePath<JSXOpeningElement>) {
+    // Returns whether `this` is allowed at given scope.
+    function isThisAllowed(scope: Scope) {
       // This specifically skips arrow functions as they do not rewrite `this`.
-      const parentMethodOrFunction = getThisFunctionParent(path);
-      if (parentMethodOrFunction === null) {
-        // We are not in a method or function. It is fine to use `this`.
-        return true;
-      }
-      if (!parentMethodOrFunction.isMethod()) {
-        // If the closest parent is a regular function, `this` will be rebound, therefore it is fine to use `this`.
-        return true;
-      }
-      // Current node is within a method, so we need to check if the method is a constructor.
-      if (parentMethodOrFunction.node.kind !== "constructor") {
-        // We are not in a constructor, therefore it is always fine to use `this`.
-        return true;
-      }
-      // Now we are in a constructor. If it is a derived class, we do not reference `this`.
-      return !isDerivedClass(
-        parentMethodOrFunction.parentPath.parentPath as NodePath<Class>,
-      );
+      do {
+        const { path } = scope;
+        if (path.isFunctionParent() && !path.isArrowFunctionExpression()) {
+          if (!path.isMethod()) {
+            // If the closest parent is a regular function, `this` will be rebound, therefore it is fine to use `this`.
+            return true;
+          }
+          // Current node is within a method, so we need to check if the method is a constructor.
+          if (path.node.kind !== "constructor") {
+            // We are not in a constructor, therefore it is always fine to use `this`.
+            return true;
+          }
+          // Now we are in a constructor. If it is a derived class, we do not reference `this`.
+          return !isDerivedClass(path.parentPath.parentPath as NodePath<Class>);
+        }
+        if (path.isTSModuleBlock()) {
+          // If the closeset parent is a TS Module block, `this` will not be allowed.
+          return false;
+        }
+      } while ((scope = scope.parent));
+      // We are not in a method or function. It is fine to use `this`.
+      return true;
     }
 
     function call(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14270
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we avoid generating `this` within in a TS module block since they are invalid TypeScript. Currently `this` within module block e.g. 
```ts
namespace X {
  const x = () => this
}
```
is parsed successfully, we should probably throw recoverable errors, too.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14271"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

