### PR TITLE
fix(babel-highlight::index.ts): Short-circuit empty source highlighting

### DIFF
--- a/packages/babel-highlight/src/index.ts
+++ b/packages/babel-highlight/src/index.ts
@@ -217,6 +217,8 @@ if (process.env.BABEL_8_BREAKING) {
  * Highlight `text` using the token definitions in `defs`.
  */
 function highlightTokens(defs: Record<string, ChalkClass>, text: string) {
+  /** Short-circuit empty source highlighting to prevent infinite iteration */
+  if (text === '') return text
   let highlighted = "";
 
   for (const { type, value } of tokenize(text)) {

--- a/packages/babel-highlight/src/index.ts
+++ b/packages/babel-highlight/src/index.ts
@@ -218,7 +218,10 @@ if (process.env.BABEL_8_BREAKING) {
  */
 function highlightTokens(defs: Record<string, ChalkClass>, text: string) {
   /** Short-circuit empty source highlighting to prevent infinite iteration */
-  if (text === '') return text;
+  if (text === "") {
+    return text;
+  }
+
   let highlighted = "";
 
   for (const { type, value } of tokenize(text)) {

--- a/packages/babel-highlight/src/index.ts
+++ b/packages/babel-highlight/src/index.ts
@@ -218,7 +218,7 @@ if (process.env.BABEL_8_BREAKING) {
  */
 function highlightTokens(defs: Record<string, ChalkClass>, text: string) {
   /** Short-circuit empty source highlighting to prevent infinite iteration */
-  if (text === '') return text
+  if (text === '') return text;
   let highlighted = "";
 
   for (const { type, value } of tokenize(text)) {


### PR DESCRIPTION
Short-circuit empty source highlighting to prevent infinite iteration.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  NONE
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | No
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When we are using babel-highlight to highlight the stylelint output results, we surprisingly found that babel-highlight plugin fails on `empty` source files: While passing `''` to `tokenize` function, it will end up in an infinite iterator.

IMO I thought the empty source is worthless for highlighting(since the result won't disappear to be different after highlighting), so maybe a short-circuit guard will be a solution to this case 😄

FYI，the case we've encountered in this situation：
<img width="684" alt="image" src="https://user-images.githubusercontent.com/14831358/159468282-c7b6a824-828e-4e41-a704-fa2670dcad31.png">


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14381"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

