### PR TITLE
Avoid IIFE for single-expression class static blocks

### DIFF
--- a/packages/babel-plugin-proposal-class-static-block/src/index.ts
+++ b/packages/babel-plugin-proposal-class-static-block/src/index.ts
@@ -59,12 +59,21 @@ export default declare(({ types: t, template, assertVersion }) => {
           const staticBlockRef = t.privateName(
             t.identifier(staticBlockPrivateId),
           );
+
+          let replacement;
+          const blockBody = path.node.body;
+          // We special-case the single expression case to avoid the iife, since
+          // it's common.
+          if (blockBody.length === 1 && t.isExpressionStatement(blockBody[0])) {
+            replacement = (blockBody[0] as t.ExpressionStatement).expression;
+          } else {
+            replacement = template.expression.ast`(() => { ${blockBody} })()`;
+          }
+
           path.replaceWith(
             t.classPrivateProperty(
               staticBlockRef,
-              template.expression.ast`(() => { ${
-                (path.node as t.StaticBlock).body
-              } })()`,
+              replacement,
               [],
               /* static */ true,
             ),

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/class-binding/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/class-binding/output.js
@@ -1,8 +1,6 @@
 class Foo {
   static bar = 42;
-  static #_ = (() => {
-    this.foo = Foo.bar;
-  })();
+  static #_ = this.foo = Foo.bar;
 }
 
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/class-declaration/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/class-declaration/output.js
@@ -1,8 +1,6 @@
 class Foo {
   static bar = 42;
-  static #_ = (() => {
-    this.foo = this.bar;
-  })();
+  static #_ = this.foo = this.bar;
 }
 
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/in-class-heritage/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/in-class-heritage/output.js
@@ -1,15 +1,9 @@
 class Foo extends class extends class Base {
-  static #_ = (() => {
-    this.qux = 21;
-  })();
+  static #_ = this.qux = 21;
 } {
-  static #_ = (() => {
-    this.bar = 21;
-  })();
+  static #_ = this.bar = 21;
 } {
-  static #_ = (() => {
-    this.foo = this.bar + this.qux;
-  })();
+  static #_ = this.foo = this.bar + this.qux;
 }
 
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/multiple-static-initializers/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/multiple-static-initializers/output.js
@@ -5,7 +5,5 @@ class Foo {
     this.qux1 = this.qux;
   })();
   static qux = 21;
-  static #_2 = (() => {
-    this.qux2 = this.qux;
-  })();
+  static #_2 = this.qux2 = this.qux;
 }

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/name-conflict/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/name-conflict/output.js
@@ -1,9 +1,7 @@
 class Foo {
   static #_ = 42; // static block can not be tranformed as `#_` here
 
-  static #_2 = (() => {
-    this.foo = this.#_;
-  })();
+  static #_2 = this.foo = this.#_;
 }
 
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/new-target/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/new-target/output.js
@@ -1,9 +1,7 @@
 class Base {
   constructor() {
     this.Foo = class {
-      static #_ = (() => {
-        this.foo = new.target;
-      })();
+      static #_ = this.foo = new.target;
     };
   }
 

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-binding/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-binding/output.js
@@ -1,9 +1,5 @@
 class Foo {}
 
 Foo.bar = 42;
-
-(() => {
-  Foo.foo = Foo.bar;
-})();
-
+Foo.foo = Foo.bar;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-declaration/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/class-declaration/output.js
@@ -1,9 +1,5 @@
 class Foo {}
 
 Foo.bar = 42;
-
-(() => {
-  Foo.foo = Foo.bar;
-})();
-
+Foo.foo = Foo.bar;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/in-class-heritage/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/in-class-heritage/output.js
@@ -1,13 +1,6 @@
 var _class, _class2;
 
-class Foo extends (_class = class extends (_class2 = class Base {}, (() => {
-  _class2.qux = 21;
-})(), _class2) {}, (() => {
-  _class.bar = 21;
-})(), _class) {}
+class Foo extends (_class = class extends (_class2 = class Base {}, _class2.qux = 21, _class2) {}, _class.bar = 21, _class) {}
 
