### PR TITLE
Fix the duplicate export initialization (#14272)

### DIFF
--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -460,11 +460,8 @@ function buildExportInitializationStatements(
     // We generate init statements (`exports.a = exports.b = ... = void 0`)
     // for every 100 exported names to avoid deeply-nested AST structures.
     const chunkSize = 100;
-    for (
-      let i = 0, uninitializedExportNames = [];
-      i < initStatements.length;
-      i += chunkSize
-    ) {
+    for (let i = 0; i < initStatements.length; i += chunkSize) {
+      let uninitializedExportNames = [];
       for (let j = 0; j < chunkSize && i + j < initStatements.length; j++) {
         const [exportName, initStatement] = initStatements[i + j];
         if (initStatement !== null) {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14272 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      |
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

The array `uninitializedExportNames` haven't reset to `[]` so the array would contains the previous chunks. This will make lots of duplicate initialization statements while the amount of exports more than 100.

For more detail: https://github.com/babel/babel/issues/14272

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14276"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

