### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/babel-core/src/config/printer.ts
+++ b/packages/babel-core/src/config/printer.ts
@@ -79,7 +79,7 @@ function descriptorToConfig(
       // If the unloaded descriptor is a function, i.e. `plugins: [ require("my-plugin") ]`,
       // we print the first 50 characters of the function source code and hopefully we can see
       // `name: 'my-plugin'` in the source
-      name = `[Function: ${d.value.toString().substr(0, 50)} ... ]`;
+      name = `[Function: ${d.value.toString().slice(0, 50)} ... ]`;
     }
   }
   if (name == null) {

--- a/packages/babel-highlight/src/index.ts
+++ b/packages/babel-highlight/src/index.ts
@@ -176,7 +176,7 @@ if (process.env.BABEL_8_BREAKING) {
 
       if (
         JSX_TAG.test(token.value) &&
-        (text[offset - 1] === "<" || text.substr(offset - 2, 2) == "</")
+        (text[offset - 1] === "<" || text.slice(offset - 2, offset) == "</")
       ) {
         return "jsxIdentifier";
       }

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -1606,7 +1606,7 @@ export default class Tokenizer extends CommentsParser {
             -1,
           );
           const match = this.input
-            .substr(this.state.pos - 1, 3)
+            .slice(this.state.pos - 1, this.state.pos + 2)
             .match(/^[0-7]+/);
 
           // This is never null, because of the if condition above.

--- a/scripts/parser-tests/test262/index.js
+++ b/scripts/parser-tests/test262/index.js
@@ -170,7 +170,7 @@ const runner = new TestRunner({
 
     for await (const test of stream) {
       // strip test/
-      const fileName = test.file.substr(5);
+      const fileName = test.file.slice(5);
 
       if (ignoredTests.some(start => fileName.startsWith(start))) continue;
 


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  No open issue
| Patch: Bug Fix?          | Remove of deprecated function
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | No
| License                  | MIT


[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14377"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

