### PR TITLE
Make module namespace sort compare function consistent

### DIFF
--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -449,7 +449,11 @@ function buildExportInitializationStatements(
   // https://tc39.es/ecma262/#sec-module-namespace-exotic-objects
   // The [Exports] list is ordered as if an Array of those String values
   // had been sorted using %Array.prototype.sort% using undefined as comparefn
-  initStatements.sort((a, b) => (a[0] > b[0] ? 1 : -1));
+  initStatements.sort(([a], [b]) => {
+    if (a < b) return -1;
+    if (b < a) return 1;
+    return 0;
+  });
 
   const results = [];
   if (noIncompleteNsImportDetection) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | :+1: 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added + Pass?      | N/A
| Documentation PR Link    | 
| Any Dependency Changes?  | 
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The existing function was not reflexive. The new logic basically just copies the spec text. There's not really any way to further test this afaik.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14287"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

