### PR TITLE
fix: cache

### DIFF
--- a/packages/babel-register/src/worker/transform.js
+++ b/packages/babel-register/src/worker/transform.js
@@ -122,6 +122,7 @@ function cacheLookup(opts, filename) {
     cached: null,
     store(value) {
       cache[cacheKey] = { value, mtime: fileMtime };
+      registerCache.setDirty();
       return value;
     },
   };


### PR DESCRIPTION
Incredibly, @babel/register wasn't caching anything. This is because `setDirty()` must be called on the worker cache, otherwise the check at https://github.com/babel/babel/blob/main/packages/babel-register/src/worker/cache.js#L32 always fails.

I couldn't believe it when I started digging into why caching seemed to do nothing. Lazy! ;)

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Shockingly, no one seems to have noticed until now?
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14303"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

