### PR TITLE
Exclude `helpers/*.js` from codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,4 @@ coverage:
       enabled: false
 ignore:
   - packages/babel-types/src/*/generated/*
+  - packages/babel-helpers/src/helpers/*


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We never run helpers from those files, so they are shown as 0% (even if they are actually tested).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14342"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

