### PR TITLE
Align named imports behavior in `.mjs` and `.js` files

### DIFF
--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/2775/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/2775/output.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-var _react = babelHelpers.interopRequireDefault(require("react"));
+var _react = babelHelpers.interopRequireWildcard(require("react"));
 
 var RandomComponent = /*#__PURE__*/function (_Component) {
   babelHelpers.inherits(RandomComponent, _Component);

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.ts
@@ -19,13 +19,14 @@ export default declare((api, options) => {
   const transformImportCall = createDynamicImportTransform(api);
 
   const {
-    // 'true' for non-mjs files to strictly have .default, instead of having
-    // destructuring-like behavior for their properties.
+    // 'true' for imports to strictly have .default, instead of having
+    // destructuring-like behavior for their properties. This matches the behavior
+    // of the initial Node.js (v12) behavior when importing a CommonJS without
+    // the __esMoule property.
+    // .strictNamespace is for non-mjs files, mjsStrictNamespace if for mjs files.
     strictNamespace = false,
+    mjsStrictNamespace = strictNamespace,
 
-    // 'true' for mjs files to strictly have .default, instead of having
-    // destructuring-like behavior for their properties.
-    mjsStrictNamespace = true,
     allowTopLevelThis,
     strict,
     strictMode,

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/auxiliary-comment/overview/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/auxiliary-comment/overview/output.js
@@ -31,7 +31,7 @@ _foo2 = babelHelpers.interopRequireDefault(require("foo2"))
 
 var
 /*before*/
-foo2 = babelHelpers.interopRequireDefault(require("foo3"))
+foo2 = babelHelpers.interopRequireWildcard(require("foo3"))
 /*after*/
 ;
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/import-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/import-namespace/output.js
@@ -1,7 +1,7 @@
 "use strict";
 
 function foo() {
-  const data = babelHelpers.interopRequireDefault(require("foo"));
+  const data = babelHelpers.interopRequireWildcard(require("foo"));
 
   foo = function () {
     return data;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/reexport-namespace/output.js
@@ -6,7 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.namespace = void 0;
 
 function namespace() {
-  const data = babelHelpers.interopRequireDefault(require("foo"));
+  const data = babelHelpers.interopRequireWildcard(require("foo"));
 
   namespace = function () {
     return data;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/import-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/import-namespace/output.js
@@ -1,4 +1,4 @@
 "use strict";
 
-var foo = babelHelpers.interopRequireDefault(require("./foo"));
+var foo = babelHelpers.interopRequireWildcard(require("./foo"));
 console.log(foo);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/reexport-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-local/reexport-namespace/output.js
@@ -4,5 +4,5 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.namespace = void 0;
-var namespace = babelHelpers.interopRequireDefault(require("./foo"));
+var namespace = babelHelpers.interopRequireWildcard(require("./foo"));
 exports.namespace = namespace;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/import-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/import-namespace/output.js
@@ -1,7 +1,7 @@
 "use strict";
 
 function foo1() {
-  const data = babelHelpers.interopRequireDefault(require("white"));
+  const data = babelHelpers.interopRequireWildcard(require("white"));
 
   foo1 = function () {
     return data;
@@ -10,6 +10,6 @@ function foo1() {
   return data;
 }
 
-var foo2 = babelHelpers.interopRequireDefault(require("black"));
+var foo2 = babelHelpers.interopRequireWildcard(require("black"));
 console.log(foo1());
 console.log(foo2);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-whitelist/reexport-namespace/output.js
@@ -6,7 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.namespace2 = exports.namespace1 = void 0;
 
 function namespace1() {
-  const data = babelHelpers.interopRequireDefault(require("white"));
+  const data = babelHelpers.interopRequireWildcard(require("white"));
 
   namespace1 = function () {
     return data;
@@ -21,5 +21,5 @@ Object.defineProperty(exports, "namespace1", {
     return namespace1();
   }
 });
-var namespace2 = babelHelpers.interopRequireDefault(require("black"));
+var namespace2 = babelHelpers.interopRequireWildcard(require("black"));
 exports.namespace2 = namespace2;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/exec.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/exec.js
@@ -1,5 +1,5 @@
+// No exception should be thrown
 import * as foo from "./moduleWithGetter";
 
+expect(foo.baz).toBe(123);
 expect(() => foo.boo).toThrow();
-
-// No exception should be thrown

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["transform-modules-commonjs", { "mjsStrictNamespace": false }]]
+  "plugins": ["transform-modules-commonjs"]
 }

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/exec.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/exec.js
@@ -1,0 +1,4 @@
+// No exception should be thrown
+import Foo, { baz } from "./moduleWithGetter";
+
+expect(baz).toBe(123);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/exec.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/exec.mjs
@@ -1,3 +1,0 @@
-import Foo, { baz } from "./moduleWithGetter";
-
-// No exception should be thrown

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/output.js
@@ -16,6 +16,8 @@ Object.defineProperty(exports, "baz", {
   }
 });
 
-var _moduleWithGetter = _interopRequireDefault(require("./moduleWithGetter"));
+var _moduleWithGetter = _interopRequireWildcard(require("./moduleWithGetter"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/output.js
@@ -2,9 +2,13 @@
 
 var _foo = _interopRequireDefault(require("foo"));
 
-var Bar = _interopRequireDefault(require("bar"));
+var Bar = _interopRequireWildcard(require("bar"));
 
 var _baz = require("baz");
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/reference-source-map/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/reference-source-map/output.js
@@ -6,7 +6,7 @@ var _two = require("two");
 
 var _three = require("three");
 
-var aNamespace = babelHelpers.interopRequireDefault(require("four"));
+var aNamespace = babelHelpers.interopRequireWildcard(require("four"));
 console.log(_one.default);
 console.log(_two.aNamed);
 console.log(_three.orig);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/lazy-7176/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/lazy-7176/output.js
@@ -1,7 +1,7 @@
 "use strict";
 
 function mod() {
-  const data = babelHelpers.interopRequireDefault(require("mod"));
+  const data = babelHelpers.interopRequireWildcard(require("mod"));
 
   mod = function () {
     return data;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/options.json
@@ -1,8 +1,3 @@
 {
-  "plugins": [
-    [
-      "transform-modules-commonjs",
-      { "strict": true, "mjsStrictNamespace": false }
-    ]
-  ]
+  "plugins": [["transform-modules-commonjs", { "strict": true }]]
 }

--- a/packages/babel-preset-env/test/fixtures/export-namespace-from/auto-esm-not-supported/output.js
+++ b/packages/babel-preset-env/test/fixtures/export-namespace-from/auto-esm-not-supported/output.js
@@ -5,6 +5,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.foo = void 0;
 
-var _foo = babelHelpers.interopRequireDefault(require("./foo.mjs"));
+var _foo = babelHelpers.interopRequireWildcard(require("./foo.mjs"));
 
 exports.foo = _foo;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14365
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The new behavior of defaulting to `false` is compatible with the old one, because it's strictly additive. When importing with `import * as ns` a file that exports `module.exports = { foo: 1 }` from an mjs file, the previous value of `ns` was `{ default: { foo: 1 } }` and now it will be `{ default: { foo: 1 }, foo: 1 }`.

This aligns the `.mjs` behavior with what we do in `.js` files, and with what Node.js does.

In Babel 8 we will remove `mjsStrictNamespace` option. We should probably also remove `strictNamespace`, now that Node.js doesn't have that behavior anymore.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14366"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

