### PR TITLE
Fix some minor (language, not code) syntax and type errors.

### DIFF
--- a/test/jest-light-runner/src/worker-runner.js
+++ b/test/jest-light-runner/src/worker-runner.js
@@ -4,14 +4,14 @@ import { performance } from "perf_hooks";
 import snapshot from "jest-snapshot";
 import expect from "expect";
 import * as circus from "jest-circus";
-import { inspect } from "util"
+import { inspect } from "util";
 
 import "./global-setup.js";
 
-/** @typedef {{ failures: number, passses: number, pending: number, start: number, end: number }} Stats */
-/** @typedef {{ ancestors: string[], title: string, errors: Error[], skipped: boolean }} InternalTestResult */
+/** @typedef {{ failures: number, passes: number, pending: number, start: number, end: number }} Stats */
+/** @typedef {{ ancestors: string[], title: string, duration: number, errors: Error[], skipped: boolean }} InternalTestResult */
 
-// Node.js workers (worker_therads) don't support
+// Node.js workers (worker_threads) don't support
 // process.chdir, that we use multiple times in our tests.
 // We can "polyfill" it for process.cwd() usage, but it
 // won't affect path.* and fs.* functions.
@@ -53,7 +53,7 @@ export default async function ({
   stats.end = performance.now();
 
   snapshotState._inlineSnapshots.forEach(({ frame }) => {
-    // When using native ESM, errors have an URL location.
+    // When using native ESM, errors have a URL location.
     // Jest expects paths.
     frame.file = fileURLToPath(frame.file);
   });
@@ -140,7 +140,7 @@ async function runTest(fn, stats, results, ancestors, name) {
     errors.push(error);
   });
 
-  // Get suppressed errors from ``jest-matchers`` that weren't throw during
+  // Get suppressed errors from ``jest-matchers`` that weren't thrown during
   // test execution and add them to the test result, potentially failing
   // a passing test.
   const { suppressedErrors } = expect.getState();

--- a/test/runtime-integration/bundlers.cjs
+++ b/test/runtime-integration/bundlers.cjs
@@ -33,13 +33,12 @@ function test(name, command, directory, output, first) {
   });
 
   const expectedPath = path.join(__dirname, "expected-bundler.txt");
-  let expected = fs.readFileSync(expectedPath, "utf8");
+  const expected = fs.readFileSync(expectedPath, "utf8");
 
   if (expected === out) {
     console.log("OK");
   } else if (first && process.env.OVERWRITE) {
     fs.writeFileSync(expectedPath, out);
-    expected = out;
     console.log("UPDATED");
   } else {
     console.error("FAILED\n");

--- a/test/runtime-integration/node.cjs
+++ b/test/runtime-integration/node.cjs
@@ -18,7 +18,7 @@ if (
 
   test("ESM", "./src/main-esm.mjs", expectedEsm);
   // TODO: This never worked in any Babel version
-  // test("ESM - absoluteRuntime", "--esperimental-modules ./src/absolute/main-esm.mjs", "expected-esm-absolute.txt");
+  // test("ESM - absoluteRuntime", "--experimental-modules ./src/absolute/main-esm.mjs", "expected-esm-absolute.txt");
 }
 
 const expectedCjs =


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No, I don't think it needs testing.
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In the [last PR](https://github.com/babel/babel/pull/14294), in order to find out how to test the code, I carefully looked at all the files in the `/test` directory, although I didn't find the right way in the end, but found some very minor issues, so I tried to fix them.

The only point of contention may lie in the modification of the file `test/runtime-integration/bundlers.cjs`. In the original file, I don't know the reason. At the end, the operation of `expected = out;` was executed, but later This variable is not used, so I don't think it makes sense, it should be a constant.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14352"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

