### PR TITLE
Add missing semicolons in 2021-12 decorators output

### DIFF
--- a/packages/babel-plugin-proposal-decorators/src/transformer-2021-12.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-2021-12.ts
@@ -991,7 +991,7 @@ function transformClass(
 
   // When path is a ClassExpression, path.insertBefore will convert `path`
   // into a SequenceExpression
-  path.insertBefore(assignments);
+  path.insertBefore(assignments.map(expr => t.expressionStatement(expr)));
 
   // Recrawl the scope to make sure new identifiers are properly synced
   path.scope.crawl();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
@@ -2,7 +2,7 @@ var _init_a, _init_b, _computedKey, _init_computedKey, _initProto;
 
 const dec = () => {};
 
-_computedKey = 'c'
+_computedKey = 'c';
 
 var _A = /*#__PURE__*/new WeakMap();
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-public/output.js
@@ -2,7 +2,7 @@ var _init_a, _init_b, _computedKey, _init_computedKey, _initStatic;
 
 const dec = () => {};
 
-_computedKey = 'c'
+_computedKey = 'c';
 
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/public/output.js
@@ -2,7 +2,7 @@ var _init_a, _init_b, _computedKey, _init_computedKey, _initProto;
 
 const dec = () => {};
 
-_computedKey = 'c'
+_computedKey = 'c';
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-public/output.js
@@ -2,7 +2,7 @@ var _init_a, _init_b, _computedKey, _init_computedKey, _initStatic;
 
 const dec = () => {};
 
-_computedKey = 'c'
+_computedKey = 'c';
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/inheritance/output.js
@@ -4,7 +4,7 @@ const dec = () => {};
 
 let _Bar;
 
-_dec = dec1
+_dec = dec1;
 
 class Bar {
   static {
@@ -18,7 +18,7 @@ class Bar {
 
 let _Foo;
 
-_dec2 = dec2
+_dec2 = dec2;
 
 class Foo extends _Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -2,8 +2,8 @@ var _computedKey, _computedKey2, _initProto;
 
 const dec = () => {};
 
-_computedKey = getKey()
-_computedKey2 = getKey()
+_computedKey = getKey();
+_computedKey2 = getKey();
 
 class Foo {
   constructor(...args) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -2,8 +2,8 @@ var _computedKey, _computedKey2, _initProto;
 
 const dec = () => {};
 
-_computedKey = getKeyI()
-_computedKey2 = getKeyJ()
+_computedKey = getKeyI();
+_computedKey2 = getKeyJ();
 
 class Foo {
   constructor(...args) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-ast/output.js
@@ -2,8 +2,8 @@ var _computedKey, _computedKey2, _initProto;
 
 const dec = () => {};
 
-_computedKey = getKey()
-_computedKey2 = getKey()
+_computedKey = getKey();
+_computedKey2 = getKey();
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-value/output.js
@@ -2,8 +2,8 @@ var _computedKey, _computedKey2, _initProto;
 
 const dec = () => {};
 
-_computedKey = getKeyI()
-_computedKey2 = getKeyJ()
+_computedKey = getKeyI();
+_computedKey2 = getKeyJ();
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-anonymous/output.mjs
@@ -2,7 +2,7 @@ var _initClass, _dec;
 
 let _A;
 
-_dec = dec
+_dec = dec;
 
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-named/output.mjs
@@ -2,7 +2,7 @@ var _initClass, _dec;
 
 let _default2;
 
-_dec = dec
+_dec = dec;
 
 class _default {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/member-decorator/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/member-decorator/output.mjs
@@ -1,6 +1,6 @@
 var _dec, _init_x;
 
-_dec = dec
+_dec = dec;
 export class A {
   static {
     [_init_x] = babelHelpers.applyDecs(this, [[_dec, 0, "x"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/named/output.mjs
@@ -2,7 +2,7 @@ var _initClass, _dec;
 
 let _A;
 
-_dec = dec
+_dec = dec;
 
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/public/output.js
@@ -2,7 +2,7 @@ var _init_a, _init_b, _computedKey, _init_computedKey;
 
 const dec = () => {};
 
-_computedKey = 'c'
+_computedKey = 'c';
 
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-public/output.js
@@ -2,7 +2,7 @@ var _init_a, _init_b, _computedKey, _init_computedKey;
 
 const dec = () => {};
 
-_computedKey = 'c'
+_computedKey = 'c';
 
 class Foo {}
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/public/output.js
@@ -2,7 +2,7 @@ var _init_a, _init_b, _computedKey, _init_computedKey;
 
 const dec = () => {};
 
-_computedKey = 'c'
+_computedKey = 'c';
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/static-public/output.js
@@ -2,7 +2,7 @@ var _init_a, _init_b, _computedKey, _init_computedKey;
 
 const dec = () => {};
 
-_computedKey = 'c'
+_computedKey = 'c';
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initProto;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   constructor(...args) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initStatic;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
@@ -2,8 +2,8 @@ var _computedKey, _computedKey2, _initProto;
 
 const dec = () => {};
 
-_computedKey = 'b'
-_computedKey2 = 'b'
+_computedKey = 'b';
+_computedKey2 = 'b';
 
 class Foo {
   constructor(...args) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-public/output.js
@@ -2,8 +2,8 @@ var _computedKey, _computedKey2, _initStatic;
 
 const dec = () => {};
 
-_computedKey = 'b'
-_computedKey2 = 'b'
+_computedKey = 'b';
+_computedKey2 = 'b';
 
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/public/output.js
@@ -2,8 +2,8 @@ var _computedKey, _computedKey2, _initProto;
 
 const dec = () => {};
 
-_computedKey = 'b'
-_computedKey2 = 'b'
+_computedKey = 'b';
+_computedKey2 = 'b';
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/static-public/output.js
@@ -2,8 +2,8 @@ var _computedKey, _computedKey2, _initStatic;
 
 const dec = () => {};
 
-_computedKey = 'b'
-_computedKey2 = 'b'
+_computedKey = 'b';
+_computedKey2 = 'b';
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initProto;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/static-public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initStatic;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initProto;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   constructor(...args) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initStatic;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   static a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initProto;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/static-public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initStatic;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -2,7 +2,7 @@ var _dec, _initProto;
 
 const dec = () => {};
 
-_dec = deco
+_dec = deco;
 
 class A extends B {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
@@ -4,14 +4,14 @@ const dec = () => {};
 
 let _Foo;
 
-_dec = call()
-_dec2 = chain.expr()
-_dec3 = arbitrary + expr
-_dec4 = array[expr]
-_dec5 = call()
-_dec6 = chain.expr()
-_dec7 = arbitrary + expr
-_dec8 = array[expr]
+_dec = call();
+_dec2 = chain.expr();
+_dec3 = arbitrary + expr;
+_dec4 = array[expr];
+_dec5 = call();
+_dec6 = chain.expr();
+_dec7 = arbitrary + expr;
+_dec8 = array[expr];
 
 var _a = /*#__PURE__*/new WeakMap();
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -2,7 +2,7 @@ var _dec, _initProto, _dec2, _initProto2;
 
 const dec = () => {};
 
-_dec = deco
+_dec = deco;
 
 class A extends B {
   static {
@@ -21,7 +21,7 @@ class A extends B {
 
 }
 
-_dec2 = deco
+_dec2 = deco;
 
 class C extends B {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
@@ -4,14 +4,14 @@ const dec = () => {};
 
 let _Foo;
 
-_dec = call()
-_dec2 = chain.expr()
-_dec3 = arbitrary + expr
-_dec4 = array[expr]
-_dec5 = call()
-_dec6 = chain.expr()
-_dec7 = arbitrary + expr
-_dec8 = array[expr]
+_dec = call();
+_dec2 = chain.expr();
+_dec3 = arbitrary + expr;
+_dec4 = array[expr];
+_dec5 = call();
+_dec6 = chain.expr();
+_dec7 = arbitrary + expr;
+_dec8 = array[expr];
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initProto;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   constructor(...args) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initStatic;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   static set a(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initProto;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/static-public/output.js
@@ -2,7 +2,7 @@ var _computedKey, _initStatic;
 
 const dec = () => {};
 
-_computedKey = 'b'
+_computedKey = 'b';
 
 class Foo {
   static {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14398"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

