### PR TITLE
Minor legibility cleanup

### DIFF
--- a/packages/babel-plugin-syntax-jsx/src/index.ts
+++ b/packages/babel-plugin-syntax-jsx/src/index.ts
@@ -7,17 +7,14 @@ export default declare(api => {
     name: "syntax-jsx",
 
     manipulateOptions(opts, parserOpts) {
+      const { plugins } = parserOpts;
       // If the Typescript plugin already ran, it will have decided whether
       // or not this is a TSX file.
-      if (
-        parserOpts.plugins.some(
-          p => (Array.isArray(p) ? p[0] : p) === "typescript",
-        )
-      ) {
+      if (plugins.some(p => (Array.isArray(p) ? p[0] : p) === "typescript")) {
         return;
       }
 
-      parserOpts.plugins.push("jsx");
+      plugins.push("jsx");
     },
   };
 });


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          |No
| Major: Breaking Change?  |No
| Minor: New Feature?      |No
| Tests Added + Pass?      | No
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT


I'm making this PR mostly to test Github's "edit this file" mechanism, which was broken last time I tried it because by fork of babel still had the default branch set to `master` because it was old. That led to "edit this file" working incorrectly. It seems that changing my default branch to `main` did cause the feature to create the fork with the correct target.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14448"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

