### PR TITLE
Allow keywords in TS qualified types

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -560,10 +560,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (this.eat(tt.dot)) {
         // In this instance, the entity name will actually itself be a
         // qualifier, so allow it to be a reserved word as well.
-        node.qualifier = this.tsParseEntityName({
-          allowReservedEntityName: true,
-          allowReservedQualifiers: true,
-        });
+        node.qualifier = this.tsParseEntityName();
       }
       if (this.match(tt.lt)) {
         node.typeParameters = this.tsParseTypeArguments();
@@ -571,33 +568,20 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return this.finishNode(node, "TSImportType");
     }
 
-    tsParseEntityName({
-      allowReservedEntityName,
-      allowReservedQualifiers,
-    }: {
-      allowReservedEntityName: TokenType | boolean,
-      allowReservedQualifiers: boolean,
-    }): N.TsEntityName {
-      let entity: N.TsEntityName = this.parseIdentifier(
-        allowReservedEntityName === true ||
-          (allowReservedEntityName !== false &&
-            this.match(allowReservedEntityName)),
-      );
+    tsParseEntityName(allowReservedWords: boolean = true): N.TsEntityName {
+      let entity: N.TsEntityName = this.parseIdentifier(allowReservedWords);
       while (this.eat(tt.dot)) {
         const node: N.TsQualifiedName = this.startNodeAtNode(entity);
         node.left = entity;
-        node.right = this.parseIdentifier(allowReservedQualifiers);
+        node.right = this.parseIdentifier(allowReservedWords);
         entity = this.finishNode(node, "TSQualifiedName");
       }
       return entity;
     }
 
-    tsParseTypeReference(allowConst: boolean = false): N.TsTypeReference {
+    tsParseTypeReference(): N.TsTypeReference {
       const node: N.TsTypeReference = this.startNode();
-      node.typeName = this.tsParseEntityName({
-        allowReservedEntityName: allowConst && tt._const,
-        allowReservedQualifiers: true,
-      });
+      node.typeName = this.tsParseEntityName();
       if (!this.hasPrecedingLineBreak() && this.match(tt.lt)) {
         node.typeParameters = this.tsParseTypeArguments();
       }
@@ -625,10 +609,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (this.match(tt._import)) {
         node.exprName = this.tsParseImportType();
       } else {
-        node.exprName = this.tsParseEntityName({
-          allowReservedEntityName: false,
-          allowReservedQualifiers: true,
-        });
+        node.exprName = this.tsParseEntityName();
       }
       return this.finishNode(node, "TSTypeQuery");
     }
@@ -678,7 +659,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (this.lookahead().type !== tt._const) return null;
 
       this.next();
-      const typeReference = this.tsParseTypeReference(/* allowConst */ true);
+      const typeReference = this.tsParseTypeReference();
 
       // If the type reference has type parameters, then you are using it as a
       // type and not as a const signifier. We'll *never* be able to find this
@@ -1595,12 +1576,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     tsParseExpressionWithTypeArguments(): N.TsExpressionWithTypeArguments {
       const node: N.TsExpressionWithTypeArguments = this.startNode();
-      // Note: TS uses parseLeftHandSideExpressionOrHigher,
-      // then has grammar errors later if it's not an EntityName.
-      node.expression = this.tsParseEntityName({
-        allowReservedEntityName: false,
-        allowReservedQualifiers: false,
-      });
+      node.expression = this.tsParseEntityName();
       if (this.match(tt.lt)) {
         node.typeParameters = this.tsParseTypeArguments();
       }
@@ -1833,10 +1809,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     tsParseModuleReference(): N.TsModuleReference {
       return this.tsIsExternalModuleReference()
         ? this.tsParseExternalModuleReference()
-        : this.tsParseEntityName({
-            allowReservedEntityName: false,
-            allowReservedQualifiers: false,
-          });
+        : this.tsParseEntityName(/* allowReservedWords */ false);
     }
 
     tsParseExternalModuleReference(): N.TsExternalModuleReference {

--- a/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2/input.ts
@@ -1,0 +1,4 @@
+// These are valid TypeScript syntax (the parser doesn't produce any error),
+// but they are always type-checking errors.
+interface A extends this.B {}
+type T = typeof var.bar;

--- a/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2/output.json
@@ -1,0 +1,98 @@
+{
+  "type": "File",
+  "start":0,"end":176,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":24,"index":176}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":176,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":24,"index":176}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSInterfaceDeclaration",
+        "start":122,"end":151,"loc":{"start":{"line":3,"column":0,"index":122},"end":{"line":3,"column":29,"index":151}},
+        "id": {
+          "type": "Identifier",
+          "start":132,"end":133,"loc":{"start":{"line":3,"column":10,"index":132},"end":{"line":3,"column":11,"index":133},"identifierName":"A"},
+          "name": "A"
+        },
+        "extends": [
+          {
+            "type": "TSExpressionWithTypeArguments",
+            "start":142,"end":148,"loc":{"start":{"line":3,"column":20,"index":142},"end":{"line":3,"column":26,"index":148}},
+            "expression": {
+              "type": "TSQualifiedName",
+              "start":142,"end":148,"loc":{"start":{"line":3,"column":20,"index":142},"end":{"line":3,"column":26,"index":148}},
+              "left": {
+                "type": "Identifier",
+                "start":142,"end":146,"loc":{"start":{"line":3,"column":20,"index":142},"end":{"line":3,"column":24,"index":146},"identifierName":"this"},
+                "name": "this"
+              },
+              "right": {
+                "type": "Identifier",
+                "start":147,"end":148,"loc":{"start":{"line":3,"column":25,"index":147},"end":{"line":3,"column":26,"index":148},"identifierName":"B"},
+                "name": "B"
+              }
+            }
+          }
+        ],
+        "body": {
+          "type": "TSInterfaceBody",
+          "start":149,"end":151,"loc":{"start":{"line":3,"column":27,"index":149},"end":{"line":3,"column":29,"index":151}},
+          "body": []
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " These are valid TypeScript syntax (the parser doesn't produce any error),",
+            "start":0,"end":76,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":76,"index":76}}
+          },
+          {
+            "type": "CommentLine",
+            "value": " but they are always type-checking errors.",
+            "start":77,"end":121,"loc":{"start":{"line":2,"column":0,"index":77},"end":{"line":2,"column":44,"index":121}}
+          }
+        ]
+      },
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start":152,"end":176,"loc":{"start":{"line":4,"column":0,"index":152},"end":{"line":4,"column":24,"index":176}},
+        "id": {
+          "type": "Identifier",
+          "start":157,"end":158,"loc":{"start":{"line":4,"column":5,"index":157},"end":{"line":4,"column":6,"index":158},"identifierName":"T"},
+          "name": "T"
+        },
+        "typeAnnotation": {
+          "type": "TSTypeQuery",
+          "start":161,"end":175,"loc":{"start":{"line":4,"column":9,"index":161},"end":{"line":4,"column":23,"index":175}},
+          "exprName": {
+            "type": "TSQualifiedName",
+            "start":168,"end":175,"loc":{"start":{"line":4,"column":16,"index":168},"end":{"line":4,"column":23,"index":175}},
+            "left": {
+              "type": "Identifier",
+              "start":168,"end":171,"loc":{"start":{"line":4,"column":16,"index":168},"end":{"line":4,"column":19,"index":171},"identifierName":"var"},
+              "name": "var"
+            },
+            "right": {
+              "type": "Identifier",
+              "start":172,"end":175,"loc":{"start":{"line":4,"column":20,"index":172},"end":{"line":4,"column":23,"index":175},"identifierName":"bar"},
+              "name": "bar"
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " These are valid TypeScript syntax (the parser doesn't produce any error),",
+      "start":0,"end":76,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":76,"index":76}}
+    },
+    {
+      "type": "CommentLine",
+      "value": " but they are always type-checking errors.",
+      "start":77,"end":121,"loc":{"start":{"line":2,"column":0,"index":77},"end":{"line":2,"column":44,"index":121}}
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-disallowed/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-disallowed/input.ts
@@ -1,0 +1,2 @@
+import X = Y.if;
+import A = this.A;

--- a/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-disallowed/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-disallowed/output.json
@@ -1,0 +1,67 @@
+{
+  "type": "File",
+  "start":0,"end":35,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":18,"index":35}},
+  "errors": [
+    "SyntaxError: Unexpected keyword 'if'. (1:13)",
+    "SyntaxError: Unexpected keyword 'this'. (2:11)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":35,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":18,"index":35}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":0,"end":16,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":16,"index":16}},
+        "importKind": "value",
+        "isExport": false,
+        "id": {
+          "type": "Identifier",
+          "start":7,"end":8,"loc":{"start":{"line":1,"column":7,"index":7},"end":{"line":1,"column":8,"index":8},"identifierName":"X"},
+          "name": "X"
+        },
+        "moduleReference": {
+          "type": "TSQualifiedName",
+          "start":11,"end":15,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":15,"index":15}},
+          "left": {
+            "type": "Identifier",
+            "start":11,"end":12,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":12,"index":12},"identifierName":"Y"},
+            "name": "Y"
+          },
+          "right": {
+            "type": "Identifier",
+            "start":13,"end":15,"loc":{"start":{"line":1,"column":13,"index":13},"end":{"line":1,"column":15,"index":15},"identifierName":"if"},
+            "name": "if"
+          }
+        }
+      },
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start":17,"end":35,"loc":{"start":{"line":2,"column":0,"index":17},"end":{"line":2,"column":18,"index":35}},
+        "importKind": "value",
+        "isExport": false,
+        "id": {
+          "type": "Identifier",
+          "start":24,"end":25,"loc":{"start":{"line":2,"column":7,"index":24},"end":{"line":2,"column":8,"index":25},"identifierName":"A"},
+          "name": "A"
+        },
+        "moduleReference": {
+          "type": "TSQualifiedName",
+          "start":28,"end":34,"loc":{"start":{"line":2,"column":11,"index":28},"end":{"line":2,"column":17,"index":34}},
+          "left": {
+            "type": "Identifier",
+            "start":28,"end":32,"loc":{"start":{"line":2,"column":11,"index":28},"end":{"line":2,"column":15,"index":32},"identifierName":"this"},
+            "name": "this"
+          },
+          "right": {
+            "type": "Identifier",
+            "start":33,"end":34,"loc":{"start":{"line":2,"column":16,"index":33},"end":{"line":2,"column":17,"index":34},"identifierName":"A"},
+            "name": "A"
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type/input.ts
@@ -1,0 +1,2 @@
+interface A extends T.if {}
+type T = typeof this.bar;

--- a/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type/output.json
@@ -1,0 +1,74 @@
+{
+  "type": "File",
+  "start":0,"end":53,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":25,"index":53}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":53,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":25,"index":53}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSInterfaceDeclaration",
+        "start":0,"end":27,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":27,"index":27}},
+        "id": {
+          "type": "Identifier",
+          "start":10,"end":11,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":11,"index":11},"identifierName":"A"},
+          "name": "A"
+        },
+        "extends": [
+          {
+            "type": "TSExpressionWithTypeArguments",
+            "start":20,"end":24,"loc":{"start":{"line":1,"column":20,"index":20},"end":{"line":1,"column":24,"index":24}},
+            "expression": {
+              "type": "TSQualifiedName",
+              "start":20,"end":24,"loc":{"start":{"line":1,"column":20,"index":20},"end":{"line":1,"column":24,"index":24}},
+              "left": {
+                "type": "Identifier",
+                "start":20,"end":21,"loc":{"start":{"line":1,"column":20,"index":20},"end":{"line":1,"column":21,"index":21},"identifierName":"T"},
+                "name": "T"
+              },
+              "right": {
+                "type": "Identifier",
+                "start":22,"end":24,"loc":{"start":{"line":1,"column":22,"index":22},"end":{"line":1,"column":24,"index":24},"identifierName":"if"},
+                "name": "if"
+              }
+            }
+          }
+        ],
+        "body": {
+          "type": "TSInterfaceBody",
+          "start":25,"end":27,"loc":{"start":{"line":1,"column":25,"index":25},"end":{"line":1,"column":27,"index":27}},
+          "body": []
+        }
+      },
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start":28,"end":53,"loc":{"start":{"line":2,"column":0,"index":28},"end":{"line":2,"column":25,"index":53}},
+        "id": {
+          "type": "Identifier",
+          "start":33,"end":34,"loc":{"start":{"line":2,"column":5,"index":33},"end":{"line":2,"column":6,"index":34},"identifierName":"T"},
+          "name": "T"
+        },
+        "typeAnnotation": {
+          "type": "TSTypeQuery",
+          "start":37,"end":52,"loc":{"start":{"line":2,"column":9,"index":37},"end":{"line":2,"column":24,"index":52}},
+          "exprName": {
+            "type": "TSQualifiedName",
+            "start":44,"end":52,"loc":{"start":{"line":2,"column":16,"index":44},"end":{"line":2,"column":24,"index":52}},
+            "left": {
+              "type": "Identifier",
+              "start":44,"end":48,"loc":{"start":{"line":2,"column":16,"index":44},"end":{"line":2,"column":20,"index":48},"identifierName":"this"},
+              "name": "this"
+            },
+            "right": {
+              "type": "Identifier",
+              "start":49,"end":52,"loc":{"start":{"line":2,"column":21,"index":49},"end":{"line":2,"column":24,"index":52},"identifierName":"bar"},
+              "name": "bar"
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/scripts/parser-tests/typescript/allowlist.txt
+++ b/scripts/parser-tests/typescript/allowlist.txt
@@ -23,11 +23,8 @@ classExpressionWithDecorator1.ts
 classExtendsMultipleBaseClasses.ts
 classOverloadForFunction.ts
 classWithEmptyTypeParameter.ts
-# TypeScript doesn't allow a parameter to be named arguments even in non-strict mode, which we don't catch.
 collisionArgumentsArrowFunctions.ts
-# TypeScript doesn't allow a parameter to be named arguments even in non-strict mode, which we don't catch.
 collisionArgumentsFunction.ts
-# TypeScript doesn't allow a parameter to be named arguments even in non-strict mode, which we don't catch.
 collisionArgumentsFunctionExpressions.ts
 constDeclarations-invalidContexts.ts
 constDeclarations-scopes.ts
@@ -41,7 +38,6 @@ declareModifierOnImport1.ts
 decoratorsOnComputedProperties.ts
 decrementAndIncrementOperators.ts
 defaultArgsInOverloads.ts
-defaultIsNotVisibleInLocalScope.ts
 defaultValueInFunctionTypes.ts
 deleteOperatorInStrictMode.ts
 duplicateIdentifierBindingElementInParameterDeclaration1.ts
@@ -58,7 +54,6 @@ emptyGenericParamList.ts
 emptyTypeArgumentList.ts
 emptyTypeArgumentListWithNew.ts
 enumGenericTypeClash.ts
-# We don't support ES3-style octal literal errors.
 es3-oldStyleOctalLiteralInEnums.ts
 es3-oldStyleOctalLiteralTypes.ts
 es6ImportDefaultBindingFollowedWithNamedImport1InEs5.ts
@@ -78,9 +73,7 @@ exportEqualsOfModule.ts
 exportSameNameFuncVar.ts
 exportSpecifierAndExportedMemberDeclaration.ts
 exportSpecifierAndLocalMemberDeclaration.ts
-# We handle this fine, but it doesn't consider the different files together
 exportSpecifierForAGlobal.ts
-# We handle this fine, but it doesn't consider the different files together
 exportSpecifierReferencingOuterDeclaration2.ts
 expressionsForbiddenInParameterInitializers.ts
 extendsClauseAlreadySeen.ts
@@ -106,9 +99,8 @@ indexTypeCheck.ts
 indexWithoutParamType.ts
 indexerSignatureWithRestParam.ts
 interfaceMayNotBeExtendedWitACall.ts
-interfaceWithImplements1.ts
-# We correctly identify this error, but we can't bring it in without bringing a bunch of other tests too.
 interfaceNaming1.ts
+interfaceWithImplements1.ts
 jsxAttributeWithoutExpressionReact.tsx
 letAndVarRedeclaration.ts
 letAsIdentifier.ts
@@ -129,24 +121,21 @@ moduleDuplicateIdentifiers.ts
 moduleSharesNameWithImportDeclarationInsideIt3.ts
 moduleSharesNameWithImportDeclarationInsideIt5.ts
 multipleClassPropertyModifiersErrors.ts
-multipleInheritance.ts
 multipleExports.ts
+multipleInheritance.ts
 nameCollisions.ts
 noImplicitAnyDestructuringVarDeclaration.ts
 nonMergedOverloads.ts
 parameterInitializerBeforeDestructuringEmit.ts
 parameterPropertyOutsideConstructor.ts
 parserConstructorDeclaration12.ts
-readonlyInNonPropertyParameters.ts
-redeclareParameterInCatchBlock.ts
 reExportGlobalDeclaration1.ts
-# We handle this fine, but it doesn't consider the different files together
 reExportGlobalDeclaration2.ts
-# We handle this fine, but it doesn't consider the different files together
 reExportGlobalDeclaration3.ts
-# We handle this fine, but it doesn't consider the different files together
 reExportGlobalDeclaration4.ts
 reExportUndefined1.ts
+readonlyInNonPropertyParameters.ts
+redeclareParameterInCatchBlock.ts
 restParamModifier2.ts
 shadowedReservedCompilerDeclarationsWithNoEmit.ts
 sourceMap-LineBreaks.ts

--- a/scripts/parser-tests/typescript/allowlist.txt
+++ b/scripts/parser-tests/typescript/allowlist.txt
@@ -23,9 +23,9 @@ classExpressionWithDecorator1.ts
 classExtendsMultipleBaseClasses.ts
 classOverloadForFunction.ts
 classWithEmptyTypeParameter.ts
-collisionArgumentsArrowFunctions.ts
-collisionArgumentsFunction.ts
-collisionArgumentsFunctionExpressions.ts
+collisionArgumentsArrowFunctions.ts # TypeScript doesn't allow a parameter to be named arguments even in non-strict mode, which we don't catch.
+collisionArgumentsFunction.ts # TypeScript doesn't allow a parameter to be named arguments even in non-strict mode, which we don't catch.
+collisionArgumentsFunctionExpressions.ts # TypeScript doesn't allow a parameter to be named arguments even in non-strict mode, which we don't catch.
 constDeclarations-invalidContexts.ts
 constDeclarations-scopes.ts
 constDeclarations-validContexts.ts
@@ -54,7 +54,7 @@ emptyGenericParamList.ts
 emptyTypeArgumentList.ts
 emptyTypeArgumentListWithNew.ts
 enumGenericTypeClash.ts
-es3-oldStyleOctalLiteralInEnums.ts
+es3-oldStyleOctalLiteralInEnums.ts # We don't support ES3-style octal literal errors.
 es3-oldStyleOctalLiteralTypes.ts
 es6ImportDefaultBindingFollowedWithNamedImport1InEs5.ts
 es6ImportDefaultBindingMergeErrors.ts
@@ -73,8 +73,8 @@ exportEqualsOfModule.ts
 exportSameNameFuncVar.ts
 exportSpecifierAndExportedMemberDeclaration.ts
 exportSpecifierAndLocalMemberDeclaration.ts
-exportSpecifierForAGlobal.ts
-exportSpecifierReferencingOuterDeclaration2.ts
+exportSpecifierForAGlobal.ts # We handle this fine, but it doesn't consider the different files together
+exportSpecifierReferencingOuterDeclaration2.ts # We handle this fine, but it doesn't consider the different files together
 expressionsForbiddenInParameterInitializers.ts
 extendsClauseAlreadySeen.ts
 extendsClauseAlreadySeen2.ts
@@ -99,7 +99,7 @@ indexTypeCheck.ts
 indexWithoutParamType.ts
 indexerSignatureWithRestParam.ts
 interfaceMayNotBeExtendedWitACall.ts
-interfaceNaming1.ts
+interfaceNaming1.ts # We correctly identify this error, but we can't bring it in without bringing a bunch of other tests too.
 interfaceWithImplements1.ts
 jsxAttributeWithoutExpressionReact.tsx
 letAndVarRedeclaration.ts
@@ -130,9 +130,9 @@ parameterInitializerBeforeDestructuringEmit.ts
 parameterPropertyOutsideConstructor.ts
 parserConstructorDeclaration12.ts
 reExportGlobalDeclaration1.ts
-reExportGlobalDeclaration2.ts
-reExportGlobalDeclaration3.ts
-reExportGlobalDeclaration4.ts
+reExportGlobalDeclaration2.ts # We handle this fine, but it doesn't consider the different files together
+reExportGlobalDeclaration3.ts # We handle this fine, but it doesn't consider the different files together
+reExportGlobalDeclaration4.ts # We handle this fine, but it doesn't consider the different files together
 reExportUndefined1.ts
 readonlyInNonPropertyParameters.ts
 redeclareParameterInCatchBlock.ts


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14357
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

TypeScript is way more liberal than the restrictions we introduced in #14320: it allows keywords in qualified types almost everywhere, and it handles keywords as normal identifiers.

I believe that some valid syntax will always result in a type checking error, for example `type A = if`. However, the TypeScript parser happily accepts it and only reports `if` as not being defined (I don't know if it's possible to use something like jsdoc or external declaration files to declare an `if` global type).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14362"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

