### PR TITLE
Restore numeric seaprators support in `@babel/standalone`

### DIFF
--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -69,49 +69,22 @@ const forbiddenNumericSeparatorSiblings = {
   ]),
 };
 
-const allowedNumericSeparatorSiblings = {};
-allowedNumericSeparatorSiblings.bin = new Set([
+const isAllowedNumericSeparatorSibling = {
   // 0 - 1
-  charCodes.digit0,
-  charCodes.digit1,
-]);
-allowedNumericSeparatorSiblings.oct = new Set([
+  bin: ch => ch === charCodes.digit0 || ch === charCodes.digit1,
+
   // 0 - 7
-  ...allowedNumericSeparatorSiblings.bin,
+  oct: ch => ch >= charCodes.digit0 && ch <= charCodes.digit7,
 
-  charCodes.digit2,
-  charCodes.digit3,
-  charCodes.digit4,
-  charCodes.digit5,
-  charCodes.digit6,
-  charCodes.digit7,
-]);
-allowedNumericSeparatorSiblings.dec = new Set([
   // 0 - 9
-  ...allowedNumericSeparatorSiblings.oct,
+  dec: ch => ch >= charCodes.digit0 && ch <= charCodes.digit9,
 
-  charCodes.digit8,
-  charCodes.digit9,
-]);
-
-allowedNumericSeparatorSiblings.hex = new Set([
   // 0 - 9, A - F, a - f,
-  ...allowedNumericSeparatorSiblings.dec,
-
-  charCodes.uppercaseA,
-  charCodes.uppercaseB,
-  charCodes.uppercaseC,
-  charCodes.uppercaseD,
-  charCodes.uppercaseE,
-  charCodes.uppercaseF,
-
-  charCodes.lowercaseA,
-  charCodes.lowercaseB,
-  charCodes.lowercaseC,
-  charCodes.lowercaseD,
-  charCodes.lowercaseE,
-  charCodes.lowercaseF,
-]);
+  hex: ch =>
+    (ch >= charCodes.digit0 && ch <= charCodes.digit9) ||
+    (ch >= charCodes.uppercaseA && ch <= charCodes.uppercaseF) ||
+    (ch >= charCodes.lowercaseA && ch <= charCodes.lowercaseF),
+};
 
 // Object type used to represent tokens. Note that normally, tokens
 // simply exist as properties on the parser object. This is only
@@ -1180,14 +1153,14 @@ export default class Tokenizer extends CommentsParser {
       radix === 16
         ? forbiddenNumericSeparatorSiblings.hex
         : forbiddenNumericSeparatorSiblings.decBinOct;
-    const allowedSiblings =
+    const isAllowedSibling =
       radix === 16
-        ? allowedNumericSeparatorSiblings.hex
+        ? isAllowedNumericSeparatorSibling.hex
         : radix === 10
-        ? allowedNumericSeparatorSiblings.dec
+        ? isAllowedNumericSeparatorSibling.dec
         : radix === 8
-        ? allowedNumericSeparatorSiblings.oct
-        : allowedNumericSeparatorSiblings.bin;
+        ? isAllowedNumericSeparatorSibling.oct
+        : isAllowedNumericSeparatorSibling.bin;
 
     let invalid = false;
     let total = 0;
@@ -1206,7 +1179,7 @@ export default class Tokenizer extends CommentsParser {
           });
         } else if (
           Number.isNaN(next) ||
-          !allowedSiblings.has(next) ||
+          !isAllowedSibling(next) ||
           forbiddenSiblings.has(prev) ||
           forbiddenSiblings.has(next)
         ) {

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -256,6 +256,9 @@ const require = createRequire(import.meta.url);
           }),
         ).not.toThrow();
       });
+      it("#14425 - numeric separators should be parsed correctly", () => {
+        expect(() => Babel.transform("1_1", {})).not.toThrow();
+      });
     });
   },
 );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14425
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When bundling `@babel/standalone`, we compile `@babel/parser` with the `iterableIsArray` assumption because it shrinks the bundle quite a bit. However, we must actually respect that assumption :upside_down_face: 

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14427"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

