### PR TITLE
Remove unused `@babel/helpers` code

### DIFF
--- a/packages/babel-helpers/src/index.ts
+++ b/packages/babel-helpers/src/index.ts
@@ -271,7 +271,11 @@ function loadHelper(name: string) {
     const fn = (): File => {
       if (!process.env.BABEL_8_BREAKING) {
         if (!FileClass) {
-          return { ast: file(helper.ast()) } as File;
+          const fakeFile = { ast: file(helper.ast()), path: null } as File;
+          traverse(fakeFile.ast, {
+            Program: path => (fakeFile.path = path).stop(),
+          });
+          return fakeFile;
         }
       }
       return new FileClass(

--- a/packages/babel-helpers/src/index.ts
+++ b/packages/babel-helpers/src/index.ts
@@ -253,8 +253,8 @@ interface HelperData {
     nodes: t.Program["body"];
     globals: string[];
   };
-  minVersion: () => string;
-  dependencies: Map<t.Identifier, string>;
+  minVersion: string;
+  getDependencies: () => string[];
 }
 
 const helperData: Record<string, HelperData> = Object.create(null);
@@ -290,6 +290,7 @@ function loadHelper(name: string) {
     let metadata: HelperMetadata | null = null;
 
     helperData[name] = {
+      minVersion: helper.minVersion,
       build(getDependency, id, localBindings) {
         const file = fn();
         metadata ||= getHelperMetadata(file);
@@ -300,12 +301,9 @@ function loadHelper(name: string) {
           globals: metadata.globals,
         };
       },
-      minVersion() {
-        return helper.minVersion;
-      },
-      get dependencies() {
+      getDependencies() {
         metadata ||= getHelperMetadata(fn());
-        return metadata.dependencies;
+        return Array.from(metadata.dependencies.values());
       },
     };
   }
@@ -323,11 +321,11 @@ export function get(
 }
 
 export function minVersion(name: string) {
-  return loadHelper(name).minVersion();
+  return loadHelper(name).minVersion;
 }
 
 export function getDependencies(name: string): ReadonlyArray<string> {
-  return Array.from(loadHelper(name).dependencies.values());
+  return loadHelper(name).getDependencies();
 }
 
 export function ensure(name: string, newFileClass: typeof File) {

--- a/packages/babel-helpers/src/index.ts
+++ b/packages/babel-helpers/src/index.ts
@@ -284,11 +284,15 @@ function loadHelper(name: string) {
       );
     };
 
-    const metadata = getHelperMetadata(fn());
+    // We compute the helper metadata lazily, so that we skip that
+    // work if we only need the `.minVersion` (for example because
+    // of a call to `.availableHelper` when `@babel/rutime`).
+    let metadata: HelperMetadata | null = null;
 
     helperData[name] = {
       build(getDependency, id, localBindings) {
         const file = fn();
+        metadata ||= getHelperMetadata(file);
         permuteHelperAST(file, metadata, id, localBindings, getDependency);
 
         return {
@@ -299,7 +303,10 @@ function loadHelper(name: string) {
       minVersion() {
         return helper.minVersion;
       },
-      dependencies: metadata.dependencies,
+      get dependencies() {
+        metadata ||= getHelperMetadata(fn());
+        return metadata.dependencies;
+      },
     };
   }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

- The first commit removes an unnecessary `traverse` call that we used to get the program path from a `File` (**review this with whitespaces diff disabled**)
- The second commit removes some unused code I found thanks to codecov: it was supporting helpers exporting arbitrary values, but we only export functions since we rely on hoisting
- The third commit just puts some Babel 7 code behind `if (!process.env.BABEL_8_BREAKING)` and slightly improves the related types
- The fourth commit is a perf optimization
- The fifth commit is just aesthetic
- The sixth commit is because the first commit broke compat with some old `@babel/core` versions

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14343"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

