### PR TITLE
fix: peerDependencies eslint 7.5.0 => 7.32.0

### DIFF
--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@babel/core": ">=7.11.0",
-    "eslint": "^7.5.0 || ^8.0.0"
+    "eslint": "^7.32.0 || ^8.0.0"
   },
   "dependencies": {
     "eslint-scope": "^5.1.1",

--- a/eslint/babel-eslint-plugin-development-internal/package.json
+++ b/eslint/babel-eslint-plugin-development-internal/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/babel/babel/tree/master/eslint/babel-eslint-plugin-development-internal",
   "peerDependencies": {
     "@babel/eslint-parser": ">=7.11.0",
-    "eslint": ">=7.5.0"
+    "eslint": ">=7.32.0"
   },
   "devDependencies": {
     "eslint": "^7.27.0"

--- a/eslint/babel-eslint-plugin/package.json
+++ b/eslint/babel-eslint-plugin/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://babel.dev/",
   "peerDependencies": {
     "@babel/eslint-parser": ">=7.11.0",
-    "eslint": ">=7.5.0"
+    "eslint": ">=7.32.0"
   },
   "dependencies": {
     "eslint-rule-composer": "^0.3.0"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | NO <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | peerDependencies is set eslint: ^7.5.0, but the eslint@7 latest version is v7.32.0, this may cause a npm install conflic in npm 7+
| Major: Breaking Change?  | NO
| Minor: New Feature?      | NO
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | [@babel/eslint-parser, @babel/eslint-plugin, @babel/eslint-plugin-development-internal] peerDependencies eslint 7.5.0 => 7.32.0
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Notice that these eslint parse use the peerDependencies: 
```json
"peerDependencies": {
    "@babel/core": ">=7.11.0",
    "eslint": "^7.5.0 || ^8.0.0"
},
```

When run npm install, we'll get the peer dependency conflict:

<img width="621" alt="wecom-temp-4da08c36476655835bfb73867769a2ba" src="https://user-images.githubusercontent.com/26793777/161374057-420782e5-f9de-4a78-9b0a-bd00cead8157.png">

But the question is: there are no version v7.5.0 in [eslint published version](https://www.npmjs.com/package/eslint)!

<img width="772" alt="image" src="https://user-images.githubusercontent.com/26793777/161374187-51c59c3c-25dd-4efb-baf0-a5786c6a02e4.png">

So I update the package.json in [@babel/eslint-parser, @babel/eslint-plugin, @babel/eslint-plugin-development-internal]:
```json
"peerDependencies": {
    "@babel/core": ">=7.11.0",
    "eslint": "^7.32.0 || ^8.0.0"
},
```



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14416"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

