### PR TITLE
[babel 8] `ObjectTypeAnnotation` fields must always be arrays

### DIFF
--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -438,12 +438,9 @@ describe("programmatic generation", function () {
   });
 
   it("flow object indentation", function () {
-    const objectStatement = t.objectTypeAnnotation(
-      [t.objectTypeProperty(t.identifier("bar"), t.stringTypeAnnotation())],
-      null,
-      null,
-      null,
-    );
+    const objectStatement = t.objectTypeAnnotation([
+      t.objectTypeProperty(t.identifier("bar"), t.stringTypeAnnotation()),
+    ]);
 
     const output = generate(objectStatement).code;
     expect(output).toBe(`{
@@ -454,9 +451,9 @@ describe("programmatic generation", function () {
   it("flow object exact", function () {
     const objectStatement = t.objectTypeAnnotation(
       [t.objectTypeProperty(t.identifier("bar"), t.stringTypeAnnotation())],
-      null,
-      null,
-      null,
+      undefined,
+      undefined,
+      undefined,
       true,
     );
 
@@ -476,7 +473,6 @@ describe("programmatic generation", function () {
           t.numberTypeAnnotation(),
         ),
       ],
-      null,
     );
 
     const output = generate(objectStatement).code;

--- a/packages/babel-types/src/definitions/flow.ts
+++ b/packages/babel-types/src/definitions/flow.ts
@@ -272,9 +272,21 @@ defineType("ObjectTypeAnnotation", {
     properties: validate(
       arrayOfType(["ObjectTypeProperty", "ObjectTypeSpreadProperty"]),
     ),
-    indexers: validateOptional(arrayOfType("ObjectTypeIndexer")),
-    callProperties: validateOptional(arrayOfType("ObjectTypeCallProperty")),
-    internalSlots: validateOptional(arrayOfType("ObjectTypeInternalSlot")),
+    indexers: {
+      validate: arrayOfType("ObjectTypeIndexer"),
+      optional: process.env.BABEL_8_BREAKING ? false : true,
+      default: process.env.BABEL_8_BREAKING ? [] : undefined,
+    },
+    callProperties: {
+      validate: arrayOfType("ObjectTypeCallProperty"),
+      optional: process.env.BABEL_8_BREAKING ? false : true,
+      default: process.env.BABEL_8_BREAKING ? [] : undefined,
+    },
+    internalSlots: {
+      validate: arrayOfType("ObjectTypeInternalSlot"),
+      optional: process.env.BABEL_8_BREAKING ? false : true,
+      default: process.env.BABEL_8_BREAKING ? [] : undefined,
+    },
     exact: {
       validate: assertValueType("boolean"),
       default: false,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | y
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

The fields `indexers`, `callProperties`, and `internalSlots` in the node `ObjectTypeAnnotation` are currently marked as optional. This is correct for the builder, they should be optional there.
For the TS types, this is not quite correct, because the babel parser always initializes these fields with empty arrays (https://github.com/babel/babel/blob/main/packages/babel-parser/src/plugins/flow/index.js#L1085-L1088).
The only way to set these fields to null is with the builder currently.

The change here is to not mark these fields as optional but instead provide an empty array as a default value. This way the builder still has these params as optional, but cannot be set to `null` anymore.
The Typescript types on the other hand now do not mark these fields as optional which is correct, as they are always an array, even if it might be empty.

Do you think this is a reasonable change?

~Now, is this breaking? Only the builder might be considered as a breaking change, as it does not allow `null` anymore for these fields (see change generator tests). If you think this is breaking enough I could move that behind the BABEL8 flag. Please let me know.~
After thinking about this a little more I now think this should be considered breaking. Which Flag should I use? `BABEL_TYPES_8_BREAKING ` or `BABEL_8_BREAKING`

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14465"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

