### PR TITLE
Ignore array grouping in test262 tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 FLOW_COMMIT = 92bbb5e9dacb8185aa73ea343954d0434b42c40b
-TEST262_COMMIT = f7fb969cc4934bbc5aa29a378d59325eaa84f475
+TEST262_COMMIT = f71d5e29cb1b55b9b2c90e438dbbcc31b13026c5
 TYPESCRIPT_COMMIT = b53073bf66571b4c99f0a93b8f76fb06b36d8991
 
 # Fix color output until TravisCI fixes https://github.com/travis-ci/travis-ci/issues/7967

--- a/scripts/parser-tests/test262/index.js
+++ b/scripts/parser-tests/test262/index.js
@@ -14,6 +14,7 @@ const ignoredFeatures = new Set([
   "align-detached-buffer-semantics-with-web-reality",
   "arbitrary-module-namespace-names",
   "array-find-from-last",
+  "array-grouping",
   "async-functions",
   "async-iteration",
   "arrow-function",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Ignore the `array-grouping` feature in test262 tests.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14370"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

