### PR TITLE
Fixed the `ParseResult` type in `@babel/core`

### DIFF
--- a/packages/babel-core/src/parser/index.ts
+++ b/packages/babel-core/src/parser/index.ts
@@ -1,13 +1,10 @@
 import type { Handler } from "gensync";
 import { parse } from "@babel/parser";
-import type * as t from "@babel/types";
 import { codeFrameColumns } from "@babel/code-frame";
 import generateMissingPluginMessage from "./util/missing-plugin-helper";
 import type { PluginPasses } from "../config";
 
-type AstRoot = t.File | t.Program;
-
-export type ParseResult = AstRoot;
+export type ParseResult = ReturnType<typeof parse>;
 
 export default function* parser(
   pluginPasses: PluginPasses,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT


Those types IMHO should be consistent since `@babel/core` just~ calls to `@babel/parser` here.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14333"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

