### PR TITLE
Add `funding` key for two package.json files

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -33,10 +33,20 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/babel"
-  },
+  "funding": [
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/babel"
+    },
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/babel"
+    },
+    {
+      "type": "gitcoin",
+      "url": "https://gitcoin.co/grants/2906/babel-compiler-for-next-generation-javascript"
+    }
+  ],
   "browser": {
     "./lib/config/files/index.js": "./lib/config/files/index-browser.js",
     "./lib/config/resolve-targets.js": "./lib/config/resolve-targets-browser.js",

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -14,6 +14,20 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-preset-env"
   },
+  "funding": [
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/babel"
+    },
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/babel"
+    },
+    {
+      "type": "gitcoin",
+      "url": "https://gitcoin.co/grants/2906/babel-compiler-for-next-generation-javascript"
+    }
+  ],
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/compat-data": "workspace:^",


### PR DESCRIPTION
Hi!

I'm submitting this PR because in the [simple-icons](https://github.com/simple-icons/simple-icons) project we are trying to automate as much as possible our monetary contributions to our direct dependencies, so having this metadata in the package.json files allows us to programmatically know easily how we can fund them. The `funding` key in package.json accepts an array for all the ways for funding a package, see [package-json#funding](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#funding).

I'm only updating two packages because we only depend in these two: `@babel/core` and `@babel/preset-env`.

Cheers!