### PR TITLE
Pass filename to `importInterop` method

### DIFF
--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -72,7 +72,7 @@ export function rewriteModuleStatementsAndPrepareHeader(
     noInterop?;
     lazy?;
     esNamespaceOnly?;
-    filename: string;
+    filename: string | undefined;
     constantReexports?;
     enumerableModuleMeta?;
     noIncompleteNsImportDetection?: boolean;

--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -57,6 +57,7 @@ export function rewriteModuleStatementsAndPrepareHeader(
     importInterop = noInterop ? "none" : "babel",
     lazy,
     esNamespaceOnly,
+    filename,
 
     constantReexports = loose,
     enumerableModuleMeta = loose,
@@ -71,6 +72,7 @@ export function rewriteModuleStatementsAndPrepareHeader(
     noInterop?;
     lazy?;
     esNamespaceOnly?;
+    filename: string;
     constantReexports?;
     enumerableModuleMeta?;
     noIncompleteNsImportDetection?: boolean;
@@ -85,6 +87,7 @@ export function rewriteModuleStatementsAndPrepareHeader(
     initializeReexports: constantReexports,
     lazy,
     esNamespaceOnly,
+    filename,
   });
 
   if (!allowTopLevelThis) {

--- a/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
+++ b/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
@@ -89,9 +89,9 @@ export function validateImportInteropOption(
   return importInterop;
 }
 
-function resolveImportInterop(importInterop, source) {
+function resolveImportInterop(importInterop, source, filename: string) {
   if (typeof importInterop === "function") {
-    return validateImportInteropOption(importInterop(source));
+    return validateImportInteropOption(importInterop(source, filename));
   }
   return importInterop;
 }
@@ -108,6 +108,7 @@ export default function normalizeModuleAndLoadMetadata(
     initializeReexports = false,
     lazy = false,
     esNamespaceOnly = false,
+    filename,
   },
 ): ModuleMetadata {
   if (!exportName) {
@@ -136,6 +137,7 @@ export default function normalizeModuleAndLoadMetadata(
     const resolvedInterop = resolveImportInterop(
       importInterop,
       metadata.source,
+      filename,
     );
 
     if (resolvedInterop === "none") {

--- a/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
+++ b/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
@@ -89,7 +89,11 @@ export function validateImportInteropOption(
   return importInterop;
 }
 
-function resolveImportInterop(importInterop, source, filename: string) {
+function resolveImportInterop(
+  importInterop,
+  source,
+  filename: string | undefined,
+) {
   if (typeof importInterop === "function") {
     return validateImportInteropOption(importInterop(source, filename));
   }

--- a/packages/babel-plugin-transform-modules-amd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-amd/src/index.ts
@@ -118,6 +118,7 @@ export default declare((api, options) => {
               allowTopLevelThis,
               importInterop,
               noInterop,
+              filename: this.opts.filename,
             },
           );
 

--- a/packages/babel-plugin-transform-modules-amd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-amd/src/index.ts
@@ -118,7 +118,7 @@ export default declare((api, options) => {
               allowTopLevelThis,
               importInterop,
               noInterop,
-              filename: this.opts.filename,
+              filename: this.file.opts.filename,
             },
           );
 

--- a/packages/babel-plugin-transform-modules-amd/test/importInterop-function.js
+++ b/packages/babel-plugin-transform-modules-amd/test/importInterop-function.js
@@ -1,43 +1,81 @@
 import * as babel from "@babel/core";
 import transformAmd from "../lib/index.js";
 import externalHelpers from "@babel/plugin-external-helpers";
+import path from "path";
 
-it("'importInterop' accepts a function", function () {
-  const code = `
-    import a from "a";
-    import b from "b";
-    import c from "c";
+describe("'importInterop'", () => {
+  function transform(code, importInterop, filename) {
+    return babel.transformSync(code, {
+      configFile: false,
+      filename,
+      ast: false,
+      plugins: [
+        [externalHelpers, { helperVersion: "7.100.0" }],
+        [transformAmd, { importInterop }],
+      ],
+    }).code;
+  }
 
-    a();
-    b();
-    c();
-  `;
+  it("'importInterop' accepts a function", () => {
+    const code = `
+      import a from "a";
+      import b from "b";
+      import c from "c";
 
-  const importInterop = source => {
-    if (source === "a") return "babel";
-    else if (source === "b") return "node";
-    else if (source === "c") return "none";
-  };
+      a();
+      b();
+      c();
+    `;
 
-  const output = babel.transformSync(code, {
-    configFile: false,
-    ast: false,
-    plugins: [
-      [externalHelpers, { helperVersion: "7.100.0" }],
-      [transformAmd, { importInterop }],
-    ],
-  }).code;
+    const importInterop = source => {
+      if (source === "a") return "babel";
+      else if (source === "b") return "node";
+      else if (source === "c") return "none";
+    };
 
-  expect(output).toMatchInlineSnapshot(`
-    "define([\\"a\\", \\"b\\", \\"c\\"], function (_a, _b, _c) {
-      \\"use strict\\";
+    expect(transform(code, importInterop)).toMatchInlineSnapshot(`
+      "define([\\"a\\", \\"b\\", \\"c\\"], function (_a, _b, _c) {
+        \\"use strict\\";
 
-      _a = babelHelpers.interopRequireDefault(_a);
-      (0, _a.default)();
+        _a = babelHelpers.interopRequireDefault(_a);
+        (0, _a.default)();
 
-      _b();
+        _b();
 
-      (0, _c.default)();
-    });"
-  `);
+        (0, _c.default)();
+      });"
+    `);
+  });
+
+  it("gets called with the filename if present", () => {
+    const code = `
+      import a from "a";
+      import b from "b";
+    `;
+
+    const importInterop = jest.fn(() => "babel");
+
+    const filename = "path/to/fake-filename.js";
+
+    transform(code, importInterop, filename);
+
+    expect(importInterop).toHaveBeenCalledTimes(2);
+    expect(importInterop).toHaveBeenCalledWith("a", path.resolve(filename));
+    expect(importInterop).toHaveBeenCalledWith("b", path.resolve(filename));
+  });
+
+  it("gets called with undefined if the filename is not present", () => {
+    const code = `
+      import a from "a";
+      import b from "b";
+    `;
+
+    const importInterop = jest.fn(() => "babel");
+
+    transform(code, importInterop);
+
+    expect(importInterop).toHaveBeenCalledTimes(2);
+    expect(importInterop).toHaveBeenCalledWith("a", undefined);
+    expect(importInterop).toHaveBeenCalledWith("b", undefined);
+  });
 });

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.ts
@@ -211,6 +211,7 @@ export default declare((api, options) => {
                   ? mjsStrictNamespace
                   : strictNamespace,
               noIncompleteNsImportDetection,
+              filename: this.file.opts.filename,
             },
           );
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/importInterop-function.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/importInterop-function.js
@@ -1,6 +1,7 @@
 import * as babel from "@babel/core";
 import transformCommonjs from "../lib/index.js";
 import externalHelpers from "@babel/plugin-external-helpers";
+import path from "path";
 
 it("'importInterop' accepts a function", function () {
   const code = `
@@ -13,14 +14,17 @@ it("'importInterop' accepts a function", function () {
     c();
   `;
 
-  const importInterop = source => {
+  const importInterop = jest.fn(source => {
     if (source === "a") return "babel";
     else if (source === "b") return "node";
     else if (source === "c") return "none";
-  };
+  });
+
+  const filename = "path/to/fake-filename.js";
 
   const output = babel.transformSync(code, {
     configFile: false,
+    filename,
     ast: false,
     plugins: [
       [externalHelpers, { helperVersion: "7.100.0" }],
@@ -43,4 +47,9 @@ it("'importInterop' accepts a function", function () {
 
     (0, _c.default)();"
   `);
+
+  const resolvedFilename = path.resolve(filename);
+  expect(importInterop).toHaveBeenCalledWith("a", resolvedFilename);
+  expect(importInterop).toHaveBeenCalledWith("b", resolvedFilename);
+  expect(importInterop).toHaveBeenCalledWith("c", resolvedFilename);
 });

--- a/packages/babel-plugin-transform-modules-umd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-umd/src/index.ts
@@ -160,6 +160,7 @@ export default declare((api, options) => {
               allowTopLevelThis,
               noInterop,
               importInterop,
+              filename: this.opts.filename,
             },
           );
 

--- a/packages/babel-plugin-transform-modules-umd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-umd/src/index.ts
@@ -160,7 +160,7 @@ export default declare((api, options) => {
               allowTopLevelThis,
               noInterop,
               importInterop,
-              filename: this.opts.filename,
+              filename: this.file.opts.filename,
             },
           );
 

--- a/packages/babel-plugin-transform-modules-umd/test/importInterop-function.js
+++ b/packages/babel-plugin-transform-modules-umd/test/importInterop-function.js
@@ -1,55 +1,93 @@
 import * as babel from "@babel/core";
 import transformUmd from "../lib/index.js";
 import externalHelpers from "@babel/plugin-external-helpers";
+import path from "path";
 
-it("'importInterop' accepts a function", function () {
-  const code = `
-    import a from "a";
-    import b from "b";
-    import c from "c";
+describe("'importInterop'", () => {
+  function transform(code, importInterop, filename) {
+    return babel.transformSync(code, {
+      configFile: false,
+      filename,
+      ast: false,
+      plugins: [
+        [externalHelpers, { helperVersion: "7.100.0" }],
+        [transformUmd, { importInterop }],
+      ],
+    }).code;
+  }
 
-    a();
-    b();
-    c();
-  `;
+  it("'importInterop' accepts a function", () => {
+    const code = `
+      import a from "a";
+      import b from "b";
+      import c from "c";
 
-  const importInterop = source => {
-    if (source === "a") return "babel";
-    else if (source === "b") return "node";
-    else if (source === "c") return "none";
-  };
+      a();
+      b();
+      c();
+    `;
 
-  const output = babel.transformSync(code, {
-    configFile: false,
-    ast: false,
-    plugins: [
-      [externalHelpers, { helperVersion: "7.100.0" }],
-      [transformUmd, { importInterop }],
-    ],
-  }).code;
+    const importInterop = source => {
+      if (source === "a") return "babel";
+      else if (source === "b") return "node";
+      else if (source === "c") return "none";
+    };
 
-  expect(output).toMatchInlineSnapshot(`
-    "(function (global, factory) {
-      if (typeof define === \\"function\\" && define.amd) {
-        define([\\"a\\", \\"b\\", \\"c\\"], factory);
-      } else if (typeof exports !== \\"undefined\\") {
-        factory(require(\\"a\\"), require(\\"b\\"), require(\\"c\\"));
-      } else {
-        var mod = {
-          exports: {}
-        };
-        factory(global.a, global.b, global.c);
-        global.unknown = mod.exports;
-      }
-    })(typeof globalThis !== \\"undefined\\" ? globalThis : typeof self !== \\"undefined\\" ? self : this, function (_a, _b, _c) {
-      \\"use strict\\";
+    expect(transform(code, importInterop)).toMatchInlineSnapshot(`
+      "(function (global, factory) {
+        if (typeof define === \\"function\\" && define.amd) {
+          define([\\"a\\", \\"b\\", \\"c\\"], factory);
+        } else if (typeof exports !== \\"undefined\\") {
+          factory(require(\\"a\\"), require(\\"b\\"), require(\\"c\\"));
+        } else {
+          var mod = {
+            exports: {}
+          };
+          factory(global.a, global.b, global.c);
+          global.unknown = mod.exports;
+        }
+      })(typeof globalThis !== \\"undefined\\" ? globalThis : typeof self !== \\"undefined\\" ? self : this, function (_a, _b, _c) {
+        \\"use strict\\";
 
-      _a = babelHelpers.interopRequireDefault(_a);
-      (0, _a.default)();
+        _a = babelHelpers.interopRequireDefault(_a);
+        (0, _a.default)();
 
-      _b();
+        _b();
 
-      (0, _c.default)();
-    });"
-  `);
+        (0, _c.default)();
+      });"
+    `);
+  });
+
+  it("gets called with the filename if present", () => {
+    const code = `
+      import a from "a";
+      import b from "b";
+    `;
+
+    const importInterop = jest.fn(() => "babel");
+
+    const filename = "path/to/fake-filename.js";
+
+    transform(code, importInterop, filename);
+
+    expect(importInterop).toHaveBeenCalledTimes(2);
+    expect(importInterop).toHaveBeenCalledWith("a", path.resolve(filename));
+    expect(importInterop).toHaveBeenCalledWith("b", path.resolve(filename));
+  });
+
+  it("gets called with undefined if the filename is not present", () => {
+    const code = `
+      import a from "a";
+      import b from "b";
+    `;
+
+    const importInterop = jest.fn(() => "babel");
+
+    transform(code, importInterop);
+
+    expect(importInterop).toHaveBeenCalledTimes(2);
+    expect(importInterop).toHaveBeenCalledWith("a", undefined);
+    expect(importInterop).toHaveBeenCalledWith("b", undefined);
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    |  babel/website#2639
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
[babel/plugin-transform-modules-commonjs](https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs)'s `importInterop` function signature is currently: `(specifier: string) =>`. This allows the function to implement heuristic-based decisions, like "if it starts with `./`, then use strategy `babel`, otherwise `node`.".

I would like to implement an `importInterop` function in my project where the build process actually inspects the file being imported, then picks the right strategy based on that file's contents. I can't do this from the `specifier` alone, because I need to know where to resolve from. For that, we must also pass the `filename` of the file doing the import.

[Slack context](https://babeljs.slack.com/archives/C062LH50D/p1631634271002200).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14456"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

