### PR TITLE
Defer `<T>() => {}` TSX error to Babel 8

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -3119,13 +3119,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return expr;
       }, state);
 
-      if (invalidSingleType) {
-        this.raise(TSErrors.SingleTypeParameterWithoutTrailingComma, {
-          at: createPositionWithColumnOffset(invalidSingleType.loc.end, 1),
-          typeParameterName: process.env.BABEL_8_BREAKING
-            ? invalidSingleType.name.name
-            : invalidSingleType.name,
-        });
+      if (process.env.BABEL_8_BREAKING) {
+        if (invalidSingleType) {
+          this.raise(TSErrors.SingleTypeParameterWithoutTrailingComma, {
+            at: createPositionWithColumnOffset(invalidSingleType.loc.end, 1),
+            typeParameterName: invalidSingleType.name.name,
+          });
+        }
       }
 
       /*:: invariant(arrow.node != null) */

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx-babel-7/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx-babel-7/output.json
@@ -1,9 +1,6 @@
 {
   "type": "File",
   "start":0,"end":79,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":18,"index":79}},
-  "errors": [
-    "SyntaxError: Single type parameter T should have a trailing comma. Example usage: <T,>. (2:3)"
-  ],
   "program": {
     "type": "Program",
     "start":0,"end":79,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":18,"index":79}},

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx/input.ts
@@ -1,2 +1,4 @@
-// Same as `generic`. Verify that JSX doesn't change things.
+// Generics without trailing comma are disallowed in JSX
+<T>(a: T): T => a;
+
 <T,>(a: T): T => a;

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx/output.json
@@ -1,27 +1,30 @@
 {
   "type": "File",
-  "start":0,"end":80,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":19,"index":80}},
+  "start":0,"end":96,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":19,"index":96}},
+  "errors": [
+    "SyntaxError: Single type parameter T should have a trailing comma. Example usage: <T,>. (2:3)"
+  ],
   "program": {
     "type": "Program",
-    "start":0,"end":80,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":19,"index":80}},
+    "start":0,"end":96,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":19,"index":96}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "ExpressionStatement",
-        "start":61,"end":80,"loc":{"start":{"line":2,"column":0,"index":61},"end":{"line":2,"column":19,"index":80}},
+        "start":57,"end":75,"loc":{"start":{"line":2,"column":0,"index":57},"end":{"line":2,"column":18,"index":75}},
         "expression": {
           "type": "ArrowFunctionExpression",
-          "start":61,"end":79,"loc":{"start":{"line":2,"column":0,"index":61},"end":{"line":2,"column":18,"index":79}},
+          "start":57,"end":74,"loc":{"start":{"line":2,"column":0,"index":57},"end":{"line":2,"column":17,"index":74}},
           "returnType": {
             "type": "TSTypeAnnotation",
-            "start":71,"end":74,"loc":{"start":{"line":2,"column":10,"index":71},"end":{"line":2,"column":13,"index":74}},
+            "start":66,"end":69,"loc":{"start":{"line":2,"column":9,"index":66},"end":{"line":2,"column":12,"index":69}},
             "typeAnnotation": {
               "type": "TSTypeReference",
-              "start":73,"end":74,"loc":{"start":{"line":2,"column":12,"index":73},"end":{"line":2,"column":13,"index":74}},
+              "start":68,"end":69,"loc":{"start":{"line":2,"column":11,"index":68},"end":{"line":2,"column":12,"index":69}},
               "typeName": {
                 "type": "Identifier",
-                "start":73,"end":74,"loc":{"start":{"line":2,"column":12,"index":73},"end":{"line":2,"column":13,"index":74},"identifierName":"T"},
+                "start":68,"end":69,"loc":{"start":{"line":2,"column":11,"index":68},"end":{"line":2,"column":12,"index":69},"identifierName":"T"},
                 "name": "T"
               }
             }
@@ -32,17 +35,17 @@
           "params": [
             {
               "type": "Identifier",
-              "start":66,"end":70,"loc":{"start":{"line":2,"column":5,"index":66},"end":{"line":2,"column":9,"index":70},"identifierName":"a"},
+              "start":61,"end":65,"loc":{"start":{"line":2,"column":4,"index":61},"end":{"line":2,"column":8,"index":65},"identifierName":"a"},
               "name": "a",
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
-                "start":67,"end":70,"loc":{"start":{"line":2,"column":6,"index":67},"end":{"line":2,"column":9,"index":70}},
+                "start":62,"end":65,"loc":{"start":{"line":2,"column":5,"index":62},"end":{"line":2,"column":8,"index":65}},
                 "typeAnnotation": {
                   "type": "TSTypeReference",
-                  "start":69,"end":70,"loc":{"start":{"line":2,"column":8,"index":69},"end":{"line":2,"column":9,"index":70}},
+                  "start":64,"end":65,"loc":{"start":{"line":2,"column":7,"index":64},"end":{"line":2,"column":8,"index":65}},
                   "typeName": {
                     "type": "Identifier",
-                    "start":69,"end":70,"loc":{"start":{"line":2,"column":8,"index":69},"end":{"line":2,"column":9,"index":70},"identifierName":"T"},
+                    "start":64,"end":65,"loc":{"start":{"line":2,"column":7,"index":64},"end":{"line":2,"column":8,"index":65},"identifierName":"T"},
                     "name": "T"
                   }
                 }
@@ -51,35 +54,99 @@
           ],
           "body": {
             "type": "Identifier",
-            "start":78,"end":79,"loc":{"start":{"line":2,"column":17,"index":78},"end":{"line":2,"column":18,"index":79},"identifierName":"a"},
+            "start":73,"end":74,"loc":{"start":{"line":2,"column":16,"index":73},"end":{"line":2,"column":17,"index":74},"identifierName":"a"},
             "name": "a"
           },
           "typeParameters": {
             "type": "TSTypeParameterDeclaration",
-            "start":61,"end":65,"loc":{"start":{"line":2,"column":0,"index":61},"end":{"line":2,"column":4,"index":65}},
+            "start":57,"end":60,"loc":{"start":{"line":2,"column":0,"index":57},"end":{"line":2,"column":3,"index":60}},
             "params": [
               {
                 "type": "TSTypeParameter",
-                "start":62,"end":63,"loc":{"start":{"line":2,"column":1,"index":62},"end":{"line":2,"column":2,"index":63}},
+                "start":58,"end":59,"loc":{"start":{"line":2,"column":1,"index":58},"end":{"line":2,"column":2,"index":59}},
                 "name": {
                   "type": "Identifier",
-                  "start":62,"end":63,"loc":{"start":{"line":2,"column":1,"index":62},"end":{"line":2,"column":2,"index":63},"identifierName":"T"},
+                  "start":58,"end":59,"loc":{"start":{"line":2,"column":1,"index":58},"end":{"line":2,"column":2,"index":59},"identifierName":"T"},
                   "name": "T"
                 }
               }
-            ],
-            "extra": {
-              "trailingComma": 63
-            }
+            ]
           }
         },
         "leadingComments": [
           {
             "type": "CommentLine",
-            "value": " Same as `generic`. Verify that JSX doesn't change things.",
-            "start":0,"end":60,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":60,"index":60}}
+            "value": " Generics without trailing comma are disallowed in JSX",
+            "start":0,"end":56,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":56,"index":56}}
           }
         ]
+      },
+      {
+        "type": "ExpressionStatement",
+        "start":77,"end":96,"loc":{"start":{"line":4,"column":0,"index":77},"end":{"line":4,"column":19,"index":96}},
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start":77,"end":95,"loc":{"start":{"line":4,"column":0,"index":77},"end":{"line":4,"column":18,"index":95}},
+          "returnType": {
+            "type": "TSTypeAnnotation",
+            "start":87,"end":90,"loc":{"start":{"line":4,"column":10,"index":87},"end":{"line":4,"column":13,"index":90}},
+            "typeAnnotation": {
+              "type": "TSTypeReference",
+              "start":89,"end":90,"loc":{"start":{"line":4,"column":12,"index":89},"end":{"line":4,"column":13,"index":90}},
+              "typeName": {
+                "type": "Identifier",
+                "start":89,"end":90,"loc":{"start":{"line":4,"column":12,"index":89},"end":{"line":4,"column":13,"index":90},"identifierName":"T"},
+                "name": "T"
+              }
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": false,
+          "params": [
+            {
+              "type": "Identifier",
+              "start":82,"end":86,"loc":{"start":{"line":4,"column":5,"index":82},"end":{"line":4,"column":9,"index":86},"identifierName":"a"},
+              "name": "a",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":83,"end":86,"loc":{"start":{"line":4,"column":6,"index":83},"end":{"line":4,"column":9,"index":86}},
+                "typeAnnotation": {
+                  "type": "TSTypeReference",
+                  "start":85,"end":86,"loc":{"start":{"line":4,"column":8,"index":85},"end":{"line":4,"column":9,"index":86}},
+                  "typeName": {
+                    "type": "Identifier",
+                    "start":85,"end":86,"loc":{"start":{"line":4,"column":8,"index":85},"end":{"line":4,"column":9,"index":86},"identifierName":"T"},
+                    "name": "T"
+                  }
+                }
+              }
+            }
+          ],
+          "body": {
+            "type": "Identifier",
+            "start":94,"end":95,"loc":{"start":{"line":4,"column":17,"index":94},"end":{"line":4,"column":18,"index":95},"identifierName":"a"},
+            "name": "a"
+          },
+          "typeParameters": {
+            "type": "TSTypeParameterDeclaration",
+            "start":77,"end":81,"loc":{"start":{"line":4,"column":0,"index":77},"end":{"line":4,"column":4,"index":81}},
+            "params": [
+              {
+                "type": "TSTypeParameter",
+                "start":78,"end":79,"loc":{"start":{"line":4,"column":1,"index":78},"end":{"line":4,"column":2,"index":79}},
+                "name": {
+                  "type": "Identifier",
+                  "start":78,"end":79,"loc":{"start":{"line":4,"column":1,"index":78},"end":{"line":4,"column":2,"index":79},"identifierName":"T"},
+                  "name": "T"
+                }
+              }
+            ],
+            "extra": {
+              "trailingComma": 79
+            }
+          }
+        }
       }
     ],
     "directives": []
@@ -87,8 +154,8 @@
   "comments": [
     {
       "type": "CommentLine",
-      "value": " Same as `generic`. Verify that JSX doesn't change things.",
-      "start":0,"end":60,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":60,"index":60}}
+      "value": " Generics without trailing comma are disallowed in JSX",
+      "start":0,"end":56,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":56,"index":56}}
     }
   ]
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes #14361
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

https://github.com/babel/babel/pull/14135 (which disallows `<T>() => {}` in TSX files, since it should be written as `<T,>() => {}`) caused problems for multiple users (at least 5 already reported it).

The reason is that most people enable the JSX and TS presets on all files, making also `.ts` be parsed as `.tsx`. This is wrong in theory, but until Babel 7.17.0 it always worked since TSX was just a superset of TS (except for the legacy `<T> v` type casts, but everyone uses `v as T` now). Even if #14135 is technically correct, it introduced a new error for everyone using single type arguments without a trailing comma and with that misconfiguration.

This error is correct so we should do it, but we could consider it as a breaking change and wait until Babel 8.

> I'm marking this as `i: discussion` because while I think we should do it I'd accept a "we are doing the correct thing by raising the error, so we shouldn't revert it".

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14367"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