-(() => {
-  Foo.foo = Foo.bar + Foo.qux;
-})();
-
+Foo.foo = Foo.bar + Foo.qux;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/multiple-static-initializers/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/multiple-static-initializers/output.js
@@ -13,7 +13,4 @@ Object.defineProperty(Foo, _bar, {
 })();
 
 Foo.qux = 21;
-
-(() => {
-  Foo.qux2 = Foo.qux;
-})();
+Foo.qux2 = Foo.qux;

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/name-conflict/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/name-conflict/output.js
@@ -6,9 +6,5 @@ Object.defineProperty(Foo, _, {
   writable: true,
   value: 42
 });
-
-(() => {
-  Foo.foo = babelHelpers.classPrivateFieldLooseBase(Foo, _)[_];
-})();
-
+Foo.foo = babelHelpers.classPrivateFieldLooseBase(Foo, _)[_];
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/super-static-block/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/super-static-block/output.js
@@ -1,13 +1,7 @@
 var _ref, _class;
 
-class Foo extends (_ref = (_class = class _ref {}, (() => {
-  _class.bar = 42;
-})(), _class)) {}
+class Foo extends (_ref = (_class = class _ref {}, _class.bar = 42, _class)) {}
 
 Foo.bar = 21;
-
-(() => {
-  Foo.foo = _ref.bar;
-})();
-
+Foo.foo = _ref.bar;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/class-binding/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/class-binding/output.js
@@ -1,9 +1,5 @@
 class Foo {}
 
 babelHelpers.defineProperty(Foo, "bar", 42);
-
-(() => {
-  Foo.foo = Foo.bar;
-})();
-
+Foo.foo = Foo.bar;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/class-declaration/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/class-declaration/output.js
@@ -1,9 +1,5 @@
 class Foo {}
 
 babelHelpers.defineProperty(Foo, "bar", 42);
-
-(() => {
-  Foo.foo = Foo.bar;
-})();
-
+Foo.foo = Foo.bar;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/in-class-heritage/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/in-class-heritage/output.js
@@ -1,13 +1,6 @@
 var _class, _class2;
 
-class Foo extends (_class = class extends (_class2 = class Base {}, (() => {
-  _class2.qux = 21;
-})(), _class2) {}, (() => {
-  _class.bar = 21;
-})(), _class) {}
+class Foo extends (_class = class extends (_class2 = class Base {}, _class2.qux = 21, _class2) {}, _class.bar = 21, _class) {}
 
-(() => {
-  Foo.foo = Foo.bar + Foo.qux;
-})();
-
+Foo.foo = Foo.bar + Foo.qux;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/multiple-static-initializers/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/multiple-static-initializers/output.js
@@ -11,7 +11,4 @@ var _bar = {
 })();
 
 babelHelpers.defineProperty(Foo, "qux", 21);
-
-(() => {
-  Foo.qux2 = Foo.qux;
-})();
+Foo.qux2 = Foo.qux;

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/name-conflict/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/name-conflict/output.js
@@ -4,9 +4,5 @@ var _ = {
   writable: true,
   value: 42
 };
-
-(() => {
-  Foo.foo = babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _);
-})();
-
+Foo.foo = babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _);
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/new-target/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/new-target/output.js
@@ -2,9 +2,7 @@ class Base {
   constructor() {
     var _class;
 
-    this.Foo = (_class = class {}, (() => {
-      _class.foo = void 0;
-    })(), _class);
+    this.Foo = (_class = class {}, _class.foo = void 0, _class);
   }
 
 }

