### PR TITLE
Make all babel breaking 8 checks null safe

### DIFF
--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -369,13 +369,13 @@ export const functionCommon = {
 
 export const functionTypeAnnotationCommon = {
   returnType: {
-    validate: process.env.BABEL_8_BREAKING
+    validate: process?.env?.BABEL_8_BREAKING
       ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
       : assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
     optional: true,
   },
   typeParameters: {
-    validate: process.env.BABEL_8_BREAKING
+    validate: process?.env?.BABEL_8_BREAKING
       ? assertNodeType("TypeParameterDeclaration", "TSTypeParameterDeclaration")
       : assertNodeType(
           "TypeParameterDeclaration",
@@ -455,7 +455,7 @@ defineType("FunctionExpression", {
 
 export const patternLikeCommon = {
   typeAnnotation: {
-    validate: process.env.BABEL_8_BREAKING
+    validate: process?.env?.BABEL_8_BREAKING
       ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
       : assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
     optional: true,
@@ -1294,7 +1294,7 @@ defineType("ClassExpression", {
       optional: true,
     },
     typeParameters: {
-      validate: process.env.BABEL_8_BREAKING
+      validate: process?.env?.BABEL_8_BREAKING
         ? assertNodeType(
             "TypeParameterDeclaration",
             "TSTypeParameterDeclaration",
@@ -1351,7 +1351,7 @@ defineType("ClassDeclaration", {
       validate: assertNodeType("Identifier"),
     },
     typeParameters: {
-      validate: process.env.BABEL_8_BREAKING
+      validate: process?.env?.BABEL_8_BREAKING
         ? assertNodeType(
             "TypeParameterDeclaration",
             "TSTypeParameterDeclaration",
@@ -2101,7 +2101,7 @@ defineType("ClassProperty", {
       optional: true,
     },
     typeAnnotation: {
-      validate: process.env.BABEL_8_BREAKING
+      validate: process?.env?.BABEL_8_BREAKING
         ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
         : assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
       optional: true,
@@ -2175,7 +2175,7 @@ defineType("ClassAccessorProperty", {
       optional: true,
     },
     typeAnnotation: {
-      validate: process.env.BABEL_8_BREAKING
+      validate: process?.env?.BABEL_8_BREAKING
         ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
         : assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
       optional: true,
@@ -2215,7 +2215,7 @@ defineType("ClassPrivateProperty", {
       optional: true,
     },
     typeAnnotation: {
-      validate: process.env.BABEL_8_BREAKING
+      validate: process?.env?.BABEL_8_BREAKING
         ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
         : assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
       optional: true,

--- a/packages/babel-types/src/definitions/misc.ts
+++ b/packages/babel-types/src/definitions/misc.ts
@@ -8,7 +8,7 @@ import { PLACEHOLDERS } from "./placeholders";
 
 const defineType = defineAliasedType("Miscellaneous");
 
-if (!process.env.BABEL_8_BREAKING) {
+if (!process?.env?.BABEL_8_BREAKING) {
   defineType("Noop", {
     visitor: [],
   });

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -24,13 +24,13 @@ const bool = assertValueType("boolean");
 
 const tSFunctionTypeAnnotationCommon = {
   returnType: {
-    validate: process.env.BABEL_8_BREAKING
+    validate: process?.env?.BABEL_8_BREAKING
       ? assertNodeType("TSTypeAnnotation")
       : assertNodeType("TSTypeAnnotation", "Noop"),
     optional: true,
   },
   typeParameters: {
-    validate: process.env.BABEL_8_BREAKING
+    validate: process?.env?.BABEL_8_BREAKING
       ? assertNodeType("TSTypeParameterDeclaration")
       : assertNodeType("TSTypeParameterDeclaration", "Noop"),
     optional: true,
@@ -94,10 +94,9 @@ defineType("TSQualifiedName", {
 
 const signatureDeclarationCommon = {
   typeParameters: validateOptionalType("TSTypeParameterDeclaration"),
-  [process.env.BABEL_8_BREAKING ? "params" : "parameters"]: validateArrayOfType(
-    ["Identifier", "RestElement"],
-  ),
-  [process.env.BABEL_8_BREAKING ? "returnType" : "typeAnnotation"]:
+  [process?.env?.BABEL_8_BREAKING ? "params" : "parameters"]:
+    validateArrayOfType(["Identifier", "RestElement"]),
+  [process?.env?.BABEL_8_BREAKING ? "returnType" : "typeAnnotation"]:
     validateOptionalType("TSTypeAnnotation"),
 };
 
@@ -105,8 +104,8 @@ const callConstructSignatureDeclaration = {
   aliases: ["TSTypeElement"],
   visitor: [
     "typeParameters",
-    process.env.BABEL_8_BREAKING ? "params" : "parameters",
-    process.env.BABEL_8_BREAKING ? "returnType" : "typeAnnotation",
+    process?.env?.BABEL_8_BREAKING ? "params" : "parameters",
+    process?.env?.BABEL_8_BREAKING ? "returnType" : "typeAnnotation",
   ],
   fields: signatureDeclarationCommon,
 };
@@ -142,8 +141,8 @@ defineType("TSMethodSignature", {
   visitor: [
     "key",
     "typeParameters",
-    process.env.BABEL_8_BREAKING ? "params" : "parameters",
-    process.env.BABEL_8_BREAKING ? "returnType" : "typeAnnotation",
+    process?.env?.BABEL_8_BREAKING ? "params" : "parameters",
+    process?.env?.BABEL_8_BREAKING ? "returnType" : "typeAnnotation",
   ],
   fields: {
     ...signatureDeclarationCommon,
@@ -199,8 +198,8 @@ const fnOrCtrBase = {
   aliases: ["TSType"],
   visitor: [
     "typeParameters",
-    process.env.BABEL_8_BREAKING ? "params" : "parameters",
-    process.env.BABEL_8_BREAKING ? "returnType" : "typeAnnotation",
+    process?.env?.BABEL_8_BREAKING ? "params" : "parameters",
+    process?.env?.BABEL_8_BREAKING ? "returnType" : "typeAnnotation",
   ],
 };
 
@@ -603,7 +602,7 @@ defineType("TSTypeParameter", {
   visitor: ["constraint", "default"],
   fields: {
     name: {
-      validate: !process.env.BABEL_8_BREAKING
+      validate: !process?.env?.BABEL_8_BREAKING
         ? assertValueType("string")
         : assertNodeType("Identifier"),
     },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14314  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This makes all process.env checks in @babel/types null safe.
Another option includes making a wrapper function to check if the process.env is breaking.
This is to make a ligher alternative to @babel/standalone work (@babel/types, @babel/traverse, @babel/generate) for modern bundlers