### PR TITLE
environmentVisitor should skip decorator expressions

### DIFF
--- a/packages/babel-helper-environment-visitor/package.json
+++ b/packages/babel-helper-environment-visitor/package.json
@@ -17,11 +17,9 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "dependencies": {
-    "@babel/types": "workspace:^"
-  },
   "devDependencies": {
-    "@babel/traverse": "workspace:^"
+    "@babel/traverse": "workspace:^",
+    "@babel/types": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-environment-visitor/src/index.ts
+++ b/packages/babel-helper-environment-visitor/src/index.ts
@@ -32,7 +32,7 @@ export function requeueComputedKeyAndDecorators(
 // environmentVisitor should be used when traversing the whole class and not for specific class elements/methods.
 // For perf reasons, the environmentVisitor might be traversed with `{ noScope: true }`, which means `path.scope` is undefined.
 // Avoid using `path.scope` here
-export default {
+const visitor: Visitor = {
   FunctionParent(path) {
     if (path.isArrowFunctionExpression()) {
       // arrows are not skipped because they inherit the context.
@@ -44,10 +44,13 @@ export default {
       }
     }
   },
-  "ClassProperty|ClassPrivateProperty"(
-    path: NodePath<t.ClassProperty | t.ClassPrivateProperty>,
-  ) {
+  Property(path) {
+    if (path.isObjectProperty()) {
+      return;
+    }
     path.skip();
     requeueComputedKeyAndDecorators(path);
   },
-} as Visitor<unknown>;
+};
+
+export default visitor;

--- a/packages/babel-helper-environment-visitor/src/index.ts
+++ b/packages/babel-helper-environment-visitor/src/index.ts
@@ -13,10 +13,11 @@ export function skipAllButComputedKey(
 }
 
 function skipAndrequeueComputedKeysAndDecorators(
-  path: NodePath<t.Method | t.ClassProperty>,
+  path: NodePath<t.Method | t.Property>,
 ) {
   path.skip();
   const { context } = path;
+  //@ts-ignore ClassPrivateProperty does not have computed
   if (path.node.computed) {
     // requeue the computed key
     context.maybeQueue(path.get("key"));
@@ -43,7 +44,9 @@ export default {
       path.skip();
     }
   },
-  ClassProperty(path) {
+  "ClassProperty|ClassPrivateProperty"(
+    path: NodePath<t.ClassProperty | t.ClassPrivateProperty>,
+  ) {
     skipAndrequeueComputedKeysAndDecorators(path);
   },
 } as Visitor<unknown>;

--- a/packages/babel-helper-environment-visitor/src/index.ts
+++ b/packages/babel-helper-environment-visitor/src/index.ts
@@ -46,4 +46,4 @@ export default {
   ClassProperty(path) {
     skipAndrequeueComputedKeysAndDecorators(path);
   },
-} as Visitor<any>;
+} as Visitor<unknown>;

--- a/packages/babel-helper-environment-visitor/src/index.ts
+++ b/packages/babel-helper-environment-visitor/src/index.ts
@@ -12,16 +12,16 @@ export function skipAllButComputedKey(
   }
 }
 
-export function requeueComputedKeyAndDecorator(
+export function requeueComputedKeyAndDecorators(
   path: NodePath<t.Method | t.Property>,
 ) {
-  const { context } = path;
+  const { context, node } = path;
   //@ts-ignore ClassPrivateProperty does not have computed
-  if (path.node.computed) {
+  if (node.computed) {
     // requeue the computed key
     context.maybeQueue(path.get("key"));
   }
-  if (path.node.decorators) {
+  if (node.decorators) {
     for (const decorator of path.get("decorators")) {
       // requeue the decorators
       context.maybeQueue(decorator);
@@ -40,7 +40,7 @@ export default {
     } else {
       path.skip();
       if (path.isMethod()) {
-        requeueComputedKeyAndDecorator(path);
+        requeueComputedKeyAndDecorators(path);
       }
     }
   },
@@ -48,6 +48,6 @@ export default {
     path: NodePath<t.ClassProperty | t.ClassPrivateProperty>,
   ) {
     path.skip();
-    requeueComputedKeyAndDecorator(path);
+    requeueComputedKeyAndDecorators(path);
   },
 } as Visitor<unknown>;

--- a/packages/babel-helper-environment-visitor/src/index.ts
+++ b/packages/babel-helper-environment-visitor/src/index.ts
@@ -12,10 +12,9 @@ export function skipAllButComputedKey(
   }
 }
 
-function skipAndrequeueComputedKeysAndDecorators(
+export function requeueComputedKeyAndDecorator(
   path: NodePath<t.Method | t.Property>,
 ) {
-  path.skip();
   const { context } = path;
   //@ts-ignore ClassPrivateProperty does not have computed
   if (path.node.computed) {
@@ -38,15 +37,17 @@ export default {
     if (path.isArrowFunctionExpression()) {
       // arrows are not skipped because they inherit the context.
       return;
-    } else if (path.isMethod()) {
-      skipAndrequeueComputedKeysAndDecorators(path);
     } else {
       path.skip();
+      if (path.isMethod()) {
+        requeueComputedKeyAndDecorator(path);
+      }
     }
   },
   "ClassProperty|ClassPrivateProperty"(
     path: NodePath<t.ClassProperty | t.ClassPrivateProperty>,
   ) {
-    skipAndrequeueComputedKeysAndDecorators(path);
+    path.skip();
+    requeueComputedKeyAndDecorator(path);
   },
 } as Visitor<unknown>;

--- a/packages/babel-helper-environment-visitor/src/index.ts
+++ b/packages/babel-helper-environment-visitor/src/index.ts
@@ -1,38 +1,33 @@
-import type { NodePath } from "@babel/traverse";
-import { VISITOR_KEYS, staticBlock } from "@babel/types";
+import type { NodePath, Visitor } from "@babel/traverse";
 import type * as t from "@babel/types";
+import type { PluginPass } from "@babel/core";
 
 // TODO (Babel 8): Don't export this function.
 export function skipAllButComputedKey(
   path: NodePath<t.Method | t.ClassProperty>,
 ) {
-  // If the path isn't computed, just skip everything.
-  if (!path.node.computed) {
-    path.skip();
-    return;
-  }
-
-  // So it's got a computed key. Make sure to skip every other key the
-  // traversal would visit.
-  const keys = VISITOR_KEYS[path.type];
-  for (const key of keys) {
-    if (key !== "key") path.skipKey(key);
+  path.skip();
+  if (path.node.computed) {
+    // requeue the computed key
+    path.context.maybeQueue(path.get("key"));
   }
 }
-
-// Methods are handled by the Method visitor; arrows are not skipped because they inherit the context.
-const skipKey = process.env.BABEL_8_BREAKING
-  ? "StaticBlock|ClassPrivateProperty|TypeAnnotation|FunctionDeclaration|FunctionExpression"
-  : (staticBlock ? "StaticBlock|" : "") +
-    "ClassPrivateProperty|TypeAnnotation|FunctionDeclaration|FunctionExpression";
 
 // environmentVisitor should be used when traversing the whole class and not for specific class elements/methods.
 // For perf reasons, the environmentVisitor might be traversed with `{ noScope: true }`, which means `path.scope` is undefined.
 // Avoid using `path.scope` here
 export default {
-  [skipKey]: path => path.skip(),
-
-  "Method|ClassProperty"(path: NodePath<t.Method | t.ClassProperty>) {
+  FunctionParent(path) {
+    if (path.isArrowFunctionExpression()) {
+      // arrows are not skipped because they inherit the context.
+      return;
+    } else if (path.isMethod()) {
+      skipAllButComputedKey(path);
+    } else {
+      path.skip();
+    }
+  },
+  ClassProperty(path) {
     skipAllButComputedKey(path);
   },
-};
+} as Visitor<PluginPass>;

--- a/packages/babel-helper-environment-visitor/src/index.ts
+++ b/packages/babel-helper-environment-visitor/src/index.ts
@@ -1,6 +1,5 @@
 import type { NodePath, Visitor } from "@babel/traverse";
 import type * as t from "@babel/types";
-import type { PluginPass } from "@babel/core";
 
 // TODO (Babel 8): Don't export this function.
 export function skipAllButComputedKey(
@@ -47,4 +46,4 @@ export default {
   ClassProperty(path) {
     skipAndrequeueComputedKeysAndDecorators(path);
   },
-} as Visitor<PluginPass>;
+} as Visitor<any>;

--- a/packages/babel-helper-replace-supers/src/index.ts
+++ b/packages/babel-helper-replace-supers/src/index.ts
@@ -57,7 +57,9 @@ const visitor = traverse.visitors.merge<
   },
 ]);
 
-const unshadowSuperBindingVisitor = traverse.visitors.merge([
+const unshadowSuperBindingVisitor = traverse.visitors.merge<{
+  refName: string;
+}>([
   environmentVisitor,
   {
     Scopable(path, { refName }) {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/options.json
@@ -1,3 +1,8 @@
 {
-  "plugins": ["proposal-class-properties", "transform-classes"]
+  "plugins": [
+    ["proposal-decorators", { "version": "2021-12" }],
+    "proposal-class-static-block",
+    "proposal-class-properties",
+    "transform-classes"
+  ]
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-decorator/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-decorator/exec.js
@@ -1,0 +1,18 @@
+"use strict";
+class Hello {
+  constructor() {
+    return () => () => "hello";
+  }
+}
+
+class Outer extends Hello {
+  constructor() {
+    class Inner {
+      @(super()) hello;
+    }
+
+    return new Inner();
+  }
+}
+
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-decorator/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-decorator/input.js
@@ -1,0 +1,18 @@
+"use strict";
+class Hello {
+  constructor() {
+    return () => () => "hello";
+  }
+}
+
+class Outer extends Hello {
+  constructor() {
+    class Inner {
+      @(super()) hello;
+    }
+
+    return new Inner();
+  }
+}
+
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
@@ -16,7 +16,7 @@ let Outer = /*#__PURE__*/function (_Hello) {
     var _this;
 
     babelHelpers.classCallCheck(this, Outer);
-    _dec = _this = _super.call(this)
+    _dec = _this = _super.call(this);
     let Inner = /*#__PURE__*/babelHelpers.createClass(function Inner() {
       babelHelpers.classCallCheck(this, Inner);
       babelHelpers.defineProperty(this, "hello", _init_hello(this));

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
@@ -1,0 +1,31 @@
+"use strict";
+
+let Hello = /*#__PURE__*/babelHelpers.createClass(function Hello() {
+  babelHelpers.classCallCheck(this, Hello);
+  return () => () => "hello";
+});
+
+let Outer = /*#__PURE__*/function (_Hello) {
+  babelHelpers.inherits(Outer, _Hello);
+
+  var _super = babelHelpers.createSuper(Outer);
+
+  function Outer() {
+    var _dec, _init_hello;
+
+    var _this;
+
+    babelHelpers.classCallCheck(this, Outer);
+    _dec = _this = _super.call(this)
+    let Inner = /*#__PURE__*/babelHelpers.createClass(function Inner() {
+      babelHelpers.classCallCheck(this, Inner);
+      babelHelpers.defineProperty(this, "hello", _init_hello(this));
+    });
+    [_init_hello] = babelHelpers.applyDecs(Inner, [[_dec, 0, "hello"]], []);
+    return babelHelpers.possibleConstructorReturn(_this, new Inner());
+  }
+
+  return babelHelpers.createClass(Outer);
+}(Hello);
+
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/exec.js
@@ -1,0 +1,19 @@
+"use strict";
+class Hello {
+  toString() {
+    return 'hello';
+  }
+}
+
+class Outer extends Hello {
+  constructor() {
+    super();
+    class Inner {
+      accessor [super.toString()] = 'hello';
+    }
+
+    return new Inner();
+  }
+}
+
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/input.js
@@ -1,0 +1,19 @@
+"use strict";
+class Hello {
+  toString() {
+    return 'hello';
+  }
+}
+
+class Outer extends Hello {
+  constructor() {
+    super();
+    class Inner {
+      accessor [super.toString()] = 'hello';
+    }
+
+    return new Inner();
+  }
+}
+
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    ["proposal-decorators", { "version": "2021-12" }],
+    "proposal-class-static-block",
+    "proposal-class-properties",
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/output.js
@@ -1,0 +1,64 @@
+"use strict";
+
+let Hello = /*#__PURE__*/function () {
+  function Hello() {
+    babelHelpers.classCallCheck(this, Hello);
+  }
+
+  babelHelpers.createClass(Hello, [{
+    key: "toString",
+    value: function toString() {
+      return 'hello';
+    }
+  }]);
+  return Hello;
+}();
+
+let Outer = /*#__PURE__*/function (_Hello) {
+  babelHelpers.inherits(Outer, _Hello);
+
+  var _super = babelHelpers.createSuper(Outer);
+
+  function Outer() {
+    let _babelHelpers$get$cal, _babelHelpers$get$cal2;
+
+    var _thisSuper, _this;
+
+    babelHelpers.classCallCheck(this, Outer);
+    _this = _super.call(this);
+
+    var _A = /*#__PURE__*/new WeakMap();
+
+    _babelHelpers$get$cal = babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper);
+    _babelHelpers$get$cal2 = babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper);
+
+    let Inner = /*#__PURE__*/function () {
+      function Inner() {
+        babelHelpers.classCallCheck(this, Inner);
+        babelHelpers.classPrivateFieldInitSpec(this, _A, {
+          writable: true,
+          value: 'hello'
+        });
+      }
+
+      babelHelpers.createClass(Inner, [{
+        key: _babelHelpers$get$cal,
+        get: function () {
+          return babelHelpers.classPrivateFieldGet(this, _A);
+        }
+      }, {
+        key: _babelHelpers$get$cal2,
+        set: function (v) {
+          babelHelpers.classPrivateFieldSet(this, _A, v);
+        }
+      }]);
+      return Inner;
+    }();
+
+    return babelHelpers.possibleConstructorReturn(_this, new Inner());
+  }
+
+  return babelHelpers.createClass(Outer);
+}(Hello);
+
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-decorator/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-decorator/exec.js
@@ -1,0 +1,17 @@
+"use strict";
+class Hello {
+  dec() { return () => "hello" }
+}
+
+class Outer extends Hello {
+  constructor() {
+    super();
+    class Inner {
+      @(super.dec) hello;
+    }
+
+    return new Inner();
+  }
+}
+
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-decorator/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-decorator/input.js
@@ -1,0 +1,17 @@
+"use strict";
+class Hello {
+  dec() { return () => "hello" }
+}
+
+class Outer extends Hello {
+  constructor() {
+    super();
+    class Inner {
+      @(super.dec) hello;
+    }
+
+    return new Inner();
+  }
+}
+
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
@@ -1,0 +1,41 @@
+"use strict";
+
+let Hello = /*#__PURE__*/function () {
+  function Hello() {
+    babelHelpers.classCallCheck(this, Hello);
+  }
+
+  babelHelpers.createClass(Hello, [{
+    key: "dec",
+    value: function dec() {
+      return () => "hello";
+    }
+  }]);
+  return Hello;
+}();
+
+let Outer = /*#__PURE__*/function (_Hello) {
+  babelHelpers.inherits(Outer, _Hello);
+
+  var _super = babelHelpers.createSuper(Outer);
+
+  function Outer() {
+    var _dec, _init_hello;
+
+    var _thisSuper, _this;
+
+    babelHelpers.classCallCheck(this, Outer);
+    _this = _super.call(this);
+    _dec = babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "dec", _thisSuper)
+    let Inner = /*#__PURE__*/babelHelpers.createClass(function Inner() {
+      babelHelpers.classCallCheck(this, Inner);
+      babelHelpers.defineProperty(this, "hello", _init_hello(this));
+    });
+    [_init_hello] = babelHelpers.applyDecs(Inner, [[_dec, 0, "hello"]], []);
+    return babelHelpers.possibleConstructorReturn(_this, new Inner());
+  }
+
+  return babelHelpers.createClass(Outer);
+}(Hello);
+
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
@@ -26,7 +26,7 @@ let Outer = /*#__PURE__*/function (_Hello) {
 
     babelHelpers.classCallCheck(this, Outer);
     _this = _super.call(this);
-    _dec = babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "dec", _thisSuper)
+    _dec = babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "dec", _thisSuper);
     let Inner = /*#__PURE__*/babelHelpers.createClass(function Inner() {
       babelHelpers.classCallCheck(this, Inner);
       babelHelpers.defineProperty(this, "hello", _init_hello(this));

--- a/packages/babel-plugin-proposal-decorators/src/transformer-2021-12.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-2021-12.ts
@@ -502,7 +502,7 @@ function transformClass(
     if (element.node.decorators && element.node.decorators.length > 0) {
       hasElementDecorators = true;
     } else if (element.node.type === "ClassAccessorProperty") {
-      const { key, value, static: isStatic } = element.node;
+      const { key, value, static: isStatic, computed } = element.node;
 
       const newId = generateClassPrivateUid();
 
@@ -511,7 +511,7 @@ function transformClass(
       const newField = generateClassProperty(newId, valueNode, isStatic);
 
       const [newPath] = element.replaceWith(newField);
-      addProxyAccessorsFor(newPath, key, newId, element.node.computed);
+      addProxyAccessorsFor(newPath, key, newId, computed);
     }
   }
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/undecorated-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/undecorated-public/output.js
@@ -38,11 +38,11 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _B, v);
   }
 
-  get 'c'() {
+  get ['c']() {
     return babelHelpers.classPrivateFieldGet(this, _C);
   }
 
-  set 'c'(v) {
+  set ['c'](v) {
     babelHelpers.classPrivateFieldSet(this, _C, v);
   }
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/undecorated-static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/undecorated-static-public/output.js
@@ -17,11 +17,11 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _B, v);
   }
 
-  static get 'c'() {
+  static get ['c']() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _C);
   }
 
-  static set 'c'(v) {
+  static set ['c'](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _C, v);
   }
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/undecorated-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/undecorated-public/output.js
@@ -23,11 +23,11 @@ class Foo {
 
   #C = 456;
 
-  get 'c'() {
+  get ['c']() {
     return this.#C;
   }
 
-  set 'c'(v) {
+  set ['c'](v) {
     this.#C = v;
   }
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/undecorated-static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/undecorated-static-public/output.js
@@ -23,11 +23,11 @@ class Foo {
 
   static #C = 456;
 
-  static get 'c'() {
+  static get ['c']() {
     return this.#C;
   }
 
-  static set 'c'(v) {
+  static set ['c'](v) {
     this.#C = v;
   }
 

--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -132,8 +132,13 @@ export function setScope(this: NodePath) {
 
   let path = this.parentPath;
 
-  // Skip method scope if is computed method key
-  if (this.key === "key" && path.isMethod()) path = path.parentPath;
+  // Skip method scope if is computed method key or decorator expression
+  if (
+    (this.key === "key" || this.listKey === "decorators") &&
+    path.isMethod()
+  ) {
+    path = path.parentPath;
+  }
 
   let target;
   while (path && !target) {

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -425,10 +425,10 @@ export default class Scope {
     let parent,
       path = this.path;
     do {
-      // Skip method scope if coming from inside computed key
-      const isKey = path.key === "key";
+      // Skip method scope if coming from inside computed key or decorator expression
+      const shouldSkip = path.key === "key" || path.listKey === "decorators";
       path = path.parentPath;
-      if (isKey && path.isMethod()) path = path.parentPath;
+      if (shouldSkip && path.isMethod()) path = path.parentPath;
       if (path && path.isScope()) parent = path;
     } while (path && !parent);
 

--- a/packages/babel-traverse/src/scope/lib/renamer.ts
+++ b/packages/babel-traverse/src/scope/lib/renamer.ts
@@ -8,7 +8,7 @@ import {
   variableDeclarator,
 } from "@babel/types";
 import type { Visitor } from "../../types";
-import { requeueComputedKeyAndDecorator } from "@babel/helper-environment-visitor";
+import { requeueComputedKeyAndDecorators } from "@babel/helper-environment-visitor";
 
 const renameVisitor: Visitor<Renamer> = {
   ReferencedIdentifier({ node }, state) {
@@ -26,7 +26,7 @@ const renameVisitor: Visitor<Renamer> = {
     ) {
       path.skip();
       if (path.isMethod()) {
-        requeueComputedKeyAndDecorator(path);
+        requeueComputedKeyAndDecorators(path);
       }
     }
   },

--- a/packages/babel-traverse/src/scope/lib/renamer.ts
+++ b/packages/babel-traverse/src/scope/lib/renamer.ts
@@ -1,7 +1,6 @@
 import Binding from "../binding";
 import splitExportDeclaration from "@babel/helper-split-export-declaration";
 import {
-  VISITOR_KEYS,
   assignmentExpression,
   identifier,
   toExpression,
@@ -9,6 +8,7 @@ import {
   variableDeclarator,
 } from "@babel/types";
 import type { Visitor } from "../../types";
+import type NodePath from "../../path";
 
 const renameVisitor: Visitor<Renamer> = {
   ReferencedIdentifier({ node }, state) {
@@ -24,7 +24,7 @@ const renameVisitor: Visitor<Renamer> = {
         state.binding.identifier,
       )
     ) {
-      skipAllButComputedMethodKey(path);
+      skipAndrequeueComputedKeysAndDecorators(path);
     }
   },
 
@@ -147,17 +147,19 @@ export default class Renamer {
   }
 }
 
-function skipAllButComputedMethodKey(path) {
-  // If the path isn't method with computed key, just skip everything.
-  if (!path.isMethod() || !path.node.computed) {
-    path.skip();
-    return;
-  }
-
-  // So it's a method with a computed key. Make sure to skip every other key the
-  // traversal would visit.
-  const keys = VISITOR_KEYS[path.type];
-  for (const key of keys) {
-    if (key !== "key") path.skipKey(key);
+function skipAndrequeueComputedKeysAndDecorators(path: NodePath) {
+  path.skip();
+  if (path.isMethod()) {
+    const { context } = path;
+    if (path.node.computed) {
+      // requeue the computed key
+      context.maybeQueue(path.get("key"));
+    }
+    if (path.node.decorators) {
+      for (const decorator of path.get("decorators")) {
+        // requeue the decorators
+        context.maybeQueue(decorator);
+      }
+    }
   }
 }

--- a/packages/babel-traverse/test/fixtures/rename/decorator-expression/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/decorator-expression/input.js
@@ -1,0 +1,8 @@
+let a = () => () => "outside";
+
+class C {
+  @a a() {
+    let a = "inside";
+    return a;
+  }
+};

--- a/packages/babel-traverse/test/fixtures/rename/decorator-expression/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/decorator-expression/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin", ["syntax-decorators", { "version": "2021-12" }]]
+}

--- a/packages/babel-traverse/test/fixtures/rename/decorator-expression/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/decorator-expression/output.js
@@ -1,0 +1,12 @@
+let z = () => () => "outside";
+
+class C {
+  @z
+  a() {
+    let a = "inside";
+    return a;
+  }
+
+}
+
+;

--- a/packages/babel-traverse/test/fixtures/rename/decorator-expression/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/decorator-expression/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      Program(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -256,6 +256,32 @@ describe("scope", () => {
       });
     });
 
+    describe("decorator", () => {
+      const parserOptions = {
+        plugins: [["decorators", { decoratorsBeforeExport: true }]],
+      };
+      it("should not have visibility of declarations inside method body", () => {
+        expect(
+          getPath(
+            `var a = "outside"; class foo { @(() => () => a) m() { let a = "inside"; } }`,
+            parserOptions,
+          )
+            .get("body.1.body.body.0.decorators.0.expression.body.body")
+            .scope.getBinding("a").path.node.init.value,
+        ).toBe("outside");
+      });
+      it("should not have visibility on parameter bindings", () => {
+        expect(
+          getPath(
+            `var a = "outside"; class foo { @(() => () => a) m(a = "inside") {} }`,
+            parserOptions,
+          )
+            .get("body.1.body.body.0.decorators.0.expression.body.body")
+            .scope.getBinding("a").path.node.init.value,
+        ).toBe("outside");
+      });
+    });
+
     it("variable declaration", function () {
       expect(getPath("var foo = null;").scope.getBinding("foo").path.type).toBe(
         "VariableDeclarator",

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -266,6 +266,20 @@ describe("validators", function () {
       });
     });
 
+    describe("ClassDeclaration", () => {
+      it("returns true if node is a class heritage", function () {
+        const node = t.identifier("A");
+        const parent = t.classDeclaration(
+          t.identifier("C"),
+          node,
+          t.classBody([]),
+          [],
+        );
+
+        expect(t.isReferenced(node, parent)).toBe(true);
+      });
+    });
+
     describe("exports", function () {
       it("returns false for re-exports", function () {
         const node = t.identifier("foo");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we reimplement `skipAllButComputedKey` so we can remove `@babel/types` deps of the environment-visitor helper. In the 2nd commit we expand similar logic to decorator expressions as well. Note that the test cases are already passing in main because the decorator transforms will hoist the expression. In the last commit we apply similar changes to the renamer.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14371"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

