### PR TITLE
[hack pipes] Inline topic token when possible

### DIFF
--- a/packages/babel-plugin-proposal-pipeline-operator/src/hackVisitor.ts
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/hackVisitor.ts
@@ -22,21 +22,21 @@ export default {
         return;
       }
 
-      const topicVariable = scope.generateUidIdentifierBasedOnNode(node);
       const pipeBodyPath = path.get("right");
-
-      scope.push({ id: topicVariable });
-
       if (pipeBodyPath.node.type === "TopicReference") {
         // If the pipe body is itself a lone topic reference,
-        // then replace it with the topic variable.
-        pipeBodyPath.replaceWith(t.cloneNode(topicVariable));
-      } else {
-        // Replace topic references with the topic variable.
-        pipeBodyPath.traverse(topicReferenceReplacementVisitor, {
-          topicVariable,
-        });
+        // then replace the whole expression with its left operand.
+        path.replaceWith(node.left);
+        return;
       }
+
+      const topicVariable = scope.generateUidIdentifierBasedOnNode(node);
+      scope.push({ id: topicVariable });
+
+      // Replace topic references with the topic variable.
+      pipeBodyPath.traverse(topicReferenceReplacementVisitor, {
+        topicVariable,
+      });
 
       // Replace the pipe expression itself with an assignment expression.
       path.replaceWith(

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/hash-tuple/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/hash-tuple/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
 Tuple(0);
-_ref = 1, Tuple(0, _ref);
+Tuple(0, 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-identity/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-identity/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const result = (_ref = 5, _ref);
+const result = 5;
 expect(result).toBe(5);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-addition/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-addition/input.js
@@ -1,3 +1,3 @@
-const result = 5 |> ^ + 1 |> ^ + ^;
+const result = 5 |> ^ + 1 |> 2 + ^ |> ^ + ^;
 
 expect(result).toBe(12);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-addition/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-addition/output.js
@@ -1,4 +1,4 @@
-var _ref, _ref2;
+var _ref;
 
-const result = (_ref2 = 5, (_ref = _ref2 + 1, _ref + _ref));
+const result = (_ref = 2 + (5 + 1), _ref + _ref);
 expect(result).toBe(12);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-arrow-function-and-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-arrow-function-and-nested-pipe/output.js
@@ -1,8 +1,8 @@
-var _ref4, _ref5, _ref6;
+var _ref2;
 
-const result = (_ref6 = 5, (_ref5 = Math.pow(_ref6, 2), (_ref4 = [1, 2, 3].map(n => {
-  var _ref, _ref2, _ref3;
+const result = (_ref2 = Math.pow(5, 2), [1, 2, 3].map(n => {
+  var _ref;
 
-  return _ref3 = n + _ref5, (_ref2 = _ref3 * 2, (_ref = `${_ref2} apples`, _ref.toUpperCase()));
-}), _ref4.join())));
+  return _ref = (n + _ref2) * 2, `${_ref} apples`.toUpperCase();
+}).join());
 expect(result).toEqual('52 APPLES,54 APPLES,56 APPLES');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-arrow-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-arrow-function/output.js
@@ -1,8 +1,8 @@
-var _ref, _ref2, _ref3;
+var _ref;
 
-const result = (_ref3 = -2.2 // -2.2
-, (_ref2 = Math.floor(_ref3) // -3
-, (_ref = () => Math.pow(_ref2, 5) // () => -243
-, _ref()))); // -243
+const result = (_ref = Math.floor(-2.2 // -2.2
+) // -3
+, (() => Math.pow(_ref, 5) // () => -243
+)()); // -243
 
 expect(result).toBe(-243);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-await/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-await/output.js
@@ -3,9 +3,9 @@ function triple(x) {
 }
 
 async function asyncFunction(n) {
-  var _ref, _ref2, _ref3;
+  var _ref;
 
-  return _ref3 = n, (_ref2 = Math.abs(_ref3), (_ref = await Promise.resolve(_ref2), triple(_ref)));
+  return _ref = Math.abs(n), triple(await Promise.resolve(_ref));
 }
 
 asyncFunction(-7).then(result => {

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-class-expression-and-private-properties/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-class-expression-and-private-properties/output.js
@@ -1,10 +1,8 @@
-var _ref, _ref2, _ref3;
-
-const result = (_ref3 = 1, (_ref2 = class {
+const result = new class {
   #baz;
 
   constructor() {
-    this.#baz = _ref3;
+    this.#baz = 1;
   }
 
   #bar() {
@@ -15,5 +13,5 @@ const result = (_ref3 = 1, (_ref2 = class {
     return this.#bar() + 3;
   }
 
-}, (_ref = new _ref2(), _ref.foo())));
+}().foo();
 expect(result).toBe(1 + 2 + 3);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-eval/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-eval/output.js
@@ -1,5 +1,3 @@
-var _ref;
-
 const program = '(function() { return this; })()';
-const result = (_ref = program, eval(_ref));
+const result = eval(program);
 expect(result).not.toBeUndefined();

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-nested-pipe/output.js
@@ -1,4 +1,4 @@
-var _ref, _ref2, _ref3, _ref4;
+var _ref;
 
-const result = (_ref4 = 5, (_ref3 = Math.pow(_ref4, 2), (_ref2 = _ref3 + 1, (_ref = `${_ref2} apples`, _ref.toUpperCase()))));
+const result = (_ref = Math.pow(5, 2) + 1, `${_ref} apples`.toUpperCase());
 expect(result).toEqual('26 APPLES');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-object-literal/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-object-literal/output.js
@@ -1,11 +1,11 @@
-var _ref, _ref2, _ref3;
+var _ref;
 
 function area(rect) {
   return rect.width * rect.height;
 }
 
-const result = (_ref3 = -5, (_ref2 = Math.abs(_ref3), (_ref = {
-  width: _ref2,
-  height: _ref2 + 3
-}, area(_ref))));
+const result = (_ref = Math.abs(-5), area({
+  width: _ref,
+  height: _ref + 3
+}));
 expect(result).toBe(40);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-topic-method-call/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-topic-method-call/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const result = (_ref = 'Hello', _ref.toUpperCase());
+const result = 'Hello'.toUpperCase();
 expect(result).toBe('HELLO');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-yield/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-body-with-yield/output.js
@@ -1,7 +1,7 @@
 function* myGenerator(n) {
-  var _ref, _ref2;
+  var _ref;
 
-  return _ref2 = n, (_ref = yield _ref2, Math.abs(_ref));
+  return _ref = yield n, Math.abs(_ref);
 }
 
 const myIterator = myGenerator(15);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-head-with-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-head-with-nested-pipe/output.js
@@ -1,4 +1,2 @@
-var _ref, _ref2;
-
-const result = (_ref2 = (_ref = 5, Math.pow(_ref, 2)), _ref2 + 1);
+const result = Math.pow(5, 2) + 1;
 expect(result).toEqual(26);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-in-arrow-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/pipe-in-arrow-function/output.js
@@ -1,10 +1,10 @@
 const result = () => {
-  var _ref, _ref2, _ref3;
+  var _ref;
 
-  return _ref3 = -2.2 // -2.2
-  , (_ref2 = Math.floor(_ref3) // -3
-  , (_ref = () => Math.pow(_ref2, 5) // () => -243
-  , _ref()));
+  return _ref = Math.floor(-2.2 // -2.2
+  ) // -3
+  , (() => Math.pow(_ref, 5) // () => -243
+  )();
 }; // -243
 
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/topic-token-in-function/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/topic-token-in-function/exec.js
@@ -1,0 +1,9 @@
+let x = 0;
+
+let fnA = x++ |> (() => ^);
+let fnB = x++ |> (0, () => ^);
+
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/topic-token-in-function/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/topic-token-in-function/input.js
@@ -1,0 +1,9 @@
+let x = 0;
+
+let fnA = x++ |> (() => ^);
+let fnB = x++ |> (0, () => ^);
+
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/topic-token-in-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/topic-token-in-function/output.js
@@ -1,0 +1,9 @@
+var _ref, _ref2;
+
+let x = 0;
+let fnA = (_ref = x++, () => _ref);
+let fnB = (_ref2 = x++, (0, () => _ref2));
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/transform-arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/transform-arrow-functions/output.js
@@ -1,8 +1,6 @@
-var _ref, _ref2;
-
 const triple = function (x) {
   return x * 3;
 };
 
-const result = (_ref2 = -7, (_ref = Math.abs(_ref2), triple(_ref)));
+const result = triple(Math.abs(-7));
 return expect(result).toBe(21);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/transform-await-and-arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/transform-await-and-arrow-functions/output.js
@@ -3,9 +3,9 @@ const triple = function (x) {
 };
 
 async function myFunction(n) {
-  var _ref, _ref2, _ref3, _ref4;
+  var _ref;
 
-  return _ref4 = n, (_ref3 = Math.abs(_ref4), (_ref2 = Promise.resolve(_ref3), (_ref = await _ref2, triple(_ref))));
+  return _ref = Math.abs(n), triple(await Promise.resolve(_ref));
 }
 
 return myFunction(-7).then(function (result) {

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/while-statement-with-pipe-in-condition/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/while-statement-with-pipe-in-condition/exec.js
@@ -1,7 +1,7 @@
 let i = 0;
 let sum = 0;
 
-while (i |> (i = ^ + 1) |> ^ <= 10)
+while (i |> (i = 2 * ^ - ^ + 1) |> ^ <= 10)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/while-statement-with-pipe-in-condition/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/while-statement-with-pipe-in-condition/input.js
@@ -1,7 +1,7 @@
 let i = 0;
 let sum = 0;
 
-while (i |> (i = ^ + 1) |> ^ <= 10)
+while (i |> (i = 2 * ^ - ^ + 1) |> ^ <= 10)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/while-statement-with-pipe-in-condition/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/while-statement-with-pipe-in-condition/output.js
@@ -1,8 +1,8 @@
 let i = 0;
 let sum = 0;
 
-while (_ref2 = i, (_ref = i = _ref2 + 1, _ref <= 10)) {
-  var _ref, _ref2;
+while (_ref = i, (i = 2 * _ref - _ref + 1) <= 10) {
+  var _ref;
 
   sum += i;
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-assignment/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-assignment/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const x = (_ref = 0, _ref + 1);
+const x = 0 + 1;
 expect(x).toBe(1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-init/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-init/input.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0 |> ^; i <= 10; i++)
+for (var i = 0 |> ^*^; i <= 10; i++)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-init/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-init/output.js
@@ -1,6 +1,6 @@
 let sum = 0;
 
-for (var i = (_ref = 0, _ref); i <= 10; i++) {
+for (var i = (_ref = 0, _ref * _ref); i <= 10; i++) {
   var _ref;
 
   sum += i;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-test/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-test/exec.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0; i |> ^ <= 10; i++)
+for (var i = 0; i |> ^ + ^ <= 20; i++)
   sum = sum + i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1)

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-test/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-test/input.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0; i |> ^ <= 10; i++)
+for (var i = 0; i |> ^ + ^ <= 20; i++)
   sum = sum + i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1)

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-test/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-test/output.js
@@ -1,6 +1,6 @@
 let sum = 0;
 
-for (var i = 0; _ref = i, _ref <= 10; i++) {
+for (var i = 0; _ref = i, _ref + _ref <= 20; i++) {
   var _ref;
 
   sum = sum + i;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-update/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-for-classic-statement-update/output.js
@@ -1,8 +1,6 @@
 let sum = 0;
 
-for (var i = 0; i <= 10; i = (_ref = i, _ref + 1)) {
-  var _ref;
-
+for (var i = 0; i <= 10; i = i + 1) {
   sum = sum + i;
 }
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-generator-with-yield/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-caret/within-generator-with-yield/output.js
@@ -1,5 +1,5 @@
 function* myGenerator(n) {
-  var _ref, _ref2;
+  var _ref;
 
-  return _ref2 = n, (_ref = yield _ref2, Math.abs(_ref));
+  return _ref = yield n, Math.abs(_ref);
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/class-decorator/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/class-decorator/output.js
@@ -1,19 +1,17 @@
-var _ref;
-
 const expectedValue = 42;
 
 function decorator(target) {
   target.decoratorValue = expectedValue;
 }
 
-const result = (_ref = expectedValue, babelHelpers.decorate([decorator], function (_initialize) {
+const result = babelHelpers.decorate([decorator], function (_initialize) {
   "use strict";
 
   class _class {
     constructor() {
       _initialize(this);
 
-      this.value = _ref;
+      this.value = expectedValue;
     }
 
   }
@@ -22,6 +20,6 @@ const result = (_ref = expectedValue, babelHelpers.decorate([decorator], functio
     F: _class,
     d: []
   };
-}));
+});
 expect(result.decoratorValue).toBe(expectedValue);
 expect(new result().value).toBe(expectedValue);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/hash-tuple/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/hash-tuple/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
 Tuple(0);
-_ref = 1, Tuple(0, _ref);
+Tuple(0, 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-identity/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-identity/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const result = (_ref = 5, _ref);
+const result = 5;
 expect(result).toBe(5);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-addition/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-addition/input.js
@@ -1,3 +1,3 @@
-const result = 5 |> @@ + 1 |> @@ + @@;
+const result = 5 |> @@ + 1 |> 2 + @@ |> @@ + @@;
 
 expect(result).toBe(12);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-addition/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-addition/output.js
@@ -1,4 +1,4 @@
-var _ref, _ref2;
+var _ref;
 
-const result = (_ref2 = 5, (_ref = _ref2 + 1, _ref + _ref));
+const result = (_ref = 2 + (5 + 1), _ref + _ref);
 expect(result).toBe(12);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-arrow-function-and-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-arrow-function-and-nested-pipe/output.js
@@ -1,8 +1,8 @@
-var _ref4, _ref5, _ref6;
+var _ref2;
 
-const result = (_ref6 = 5, (_ref5 = Math.pow(_ref6, 2), (_ref4 = [1, 2, 3].map(n => {
-  var _ref, _ref2, _ref3;
+const result = (_ref2 = Math.pow(5, 2), [1, 2, 3].map(n => {
+  var _ref;
 
-  return _ref3 = n + _ref5, (_ref2 = _ref3 * 2, (_ref = `${_ref2} apples`, _ref.toUpperCase()));
-}), _ref4.join())));
+  return _ref = (n + _ref2) * 2, `${_ref} apples`.toUpperCase();
+}).join());
 expect(result).toEqual('52 APPLES,54 APPLES,56 APPLES');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-arrow-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-arrow-function/output.js
@@ -1,8 +1,8 @@
-var _ref, _ref2, _ref3;
+var _ref;
 
-const result = (_ref3 = -2.2 // -2.2
-, (_ref2 = Math.floor(_ref3) // -3
-, (_ref = () => Math.pow(_ref2, 5) // () => -243
-, _ref()))); // -243
+const result = (_ref = Math.floor(-2.2 // -2.2
+) // -3
+, (() => Math.pow(_ref, 5) // () => -243
+)()); // -243
 
 expect(result).toBe(-243);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-await/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-await/output.js
@@ -3,9 +3,9 @@ function triple(x) {
 }
 
 async function asyncFunction(n) {
-  var _ref, _ref2, _ref3;
+  var _ref;
 
-  return _ref3 = n, (_ref2 = Math.abs(_ref3), (_ref = await Promise.resolve(_ref2), triple(_ref)));
+  return _ref = Math.abs(n), triple(await Promise.resolve(_ref));
 }
 
 asyncFunction(-7).then(result => {

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-class-expression-and-private-properties/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-class-expression-and-private-properties/output.js
@@ -1,10 +1,8 @@
-var _ref, _ref2, _ref3;
-
-const result = (_ref3 = 1, (_ref2 = class {
+const result = new class {
   #baz;
 
   constructor() {
-    this.#baz = _ref3;
+    this.#baz = 1;
   }
 
   #bar() {
@@ -15,5 +13,5 @@ const result = (_ref3 = 1, (_ref2 = class {
     return this.#bar() + 3;
   }
 
-}, (_ref = new _ref2(), _ref.foo())));
+}().foo();
 expect(result).toBe(1 + 2 + 3);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-eval/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-eval/output.js
@@ -1,5 +1,3 @@
-var _ref;
-
 const program = '(function() { return this; })()';
-const result = (_ref = program, eval(_ref));
+const result = eval(program);
 expect(result).not.toBeUndefined();

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-nested-pipe/output.js
@@ -1,4 +1,4 @@
-var _ref, _ref2, _ref3, _ref4;
+var _ref;
 
-const result = (_ref4 = 5, (_ref3 = Math.pow(_ref4, 2), (_ref2 = _ref3 + 1, (_ref = `${_ref2} apples`, _ref.toUpperCase()))));
+const result = (_ref = Math.pow(5, 2) + 1, `${_ref} apples`.toUpperCase());
 expect(result).toEqual('26 APPLES');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-object-literal/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-object-literal/output.js
@@ -1,11 +1,11 @@
-var _ref, _ref2, _ref3;
+var _ref;
 
 function area(rect) {
   return rect.width * rect.height;
 }
 
-const result = (_ref3 = -5, (_ref2 = Math.abs(_ref3), (_ref = {
-  width: _ref2,
-  height: _ref2 + 3
-}, area(_ref))));
+const result = (_ref = Math.abs(-5), area({
+  width: _ref,
+  height: _ref + 3
+}));
 expect(result).toBe(40);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-topic-method-call/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-topic-method-call/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const result = (_ref = 'Hello', _ref.toUpperCase());
+const result = 'Hello'.toUpperCase();
 expect(result).toBe('HELLO');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-yield/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-body-with-yield/output.js
@@ -1,7 +1,7 @@
 function* myGenerator(n) {
-  var _ref, _ref2;
+  var _ref;
 
-  return _ref2 = n, (_ref = yield _ref2, Math.abs(_ref));
+  return _ref = yield n, Math.abs(_ref);
 }
 
 const myIterator = myGenerator(15);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-head-with-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-head-with-nested-pipe/output.js
@@ -1,4 +1,2 @@
-var _ref, _ref2;
-
-const result = (_ref2 = (_ref = 5, Math.pow(_ref, 2)), _ref2 + 1);
+const result = Math.pow(5, 2) + 1;
 expect(result).toEqual(26);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-in-arrow-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/pipe-in-arrow-function/output.js
@@ -1,10 +1,10 @@
 const result = () => {
-  var _ref, _ref2, _ref3;
+  var _ref;
 
-  return _ref3 = -2.2 // -2.2
-  , (_ref2 = Math.floor(_ref3) // -3
-  , (_ref = () => Math.pow(_ref2, 5) // () => -243
-  , _ref()));
+  return _ref = Math.floor(-2.2 // -2.2
+  ) // -3
+  , (() => Math.pow(_ref, 5) // () => -243
+  )();
 }; // -243
 
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/topic-token-in-function/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/topic-token-in-function/exec.js
@@ -1,0 +1,9 @@
+let x = 0;
+
+let fnA = x++ |> (() => @@);
+let fnB = x++ |> (0, () => @@);
+
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/topic-token-in-function/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/topic-token-in-function/input.js
@@ -1,0 +1,9 @@
+let x = 0;
+
+let fnA = x++ |> (() => @@);
+let fnB = x++ |> (0, () => @@);
+
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/topic-token-in-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/topic-token-in-function/output.js
@@ -1,0 +1,9 @@
+var _ref, _ref2;
+
+let x = 0;
+let fnA = (_ref = x++, () => _ref);
+let fnB = (_ref2 = x++, (0, () => _ref2));
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/transform-arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/transform-arrow-functions/output.js
@@ -1,8 +1,6 @@
-var _ref, _ref2;
-
 const triple = function (x) {
   return x * 3;
 };
 
-const result = (_ref2 = -7, (_ref = Math.abs(_ref2), triple(_ref)));
+const result = triple(Math.abs(-7));
 return expect(result).toBe(21);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/transform-await-and-arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/transform-await-and-arrow-functions/output.js
@@ -3,9 +3,9 @@ const triple = function (x) {
 };
 
 async function myFunction(n) {
-  var _ref, _ref2, _ref3, _ref4;
+  var _ref;
 
-  return _ref4 = n, (_ref3 = Math.abs(_ref4), (_ref2 = Promise.resolve(_ref3), (_ref = await _ref2, triple(_ref))));
+  return _ref = Math.abs(n), triple(await Promise.resolve(_ref));
 }
 
 return myFunction(-7).then(function (result) {

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/while-statement-with-pipe-in-condition/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/while-statement-with-pipe-in-condition/exec.js
@@ -1,7 +1,7 @@
 let i = 0;
 let sum = 0;
 
-while (i |> (i = @@ + 1) |> @@ <= 10)
+while (i |> (i = 2 * @@ - @@ + 1) |> @@ <= 10)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/while-statement-with-pipe-in-condition/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/while-statement-with-pipe-in-condition/input.js
@@ -1,7 +1,7 @@
 let i = 0;
 let sum = 0;
 
-while (i |> (i = @@ + 1) |> @@ <= 10)
+while (i |> (i = 2 * @@ - @@ + 1) |> @@ <= 10)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/while-statement-with-pipe-in-condition/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/while-statement-with-pipe-in-condition/output.js
@@ -1,8 +1,8 @@
 let i = 0;
 let sum = 0;
 
-while (_ref2 = i, (_ref = i = _ref2 + 1, _ref <= 10)) {
-  var _ref, _ref2;
+while (_ref = i, (i = 2 * _ref - _ref + 1) <= 10) {
+  var _ref;
 
   sum += i;
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-assignment/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-assignment/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const x = (_ref = 0, _ref + 1);
+const x = 0 + 1;
 expect(x).toBe(1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-init/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-init/input.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0 |> @@; i <= 10; i++)
+for (var i = 0 |> @@*@@; i <= 10; i++)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-init/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-init/output.js
@@ -1,6 +1,6 @@
 let sum = 0;
 
-for (var i = (_ref = 0, _ref); i <= 10; i++) {
+for (var i = (_ref = 0, _ref * _ref); i <= 10; i++) {
   var _ref;
 
   sum += i;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-test/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-test/exec.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0; i |> @@ <= 10; i++)
+for (var i = 0; i |> @@ + @@ <= 20; i++)
   sum = sum + i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1)

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-test/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-test/input.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0; i |> @@ <= 10; i++)
+for (var i = 0; i |> @@ + @@ <= 20; i++)
   sum = sum + i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1)

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-test/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-test/output.js
@@ -1,6 +1,6 @@
 let sum = 0;
 
-for (var i = 0; _ref = i, _ref <= 10; i++) {
+for (var i = 0; _ref = i, _ref + _ref <= 20; i++) {
   var _ref;
 
   sum = sum + i;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-update/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-for-classic-statement-update/output.js
@@ -1,8 +1,6 @@
 let sum = 0;
 
-for (var i = 0; i <= 10; i = (_ref = i, _ref + 1)) {
-  var _ref;
-
+for (var i = 0; i <= 10; i = i + 1) {
   sum = sum + i;
 }
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-generator-with-yield/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/within-generator-with-yield/output.js
@@ -1,5 +1,5 @@
 function* myGenerator(n) {
-  var _ref, _ref2;
+  var _ref;
 
-  return _ref2 = n, (_ref = yield _ref2, Math.abs(_ref));
+  return _ref = yield n, Math.abs(_ref);
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/class-decorator/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/class-decorator/output.js
@@ -1,19 +1,17 @@
-var _ref;
-
 const expectedValue = 42;
 
 function decorator(target) {
   target.decoratorValue = expectedValue;
 }
 
-const result = (_ref = expectedValue, babelHelpers.decorate([decorator], function (_initialize) {
+const result = babelHelpers.decorate([decorator], function (_initialize) {
   "use strict";
 
   class _class {
     constructor() {
       _initialize(this);
 
-      this.value = _ref;
+      this.value = expectedValue;
     }
 
   }
@@ -22,6 +20,6 @@ const result = (_ref = expectedValue, babelHelpers.decorate([decorator], functio
     F: _class,
     d: []
   };
-}));
+});
 expect(result.decoratorValue).toBe(expectedValue);
 expect(new result().value).toBe(expectedValue);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/hash-tuple/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/hash-tuple/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
 Tuple(0);
-_ref = 1, Tuple(0, _ref);
+Tuple(0, 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-identity/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-identity/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const result = (_ref = 5, _ref);
+const result = 5;
 expect(result).toBe(5);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-addition/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-addition/input.js
@@ -1,3 +1,3 @@
-const result = 5 |> ^^ + 1 |> ^^ + ^^;
+const result = 5 |> ^^ + 1 |> 2 + ^^ |> ^^ + ^^;
 
 expect(result).toBe(12);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-addition/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-addition/output.js
@@ -1,4 +1,4 @@
-var _ref, _ref2;
+var _ref;
 
-const result = (_ref2 = 5, (_ref = _ref2 + 1, _ref + _ref));
+const result = (_ref = 2 + (5 + 1), _ref + _ref);
 expect(result).toBe(12);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-arrow-function-and-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-arrow-function-and-nested-pipe/output.js
@@ -1,8 +1,8 @@
-var _ref4, _ref5, _ref6;
+var _ref2;
 
-const result = (_ref6 = 5, (_ref5 = Math.pow(_ref6, 2), (_ref4 = [1, 2, 3].map(n => {
-  var _ref, _ref2, _ref3;
+const result = (_ref2 = Math.pow(5, 2), [1, 2, 3].map(n => {
+  var _ref;
 
-  return _ref3 = n + _ref5, (_ref2 = _ref3 * 2, (_ref = `${_ref2} apples`, _ref.toUpperCase()));
-}), _ref4.join())));
+  return _ref = (n + _ref2) * 2, `${_ref} apples`.toUpperCase();
+}).join());
 expect(result).toEqual('52 APPLES,54 APPLES,56 APPLES');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-arrow-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-arrow-function/output.js
@@ -1,8 +1,8 @@
-var _ref, _ref2, _ref3;
+var _ref;
 
-const result = (_ref3 = -2.2 // -2.2
-, (_ref2 = Math.floor(_ref3) // -3
-, (_ref = () => Math.pow(_ref2, 5) // () => -243
-, _ref()))); // -243
+const result = (_ref = Math.floor(-2.2 // -2.2
+) // -3
+, (() => Math.pow(_ref, 5) // () => -243
+)()); // -243
 
 expect(result).toBe(-243);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-await/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-await/output.js
@@ -3,9 +3,9 @@ function triple(x) {
 }
 
 async function asyncFunction(n) {
-  var _ref, _ref2, _ref3;
+  var _ref;
 
-  return _ref3 = n, (_ref2 = Math.abs(_ref3), (_ref = await Promise.resolve(_ref2), triple(_ref)));
+  return _ref = Math.abs(n), triple(await Promise.resolve(_ref));
 }
 
 asyncFunction(-7).then(result => {

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-class-expression-and-private-properties/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-class-expression-and-private-properties/output.js
@@ -1,10 +1,8 @@
-var _ref, _ref2, _ref3;
-
-const result = (_ref3 = 1, (_ref2 = class {
+const result = new class {
   #baz;
 
   constructor() {
-    this.#baz = _ref3;
+    this.#baz = 1;
   }
 
   #bar() {
@@ -15,5 +13,5 @@ const result = (_ref3 = 1, (_ref2 = class {
     return this.#bar() + 3;
   }
 
-}, (_ref = new _ref2(), _ref.foo())));
+}().foo();
 expect(result).toBe(1 + 2 + 3);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-eval/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-eval/output.js
@@ -1,5 +1,3 @@
-var _ref;
-
 const program = '(function() { return this; })()';
-const result = (_ref = program, eval(_ref));
+const result = eval(program);
 expect(result).not.toBeUndefined();

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-nested-pipe/output.js
@@ -1,4 +1,4 @@
-var _ref, _ref2, _ref3, _ref4;
+var _ref;
 
-const result = (_ref4 = 5, (_ref3 = Math.pow(_ref4, 2), (_ref2 = _ref3 + 1, (_ref = `${_ref2} apples`, _ref.toUpperCase()))));
+const result = (_ref = Math.pow(5, 2) + 1, `${_ref} apples`.toUpperCase());
 expect(result).toEqual('26 APPLES');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-object-literal/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-object-literal/output.js
@@ -1,11 +1,11 @@
-var _ref, _ref2, _ref3;
+var _ref;
 
 function area(rect) {
   return rect.width * rect.height;
 }
 
-const result = (_ref3 = -5, (_ref2 = Math.abs(_ref3), (_ref = {
-  width: _ref2,
-  height: _ref2 + 3
-}, area(_ref))));
+const result = (_ref = Math.abs(-5), area({
+  width: _ref,
+  height: _ref + 3
+}));
 expect(result).toBe(40);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-topic-method-call/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-topic-method-call/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const result = (_ref = 'Hello', _ref.toUpperCase());
+const result = 'Hello'.toUpperCase();
 expect(result).toBe('HELLO');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-yield/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-body-with-yield/output.js
@@ -1,7 +1,7 @@
 function* myGenerator(n) {
-  var _ref, _ref2;
+  var _ref;
 
-  return _ref2 = n, (_ref = yield _ref2, Math.abs(_ref));
+  return _ref = yield n, Math.abs(_ref);
 }
 
 const myIterator = myGenerator(15);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-head-with-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-head-with-nested-pipe/output.js
@@ -1,4 +1,2 @@
-var _ref, _ref2;
-
-const result = (_ref2 = (_ref = 5, Math.pow(_ref, 2)), _ref2 + 1);
+const result = Math.pow(5, 2) + 1;
 expect(result).toEqual(26);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-in-arrow-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/pipe-in-arrow-function/output.js
@@ -1,10 +1,10 @@
 const result = () => {
-  var _ref, _ref2, _ref3;
+  var _ref;
 
-  return _ref3 = -2.2 // -2.2
-  , (_ref2 = Math.floor(_ref3) // -3
-  , (_ref = () => Math.pow(_ref2, 5) // () => -243
-  , _ref()));
+  return _ref = Math.floor(-2.2 // -2.2
+  ) // -3
+  , (() => Math.pow(_ref, 5) // () => -243
+  )();
 }; // -243
 
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/topic-token-in-function/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/topic-token-in-function/exec.js
@@ -1,0 +1,9 @@
+let x = 0;
+
+let fnA = x++ |> (() => ^^);
+let fnB = x++ |> (0, () => ^^);
+
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/topic-token-in-function/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/topic-token-in-function/input.js
@@ -1,0 +1,9 @@
+let x = 0;
+
+let fnA = x++ |> (() => ^^);
+let fnB = x++ |> (0, () => ^^);
+
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/topic-token-in-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/topic-token-in-function/output.js
@@ -1,0 +1,9 @@
+var _ref, _ref2;
+
+let x = 0;
+let fnA = (_ref = x++, () => _ref);
+let fnB = (_ref2 = x++, (0, () => _ref2));
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/transform-arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/transform-arrow-functions/output.js
@@ -1,8 +1,6 @@
-var _ref, _ref2;
-
 const triple = function (x) {
   return x * 3;
 };
 
-const result = (_ref2 = -7, (_ref = Math.abs(_ref2), triple(_ref)));
+const result = triple(Math.abs(-7));
 return expect(result).toBe(21);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/transform-await-and-arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/transform-await-and-arrow-functions/output.js
@@ -3,9 +3,9 @@ const triple = function (x) {
 };
 
 async function myFunction(n) {
-  var _ref, _ref2, _ref3, _ref4;
+  var _ref;
 
-  return _ref4 = n, (_ref3 = Math.abs(_ref4), (_ref2 = Promise.resolve(_ref3), (_ref = await _ref2, triple(_ref))));
+  return _ref = Math.abs(n), triple(await Promise.resolve(_ref));
 }
 
 return myFunction(-7).then(function (result) {

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/while-statement-with-pipe-in-condition/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/while-statement-with-pipe-in-condition/exec.js
@@ -1,7 +1,7 @@
 let i = 0;
 let sum = 0;
 
-while (i |> (i = ^^ + 1) |> ^^ <= 10)
+while (i |> (i = 2 * ^^ - ^^ + 1) |> ^^ <= 10)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/while-statement-with-pipe-in-condition/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/while-statement-with-pipe-in-condition/input.js
@@ -1,7 +1,7 @@
 let i = 0;
 let sum = 0;
 
-while (i |> (i = ^^ + 1) |> ^^ <= 10)
+while (i |> (i = 2 * ^^ - ^^ + 1) |> ^^ <= 10)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/while-statement-with-pipe-in-condition/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/while-statement-with-pipe-in-condition/output.js
@@ -1,8 +1,8 @@
 let i = 0;
 let sum = 0;
 
-while (_ref2 = i, (_ref = i = _ref2 + 1, _ref <= 10)) {
-  var _ref, _ref2;
+while (_ref = i, (i = 2 * _ref - _ref + 1) <= 10) {
+  var _ref;
 
   sum += i;
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-assignment/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-assignment/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const x = (_ref = 0, _ref + 1);
+const x = 0 + 1;
 expect(x).toBe(1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-init/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-init/input.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0 |> ^^; i <= 10; i++)
+for (var i = 0 |> ^^*^^; i <= 10; i++)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-init/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-init/output.js
@@ -1,6 +1,6 @@
 let sum = 0;
 
-for (var i = (_ref = 0, _ref); i <= 10; i++) {
+for (var i = (_ref = 0, _ref * _ref); i <= 10; i++) {
   var _ref;
 
   sum += i;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-test/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-test/exec.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0; i |> ^^ <= 10; i++)
+for (var i = 0; i |> ^^ + ^^ <= 20; i++)
   sum = sum + i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1)

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-test/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-test/input.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0; i |> ^^ <= 10; i++)
+for (var i = 0; i |> ^^ + ^^ <= 20; i++)
   sum = sum + i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1)

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-test/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-test/output.js
@@ -1,6 +1,6 @@
 let sum = 0;
 
-for (var i = 0; _ref = i, _ref <= 10; i++) {
+for (var i = 0; _ref = i, _ref + _ref <= 20; i++) {
   var _ref;
 
   sum = sum + i;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-update/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-for-classic-statement-update/output.js
@@ -1,8 +1,6 @@
 let sum = 0;
 
-for (var i = 0; i <= 10; i = (_ref = i, _ref + 1)) {
-  var _ref;
-
+for (var i = 0; i <= 10; i = i + 1) {
   sum = sum + i;
 }
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-generator-with-yield/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/within-generator-with-yield/output.js
@@ -1,5 +1,5 @@
 function* myGenerator(n) {
-  var _ref, _ref2;
+  var _ref;
 
-  return _ref2 = n, (_ref = yield _ref2, Math.abs(_ref));
+  return _ref = yield n, Math.abs(_ref);
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-identity/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-identity/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const result = (_ref = 5, _ref);
+const result = 5;
 expect(result).toBe(5);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-addition/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-addition/input.js
@@ -1,3 +1,3 @@
-const result = 5 |> # + 1 |> # + #;
+const result = 5 |> # + 1 |> 2 + # |> # + #;
 
 expect(result).toBe(12);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-addition/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-addition/output.js
@@ -1,4 +1,4 @@
-var _ref, _ref2;
+var _ref;
 
-const result = (_ref2 = 5, (_ref = _ref2 + 1, _ref + _ref));
+const result = (_ref = 2 + (5 + 1), _ref + _ref);
 expect(result).toBe(12);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-arrow-function-and-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-arrow-function-and-nested-pipe/output.js
@@ -1,8 +1,8 @@
-var _ref4, _ref5, _ref6;
+var _ref2;
 
-const result = (_ref6 = 5, (_ref5 = Math.pow(_ref6, 2), (_ref4 = [1, 2, 3].map(n => {
-  var _ref, _ref2, _ref3;
+const result = (_ref2 = Math.pow(5, 2), [1, 2, 3].map(n => {
+  var _ref;
 
-  return _ref3 = n + _ref5, (_ref2 = _ref3 * 2, (_ref = `${_ref2} apples`, _ref.toUpperCase()));
-}), _ref4.join())));
+  return _ref = (n + _ref2) * 2, `${_ref} apples`.toUpperCase();
+}).join());
 expect(result).toEqual('52 APPLES,54 APPLES,56 APPLES');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-arrow-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-arrow-function/output.js
@@ -1,8 +1,8 @@
-var _ref, _ref2, _ref3;
+var _ref;
 
-const result = (_ref3 = -2.2 // -2.2
-, (_ref2 = Math.floor(_ref3) // -3
-, (_ref = () => Math.pow(_ref2, 5) // () => -243
-, _ref()))); // -243
+const result = (_ref = Math.floor(-2.2 // -2.2
+) // -3
+, (() => Math.pow(_ref, 5) // () => -243
+)()); // -243
 
 expect(result).toBe(-243);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-await/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-await/output.js
@@ -3,9 +3,9 @@ function triple(x) {
 }
 
 async function asyncFunction(n) {
-  var _ref, _ref2, _ref3;
+  var _ref;
 
-  return _ref3 = n, (_ref2 = Math.abs(_ref3), (_ref = await Promise.resolve(_ref2), triple(_ref)));
+  return _ref = Math.abs(n), triple(await Promise.resolve(_ref));
 }
 
 asyncFunction(-7).then(result => {

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-class-expression-and-private-properties/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-class-expression-and-private-properties/output.js
@@ -1,10 +1,8 @@
-var _ref, _ref2, _ref3;
-
-const result = (_ref3 = 1, (_ref2 = class {
+const result = new class {
   #baz;
 
   constructor() {
-    this.#baz = _ref3;
+    this.#baz = 1;
   }
 
   #bar() {
@@ -15,5 +13,5 @@ const result = (_ref3 = 1, (_ref2 = class {
     return this.#bar() + 3;
   }
 
-}, (_ref = new _ref2(), _ref.foo())));
+}().foo();
 expect(result).toBe(1 + 2 + 3);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-eval/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-eval/output.js
@@ -1,5 +1,3 @@
-var _ref;
-
 const program = '(function() { return this; })()';
-const result = (_ref = program, eval(_ref));
+const result = eval(program);
 expect(result).not.toBeUndefined();

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-nested-pipe/output.js
@@ -1,4 +1,4 @@
-var _ref, _ref2, _ref3, _ref4;
+var _ref;
 
-const result = (_ref4 = 5, (_ref3 = Math.pow(_ref4, 2), (_ref2 = _ref3 + 1, (_ref = `${_ref2} apples`, _ref.toUpperCase()))));
+const result = (_ref = Math.pow(5, 2) + 1, `${_ref} apples`.toUpperCase());
 expect(result).toEqual('26 APPLES');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-object-literal/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-object-literal/output.js
@@ -1,11 +1,11 @@
-var _ref, _ref2, _ref3;
+var _ref;
 
 function area(rect) {
   return rect.width * rect.height;
 }
 
-const result = (_ref3 = -5, (_ref2 = Math.abs(_ref3), (_ref = {
-  width: _ref2,
-  height: _ref2 + 3
-}, area(_ref))));
+const result = (_ref = Math.abs(-5), area({
+  width: _ref,
+  height: _ref + 3
+}));
 expect(result).toBe(40);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-topic-method-call/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-topic-method-call/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const result = (_ref = 'Hello', _ref.toUpperCase());
+const result = 'Hello'.toUpperCase();
 expect(result).toBe('HELLO');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-yield/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-body-with-yield/output.js
@@ -1,7 +1,7 @@
 function* myGenerator(n) {
-  var _ref, _ref2;
+  var _ref;
 
-  return _ref2 = n, (_ref = yield _ref2, Math.abs(_ref));
+  return _ref = yield n, Math.abs(_ref);
 }
 
 const myIterator = myGenerator(15);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-head-with-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-head-with-nested-pipe/output.js
@@ -1,4 +1,2 @@
-var _ref, _ref2;
-
-const result = (_ref2 = (_ref = 5, Math.pow(_ref, 2)), _ref2 + 1);
+const result = Math.pow(5, 2) + 1;
 expect(result).toEqual(26);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-in-arrow-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/pipe-in-arrow-function/output.js
@@ -1,10 +1,10 @@
 const result = () => {
-  var _ref, _ref2, _ref3;
+  var _ref;
 
-  return _ref3 = -2.2 // -2.2
-  , (_ref2 = Math.floor(_ref3) // -3
-  , (_ref = () => Math.pow(_ref2, 5) // () => -243
-  , _ref()));
+  return _ref = Math.floor(-2.2 // -2.2
+  ) // -3
+  , (() => Math.pow(_ref, 5) // () => -243
+  )();
 }; // -243
 
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/topic-token-in-function/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/topic-token-in-function/exec.js
@@ -1,0 +1,9 @@
+let x = 0;
+
+let fnA = x++ |> (() => #);
+let fnB = x++ |> (0, () => #);
+
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/topic-token-in-function/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/topic-token-in-function/input.js
@@ -1,0 +1,9 @@
+let x = 0;
+
+let fnA = x++ |> (() => #);
+let fnB = x++ |> (0, () => #);
+
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/topic-token-in-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/topic-token-in-function/output.js
@@ -1,0 +1,9 @@
+var _ref, _ref2;
+
+let x = 0;
+let fnA = (_ref = x++, () => _ref);
+let fnB = (_ref2 = x++, (0, () => _ref2));
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/transform-arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/transform-arrow-functions/output.js
@@ -1,8 +1,6 @@
-var _ref, _ref2;
-
 const triple = function (x) {
   return x * 3;
 };
 
-const result = (_ref2 = -7, (_ref = Math.abs(_ref2), triple(_ref)));
+const result = triple(Math.abs(-7));
 return expect(result).toBe(21);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/transform-await-and-arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/transform-await-and-arrow-functions/output.js
@@ -3,9 +3,9 @@ const triple = function (x) {
 };
 
 async function myFunction(n) {
-  var _ref, _ref2, _ref3, _ref4;
+  var _ref;
 
-  return _ref4 = n, (_ref3 = Math.abs(_ref4), (_ref2 = Promise.resolve(_ref3), (_ref = await _ref2, triple(_ref))));
+  return _ref = Math.abs(n), triple(await Promise.resolve(_ref));
 }
 
 return myFunction(-7).then(function (result) {

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/while-statement-with-pipe-in-condition/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/while-statement-with-pipe-in-condition/exec.js
@@ -1,7 +1,7 @@
 let i = 0;
 let sum = 0;
 
-while (i |> (i = # + 1) |> # <= 10)
+while (i |> (i = 2 * # - # + 1) |> # <= 10)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/while-statement-with-pipe-in-condition/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/while-statement-with-pipe-in-condition/input.js
@@ -1,7 +1,7 @@
 let i = 0;
 let sum = 0;
 
-while (i |> (i = # + 1) |> # <= 10)
+while (i |> (i = 2 * # - # + 1) |> # <= 10)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/while-statement-with-pipe-in-condition/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/while-statement-with-pipe-in-condition/output.js
@@ -1,8 +1,8 @@
 let i = 0;
 let sum = 0;
 
-while (_ref2 = i, (_ref = i = _ref2 + 1, _ref <= 10)) {
-  var _ref, _ref2;
+while (_ref = i, (i = 2 * _ref - _ref + 1) <= 10) {
+  var _ref;
 
   sum += i;
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-assignment/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-assignment/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const x = (_ref = 0, _ref + 1);
+const x = 0 + 1;
 expect(x).toBe(1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-init/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-init/input.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0 |> #; i <= 10; i++)
+for (var i = 0 |> #*#; i <= 10; i++)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-init/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-init/output.js
@@ -1,6 +1,6 @@
 let sum = 0;
 
-for (var i = (_ref = 0, _ref); i <= 10; i++) {
+for (var i = (_ref = 0, _ref * _ref); i <= 10; i++) {
   var _ref;
 
   sum += i;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-test/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-test/exec.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0; i |> # <= 10; i++)
+for (var i = 0; i |> # + # <= 20; i++)
   sum = sum + i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1)

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-test/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-test/input.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0; i |> # <= 10; i++)
+for (var i = 0; i |> # + # <= 20; i++)
   sum = sum + i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1)

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-test/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-test/output.js
@@ -1,6 +1,6 @@
 let sum = 0;
 
-for (var i = 0; _ref = i, _ref <= 10; i++) {
+for (var i = 0; _ref = i, _ref + _ref <= 20; i++) {
   var _ref;
 
   sum = sum + i;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-update/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-for-classic-statement-update/output.js
@@ -1,8 +1,6 @@
 let sum = 0;
 
-for (var i = 0; i <= 10; i = (_ref = i, _ref + 1)) {
-  var _ref;
-
+for (var i = 0; i <= 10; i = i + 1) {
   sum = sum + i;
 }
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-generator-with-yield/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-hash/within-generator-with-yield/output.js
@@ -1,5 +1,5 @@
 function* myGenerator(n) {
-  var _ref, _ref2;
+  var _ref;
 
-  return _ref2 = n, (_ref = yield _ref2, Math.abs(_ref));
+  return _ref = yield n, Math.abs(_ref);
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/hash-tuple/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/hash-tuple/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
 Tuple(0);
-_ref = 1, Tuple(0, _ref);
+Tuple(0, 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-identity/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-identity/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const result = (_ref = 5, _ref);
+const result = 5;
 expect(result).toBe(5);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-addition/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-addition/input.js
@@ -1,3 +1,3 @@
-const result = 5 |> % + 1 |> % + %;
+const result = 5 |> % + 1 |> 2 + % |> % + %;
 
 expect(result).toBe(12);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-addition/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-addition/output.js
@@ -1,4 +1,4 @@
-var _ref, _ref2;
+var _ref;
 
-const result = (_ref2 = 5, (_ref = _ref2 + 1, _ref + _ref));
+const result = (_ref = 2 + (5 + 1), _ref + _ref);
 expect(result).toBe(12);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-arrow-function-and-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-arrow-function-and-nested-pipe/output.js
@@ -1,8 +1,8 @@
-var _ref4, _ref5, _ref6;
+var _ref2;
 
-const result = (_ref6 = 5, (_ref5 = Math.pow(_ref6, 2), (_ref4 = [1, 2, 3].map(n => {
-  var _ref, _ref2, _ref3;
+const result = (_ref2 = Math.pow(5, 2), [1, 2, 3].map(n => {
+  var _ref;
 
-  return _ref3 = n + _ref5, (_ref2 = _ref3 * 2, (_ref = `${_ref2} apples`, _ref.toUpperCase()));
-}), _ref4.join())));
+  return _ref = (n + _ref2) * 2, `${_ref} apples`.toUpperCase();
+}).join());
 expect(result).toEqual('52 APPLES,54 APPLES,56 APPLES');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-arrow-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-arrow-function/output.js
@@ -1,8 +1,8 @@
-var _ref, _ref2, _ref3;
+var _ref;
 
-const result = (_ref3 = -2.2 // -2.2
-, (_ref2 = Math.floor(_ref3) // -3
-, (_ref = () => Math.pow(_ref2, 5) // () => -243
-, _ref()))); // -243
+const result = (_ref = Math.floor(-2.2 // -2.2
+) // -3
+, (() => Math.pow(_ref, 5) // () => -243
+)()); // -243
 
 expect(result).toBe(-243);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-await/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-await/output.js
@@ -3,9 +3,9 @@ function triple(x) {
 }
 
 async function asyncFunction(n) {
-  var _ref, _ref2, _ref3;
+  var _ref;
 
-  return _ref3 = n, (_ref2 = Math.abs(_ref3), (_ref = await Promise.resolve(_ref2), triple(_ref)));
+  return _ref = Math.abs(n), triple(await Promise.resolve(_ref));
 }
 
 asyncFunction(-7).then(result => {

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-class-expression-and-private-properties/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-class-expression-and-private-properties/output.js
@@ -1,10 +1,8 @@
-var _ref, _ref2, _ref3;
-
-const result = (_ref3 = 1, (_ref2 = class {
+const result = new class {
   #baz;
 
   constructor() {
-    this.#baz = _ref3;
+    this.#baz = 1;
   }
 
   #bar() {
@@ -15,5 +13,5 @@ const result = (_ref3 = 1, (_ref2 = class {
     return this.#bar() + 3;
   }
 
-}, (_ref = new _ref2(), _ref.foo())));
+}().foo();
 expect(result).toBe(1 + 2 + 3);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-eval/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-eval/output.js
@@ -1,5 +1,3 @@
-var _ref;
-
 const program = '(function() { return this; })()';
-const result = (_ref = program, eval(_ref));
+const result = eval(program);
 expect(result).not.toBeUndefined();

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-nested-pipe/output.js
@@ -1,4 +1,4 @@
-var _ref, _ref2, _ref3, _ref4;
+var _ref;
 
-const result = (_ref4 = 5, (_ref3 = Math.pow(_ref4, 2), (_ref2 = _ref3 + 1, (_ref = `${_ref2} apples`, _ref.toUpperCase()))));
+const result = (_ref = Math.pow(5, 2) + 1, `${_ref} apples`.toUpperCase());
 expect(result).toEqual('26 APPLES');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-object-literal/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-object-literal/output.js
@@ -1,11 +1,11 @@
-var _ref, _ref2, _ref3;
+var _ref;
 
 function area(rect) {
   return rect.width * rect.height;
 }
 
-const result = (_ref3 = -5, (_ref2 = Math.abs(_ref3), (_ref = {
-  width: _ref2,
-  height: _ref2 + 3
-}, area(_ref))));
+const result = (_ref = Math.abs(-5), area({
+  width: _ref,
+  height: _ref + 3
+}));
 expect(result).toBe(40);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-topic-method-call/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-topic-method-call/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const result = (_ref = 'Hello', _ref.toUpperCase());
+const result = 'Hello'.toUpperCase();
 expect(result).toBe('HELLO');

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-yield/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-body-with-yield/output.js
@@ -1,7 +1,7 @@
 function* myGenerator(n) {
-  var _ref, _ref2;
+  var _ref;
 
-  return _ref2 = n, (_ref = yield _ref2, Math.abs(_ref));
+  return _ref = yield n, Math.abs(_ref);
 }
 
 const myIterator = myGenerator(15);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-head-with-nested-pipe/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-head-with-nested-pipe/output.js
@@ -1,4 +1,2 @@
-var _ref, _ref2;
-
-const result = (_ref2 = (_ref = 5, Math.pow(_ref, 2)), _ref2 + 1);
+const result = Math.pow(5, 2) + 1;
 expect(result).toEqual(26);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-in-arrow-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/pipe-in-arrow-function/output.js
@@ -1,10 +1,10 @@
 const result = () => {
-  var _ref, _ref2, _ref3;
+  var _ref;
 
-  return _ref3 = -2.2 // -2.2
-  , (_ref2 = Math.floor(_ref3) // -3
-  , (_ref = () => Math.pow(_ref2, 5) // () => -243
-  , _ref()));
+  return _ref = Math.floor(-2.2 // -2.2
+  ) // -3
+  , (() => Math.pow(_ref, 5) // () => -243
+  )();
 }; // -243
 
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/topic-token-in-function/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/topic-token-in-function/exec.js
@@ -1,0 +1,9 @@
+let x = 0;
+
+let fnA = x++ |> (() => %);
+let fnB = x++ |> (0, () => %);
+
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/topic-token-in-function/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/topic-token-in-function/input.js
@@ -1,0 +1,9 @@
+let x = 0;
+
+let fnA = x++ |> (() => %);
+let fnB = x++ |> (0, () => %);
+
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/topic-token-in-function/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/topic-token-in-function/output.js
@@ -1,0 +1,9 @@
+var _ref, _ref2;
+
+let x = 0;
+let fnA = (_ref = x++, () => _ref);
+let fnB = (_ref2 = x++, (0, () => _ref2));
+expect(x).toBe(2);
+expect(fnA()).toBe(0);
+expect(fnB()).toBe(1);
+expect(x).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/transform-arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/transform-arrow-functions/output.js
@@ -1,8 +1,6 @@
-var _ref, _ref2;
-
 const triple = function (x) {
   return x * 3;
 };
 
-const result = (_ref2 = -7, (_ref = Math.abs(_ref2), triple(_ref)));
+const result = triple(Math.abs(-7));
 return expect(result).toBe(21);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/transform-await-and-arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/transform-await-and-arrow-functions/output.js
@@ -3,9 +3,9 @@ const triple = function (x) {
 };
 
 async function myFunction(n) {
-  var _ref, _ref2, _ref3, _ref4;
+  var _ref;
 
-  return _ref4 = n, (_ref3 = Math.abs(_ref4), (_ref2 = Promise.resolve(_ref3), (_ref = await _ref2, triple(_ref))));
+  return _ref = Math.abs(n), triple(await Promise.resolve(_ref));
 }
 
 return myFunction(-7).then(function (result) {

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/while-statement-with-pipe-in-condition/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/while-statement-with-pipe-in-condition/exec.js
@@ -1,7 +1,7 @@
 let i = 0;
 let sum = 0;
 
-while (i |> (i = % + 1) |> % <= 10)
+while (i |> (i = 2 * % - % + 1) |> % <= 10)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/while-statement-with-pipe-in-condition/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/while-statement-with-pipe-in-condition/input.js
@@ -1,7 +1,7 @@
 let i = 0;
 let sum = 0;
 
-while (i |> (i = % + 1) |> % <= 10)
+while (i |> (i = 2 * % - % + 1) |> % <= 10)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/while-statement-with-pipe-in-condition/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/while-statement-with-pipe-in-condition/output.js
@@ -1,8 +1,8 @@
 let i = 0;
 let sum = 0;
 
-while (_ref2 = i, (_ref = i = _ref2 + 1, _ref <= 10)) {
-  var _ref, _ref2;
+while (_ref = i, (i = 2 * _ref - _ref + 1) <= 10) {
+  var _ref;
 
   sum += i;
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-assignment/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-assignment/output.js
@@ -1,4 +1,2 @@
-var _ref;
-
-const x = (_ref = 0, _ref + 1);
+const x = 0 + 1;
 expect(x).toBe(1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-init/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-init/input.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0 |> %; i <= 10; i++)
+for (var i = 0 |> %*%; i <= 10; i++)
   sum += i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-init/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-init/output.js
@@ -1,6 +1,6 @@
 let sum = 0;
 
-for (var i = (_ref = 0, _ref); i <= 10; i++) {
+for (var i = (_ref = 0, _ref * _ref); i <= 10; i++) {
   var _ref;
 
   sum += i;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-test/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-test/exec.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0; i |> % <= 10; i++)
+for (var i = 0; i |> % + % <= 20; i++)
   sum = sum + i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1)

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-test/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-test/input.js
@@ -1,5 +1,5 @@
 let sum = 0;
-for (var i = 0; i |> % <= 10; i++)
+for (var i = 0; i |> % + % <= 20; i++)
   sum = sum + i;
 
 expect(sum).toBe(10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1)

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-test/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-test/output.js
@@ -1,6 +1,6 @@
 let sum = 0;
 
-for (var i = 0; _ref = i, _ref <= 10; i++) {
+for (var i = 0; _ref = i, _ref + _ref <= 20; i++) {
   var _ref;
 
   sum = sum + i;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-update/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-for-classic-statement-update/output.js
@@ -1,8 +1,6 @@
 let sum = 0;
 
-for (var i = 0; i <= 10; i = (_ref = i, _ref + 1)) {
-  var _ref;
-
+for (var i = 0; i <= 10; i = i + 1) {
   sum = sum + i;
 }
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-generator-with-yield/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-percent/within-generator-with-yield/output.js
@@ -1,5 +1,5 @@
 function* myGenerator(n) {
-  var _ref, _ref2;
+  var _ref;
 
-  return _ref2 = n, (_ref = yield _ref2, Math.abs(_ref));
+  return _ref = yield n, Math.abs(_ref);
 }

--- a/packages/babel-standalone/test/preset-stage-1.test.js
+++ b/packages/babel-standalone/test/preset-stage-1.test.js
@@ -28,11 +28,7 @@ const require = createRequire(import.meta.url);
           ],
         ],
       }).code;
-      expect(output).toMatchInlineSnapshot(`
-"var _ref;
-
-_ref = x, _ref;"
-`);
+      expect(output).toMatchInlineSnapshot(`"x;"`);
     });
 
     it("should support hack pipeline with `#` topic token", () => {
@@ -49,11 +45,7 @@ _ref = x, _ref;"
           ],
         ],
       }).code;
-      expect(output).toMatchInlineSnapshot(`
-"var _ref;
-
-_ref = x, _ref;"
-`);
+      expect(output).toMatchInlineSnapshot(`"x;"`);
     });
     it("should support decorators versioned 2021-12", () => {
       const output = Babel.transform("@dec class C {}", {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I discovered that "removing unnecessary tmp vars" is quite satisfying :grin:

When a topic token is only used once and either:
- the lhs of `|>` is pure
- all the operations in the rhs of `|>` before evaluating the topic token are pure
the pipeline operator can be compiled without temporary variables, by directly inlining the lhs in the rhs.

cc @js-choi if you have time to review, since you initially implemented this plugin!

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14278"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

