### PR TITLE
Fix merging sourcemaps on Windows

### DIFF
--- a/packages/babel-core/src/transformation/file/merge-map.ts
+++ b/packages/babel-core/src/transformation/file/merge-map.ts
@@ -4,8 +4,16 @@ import remapping from "@ampproject/remapping";
 export default function mergeSourceMap(
   inputMap: SourceMap,
   map: SourceMap,
-  source: string,
+  sourceFileName: string,
 ): SourceMap {
+  // On win32 machines, the sourceFileName uses backslash paths like
+  // `C:\foo\bar.js`. But sourcemaps are always posix paths, so we need to
+  // normalize to regular slashes before we can merge (else we won't find the
+  // source associated with our input map).
+  // This mirrors code done while generating the output map at
+  // https://github.com/babel/babel/blob/5c2fcadc9ae34fd20dd72b1111d5cf50476d700d/packages/babel-generator/src/source-map.ts#L102
+  const source = sourceFileName.replace(/\\/g, "/");
+
   // Prevent an infinite recursion if one of the input map's sources has the
   // same resolved path as the input map. In the case, it would keep find the
   // input map, then get it's sources which will include a path like the input


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14277 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

On win32 machines, the sourceFileName uses backslash paths like
`C:\foo\bar.js`. But sourcemaps are always posix paths, so we need to
normalize to regular slashes before we can merge (else we won't find the
source associated with our input map).

This mirrors code done while generating the output map at
https://github.com/babel/babel/blob/5c2fcadc9ae34fd20dd72b1111d5cf50476d700d/packages/babel-generator/src/source-map.ts#L102


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14282"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

