### PR TITLE
Fix `import type/typeof` printing with no specifiers

### DIFF
--- a/packages/babel-generator/src/generators/modules.ts
+++ b/packages/babel-generator/src/generators/modules.ts
@@ -183,6 +183,7 @@ export function ImportDeclaration(this: Printer, node: t.ImportDeclaration) {
   }
 
   const specifiers = node.specifiers.slice(0);
+  const specifiersLength = specifiers.length;
   if (specifiers?.length) {
     // print "special" specifiers first
     for (;;) {
@@ -209,6 +210,18 @@ export function ImportDeclaration(this: Printer, node: t.ImportDeclaration) {
       this.token("}");
     }
 
+    if (node.importKind !== "type" && node.importKind !== "typeof") {
+      this.space();
+      this.word("from");
+      this.space();
+    }
+  }
+
+  if (node.importKind === "type" || node.importKind === "typeof") {
+    if (!specifiersLength) {
+      this.token("{");
+      this.token("}");
+    }
     this.space();
     this.word("from");
     this.space();

--- a/packages/babel-generator/src/generators/modules.ts
+++ b/packages/babel-generator/src/generators/modules.ts
@@ -177,51 +177,41 @@ export function ImportDeclaration(this: Printer, node: t.ImportDeclaration) {
   this.word("import");
   this.space();
 
-  if (node.importKind === "type" || node.importKind === "typeof") {
+  const isTypeKind = node.importKind === "type" || node.importKind === "typeof";
+  if (isTypeKind) {
     this.word(node.importKind);
     this.space();
   }
 
   const specifiers = node.specifiers.slice(0);
-  const specifiersLength = specifiers.length;
-  if (specifiers?.length) {
-    // print "special" specifiers first
-    for (;;) {
-      const first = specifiers[0];
-      if (
-        isImportDefaultSpecifier(first) ||
-        isImportNamespaceSpecifier(first)
-      ) {
-        this.print(specifiers.shift(), node);
-        if (specifiers.length) {
-          this.token(",");
-          this.space();
-        }
-      } else {
-        break;
+  const hasSpecifiers = !!specifiers.length;
+  // print "special" specifiers first. The loop condition is constant,
+  // but there is a "break" in the body.
+  while (hasSpecifiers) {
+    const first = specifiers[0];
+    if (isImportDefaultSpecifier(first) || isImportNamespaceSpecifier(first)) {
+      this.print(specifiers.shift(), node);
+      if (specifiers.length) {
+        this.token(",");
+        this.space();
       }
-    }
-
-    if (specifiers.length) {
-      this.token("{");
-      this.space();
-      this.printList(specifiers, node);
-      this.space();
-      this.token("}");
-    }
-
-    if (node.importKind !== "type" && node.importKind !== "typeof") {
-      this.space();
-      this.word("from");
-      this.space();
+    } else {
+      break;
     }
   }
 
-  if (node.importKind === "type" || node.importKind === "typeof") {
-    if (!specifiersLength) {
-      this.token("{");
-      this.token("}");
-    }
+  if (specifiers.length) {
+    this.token("{");
+    this.space();
+    this.printList(specifiers, node);
+    this.space();
+    this.token("}");
+  } else if (isTypeKind && !hasSpecifiers) {
+    this.token("{");
+    this.token("}");
+  }
+
+  if (hasSpecifiers || isTypeKind) {
     this.space();
     this.word("from");
     this.space();

--- a/packages/babel-generator/test/fixtures/flow/import-typeof/input.ts
+++ b/packages/babel-generator/test/fixtures/flow/import-typeof/input.ts
@@ -1,0 +1,1 @@
+import typeof U from "x" 

--- a/packages/babel-generator/test/fixtures/flow/import-typeof/output.js
+++ b/packages/babel-generator/test/fixtures/flow/import-typeof/output.js
@@ -1,0 +1,1 @@
+import typeof U from "x";

--- a/packages/babel-generator/test/fixtures/typescript/import-type-empty-object/input.ts
+++ b/packages/babel-generator/test/fixtures/typescript/import-type-empty-object/input.ts
@@ -1,0 +1,2 @@
+import type {} from 'some-module';
+export type {} from "some-module"

--- a/packages/babel-generator/test/fixtures/typescript/import-type-empty-object/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/import-type-empty-object/output.js
@@ -1,0 +1,2 @@
+import type {} from 'some-module';
+export type {} from "some-module";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14250 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Empty braces will still be printed even if the there are no specifers, check added for importKind, empty braces will be printed on type and typeof imports.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14309"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

