### PR TITLE
feat: helper-module-imports adds specifiers to existing imports

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -419,6 +419,8 @@ expect.extend({
     const pass = actual === code;
     return {
       pass,
+      actual,
+      expected: code,
       message: () => {
         const diffString = this.utils.diff(code, actual, {
           expand: false,

--- a/packages/babel-plugin-proposal-class-static-block/src/index.ts
+++ b/packages/babel-plugin-proposal-class-static-block/src/index.ts
@@ -20,7 +20,7 @@ function generateUid(scope, denyList: Set<string>) {
   let uid;
   let i = 1;
   do {
-    uid = scope._generateUid(name, i);
+    uid = scope._generateUid(i, name);
     i++;
   } while (denyList.has(uid));
   return uid;

--- a/packages/babel-plugin-proposal-record-and-tuple/test/fixtures/import-polyfill/custom-name-implies-should-import/output.mjs
+++ b/packages/babel-plugin-proposal-record-and-tuple/test/fixtures/import-polyfill/custom-name-implies-should-import/output.mjs
@@ -1,5 +1,4 @@
-import { Tuple as _Tuple } from "my-polyfill";
-import { Record as _Record } from "my-polyfill";
+import { Record as _Record, Tuple as _Tuple } from "my-polyfill";
 
 const r2 = _Record({
   a: _Record({

--- a/packages/babel-plugin-proposal-record-and-tuple/test/fixtures/import-polyfill/custom-name/output.mjs
+++ b/packages/babel-plugin-proposal-record-and-tuple/test/fixtures/import-polyfill/custom-name/output.mjs
@@ -1,5 +1,4 @@
-import { Tuple as _Tuple } from "my-polyfill";
-import { Record as _Record } from "my-polyfill";
+import { Record as _Record, Tuple as _Tuple } from "my-polyfill";
 
 const r2 = _Record({
   a: _Record({

--- a/packages/babel-plugin-proposal-record-and-tuple/test/fixtures/import-polyfill/default-name/output.mjs
+++ b/packages/babel-plugin-proposal-record-and-tuple/test/fixtures/import-polyfill/default-name/output.mjs
@@ -1,5 +1,4 @@
-import { Tuple as _Tuple } from "@bloomberg/record-tuple-polyfill";
-import { Record as _Record } from "@bloomberg/record-tuple-polyfill";
+import { Record as _Record, Tuple as _Tuple } from "@bloomberg/record-tuple-polyfill";
 
 const r2 = _Record({
   a: _Record({

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/auto-import-dev/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/auto-import-dev/output.mjs
@@ -1,7 +1,6 @@
 var _jsxFileName = "<CWD>/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/auto-import-dev/input.js";
-import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
+import { jsxDEV as _jsxDEV, Fragment as _Fragment } from "react/jsx-dev-runtime";
 import { createElement as _createElement } from "react";
-import { Fragment as _Fragment } from "react/jsx-dev-runtime";
 
 var x = /*#__PURE__*/_jsxDEV(_Fragment, {
   children: /*#__PURE__*/_jsxDEV("div", {

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/auto-import-dev-windows/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/windows/auto-import-dev-windows/output.mjs
@@ -1,7 +1,6 @@
 var _jsxFileName = "<CWD>\\packages\\babel-plugin-transform-react-jsx-development\\test\\fixtures\\windows\\auto-import-dev-windows\\input.js";
-import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
+import { jsxDEV as _jsxDEV, Fragment as _Fragment } from "react/jsx-dev-runtime";
 import { createElement as _createElement } from "react";
-import { Fragment as _Fragment } from "react/jsx-dev-runtime";
 
 var x = /*#__PURE__*/_jsxDEV(_Fragment, {
   children: /*#__PURE__*/_jsxDEV("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/autoImport/auto-import-react-source-type-module/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/autoImport/auto-import-react-source-type-module/output.mjs
@@ -1,7 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime";
+import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-runtime";
 import { createElement as _createElement } from "react";
-import { jsxs as _jsxs } from "react/jsx-runtime";
-import { Fragment as _Fragment } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx(_Fragment, {
   children: /*#__PURE__*/_jsxs("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/autoImport/react-defined/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/autoImport/react-defined/output.mjs
@@ -1,7 +1,6 @@
 import * as react from "react";
-import { jsx as _jsx } from "react/jsx-runtime";
-import { createElement as _createElement } from "react";
-import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+var _createElement = react.createElement;
 var y = react.createElement("div", {
   foo: 1
 });

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/concatenates-adjacent-string-literals/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/concatenates-adjacent-string-literals/output.mjs
@@ -1,5 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime";
-import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: ["foo", "bar", "baz", /*#__PURE__*/_jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/does-not-add-source-self-automatic/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/does-not-add-source-self-automatic/output.mjs
@@ -1,7 +1,5 @@
-import { jsx as _jsx } from "react/jsx-runtime";
+import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-runtime";
 import { createElement as _createElement } from "react";
-import { jsxs as _jsxs } from "react/jsx-runtime";
-import { Fragment as _Fragment } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx(_Fragment, {
   children: /*#__PURE__*/_jsxs("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-fragments-with-no-children/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-fragments-with-no-children/output.mjs
@@ -1,4 +1,3 @@
-import { Fragment as _Fragment } from "react/jsx-runtime";
-import { jsx as _jsx } from "react/jsx-runtime";
+import { Fragment as _Fragment, jsx as _jsx } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx(_Fragment, {});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-fragments/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-fragments/output.mjs
@@ -1,5 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime";
-import { Fragment as _Fragment } from "react/jsx-runtime";
+import { jsx as _jsx, Fragment as _Fragment } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsx(_Fragment, {
   children: /*#__PURE__*/_jsx("div", {})

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-static-children/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-static-children/output.mjs
@@ -1,5 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime";
-import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: [/*#__PURE__*/_jsx("span", {}), [/*#__PURE__*/_jsx("span", {}, '0'), /*#__PURE__*/_jsx("span", {}, '1')]]

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-allow-nested-fragments/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-allow-nested-fragments/output.mjs
@@ -1,6 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime";
-import { Fragment as _Fragment } from "react/jsx-runtime";
-import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-escape-xhtml-jsxtext-babel-7/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-escape-xhtml-jsxtext-babel-7/output.mjs
@@ -1,5 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime";
-import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-escape-xhtml-jsxtext/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-escape-xhtml-jsxtext/output.mjs
@@ -1,5 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime";
-import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 
 /*#__PURE__*/
 _jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-handle-attributed-elements/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-handle-attributed-elements/output.mjs
@@ -1,5 +1,4 @@
-import { jsxs as _jsxs } from "react/jsx-runtime";
-import { jsx as _jsx } from "react/jsx-runtime";
+import { jsxs as _jsxs, jsx as _jsx } from "react/jsx-runtime";
 var HelloMessage = React.createClass({
   displayName: "HelloMessage",
   render: function () {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-have-correct-comma-in-nested-children/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-have-correct-comma-in-nested-children/output.mjs
@@ -1,5 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime";
-import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: [/*#__PURE__*/_jsx("div", {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-properly-handle-keys/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-properly-handle-keys/output.mjs
@@ -1,5 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime";
-import { jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 
 var x = /*#__PURE__*/_jsxs("div", {
   children: [/*#__PURE__*/_jsx("div", {}, "1"), /*#__PURE__*/_jsx("div", {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14483 
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | ???
| Minor: New Feature?      | ???
| Tests Added + Pass?      | Yes
| Documentation PR Link    | none
| Any Dependency Changes?  | no
| License                  | MIT

This allows `@babel/helper-module-imports` to behave more like users likely expect it to by combining multiple import statements into a single import.

For example writing this in your plugin:
```js
  addSideEffect("source");
  addNamespace("source", { nameHint: "ns" });
  addDefault("source");
  addNamed("read", "source");
```js
Now outputs:
```js
import * as _ns, _default, { read as _read } from "source";
```

Furthermore existing imports are reused when possible, e.g. if you have
```js
import { read } from "source";
```
and you write `addNamed("read", "source")` instead of binding and returning a new `_read` local name the existing `read` name will be returned.

There was some existing functionality here -- imports with the same source were being merged later on, but this was too late to avoid ending up with multiple local names for the same imported name.

This PR also changes the insertion behavior for imports whose interop implementation consists of an import declaration and and a var declaration. The var declaration will now always be inserted below any other imports which are present. This solved a specific problem in the implementation: when an existing import declaration is reused it is not reordered. Thus `statements` might contain only var declarations relevant to some existing import. In that case the unchanged algorithm inserting above causes output like:
```
var _source = babelHelpers.interopRequireWildcard(_source$es6Default);
import _source$es6Default from "source";
```

I'm not sure how to categorize this in terms of semver. There is no documentation of how this works, meaning the implementation is essentially the spec and any change at all should probably be considered breaking.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14487"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

