### PR TITLE
Remove git.io shortlinks from repo

### DIFF
--- a/packages/babel-core/src/parser/util/missing-plugin-helper.ts
+++ b/packages/babel-core/src/parser/util/missing-plugin-helper.ts
@@ -2,233 +2,233 @@ const pluginNameMap = {
   asyncDoExpressions: {
     syntax: {
       name: "@babel/plugin-syntax-async-do-expressions",
-      url: "https://git.io/JYer8",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-do-expressions",
     },
   },
   classProperties: {
     syntax: {
       name: "@babel/plugin-syntax-class-properties",
-      url: "https://git.io/vb4yQ",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
     },
     transform: {
       name: "@babel/plugin-proposal-class-properties",
-      url: "https://git.io/vb4SL",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-class-properties",
     },
   },
   classPrivateProperties: {
     syntax: {
       name: "@babel/plugin-syntax-class-properties",
-      url: "https://git.io/vb4yQ",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
     },
     transform: {
       name: "@babel/plugin-proposal-class-properties",
-      url: "https://git.io/vb4SL",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-class-properties",
     },
   },
   classPrivateMethods: {
     syntax: {
       name: "@babel/plugin-syntax-class-properties",
-      url: "https://git.io/vb4yQ",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
     },
     transform: {
       name: "@babel/plugin-proposal-private-methods",
-      url: "https://git.io/JvpRG",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-private-methods",
     },
   },
   classStaticBlock: {
     syntax: {
       name: "@babel/plugin-syntax-class-static-block",
-      url: "https://git.io/JTLB6",
+      url: "https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-syntax-class-static-block",
     },
     transform: {
       name: "@babel/plugin-proposal-class-static-block",
-      url: "https://git.io/JTLBP",
+      url: "https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-proposal-class-static-block",
     },
   },
   decimal: {
     syntax: {
       name: "@babel/plugin-syntax-decimal",
-      url: "https://git.io/JfKOH",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-decimal",
     },
   },
   decorators: {
     syntax: {
       name: "@babel/plugin-syntax-decorators",
-      url: "https://git.io/vb4y9",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-decorators",
     },
     transform: {
       name: "@babel/plugin-proposal-decorators",
-      url: "https://git.io/vb4ST",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-decorators",
     },
   },
   doExpressions: {
     syntax: {
       name: "@babel/plugin-syntax-do-expressions",
-      url: "https://git.io/vb4yh",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-do-expressions",
     },
     transform: {
       name: "@babel/plugin-proposal-do-expressions",
-      url: "https://git.io/vb4S3",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-do-expressions",
     },
   },
   dynamicImport: {
     syntax: {
       name: "@babel/plugin-syntax-dynamic-import",
-      url: "https://git.io/vb4Sv",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import",
     },
   },
   exportDefaultFrom: {
     syntax: {
       name: "@babel/plugin-syntax-export-default-from",
-      url: "https://git.io/vb4SO",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-default-from",
     },
     transform: {
       name: "@babel/plugin-proposal-export-default-from",
-      url: "https://git.io/vb4yH",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-default-from",
     },
   },
   exportNamespaceFrom: {
     syntax: {
       name: "@babel/plugin-syntax-export-namespace-from",
-      url: "https://git.io/vb4Sf",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from",
     },
     transform: {
       name: "@babel/plugin-proposal-export-namespace-from",
-      url: "https://git.io/vb4SG",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-namespace-from",
     },
   },
   flow: {
     syntax: {
       name: "@babel/plugin-syntax-flow",
-      url: "https://git.io/vb4yb",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-flow",
     },
     transform: {
       name: "@babel/preset-flow",
-      url: "https://git.io/JfeDn",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-preset-flow",
     },
   },
   functionBind: {
     syntax: {
       name: "@babel/plugin-syntax-function-bind",
-      url: "https://git.io/vb4y7",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-bind",
     },
     transform: {
       name: "@babel/plugin-proposal-function-bind",
-      url: "https://git.io/vb4St",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-bind",
     },
   },
   functionSent: {
     syntax: {
       name: "@babel/plugin-syntax-function-sent",
-      url: "https://git.io/vb4yN",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-sent",
     },
     transform: {
       name: "@babel/plugin-proposal-function-sent",
-      url: "https://git.io/vb4SZ",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-sent",
     },
   },
   importMeta: {
     syntax: {
       name: "@babel/plugin-syntax-import-meta",
-      url: "https://git.io/vbKK6",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-import-meta",
     },
   },
   jsx: {
     syntax: {
       name: "@babel/plugin-syntax-jsx",
-      url: "https://git.io/vb4yA",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx",
     },
     transform: {
       name: "@babel/preset-react",
-      url: "https://git.io/JfeDR",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-preset-react",
     },
   },
   importAssertions: {
     syntax: {
       name: "@babel/plugin-syntax-import-assertions",
-      url: "https://git.io/JUbkv",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-import-assertions",
     },
   },
   moduleStringNames: {
     syntax: {
       name: "@babel/plugin-syntax-module-string-names",
-      url: "https://git.io/JTL8G",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-module-string-names",
     },
   },
   numericSeparator: {
     syntax: {
       name: "@babel/plugin-syntax-numeric-separator",
-      url: "https://git.io/vb4Sq",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-numeric-separator",
     },
     transform: {
       name: "@babel/plugin-proposal-numeric-separator",
-      url: "https://git.io/vb4yS",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-numeric-separator",
     },
   },
   optionalChaining: {
     syntax: {
       name: "@babel/plugin-syntax-optional-chaining",
-      url: "https://git.io/vb4Sc",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining",
     },
     transform: {
       name: "@babel/plugin-proposal-optional-chaining",
-      url: "https://git.io/vb4Sk",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-chaining",
     },
   },
   pipelineOperator: {
     syntax: {
       name: "@babel/plugin-syntax-pipeline-operator",
-      url: "https://git.io/vb4yj",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-pipeline-operator",
     },
     transform: {
       name: "@babel/plugin-proposal-pipeline-operator",
-      url: "https://git.io/vb4SU",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-pipeline-operator",
     },
   },
   privateIn: {
     syntax: {
       name: "@babel/plugin-syntax-private-property-in-object",
-      url: "https://git.io/JfK3q",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-private-property-in-object",
     },
     transform: {
       name: "@babel/plugin-proposal-private-property-in-object",
-      url: "https://git.io/JfK3O",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-private-property-in-object",
     },
   },
   recordAndTuple: {
     syntax: {
       name: "@babel/plugin-syntax-record-and-tuple",
-      url: "https://git.io/JvKp3",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-record-and-tuple",
     },
   },
   regexpUnicodeSets: {
     syntax: {
       name: "@babel/plugin-syntax-unicode-sets-regex",
-      url: "https://git.io/J9GTd",
+      url: "https://github.com/babel/babel/blob/main/packages/babel-plugin-syntax-unicode-sets-regex/README.md",
     },
     transform: {
       name: "@babel/plugin-proposal-unicode-sets-regex",
-      url: "https://git.io/J9GTQ",
+      url: "https://github.com/babel/babel/blob/main/packages/babel-plugin-proposalunicode-sets-regex/README.md",
     },
   },
   throwExpressions: {
     syntax: {
       name: "@babel/plugin-syntax-throw-expressions",
-      url: "https://git.io/vb4SJ",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-throw-expressions",
     },
     transform: {
       name: "@babel/plugin-proposal-throw-expressions",
-      url: "https://git.io/vb4yF",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-throw-expressions",
     },
   },
   typescript: {
     syntax: {
       name: "@babel/plugin-syntax-typescript",
-      url: "https://git.io/vb4SC",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-typescript",
     },
     transform: {
       name: "@babel/preset-typescript",
-      url: "https://git.io/JfeDz",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-preset-typescript",
     },
   },
 
@@ -239,51 +239,51 @@ const pluginNameMap = {
   asyncGenerators: {
     syntax: {
       name: "@babel/plugin-syntax-async-generators",
-      url: "https://git.io/vb4SY",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators",
     },
     transform: {
       name: "@babel/plugin-proposal-async-generator-functions",
-      url: "https://git.io/vb4yp",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions",
     },
   },
   logicalAssignment: {
     syntax: {
       name: "@babel/plugin-syntax-logical-assignment-operators",
-      url: "https://git.io/vAlBp",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-logical-assignment-operators",
     },
     transform: {
       name: "@babel/plugin-proposal-logical-assignment-operators",
-      url: "https://git.io/vAlRe",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-logical-assignment-operators",
     },
   },
   nullishCoalescingOperator: {
     syntax: {
       name: "@babel/plugin-syntax-nullish-coalescing-operator",
-      url: "https://git.io/vb4yx",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator",
     },
     transform: {
       name: "@babel/plugin-proposal-nullish-coalescing-operator",
-      url: "https://git.io/vb4Se",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-nullish-coalescing-opearator",
     },
   },
   objectRestSpread: {
     syntax: {
       name: "@babel/plugin-syntax-object-rest-spread",
-      url: "https://git.io/vb4y5",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread",
     },
     transform: {
       name: "@babel/plugin-proposal-object-rest-spread",
-      url: "https://git.io/vb4Ss",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread",
     },
   },
   optionalCatchBinding: {
     syntax: {
       name: "@babel/plugin-syntax-optional-catch-binding",
-      url: "https://git.io/vb4Sn",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding",
     },
     transform: {
       name: "@babel/plugin-proposal-optional-catch-binding",
-      url: "https://git.io/vb4SI",
+      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding",
     },
   },
 };

--- a/packages/babel-core/src/parser/util/missing-plugin-helper.ts
+++ b/packages/babel-core/src/parser/util/missing-plugin-helper.ts
@@ -2,37 +2,37 @@ const pluginNameMap = {
   asyncDoExpressions: {
     syntax: {
       name: "@babel/plugin-syntax-async-do-expressions",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-do-expressions",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-async-do-expressions",
     },
   },
   classProperties: {
     syntax: {
       name: "@babel/plugin-syntax-class-properties",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-class-properties",
     },
     transform: {
       name: "@babel/plugin-proposal-class-properties",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-class-properties",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-class-properties",
     },
   },
   classPrivateProperties: {
     syntax: {
       name: "@babel/plugin-syntax-class-properties",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-class-properties",
     },
     transform: {
       name: "@babel/plugin-proposal-class-properties",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-class-properties",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-class-properties",
     },
   },
   classPrivateMethods: {
     syntax: {
       name: "@babel/plugin-syntax-class-properties",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-class-properties",
     },
     transform: {
       name: "@babel/plugin-proposal-private-methods",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-private-methods",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-private-methods",
     },
   },
   classStaticBlock: {
@@ -48,157 +48,157 @@ const pluginNameMap = {
   decimal: {
     syntax: {
       name: "@babel/plugin-syntax-decimal",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-decimal",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-decimal",
     },
   },
   decorators: {
     syntax: {
       name: "@babel/plugin-syntax-decorators",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-decorators",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-decorators",
     },
     transform: {
       name: "@babel/plugin-proposal-decorators",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-decorators",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-decorators",
     },
   },
   doExpressions: {
     syntax: {
       name: "@babel/plugin-syntax-do-expressions",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-do-expressions",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-do-expressions",
     },
     transform: {
       name: "@babel/plugin-proposal-do-expressions",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-do-expressions",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-do-expressions",
     },
   },
   dynamicImport: {
     syntax: {
       name: "@babel/plugin-syntax-dynamic-import",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-dynamic-import",
     },
   },
   exportDefaultFrom: {
     syntax: {
       name: "@babel/plugin-syntax-export-default-from",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-default-from",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-export-default-from",
     },
     transform: {
       name: "@babel/plugin-proposal-export-default-from",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-default-from",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-export-default-from",
     },
   },
   exportNamespaceFrom: {
     syntax: {
       name: "@babel/plugin-syntax-export-namespace-from",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-export-namespace-from",
     },
     transform: {
       name: "@babel/plugin-proposal-export-namespace-from",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-namespace-from",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-export-namespace-from",
     },
   },
   flow: {
     syntax: {
       name: "@babel/plugin-syntax-flow",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-flow",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-flow",
     },
     transform: {
       name: "@babel/preset-flow",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-preset-flow",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-preset-flow",
     },
   },
   functionBind: {
     syntax: {
       name: "@babel/plugin-syntax-function-bind",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-bind",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-function-bind",
     },
     transform: {
       name: "@babel/plugin-proposal-function-bind",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-bind",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-function-bind",
     },
   },
   functionSent: {
     syntax: {
       name: "@babel/plugin-syntax-function-sent",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-sent",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-function-sent",
     },
     transform: {
       name: "@babel/plugin-proposal-function-sent",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-sent",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-function-sent",
     },
   },
   importMeta: {
     syntax: {
       name: "@babel/plugin-syntax-import-meta",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-import-meta",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-import-meta",
     },
   },
   jsx: {
     syntax: {
       name: "@babel/plugin-syntax-jsx",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-jsx",
     },
     transform: {
       name: "@babel/preset-react",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-preset-react",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-preset-react",
     },
   },
   importAssertions: {
     syntax: {
       name: "@babel/plugin-syntax-import-assertions",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-import-assertions",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-import-assertions",
     },
   },
   moduleStringNames: {
     syntax: {
       name: "@babel/plugin-syntax-module-string-names",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-module-string-names",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-module-string-names",
     },
   },
   numericSeparator: {
     syntax: {
       name: "@babel/plugin-syntax-numeric-separator",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-numeric-separator",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-numeric-separator",
     },
     transform: {
       name: "@babel/plugin-proposal-numeric-separator",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-numeric-separator",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-numeric-separator",
     },
   },
   optionalChaining: {
     syntax: {
       name: "@babel/plugin-syntax-optional-chaining",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-optional-chaining",
     },
     transform: {
       name: "@babel/plugin-proposal-optional-chaining",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-chaining",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-optional-chaining",
     },
   },
   pipelineOperator: {
     syntax: {
       name: "@babel/plugin-syntax-pipeline-operator",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-pipeline-operator",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-pipeline-operator",
     },
     transform: {
       name: "@babel/plugin-proposal-pipeline-operator",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-pipeline-operator",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-pipeline-operator",
     },
   },
   privateIn: {
     syntax: {
       name: "@babel/plugin-syntax-private-property-in-object",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-private-property-in-object",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-private-property-in-object",
     },
     transform: {
       name: "@babel/plugin-proposal-private-property-in-object",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-private-property-in-object",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-private-property-in-object",
     },
   },
   recordAndTuple: {
     syntax: {
       name: "@babel/plugin-syntax-record-and-tuple",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-record-and-tuple",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-record-and-tuple",
     },
   },
   regexpUnicodeSets: {
@@ -214,21 +214,21 @@ const pluginNameMap = {
   throwExpressions: {
     syntax: {
       name: "@babel/plugin-syntax-throw-expressions",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-throw-expressions",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-throw-expressions",
     },
     transform: {
       name: "@babel/plugin-proposal-throw-expressions",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-throw-expressions",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-throw-expressions",
     },
   },
   typescript: {
     syntax: {
       name: "@babel/plugin-syntax-typescript",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-typescript",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-typescript",
     },
     transform: {
       name: "@babel/preset-typescript",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-preset-typescript",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-preset-typescript",
     },
   },
 
@@ -239,51 +239,51 @@ const pluginNameMap = {
   asyncGenerators: {
     syntax: {
       name: "@babel/plugin-syntax-async-generators",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-async-generators",
     },
     transform: {
       name: "@babel/plugin-proposal-async-generator-functions",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-async-generator-functions",
     },
   },
   logicalAssignment: {
     syntax: {
       name: "@babel/plugin-syntax-logical-assignment-operators",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-logical-assignment-operators",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-logical-assignment-operators",
     },
     transform: {
       name: "@babel/plugin-proposal-logical-assignment-operators",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-logical-assignment-operators",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-logical-assignment-operators",
     },
   },
   nullishCoalescingOperator: {
     syntax: {
       name: "@babel/plugin-syntax-nullish-coalescing-operator",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-nullish-coalescing-operator",
     },
     transform: {
       name: "@babel/plugin-proposal-nullish-coalescing-operator",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-nullish-coalescing-opearator",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-nullish-coalescing-opearator",
     },
   },
   objectRestSpread: {
     syntax: {
       name: "@babel/plugin-syntax-object-rest-spread",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-object-rest-spread",
     },
     transform: {
       name: "@babel/plugin-proposal-object-rest-spread",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-object-rest-spread",
     },
   },
   optionalCatchBinding: {
     syntax: {
       name: "@babel/plugin-syntax-optional-catch-binding",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-optional-catch-binding",
     },
     transform: {
       name: "@babel/plugin-proposal-optional-catch-binding",
-      url: "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding",
+      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-optional-catch-binding",
     },
   },
 };

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -798,7 +798,7 @@ describe("api", function () {
               "Support for the experimental syntax 'pipelineOperator' isn't currently enabled (1:3):",
             );
             expect(err.message).toMatch(
-              "Add @babel/plugin-proposal-pipeline-operator (https://git.io/vb4SU) to the " +
+              "Add @babel/plugin-proposal-pipeline-operator (https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-pipeline-operator) to the " +
                 "'plugins' section of your Babel config to enable transformation.",
             );
             resolve();
@@ -817,7 +817,7 @@ describe("api", function () {
               "Support for the experimental syntax 'doExpressions' isn't currently enabled (1:2):",
             );
             expect(err.message).toMatch(
-              "Add @babel/plugin-proposal-do-expressions (https://git.io/vb4S3) to the " +
+              "Add @babel/plugin-proposal-do-expressions (https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-do-expressions) to the " +
                 "'plugins' section of your Babel config to enable transformation.",
             );
             resolve();

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -798,7 +798,7 @@ describe("api", function () {
               "Support for the experimental syntax 'pipelineOperator' isn't currently enabled (1:3):",
             );
             expect(err.message).toMatch(
-              "Add @babel/plugin-proposal-pipeline-operator (https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-pipeline-operator) to the " +
+              "Add @babel/plugin-proposal-pipeline-operator (https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-pipeline-operator) to the " +
                 "'plugins' section of your Babel config to enable transformation.",
             );
             resolve();
@@ -817,7 +817,7 @@ describe("api", function () {
               "Support for the experimental syntax 'doExpressions' isn't currently enabled (1:2):",
             );
             expect(err.message).toMatch(
-              "Add @babel/plugin-proposal-do-expressions (https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-do-expressions) to the " +
+              "Add @babel/plugin-proposal-do-expressions (https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-do-expressions) to the " +
                 "'plugins' section of your Babel config to enable transformation.",
             );
             resolve();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

Github has deprecated git.io and will be [disabling all links on April 29th](https://github.blog/changelog/2022-04-25-git-io-deprecation/).
This PR replaces all git.io shortened links with the URL they redirect to.


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Removed soon-to-be-invalid shortlinks
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR Link    | N/A<!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14493"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