--- a/packages/babel-plugin-proposal-class-static-block/test/plugin-ordering.test.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/plugin-ordering.test.js
@@ -26,9 +26,7 @@ describe("plugin ordering", () => {
 
       class Foo {}
 
-      (() => {
-        Foo.foo = Foo.bar;
-      })();
+      Foo.foo = Foo.bar;
 
       _defineProperty(Foo, \\"bar\\", 42);"
     `);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/private/output.js
@@ -48,14 +48,12 @@ function _get_b2() {
   _get_b(this);
 }
 
-(() => {
-  [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 1, "a", function () {
-    return babelHelpers.classPrivateFieldGet(this, _A);
-  }, function (value) {
-    babelHelpers.classPrivateFieldSet(this, _A, value);
-  }], [dec, 1, "b", function () {
-    return babelHelpers.classPrivateFieldGet(this, _B);
-  }, function (value) {
-    babelHelpers.classPrivateFieldSet(this, _B, value);
-  }]], []);
-})();
+[_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 1, "a", function () {
+  return babelHelpers.classPrivateFieldGet(this, _A);
+}, function (value) {
+  babelHelpers.classPrivateFieldSet(this, _A, value);
+}], [dec, 1, "b", function () {
+  return babelHelpers.classPrivateFieldGet(this, _B);
+}, function (value) {
+  babelHelpers.classPrivateFieldSet(this, _B, value);
+}]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
@@ -52,6 +52,4 @@ class Foo {
 
 }
 
-(() => {
-  [_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, _computedKey]], []);
-})();
+[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, _computedKey]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions/output.js
@@ -2,52 +2,16 @@ var _initClass, _A, _class, _initClass2, _C, _class2, _initClass3, _D, _class3, 
 
 const dec = () => {};
 
-const A = ((_class = class A {}, (() => {
-  [_A, _initClass] = babelHelpers.applyDecs(_class, [], [dec]);
-})(), (() => {
-  _initClass();
-})()), _A);
-const B = ((_class2 = class C {}, (() => {
-  [_C, _initClass2] = babelHelpers.applyDecs(_class2, [], [dec]);
-})(), (() => {
-  _initClass2();
-})()), _C);
-const D = ((_class3 = class D {}, (() => {
-  [_D, _initClass3] = babelHelpers.applyDecs(_class3, [], [dec]);
-})(), (() => {
-  _initClass3();
-})()), _D);
-const E = (((_class4 = class {}, (() => {
-  [_decorated_class, _initClass4] = babelHelpers.applyDecs(_class4, [], [dec]);
-})(), (() => {
-  _initClass4();
-})()), _decorated_class), 123);
-const F = [((_class5 = class G {}, (() => {
-  [_G, _initClass5] = babelHelpers.applyDecs(_class5, [], [dec]);
-})(), (() => {
-  _initClass5();
-})()), _G), ((_class6 = class {}, (() => {
-  [_decorated_class2, _initClass6] = babelHelpers.applyDecs(_class6, [], [dec]);
-})(), (() => {
-  _initClass6();
-})()), _decorated_class2)];
-const H = ((_class7 = class H extends I {}, (() => {
-  [_H, _initClass7] = babelHelpers.applyDecs(_class7, [], [dec]);
-})(), (() => {
-  _initClass7();
-})()), _H);
-const J = ((_class8 = class K extends L {}, (() => {
-  [_K, _initClass8] = babelHelpers.applyDecs(_class8, [], [dec]);
-})(), (() => {
-  _initClass8();
-})()), _K);
+const A = ((_class = class A {}, [_A, _initClass] = babelHelpers.applyDecs(_class, [], [dec]), _initClass()), _A);
+const B = ((_class2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs(_class2, [], [dec]), _initClass2()), _C);
+const D = ((_class3 = class D {}, [_D, _initClass3] = babelHelpers.applyDecs(_class3, [], [dec]), _initClass3()), _D);
+const E = (((_class4 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs(_class4, [], [dec]), _initClass4()), _decorated_class), 123);
+const F = [((_class5 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs(_class5, [], [dec]), _initClass5()), _G), ((_class6 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs(_class6, [], [dec]), _initClass6()), _decorated_class2)];
+const H = ((_class7 = class H extends I {}, [_H, _initClass7] = babelHelpers.applyDecs(_class7, [], [dec]), _initClass7()), _H);
+const J = ((_class8 = class K extends L {}, [_K, _initClass8] = babelHelpers.applyDecs(_class8, [], [dec]), _initClass8()), _K);
 
 function classFactory() {
   var _initClass9, _decorated_class3, _class9;
 
-  return (_class9 = class {}, (() => {
-    [_decorated_class3, _initClass9] = babelHelpers.applyDecs(_class9, [], [dec]);
-  })(), (() => {
-    _initClass9();
-  })()), _decorated_class3;
+  return (_class9 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs(_class9, [], [dec]), _initClass9()), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/inheritance/output.js
@@ -8,22 +8,14 @@ let _Bar;
 
 class Bar {}
 
-(() => {
-  [_Bar, _initClass] = babelHelpers.applyDecs(Bar, [], [dec1]);
-})();
+[_Bar, _initClass] = babelHelpers.applyDecs(Bar, [], [dec1]);
 
-(() => {
-  _initClass();
-})();
+_initClass();
 
 let _Foo;
 
 class Foo extends _Bar {}
 
-(() => {
-  [_Foo, _initClass2] = babelHelpers.applyDecs(Foo, [], [dec2]);
-})();
+[_Foo, _initClass2] = babelHelpers.applyDecs(Foo, [], [dec2]);
 
-(() => {
-  _initClass2();
-})();
+_initClass2();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/initializers/output.js
@@ -12,9 +12,7 @@ new (_temp = class extends babelHelpers.identity {
 }, (() => {
   class Foo {}
 
-  (() => {
-    [_Foo, _initClass] = babelHelpers.applyDecs(Foo, [], [dec]);
-  })();
+  [_Foo, _initClass] = babelHelpers.applyDecs(Foo, [], [dec]);
 })(), _temp)();
 
 let _Bar;
@@ -29,7 +27,5 @@ new (_temp2 = class extends babelHelpers.identity {
 }, (() => {
   class Bar extends _Foo {}
 
-  (() => {
-    [_Bar, _initClass2] = babelHelpers.applyDecs(Bar, [], [dec]);
-  })();
+  [_Bar, _initClass2] = babelHelpers.applyDecs(Bar, [], [dec]);
 })(), _temp2)();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -24,9 +24,7 @@ new (_x = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), (_temp = 
 
   }
 
-  (() => {
-    [_Foo, _initClass] = babelHelpers.applyDecs(Foo, [], [dec]);
-  })();
+  [_Foo, _initClass] = babelHelpers.applyDecs(Foo, [], [dec]);
 })(), _temp))();
 
 function _m2() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-this/output.js
@@ -16,7 +16,5 @@ new (_temp = class extends babelHelpers.identity {
 }, (() => {
   class Foo {}
 
-  (() => {
-    [_Foo, _initClass] = babelHelpers.applyDecs(Foo, [], [dec]);
-  })();
+  [_Foo, _initClass] = babelHelpers.applyDecs(Foo, [], [dec]);
 })(), _temp)();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-with-expr/output.js
@@ -7,9 +7,5 @@ const Foo = ((_class = class Bar {
     babelHelpers.defineProperty(this, "bar", new _Bar());
   }
 
-}, (() => {
-  [_Bar, _initClass] = babelHelpers.applyDecs(_class, [], [dec]);
-})(), (() => {
-  _initClass();
-})()), _Bar);
+}, [_Bar, _initClass] = babelHelpers.applyDecs(_class, [], [dec]), _initClass()), _Bar);
 const foo = new Foo();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement/output.js
@@ -12,8 +12,6 @@ new (_temp = class extends babelHelpers.identity {
 }, (() => {
   class Foo {}
 
-  (() => {
-    [_Foo, _initClass] = babelHelpers.applyDecs(Foo, [], [dec]);
-  })();
+  [_Foo, _initClass] = babelHelpers.applyDecs(Foo, [], [dec]);
 })(), _temp)();
 const foo = new _Foo();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -20,6 +20,4 @@ class Foo {
 
 }
 
-(() => {
-  [_initProto] = babelHelpers.applyDecs(Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);
-})();
+[_initProto] = babelHelpers.applyDecs(Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -20,6 +20,4 @@ class Foo {
 
 }
 
-(() => {
-  [_initProto] = babelHelpers.applyDecs(Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);
-})();
+[_initProto] = babelHelpers.applyDecs(Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/method-and-field/output.js
@@ -13,6 +13,4 @@ class Foo {
 
 }
 
-(() => {
-  [_init_a, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 0, "a"], [dec, 2, "a"]], []);
-})();
+[_init_a, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 0, "a"], [dec, 2, "a"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/methods-with-same-key/output.js
@@ -17,6 +17,4 @@ class Foo {
 
 }
 
-(() => {
-  [_initProto] = babelHelpers.applyDecs(Foo, [[dec, 2, "a"], [dec, 2, "a"]], []);
-})();
+[_initProto] = babelHelpers.applyDecs(Foo, [[dec, 2, "a"], [dec, 2, "a"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/private/output.js
@@ -20,14 +20,12 @@ class Foo {
 
 }
 
-(() => {
-  [_init_a, _init_b] = babelHelpers.applyDecs(Foo, [[dec, 0, "a", function () {
-    return babelHelpers.classPrivateFieldGet(this, _a);
-  }, function (value) {
-    babelHelpers.classPrivateFieldSet(this, _a, value);
-  }], [dec, 0, "b", function () {
-    return babelHelpers.classPrivateFieldGet(this, _b);
-  }, function (value) {
-    babelHelpers.classPrivateFieldSet(this, _b, value);
-  }]], []);
-})();
+[_init_a, _init_b] = babelHelpers.applyDecs(Foo, [[dec, 0, "a", function () {
+  return babelHelpers.classPrivateFieldGet(this, _a);
+}, function (value) {
+  babelHelpers.classPrivateFieldSet(this, _a, value);
+}], [dec, 0, "b", function () {
+  return babelHelpers.classPrivateFieldGet(this, _b);
+}, function (value) {
+  babelHelpers.classPrivateFieldSet(this, _b, value);
+}]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/public/output.js
@@ -13,6 +13,4 @@ class Foo {
 
 }
 
-(() => {
-  [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(Foo, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, _computedKey]], []);
-})();
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(Foo, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, _computedKey]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-private/output.js
@@ -4,18 +4,15 @@ const dec = () => {};
 
 class Foo {}
 
-(() => {
-  [_init_a, _init_b] = babelHelpers.applyDecs(Foo, [[dec, 5, "a", function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _a);
-  }, function (value) {
-    babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _a, value);
-  }], [dec, 5, "b", function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _b);
-  }, function (value) {
-    babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _b, value);
-  }]], []);
-})();
-
+[_init_a, _init_b] = babelHelpers.applyDecs(Foo, [[dec, 5, "a", function () {
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _a);
+}, function (value) {
+  babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _a, value);
+}], [dec, 5, "b", function () {
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _b);
+}, function (value) {
+  babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _b, value);
+}]], []);
 var _a = {
   writable: true,
   value: _init_a(Foo)

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-public/output.js
@@ -6,10 +6,7 @@ _computedKey = 'c'
 
 class Foo {}
 
-(() => {
-  [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(Foo, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, _computedKey]], []);
-})();
-
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(Foo, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, _computedKey]], []);
 babelHelpers.defineProperty(Foo, "a", _init_a(Foo));
 babelHelpers.defineProperty(Foo, "b", _init_b(Foo, 123));
 babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey(Foo, 456));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
@@ -25,8 +25,6 @@ function _get_a() {
   return _call_a(this);
 }
 
-(() => {
-  [_call_a, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 3, "a", function () {
-    return this.value;
-  }]], []);
-})();
+[_call_a, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 3, "a", function () {
+  return this.value;
+}]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
@@ -21,6 +21,4 @@ class Foo {
 
 }
 
-(() => {
-  [_initProto] = babelHelpers.applyDecs(Foo, [[dec, 3, "a"], [dec, 3, _computedKey]], []);
-})();
+[_initProto] = babelHelpers.applyDecs(Foo, [[dec, 3, "a"], [dec, 3, _computedKey]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
@@ -33,10 +33,8 @@ function _set_a(v) {
   _call_a2(this, v);
 }
 
-(() => {
-  [_call_a, _call_a2, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 3, "a", function () {
-    return this.value;
-  }], [dec, 4, "a", function (v) {
-    this.value = v;
-  }]], []);
-})();
+[_call_a, _call_a2, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 3, "a", function () {
+  return this.value;
+}], [dec, 4, "a", function (v) {
+  this.value = v;
+}]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
@@ -30,6 +30,4 @@ class Foo {
 
 }
 
-(() => {
-  [_initProto] = babelHelpers.applyDecs(Foo, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, _computedKey], [dec, 4, _computedKey2]], []);
-})();
+[_initProto] = babelHelpers.applyDecs(Foo, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, _computedKey], [dec, 4, _computedKey2]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/private/output.js
@@ -21,8 +21,6 @@ class Foo {
 
 }
 
-(() => {
-  [_call_a, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 2, "a", function () {
-    return this.value;
-  }]], []);
-})();
+[_call_a, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 2, "a", function () {
+  return this.value;
+}]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
@@ -21,6 +21,4 @@ class Foo {
 
 }
 
-(() => {
-  [_initProto] = babelHelpers.applyDecs(Foo, [[dec, 2, "a"], [dec, 2, _computedKey]], []);
-})();
+[_initProto] = babelHelpers.applyDecs(Foo, [[dec, 2, "a"], [dec, 2, _computedKey]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -17,6 +17,4 @@ class A extends B {
 
 }
 
-(() => {
-  [_initProto] = babelHelpers.applyDecs(A, [[_dec, 2, "method"]], []);
-})();
+[_initProto] = babelHelpers.applyDecs(A, [[_dec, 2, "method"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
@@ -35,17 +35,11 @@ class Foo {
         babelHelpers.defineProperty(this, "bar", _init_bar(this));
       }
 
-    }, (() => {
-      [_init_bar] = babelHelpers.applyDecs(_class, [[_dec9, 0, "bar"]], []);
-    })(), _class);
+    }, [_init_bar] = babelHelpers.applyDecs(_class, [[_dec9, 0, "bar"]], []), _class);
   }
 
 }
 
-(() => {
-  [_initProto, _Foo, _initClass] = babelHelpers.applyDecs(Foo, [[[dec, _dec5, _dec6, _dec7, _dec8], 2, "method"]], [dec, _dec, _dec2, _dec3, _dec4]);
-})();
+[_initProto, _Foo, _initClass] = babelHelpers.applyDecs(Foo, [[[dec, _dec5, _dec6, _dec7, _dec8], 2, "method"]], [dec, _dec, _dec2, _dec3, _dec4]);
 
-(() => {
-  _initClass();
-})();
+_initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
@@ -25,8 +25,6 @@ function _set_a(v) {
   _call_a(this, v);
 }
 
-(() => {
-  [_call_a, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 4, "a", function (v) {
-    return this.value = v;
-  }]], []);
-})();
+[_call_a, _initProto] = babelHelpers.applyDecs(Foo, [[dec, 4, "a", function (v) {
+  return this.value = v;
+}]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
@@ -21,6 +21,4 @@ class Foo {
 
 }
 
-(() => {
-  [_initProto] = babelHelpers.applyDecs(Foo, [[dec, 4, "a"], [dec, 4, _computedKey]], []);
-})();
+[_initProto] = babelHelpers.applyDecs(Foo, [[dec, 4, "a"], [dec, 4, _computedKey]], []);

--- a/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-chrome-90/output.js
+++ b/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-chrome-90/output.js
@@ -2,7 +2,5 @@ var _fooBrandCheck = /*#__PURE__*/new WeakSet();
 
 class A {
   #foo = void _fooBrandCheck.add(this);
-  static #_ = (() => {
-    register(A, _fooBrandCheck.has(A));
-  })();
+  static #_ = register(A, _fooBrandCheck.has(A));
 }

--- a/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-firefox-70/output.js
+++ b/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-firefox-70/output.js
@@ -10,6 +10,4 @@ class A {
 
 }
 
-(() => {
-  register(A, _foo.has(A));
-})();
+register(A, _foo.has(A));


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I noticed that static blocks containing a single expression are quite common, so this PR avoids the IIFE when compiling them. Note that this optimization only affects who is not using a minifier, because minifiers can already easily unwrap IIFEs.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14275"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

