### PR TITLE
Fix infinite recursion when merge sourcemaps

### DIFF
--- a/packages/babel-core/src/transformation/file/merge-map.ts
+++ b/packages/babel-core/src/transformation/file/merge-map.ts
@@ -6,8 +6,14 @@ export default function mergeSourceMap(
   map: SourceMap,
   source: string,
 ): SourceMap {
+  // Prevent an infinite recursion if one of the input map's sources has the
+  // same resolved path as the input map. In the case, it would keep find the
+  // input map, then get it's sources which will include a path like the input
+  // map, on and on.
+  let found = false;
   const result = remapping(rootless(map), (s, ctx) => {
-    if (s === source) {
+    if (s === source && !found) {
+      found = true;
       // We empty the source location, which will prevent the sourcemap from
       // becoming relative to the input's location. Eg, if we're transforming a
       // file 'foo/bar.js', and it is a transformation of a `baz.js` file in the

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/input.js
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/input.js
@@ -1,0 +1,5 @@
+var foo = function () {
+  return 4;
+};
+
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXBzL2lucHV0LXNvdXJjZS1tYXAtc2FtZS1sb2NhdGlvbi9pbnB1dC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxVQUFVLFk7U0FBTSxDO0NBQUMiLCJzb3VyY2VzQ29udGVudCI6WyJ2YXIgZm9vID0gKCkgPT4gNDsiXX0=

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/input.js
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/input.js
@@ -2,4 +2,5 @@ var foo = function () {
   return 4;
 };
 
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXBzL2lucHV0LXNvdXJjZS1tYXAtc2FtZS1sb2NhdGlvbi9pbnB1dC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxVQUFVLFk7U0FBTSxDO0NBQUMiLCJzb3VyY2VzQ29udGVudCI6WyJ2YXIgZm9vID0gKCkgPT4gNDsiXX0=
+//# sourceMappingURL=input.js.map
+

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/input.js.map
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/input.js.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "sources": [
+    "source-maps/input-source-map-same-location/input.js"
+  ],
+  "names": [],
+  "mappings": "AAAA,UAAU,Y;SAAM,C;CAAC",
+  "sourcesContent": [
+    "var foo = () => 4;"
+  ]
+}

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/options.json
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/options.json
@@ -1,0 +1,3 @@
+{
+  "inputSourceMap": true
+}

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/output.js
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/output.js
@@ -1,0 +1,3 @@
+var foo = function () {
+  return 4;
+};

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/source-map.json
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-same-location/source-map.json
@@ -1,0 +1,7 @@
+{
+  "mappings": "AAAA,UAAU,Y;SAAM;AAAC,CAAjB",
+  "names": [],
+  "sources": ["source-maps/input-source-map-same-location/input.js"],
+  "sourcesContent": ["var foo = () => 4;"],
+  "version": 3
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14273
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

If the input map contains a source file that resolves to the same location as input map, then we'd hit an infinite recursion when attempting to build the source map tree.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14274"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

