### PR TITLE
fix: parse type parameters within correct context

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1614,9 +1614,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     ): N.TsTypeAliasDeclaration {
       node.id = this.parseIdentifier();
       this.checkIdentifier(node.id, BIND_TS_TYPE);
-
-      node.typeParameters = this.tsTryParseTypeParameters();
       node.typeAnnotation = this.tsInType(() => {
+        node.typeParameters = this.tsTryParseTypeParameters();
         this.expect(tt.eq);
 
         if (

--- a/packages/babel-parser/test/fixtures/typescript/type-alias/generic-babel-7/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/type-alias/generic-babel-7/input.ts
@@ -1,1 +1,1 @@
-type T<U> = U;
+type T<U>=U;

--- a/packages/babel-parser/test/fixtures/typescript/type-alias/generic-babel-7/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/type-alias/generic-babel-7/output.json
@@ -1,15 +1,15 @@
 {
   "type": "File",
-  "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
+  "start":0,"end":12,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":12,"index":12}},
   "program": {
     "type": "Program",
-    "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
+    "start":0,"end":12,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":12,"index":12}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "TSTypeAliasDeclaration",
-        "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
+        "start":0,"end":12,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":12,"index":12}},
         "id": {
           "type": "Identifier",
           "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"T"},
@@ -28,10 +28,10 @@
         },
         "typeAnnotation": {
           "type": "TSTypeReference",
-          "start":12,"end":13,"loc":{"start":{"line":1,"column":12,"index":12},"end":{"line":1,"column":13,"index":13}},
+          "start":10,"end":11,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":11,"index":11}},
           "typeName": {
             "type": "Identifier",
-            "start":12,"end":13,"loc":{"start":{"line":1,"column":12,"index":12},"end":{"line":1,"column":13,"index":13},"identifierName":"U"},
+            "start":10,"end":11,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":11,"index":11},"identifierName":"U"},
             "name": "U"
           }
         }

--- a/packages/babel-parser/test/fixtures/typescript/type-alias/generic/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/type-alias/generic/input.ts
@@ -1,1 +1,1 @@
-type T<U> = U;
+type T<U>=U;

--- a/packages/babel-parser/test/fixtures/typescript/type-alias/generic/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/type-alias/generic/output.json
@@ -1,15 +1,15 @@
 {
   "type": "File",
-  "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
+  "start":0,"end":12,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":12,"index":12}},
   "program": {
     "type": "Program",
-    "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
+    "start":0,"end":12,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":12,"index":12}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "TSTypeAliasDeclaration",
-        "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
+        "start":0,"end":12,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":12,"index":12}},
         "id": {
           "type": "Identifier",
           "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"T"},
@@ -32,10 +32,10 @@
         },
         "typeAnnotation": {
           "type": "TSTypeReference",
-          "start":12,"end":13,"loc":{"start":{"line":1,"column":12,"index":12},"end":{"line":1,"column":13,"index":13}},
+          "start":10,"end":11,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":11,"index":11}},
           "typeName": {
             "type": "Identifier",
-            "start":12,"end":13,"loc":{"start":{"line":1,"column":12,"index":12},"end":{"line":1,"column":13,"index":13},"identifierName":"U"},
+            "start":10,"end":11,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":11,"index":11},"identifierName":"U"},
             "name": "U"
           }
         }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14383 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The `tsTryParseTypeParameters` should run within `state.inType` so that the `>=` in `type T<U>=U` will be correctly tokenized as `tt.gt` and `tt.eq`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14384"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

