### PR TITLE
Provide plugin/preset typings from plugin-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "semver": "^6.3.0",
     "test262-stream": "^1.4.0",
     "through2": "^4.0.0",
-    "typescript": "~4.5.0"
+    "typescript": "~4.6.3"
   },
   "workspaces": [
     "codemods/*",

--- a/packages/babel-core/src/config/helpers/config-api.ts
+++ b/packages/babel-core/src/config/helpers/config-api.ts
@@ -9,7 +9,7 @@ import type {
   SimpleType,
 } from "../caching";
 
-import type { CallerMetadata } from "../validation/options";
+import type { AssumptionName, CallerMetadata } from "../validation/options";
 
 import * as Context from "../cache-contexts";
 
@@ -24,7 +24,7 @@ type CallerFactory = (
   extractor: (callerMetadata: CallerMetadata | void) => unknown,
 ) => SimpleType;
 type TargetsFunction = () => Targets;
-type AssumptionFunction = (name: string) => boolean | void;
+type AssumptionFunction = (name: AssumptionName) => boolean;
 
 export type ConfigAPI = {
   version: string;

--- a/packages/babel-core/src/config/helpers/config-api.ts
+++ b/packages/babel-core/src/config/helpers/config-api.ts
@@ -24,7 +24,7 @@ type CallerFactory = (
   extractor: (callerMetadata: CallerMetadata | void) => unknown,
 ) => SimpleType;
 type TargetsFunction = () => Targets;
-type AssumptionFunction = (name: AssumptionName) => boolean;
+type AssumptionFunction = (name: AssumptionName) => boolean | void;
 
 export type ConfigAPI = {
   version: string;

--- a/packages/babel-core/src/config/index.ts
+++ b/packages/babel-core/src/config/index.ts
@@ -9,6 +9,17 @@ export type {
 
 import type { PluginTarget } from "./validation/options";
 
+import type {
+  PluginAPI as basePluginAPI,
+  PresetAPI as basePresetAPI,
+} from "./helpers/config-api";
+export type { PluginObject } from "./validation/plugins";
+type PluginAPI = basePluginAPI & typeof import("..");
+type PresetAPI = basePresetAPI & typeof import("..");
+export type { PluginAPI, PresetAPI };
+// todo: may need to refine PresetObject to be a subset of ValidatedOptions
+export type { ValidatedOptions as PresetObject } from "./validation/options";
+
 import loadFullConfig from "./full";
 import { loadPartialConfig as loadPartialConfigRunner } from "./partial";
 

--- a/packages/babel-core/src/config/validation/option-assertions.ts
+++ b/packages/babel-core/src/config/validation/option-assertions.ts
@@ -20,6 +20,7 @@ import type {
   CallerMetadata,
   RootMode,
   TargetsListOrObject,
+  AssumptionName,
 } from "./options";
 
 import { assumptionsNames } from "./options";
@@ -462,7 +463,7 @@ export function assertAssumptions(
 
   for (const name of Object.keys(value)) {
     const subLoc = access(loc, name);
-    if (!assumptionsNames.has(name)) {
+    if (!assumptionsNames.has(name as AssumptionName)) {
       throw new Error(`${msg(subLoc)} is not a supported assumption.`);
     }
     if (typeof value[name] !== "boolean") {

--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -28,6 +28,8 @@ import {
 } from "./option-assertions";
 import type { ValidatorSet, Validator, OptionPath } from "./option-assertions";
 import type { UnloadedDescriptor } from "../config-descriptors";
+import type { ParserOptions } from "@babel/parser";
+import type { GeneratorOptions } from "@babel/generator";
 
 const ROOT_VALIDATORS: ValidatorSet = {
   cwd: assertString as Validator<ValidatedOptions["cwd"]>,
@@ -181,9 +183,9 @@ export type ValidatedOptions = {
   sourceFileName?: string;
   sourceRoot?: string;
   // Deprecate top level parserOpts
-  parserOpts?: {};
+  parserOpts?: ParserOptions;
   // Deprecate top level generatorOpts
-  generatorOpts?: {};
+  generatorOpts?: GeneratorOptions;
 };
 
 export type NormalizedOptions = {

--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -254,7 +254,7 @@ type EnvPath = Readonly<{
 
 export type NestingPath = RootPath | OverridesPath | EnvPath;
 
-export const assumptionsNames = new Set<string>([
+const knownAssumptions = [
   "arrayLikeIsIterable",
   "constantReexports",
   "constantSuper",
@@ -276,7 +276,9 @@ export const assumptionsNames = new Set<string>([
   "setSpreadProperties",
   "skipForOfIteratorClosing",
   "superIsCallableConstructor",
-]);
+] as const;
+export type AssumptionName = typeof knownAssumptions[number];
+export const assumptionsNames = new Set(knownAssumptions);
 
 function getSource(loc: NestingPath): OptionsSource {
   return loc.type === "root" ? loc.source : getSource(loc.parent);

--- a/packages/babel-core/src/config/validation/plugins.ts
+++ b/packages/babel-core/src/config/validation/plugins.ts
@@ -11,6 +11,10 @@ import type {
   OptionPath,
   RootPath,
 } from "./option-assertions";
+import type { ParserOptions } from "@babel/parser";
+import type { Visitor } from "@babel/traverse";
+import PluginPass from "../../transformation/plugin-pass";
+import type { ValidatedOptions } from "./options";
 
 // Note: The casts here are just meant to be static assertions to make sure
 // that the assertion functions actually assert that the value's type matches
@@ -31,7 +35,7 @@ const VALIDATORS: ValidatorSet = {
   >,
 };
 
-function assertVisitorMap(loc: OptionPath, value: unknown): VisitorMap {
+function assertVisitorMap(loc: OptionPath, value: unknown): Visitor {
   const obj = assertObject(loc, value);
   if (obj) {
     Object.keys(obj).forEach(prop => assertVisitorHandler(prop, obj[prop]));
@@ -45,7 +49,7 @@ function assertVisitorMap(loc: OptionPath, value: unknown): VisitorMap {
       );
     }
   }
-  return obj as VisitorMap;
+  return obj as Visitor;
 }
 
 function assertVisitorHandler(
@@ -74,17 +78,16 @@ type VisitorHandler =
       exit?: Function;
     };
 
-export type VisitorMap = {
-  [x: string]: VisitorHandler;
-};
-
-export type PluginObject = {
+export type PluginObject<S = PluginPass> = {
   name?: string;
-  manipulateOptions?: (options: unknown, parserOpts: unknown) => void;
+  manipulateOptions?: (
+    options: ValidatedOptions,
+    parserOpts: ParserOptions,
+  ) => void;
   pre?: Function;
   post?: Function;
   inherits?: Function;
-  visitor?: VisitorMap;
+  visitor?: Visitor<S>;
   parserOverride?: Function;
   generatorOverride?: Function;
 };

--- a/packages/babel-core/src/config/validation/plugins.ts
+++ b/packages/babel-core/src/config/validation/plugins.ts
@@ -13,7 +13,7 @@ import type {
 } from "./option-assertions";
 import type { ParserOptions } from "@babel/parser";
 import type { Visitor } from "@babel/traverse";
-import PluginPass from "../../transformation/plugin-pass";
+import type PluginPass from "../../transformation/plugin-pass";
 import type { ValidatedOptions } from "./options";
 
 // Note: The casts here are just meant to be static assertions to make sure

--- a/packages/babel-core/src/index.ts
+++ b/packages/babel-core/src/index.ts
@@ -29,6 +29,13 @@ export {
   loadOptionsAsync,
 } from "./config";
 
+export type {
+  PluginAPI,
+  PluginObject,
+  PresetAPI,
+  PresetObject,
+} from "./config";
+
 export { transform, transformSync, transformAsync } from "./transform";
 export {
   transformFile,

--- a/packages/babel-generator/src/generators/methods.ts
+++ b/packages/babel-generator/src/generators/methods.ts
@@ -146,7 +146,6 @@ function hasTypesOrComments(
   return !!(
     node.typeParameters ||
     node.returnType ||
-    // @ts-expect-error
     node.predicate ||
     param.typeAnnotation ||
     param.optional ||

--- a/packages/babel-generator/src/index.ts
+++ b/packages/babel-generator/src/index.ts
@@ -1,7 +1,7 @@
 import SourceMap from "./source-map";
 import Printer from "./printer";
 import type * as t from "@babel/types";
-
+import type { Opts as jsescOptions } from "jsesc";
 import type { Format } from "./printer";
 
 /**
@@ -186,19 +186,12 @@ export interface GeneratorOptions {
   /**
    * Options for outputting jsesc representation.
    */
-  jsescOption?: {
-    /**
-     * The type of quote to use in the output. If omitted, autodetects based on `ast.tokens`.
-     */
-    quotes?: "single" | "double";
+  jsescOption?: jsescOptions;
 
-    /**
-     * When enabled, the output is a valid JavaScript string literal wrapped in quotes. The type of quotes can be specified through the quotes setting.
-     * Defaults to `true`.
-     */
-    wrap?: boolean;
-  };
-
+  /**
+   * For use with the recordAndTuple token.
+   */
+  recordAndTupleSyntaxType?: "hash" | "bar";
   /**
    * For use with the Hack-style pipe operator.
    * Changes what token is used for pipe bodies’ topic references.

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -185,7 +185,7 @@ export function createClassFeaturePlugin({
         const privateNamesMap = buildPrivateNamesMap(props);
         const privateNamesNodes = buildPrivateNamesNodes(
           privateNamesMap,
-          privateFieldsAsProperties ?? loose,
+          (privateFieldsAsProperties ?? loose) as boolean,
           state,
         );
 
@@ -224,9 +224,9 @@ export function createClassFeaturePlugin({
               props,
               privateNamesMap,
               state,
-              setPublicClassFields ?? loose,
-              privateFieldsAsProperties ?? loose,
-              constantSuper ?? loose,
+              (setPublicClassFields ?? loose) as boolean,
+              (privateFieldsAsProperties ?? loose) as boolean,
+              (constantSuper ?? loose) as boolean,
               innerBinding,
             ));
         }

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import { types as t } from "@babel/core";
-import type { File } from "@babel/core";
+import type { File, PluginAPI, PluginObject } from "@babel/core";
 import type { NodePath } from "@babel/traverse";
 import nameFunction from "@babel/helper-function-name";
 import splitExportDeclaration from "@babel/helper-split-export-declaration";
@@ -14,7 +14,6 @@ import { buildDecoratedClass, hasDecorators } from "./decorators";
 import { injectInitialization, extractComputedKeys } from "./misc";
 import { enableFeature, FEATURES, isLoose, shouldTransform } from "./features";
 import { assertFieldTransformed } from "./typescript";
-import type { ParserOptions } from "@babel/parser";
 
 export { FEATURES, enableFeature, injectInitialization };
 
@@ -33,11 +32,9 @@ interface Options {
   name: string;
   feature: number;
   loose?: boolean;
-  inherits?: (api: any, options: any) => any;
-  // same as PluginObject.manipulateOptions
-  manipulateOptions?: (options: unknown, parserOpts: ParserOptions) => void;
-  // TODO(flow->ts): change to babel api
-  api?: { assumption: (key?: string) => boolean | undefined };
+  inherits?: PluginObject["inherits"];
+  manipulateOptions?: PluginObject["manipulateOptions"];
+  api?: PluginAPI;
 }
 
 export function createClassFeaturePlugin({
@@ -45,7 +42,7 @@ export function createClassFeaturePlugin({
   feature,
   loose,
   manipulateOptions,
-  // TODO(Babel 8): Remove the default value
+  // @ts-ignore TODO(Babel 8): Remove the default value
   api = { assumption: () => void 0 },
   inherits,
 }: Options) {

--- a/packages/babel-helper-create-regexp-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-regexp-features-plugin/src/index.ts
@@ -3,6 +3,7 @@ import { featuresKey, FEATURES, enableFeature, runtimeKey } from "./features";
 import { generateRegexpuOptions, canSkipRegexpu, transformFlags } from "./util";
 
 import { types as t } from "@babel/core";
+import type { PluginObject } from "@babel/core";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 
 declare const PACKAGE_JSON: { name: string; version: string };
@@ -20,8 +21,8 @@ export function createRegExpFeaturePlugin({
   name,
   feature,
   options = {} as any,
-  manipulateOptions = (() => {}) as (opts: any, parserOpts: any) => void,
-}) {
+  manipulateOptions = (() => {}) as PluginObject["manipulateOptions"],
+}): PluginObject {
   return {
     name,
 

--- a/packages/babel-helper-module-transforms/src/get-module-name.ts
+++ b/packages/babel-helper-module-transforms/src/get-module-name.ts
@@ -4,7 +4,7 @@ type RootOptions = {
   sourceRoot?: string;
 };
 
-type PluginOptions = {
+export type PluginOptions = {
   moduleId?: string;
   moduleIds?: boolean;
   getModuleId?: (moduleName: string) => string | null | undefined;

--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -185,7 +185,7 @@ export function wrapInterop(
 export function buildNamespaceInitStatements(
   metadata: ModuleMetadata,
   sourceMetadata: SourceModuleMetadata,
-  constantReexports: boolean = false,
+  constantReexports: boolean | void = false,
 ) {
   const statements = [];
 

--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -34,6 +34,7 @@ import type {
 import type { NodePath } from "@babel/traverse";
 
 export { default as getModuleName } from "./get-module-name";
+export type { PluginOptions } from "./get-module-name";
 
 export { hasExports, isSideEffectImport, isModule, rewriteThis };
 

--- a/packages/babel-helper-plugin-utils/src/index.ts
+++ b/packages/babel-helper-plugin-utils/src/index.ts
@@ -6,17 +6,17 @@ import type {
   PresetObject,
 } from "@babel/core";
 
-export function declare<S = {}, Option = {}>(
+export function declare<State = {}, Option = {}>(
   builder: (
     api: PluginAPI,
     options: Option,
     dirname: string,
-  ) => PluginObject<S & PluginPass>,
+  ) => PluginObject<State & PluginPass>,
 ): (
   api: PluginAPI,
   options: Option,
   dirname: string,
-) => PluginObject<S & PluginPass> {
+) => PluginObject<State & PluginPass> {
   // @ts-ignore
   return (api, options: Option, dirname: string) => {
     let clonedApi;

--- a/packages/babel-helper-plugin-utils/src/index.ts
+++ b/packages/babel-helper-plugin-utils/src/index.ts
@@ -6,14 +6,14 @@ import type {
   PresetObject,
 } from "@babel/core";
 
-export function declare<S = {}, Option = {}, API = PluginAPI>(
+export function declare<S = {}, Option = {}>(
   builder: (
-    api: API,
+    api: PluginAPI,
     options: Option,
     dirname: string,
   ) => PluginObject<S & PluginPass>,
 ): (
-  api: API,
+  api: PluginAPI,
   options: Option,
   dirname: string,
 ) => PluginObject<S & PluginPass> {
@@ -34,10 +34,9 @@ export function declare<S = {}, Option = {}, API = PluginAPI>(
   };
 }
 
-export const declarePreset = declare as
-  <Option = {}, API = PresetAPI>(
-    builder: (api: API, options: Option, dirname: string) => PresetObject,
-  ): (api: API, options: Option, dirname: string) => PresetObject;
+export const declarePreset = declare as <Option = {}>(
+  builder: (api: PresetAPI, options: Option, dirname: string) => PresetObject,
+) => (api: PresetAPI, options: Option, dirname: string) => PresetObject;
 
 const apiPolyfills = {
   // Not supported by Babel 7 and early versions of Babel 7 beta.

--- a/packages/babel-helper-plugin-utils/src/index.ts
+++ b/packages/babel-helper-plugin-utils/src/index.ts
@@ -34,11 +34,10 @@ export function declare<S = {}, Option = {}, API = PluginAPI>(
   };
 }
 
-export function declarePreset<Option = {}, API = PresetAPI>(
-  builder: (api: API, options: Option, dirname: string) => PresetObject,
-): (api: API, options: Option, dirname: string) => PresetObject {
-  return declare(builder as any) as any;
-}
+export const declarePreset = declare as
+  <Option = {}, API = PresetAPI>(
+    builder: (api: API, options: Option, dirname: string) => PresetObject,
+  ): (api: API, options: Option, dirname: string) => PresetObject;
 
 const apiPolyfills = {
   // Not supported by Babel 7 and early versions of Babel 7 beta.

--- a/packages/babel-parser/src/plugins/flow/index.js
+++ b/packages/babel-parser/src/plugins/flow/index.js
@@ -353,7 +353,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return type;
     }
 
-    flowParsePredicate(): N.FlowType {
+    flowParsePredicate(): N.FlowPredicate {
       const node = this.startNode();
       const moduloLoc = this.state.startLoc;
       this.next(); // eat `%`

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -182,7 +182,7 @@ export interface DecoratorsPluginOptions {
 
 export interface PipelineOperatorPluginOptions {
   proposal: "minimal" | "fsharp" | "hack" | "smart";
-  topicToken?: "%" | "#" | "@@" | "^^";
+  topicToken?: "%" | "#" | "@@" | "^^" | "^";
 }
 
 export interface RecordAndTuplePluginOptions {
@@ -191,6 +191,7 @@ export interface RecordAndTuplePluginOptions {
 
 export interface FlowPluginOptions {
   all?: boolean;
+  enums?: boolean;
 }
 
 export interface TypeScriptPluginOptions {

--- a/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/src/index.ts
+++ b/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/src/index.ts
@@ -1,6 +1,4 @@
 import { declare } from "@babel/helper-plugin-utils";
-import type { PluginPass } from "@babel/core";
-import type { Visitor } from "@babel/traverse";
 import { shouldTransform } from "./util";
 
 export default declare(api => {
@@ -20,6 +18,6 @@ export default declare(api => {
           scope.rename(name, newParamName);
         }
       },
-    } as Visitor<PluginPass>,
+    },
   };
 });

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/src/index.ts
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/src/index.ts
@@ -1,6 +1,8 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { transform } from "@babel/plugin-proposal-optional-chaining";
 import { shouldTransform } from "./util";
+import type { NodePath } from "@babel/traverse";
+import type * as t from "@babel/types";
 
 export default declare(api => {
   api.assertVersion(7);
@@ -12,7 +14,9 @@ export default declare(api => {
     name: "bugfix-v8-spread-parameters-in-optional-chaining",
 
     visitor: {
-      "OptionalCallExpression|OptionalMemberExpression"(path) {
+      "OptionalCallExpression|OptionalMemberExpression"(
+        path: NodePath<t.OptionalCallExpression | t.OptionalMemberExpression>,
+      ) {
         if (shouldTransform(path)) {
           transform(path, { noDocumentAll, pureGetters });
         }

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/src/index.ts
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/src/index.ts
@@ -7,8 +7,8 @@ import type * as t from "@babel/types";
 export default declare(api => {
   api.assertVersion(7);
 
-  const noDocumentAll = api.assumption("noDocumentAll");
-  const pureGetters = api.assumption("pureGetters");
+  const noDocumentAll = (api.assumption("noDocumentAll") ?? false) as boolean;
+  const pureGetters = (api.assumption("pureGetters") ?? false) as boolean;
 
   return {
     name: "bugfix-v8-spread-parameters-in-optional-chaining",

--- a/packages/babel-plugin-external-helpers/src/index.ts
+++ b/packages/babel-plugin-external-helpers/src/index.ts
@@ -1,7 +1,12 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default declare((api, options) => {
+export interface Options {
+  helperVersion?: string;
+  whitelist?: false | string[];
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const { helperVersion = "7.0.0-beta.0", whitelist = false } = options;

--- a/packages/babel-plugin-proposal-async-do-expressions/src/index.ts
+++ b/packages/babel-plugin-proposal-async-do-expressions/src/index.ts
@@ -2,7 +2,6 @@ import { declare } from "@babel/helper-plugin-utils";
 import syntaxAsyncDoExpressions from "@babel/plugin-syntax-async-do-expressions";
 import hoistVariables from "@babel/helper-hoist-variables";
 import type * as t from "@babel/types";
-import type { NodePath } from "@babel/traverse";
 
 export default declare(({ types: t, assertVersion }) => {
   assertVersion("^7.13.0");
@@ -12,7 +11,7 @@ export default declare(({ types: t, assertVersion }) => {
     inherits: syntaxAsyncDoExpressions,
     visitor: {
       DoExpression: {
-        exit(path: NodePath<t.DoExpression>) {
+        exit(path) {
           if (!path.is("async")) {
             // non-async do expressions are handled by proposal-do-expressions
             return;

--- a/packages/babel-plugin-proposal-async-generator-functions/src/for-await.ts
+++ b/packages/babel-plugin-proposal-async-generator-functions/src/for-await.ts
@@ -62,11 +62,11 @@ export default function (path, { getAsyncIterator }) {
 
   // remove async function wrapper
   // @ts-expect-error todo(flow->ts) improve type annotation for buildForAwait
-  template = template.body.body;
+  template = template.body.body as t.Statement[];
 
   const isLabeledParent = t.isLabeledStatement(parent);
-  const tryBody = template[3].block.body;
-  const loop = tryBody[0];
+  const tryBody = (template[3] as t.TryStatement).block.body;
+  const loop = tryBody[0] as t.ForStatement;
 
   if (isLabeledParent) {
     tryBody[0] = t.labeledStatement(parent.label, loop);

--- a/packages/babel-plugin-proposal-async-generator-functions/src/index.ts
+++ b/packages/babel-plugin-proposal-async-generator-functions/src/index.ts
@@ -2,12 +2,14 @@ import { declare } from "@babel/helper-plugin-utils";
 import remapAsyncToGenerator from "@babel/helper-remap-async-to-generator";
 import syntaxAsyncGenerators from "@babel/plugin-syntax-async-generators";
 import { types as t } from "@babel/core";
+import type { PluginPass } from "@babel/core";
+import type { Visitor } from "@babel/traverse";
 import rewriteForAwait from "./for-await";
 
 export default declare(api => {
   api.assertVersion(7);
 
-  const yieldStarVisitor = {
+  const yieldStarVisitor: Visitor<PluginPass> = {
     Function(path) {
       path.skip();
     },
@@ -22,7 +24,7 @@ export default declare(api => {
     },
   };
 
-  const forAwaitVisitor = {
+  const forAwaitVisitor: Visitor<PluginPass> = {
     Function(path) {
       path.skip();
     },
@@ -36,7 +38,7 @@ export default declare(api => {
       });
 
       const { declar, loop } = build;
-      const block = loop.body;
+      const block = loop.body as t.BlockStatement;
 
       // ensure that it's a block so we can take all its statements
       path.ensureBlock();
@@ -47,7 +49,7 @@ export default declare(api => {
       }
 
       // push the rest of the original loop body onto our new body
-      block.body.push(...node.body.body);
+      block.body.push(...(node.body as t.BlockStatement).body);
 
       t.inherits(loop, node);
       t.inherits(loop.body, node.body);
@@ -60,7 +62,7 @@ export default declare(api => {
     },
   };
 
-  const visitor = {
+  const visitor: Visitor<PluginPass> = {
     Function(path, state) {
       if (!path.node.async) return;
 

--- a/packages/babel-plugin-proposal-class-properties/src/index.ts
+++ b/packages/babel-plugin-proposal-class-properties/src/index.ts
@@ -6,7 +6,11 @@ import {
   FEATURES,
 } from "@babel/helper-create-class-features-plugin";
 
-export default declare((api, options) => {
+export interface Options {
+  loose?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   return createClassFeaturePlugin({

--- a/packages/babel-plugin-proposal-class-static-block/src/index.ts
+++ b/packages/babel-plugin-proposal-class-static-block/src/index.ts
@@ -7,7 +7,6 @@ import {
 } from "@babel/helper-create-class-features-plugin";
 
 import type * as t from "@babel/types";
-import type { NodePath } from "@babel/traverse";
 /**
  * Generate a uid that is not in `denyList`
  *
@@ -43,7 +42,7 @@ export default declare(({ types: t, template, assertVersion }) => {
       // Run on ClassBody and not on class so that if @babel/helper-create-class-features-plugin
       // is enabled it can generte optimized output without passing from the intermediate
       // private fields representation.
-      ClassBody(classBody: NodePath<t.ClassBody>) {
+      ClassBody(classBody) {
         const { scope } = classBody;
         const privateNames = new Set<string>();
         const body = classBody.get("body");

--- a/packages/babel-plugin-proposal-decorators/src/index.ts
+++ b/packages/babel-plugin-proposal-decorators/src/index.ts
@@ -8,8 +8,9 @@ import {
 } from "@babel/helper-create-class-features-plugin";
 import legacyVisitor from "./transformer-legacy";
 import transformer2021_12 from "./transformer-2021-12";
+import type { Options } from "@babel/plugin-syntax-decorators";
 
-export default declare((api, options) => {
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   // Options are validated in @babel/plugin-syntax-decorators

--- a/packages/babel-plugin-proposal-decorators/src/index.ts
+++ b/packages/babel-plugin-proposal-decorators/src/index.ts
@@ -9,6 +9,7 @@ import {
 import legacyVisitor from "./transformer-legacy";
 import transformer2021_12 from "./transformer-2021-12";
 import type { Options } from "@babel/plugin-syntax-decorators";
+export type { Options };
 
 export default declare((api, options: Options) => {
   api.assertVersion(7);

--- a/packages/babel-plugin-proposal-decorators/src/transformer-2021-12.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-2021-12.ts
@@ -4,8 +4,8 @@ import syntaxDecorators from "@babel/plugin-syntax-decorators";
 import ReplaceSupers from "@babel/helper-replace-supers";
 import splitExportDeclaration from "@babel/helper-split-export-declaration";
 import * as charCodes from "charcodes";
-import type { PluginAPI } from "@babel/core";
-import type { PluginOptions } from "..";
+import type { PluginAPI, PluginObject } from "@babel/core";
+import type { Options } from "..";
 
 type ClassDecoratableElement =
   | t.ClassMethod
@@ -1003,8 +1003,8 @@ function transformClass(
 
 export default function (
   { assertVersion, assumption }: PluginAPI,
-  { loose }: PluginOptions,
-) {
+  { loose }: Options,
+): PluginObject {
   assertVersion("^7.16.0");
 
   const VISITED = new WeakSet<NodePath>();
@@ -1015,7 +1015,9 @@ export default function (
     inherits: syntaxDecorators,
 
     visitor: {
-      "ExportNamedDeclaration|ExportDefaultDeclaration"(path) {
+      "ExportNamedDeclaration|ExportDefaultDeclaration"(
+        path: NodePath<t.ExportNamedDeclaration | t.ExportDefaultDeclaration>,
+      ) {
         const { declaration } = path.node;
         if (
           declaration?.type === "ClassDeclaration" &&
@@ -1027,7 +1029,7 @@ export default function (
         }
       },
 
-      Class(path: NodePath<t.Class>, state: any) {
+      Class(path, state) {
         if (VISITED.has(path)) return;
 
         const newPath = transformClass(path, state, constantSuper);

--- a/packages/babel-plugin-proposal-decorators/src/transformer-2021-12.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-2021-12.ts
@@ -4,6 +4,8 @@ import syntaxDecorators from "@babel/plugin-syntax-decorators";
 import ReplaceSupers from "@babel/helper-replace-supers";
 import splitExportDeclaration from "@babel/helper-split-export-declaration";
 import * as charCodes from "charcodes";
+import type { PluginAPI } from "@babel/core";
+import type { PluginOptions } from "..";
 
 type ClassDecoratableElement =
   | t.ClassMethod
@@ -999,7 +1001,10 @@ function transformClass(
   return path;
 }
 
-export default function ({ assertVersion, assumption }, { loose }) {
+export default function (
+  { assertVersion, assumption }: PluginAPI,
+  { loose }: PluginOptions,
+) {
   assertVersion("^7.16.0");
 
   const VISITED = new WeakSet<NodePath>();

--- a/packages/babel-plugin-proposal-export-default-from/src/index.ts
+++ b/packages/babel-plugin-proposal-export-default-from/src/index.ts
@@ -17,7 +17,10 @@ export default declare(api => {
 
         const specifier = specifiers.shift();
         const { exported } = specifier;
-        const uid = scope.generateUidIdentifier(exported.name);
+        const uid = scope.generateUidIdentifier(
+          // @ts-ignore Identifier ?? StringLiteral
+          exported.name ?? exported.value,
+        );
 
         const nodes = [
           t.importDeclaration(

--- a/packages/babel-plugin-proposal-export-namespace-from/src/index.ts
+++ b/packages/babel-plugin-proposal-export-namespace-from/src/index.ts
@@ -28,6 +28,7 @@ export default declare(api => {
         const specifier = specifiers.shift();
         const { exported } = specifier;
         const uid = scope.generateUidIdentifier(
+          // @ts-ignore Identifier ?? StringLiteral
           exported.name ?? exported.value,
         );
 

--- a/packages/babel-plugin-proposal-function-sent/src/index.ts
+++ b/packages/babel-plugin-proposal-function-sent/src/index.ts
@@ -51,6 +51,7 @@ export default declare(api => {
         const sentId = path.scope.generateUid("function.sent");
 
         fnPath.traverse(yieldVisitor, { sentId });
+        // @ts-expect-error A generator must not be an arrow function
         fnPath.node.body.body.unshift(
           t.variableDeclaration("let", [
             t.variableDeclarator(t.identifier(sentId), t.yieldExpression()),

--- a/packages/babel-plugin-proposal-json-strings/src/index.ts
+++ b/packages/babel-plugin-proposal-json-strings/src/index.ts
@@ -1,5 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxJsonStrings from "@babel/plugin-syntax-json-strings";
+import type * as t from "@babel/types";
+import type { NodePath } from "@babel/traverse";
 
 export default declare(api => {
   api.assertVersion(7);
@@ -19,11 +21,13 @@ export default declare(api => {
     inherits: syntaxJsonStrings.default,
 
     visitor: {
-      "DirectiveLiteral|StringLiteral"({ node }) {
+      "DirectiveLiteral|StringLiteral"({
+        node,
+      }: NodePath<t.DirectiveLiteral | t.StringLiteral>) {
         const { extra } = node;
         if (!extra?.raw) return;
 
-        extra.raw = extra.raw.replace(regex, replace);
+        extra.raw = (extra.raw as string).replace(regex, replace);
       },
     },
   };

--- a/packages/babel-plugin-proposal-logical-assignment-operators/src/index.ts
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/src/index.ts
@@ -18,20 +18,24 @@ export default declare(api => {
           return;
         }
 
-        const lhs = t.cloneNode(left);
+        const lhs = t.cloneNode(left) as t.Identifier | t.MemberExpression;
         if (t.isMemberExpression(left)) {
           const { object, property, computed } = left;
           const memo = scope.maybeGenerateMemoised(object);
           if (memo) {
             left.object = memo;
-            lhs.object = t.assignmentExpression("=", t.cloneNode(memo), object);
+            (lhs as t.MemberExpression).object = t.assignmentExpression(
+              "=",
+              t.cloneNode(memo),
+              object,
+            );
           }
 
           if (computed) {
             const memo = scope.maybeGenerateMemoised(property);
             if (memo) {
               left.property = memo;
-              lhs.property = t.assignmentExpression(
+              (lhs as t.MemberExpression).property = t.assignmentExpression(
                 "=",
                 t.cloneNode(memo),
                 // @ts-expect-error todo(flow->ts): property can be t.PrivateName
@@ -43,6 +47,7 @@ export default declare(api => {
 
         path.replaceWith(
           t.logicalExpression(
+            // @ts-ignore operatorTrunc has been tested by t.LOGICAL_OPERATORS
             operatorTrunc,
             lhs,
             t.assignmentExpression("=", left, right),

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.ts
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.ts
@@ -30,7 +30,7 @@ export default declare((api, { loose = false }: Options) => {
         } else if (scope.path.isPattern()) {
           // Replace `function (a, x = a.b ?? c) {}` to `function (a, x = (() => a.b ?? c)() ){}`
           // so the temporary variable can be injected in correct scope
-          path.replaceWith(template.ast`(() => ${path.node})()` as t.Statement);
+          path.replaceWith(template.statement.ast`(() => ${path.node})()`);
           // The injected nullish expression will be queued and eventually transformed when visited
           return;
         } else {

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.ts
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.ts
@@ -2,7 +2,11 @@ import { declare } from "@babel/helper-plugin-utils";
 import syntaxNullishCoalescingOperator from "@babel/plugin-syntax-nullish-coalescing-operator";
 import { types as t, template } from "@babel/core";
 
-export default declare((api, { loose = false }) => {
+export interface Options {
+  loose?: boolean;
+}
+
+export default declare((api, { loose = false }: Options) => {
   api.assertVersion(7);
   const noDocumentAll = api.assumption("noDocumentAll") ?? loose;
 
@@ -26,7 +30,7 @@ export default declare((api, { loose = false }) => {
         } else if (scope.path.isPattern()) {
           // Replace `function (a, x = a.b ?? c) {}` to `function (a, x = (() => a.b ?? c)() ){}`
           // so the temporary variable can be injected in correct scope
-          path.replaceWith(template.ast`(() => ${path.node})()`);
+          path.replaceWith(template.ast`(() => ${path.node})()` as t.Statement);
           // The injected nullish expression will be queued and eventually transformed when visited
           return;
         } else {

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import syntaxObjectRestSpread from "@babel/plugin-syntax-object-rest-spread";
 import { types as t } from "@babel/core";
 import type { PluginPass } from "@babel/core";
-import type { NodePath, Visitor, Scope } from "@babel/traverse";
+import type { NodePath, Scope } from "@babel/traverse";
 import { convertFunctionParams } from "@babel/plugin-transform-parameters";
 import { isRequired } from "@babel/helper-compilation-targets";
 import compatData from "@babel/compat-data/corejs2-built-ins";
@@ -20,7 +20,12 @@ if (!process.env.BABEL_8_BREAKING) {
   var ZERO_REFS = t.isReferenced(node, property, pattern) ? 1 : 0;
 }
 
-export default declare((api, opts) => {
+export interface Options {
+  useBuiltIns?: boolean;
+  loose?: boolean;
+}
+
+export default declare((api, opts: Options) => {
   api.assertVersion(7);
 
   const targets = api.targets();
@@ -675,6 +680,6 @@ export default declare((api, opts) => {
 
         path.replaceWith(exp);
       },
-    } as Visitor<PluginPass>,
+    },
   };
 });

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.ts
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.ts
@@ -11,8 +11,8 @@ export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const { loose = false } = options;
-  const noDocumentAll = api.assumption("noDocumentAll") ?? loose;
-  const pureGetters = api.assumption("pureGetters") ?? loose;
+  const noDocumentAll = (api.assumption("noDocumentAll") ?? loose) as boolean;
+  const pureGetters = (api.assumption("pureGetters") ?? loose) as boolean;
 
   return {
     name: "proposal-optional-chaining",

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.ts
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.ts
@@ -1,8 +1,13 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxOptionalChaining from "@babel/plugin-syntax-optional-chaining";
 import { transform } from "./transform";
+import type { NodePath } from "@babel/traverse";
+import type * as t from "@babel/types";
 
-export default declare((api, options) => {
+export interface Options {
+  loose?: boolean;
+}
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const { loose = false } = options;
@@ -14,7 +19,9 @@ export default declare((api, options) => {
     inherits: syntaxOptionalChaining.default,
 
     visitor: {
-      "OptionalCallExpression|OptionalMemberExpression"(path) {
+      "OptionalCallExpression|OptionalMemberExpression"(
+        path: NodePath<t.OptionalCallExpression | t.OptionalMemberExpression>,
+      ) {
         transform(path, { noDocumentAll, pureGetters });
       },
     },

--- a/packages/babel-plugin-proposal-partial-application/src/index.ts
+++ b/packages/babel-plugin-proposal-partial-application/src/index.ts
@@ -83,27 +83,23 @@ export default declare(api => {
         scope.push({ id: functionLVal });
 
         if (node.callee.type === "MemberExpression") {
-          const receiverLVal = path.scope.generateUidIdentifierBasedOnNode(
-            node.callee.object,
-          );
+          const { object: receiver, property } = node.callee;
+          const receiverLVal =
+            path.scope.generateUidIdentifierBasedOnNode(receiver);
           scope.push({ id: receiverLVal });
+
           sequenceParts.push(
-            t.assignmentExpression(
-              "=",
-              t.cloneNode(receiverLVal),
-              node.callee.object,
-            ),
+            t.assignmentExpression("=", t.cloneNode(receiverLVal), receiver),
             t.assignmentExpression(
               "=",
               t.cloneNode(functionLVal),
-              t.memberExpression(
-                t.cloneNode(receiverLVal),
-                node.callee.property,
-              ),
+              t.memberExpression(t.cloneNode(receiverLVal), property),
             ),
             ...argsInitializers,
             t.functionExpression(
-              t.cloneNode(node.callee.property),
+              t.isIdentifier(property)
+                ? t.cloneNode(property)
+                : path.scope.generateUidIdentifierBasedOnNode(property),
               placeholdersParams,
               t.blockStatement(
                 [

--- a/packages/babel-plugin-proposal-partial-application/src/index.ts
+++ b/packages/babel-plugin-proposal-partial-application/src/index.ts
@@ -125,10 +125,17 @@ export default declare(api => {
           );
         } else {
           sequenceParts.push(
-            t.assignmentExpression("=", t.cloneNode(functionLVal), node.callee),
+            t.assignmentExpression(
+              "=",
+              t.cloneNode(functionLVal),
+              // @ts-expect-error V8 intrinsics will not support partial application
+              node.callee,
+            ),
             ...argsInitializers,
             t.functionExpression(
-              t.cloneNode(node.callee),
+              t.isIdentifier(node.callee)
+                ? t.cloneNode(node.callee)
+                : path.scope.generateUidIdentifierBasedOnNode(node.callee),
               placeholdersParams,
               t.blockStatement(
                 [

--- a/packages/babel-plugin-proposal-partial-application/test/fixtures/general/curry/exec.js
+++ b/packages/babel-plugin-proposal-partial-application/test/fixtures/general/curry/exec.js
@@ -1,0 +1,5 @@
+const binary = x => (y, z) => x( y, z );
+
+const add1 = binary((y, z) => y + z)(1, ?);
+
+expect(add1(1)).toBe(2);

--- a/packages/babel-plugin-proposal-partial-application/test/fixtures/general/curry/input.js
+++ b/packages/babel-plugin-proposal-partial-application/test/fixtures/general/curry/input.js
@@ -1,0 +1,3 @@
+const binary = x => (y, z) => x( y, z );
+
+const add1 = binary((y, z) => y + z)(1, ?);

--- a/packages/babel-plugin-proposal-partial-application/test/fixtures/general/curry/output.js
+++ b/packages/babel-plugin-proposal-partial-application/test/fixtures/general/curry/output.js
@@ -1,0 +1,7 @@
+var _binary;
+
+const binary = x => (y, z) => x(y, z);
+
+const add1 = (_binary = binary((y, z) => y + z), function _binary2(_argPlaceholder) {
+  return _binary(1, _argPlaceholder);
+});

--- a/packages/babel-plugin-proposal-partial-application/test/fixtures/general/member-expression-private-name/exec.js
+++ b/packages/babel-plugin-proposal-partial-application/test/fixtures/general/member-expression-private-name/exec.js
@@ -1,0 +1,12 @@
+class obj {
+  static #add = (x, y) => x + y;
+  static test() {
+    const addOne = obj.#add(1, ?);
+
+    expect(addOne(5)).toEqual(6);
+    expect(addOne.length).toEqual(1);
+    expect(addOne.name).toEqual("_add");
+  }
+}
+
+obj.test();

--- a/packages/babel-plugin-proposal-partial-application/test/fixtures/general/member-expression-private-name/input.js
+++ b/packages/babel-plugin-proposal-partial-application/test/fixtures/general/member-expression-private-name/input.js
@@ -1,0 +1,8 @@
+class obj {
+  static #add = (x, y) => x + y;
+  static test() {
+    const addOne = obj.#add(1, ?);
+  }
+}
+
+obj.test();

--- a/packages/babel-plugin-proposal-partial-application/test/fixtures/general/member-expression-private-name/options.json
+++ b/packages/babel-plugin-proposal-partial-application/test/fixtures/general/member-expression-private-name/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["proposal-partial-application"],
+  "minNodeVersion": "12.11.0"
+}

--- a/packages/babel-plugin-proposal-partial-application/test/fixtures/general/member-expression-private-name/output.js
+++ b/packages/babel-plugin-proposal-partial-application/test/fixtures/general/member-expression-private-name/output.js
@@ -1,0 +1,14 @@
+class obj {
+  static #add = (x, y) => x + y;
+
+  static test() {
+    var _obj$add, _obj;
+
+    const addOne = (_obj = obj, _obj$add = _obj.#add, function _add(_argPlaceholder) {
+      return _obj$add.call(_obj, 1, _argPlaceholder);
+    });
+  }
+
+}
+
+obj.test();

--- a/packages/babel-plugin-proposal-pipeline-operator/src/hackVisitor.ts
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/hackVisitor.ts
@@ -1,10 +1,13 @@
 import { types as t } from "@babel/core";
 import type { NodePath, Visitor } from "@babel/traverse";
+import type { PluginPass } from "@babel/core";
 
-const topicReferenceVisitor: Visitor<{
+interface State {
   topicReferences: NodePath<t.TopicReference>[];
   sideEffectsBeforeFirstTopicReference: boolean;
-}> = {
+}
+
+const topicReferenceVisitor: Visitor<State> = {
   exit(path, state) {
     if (path.isTopicReference()) {
       state.topicReferences.push(path);
@@ -79,10 +82,15 @@ export default {
       // Replace the pipe expression itself with an assignment expression.
       path.replaceWith(
         t.sequenceExpression([
-          t.assignmentExpression("=", t.cloneNode(topicVariable), node.left),
+          t.assignmentExpression(
+            "=",
+            t.cloneNode(topicVariable),
+            // @ts-ignore node.left must not be a PrivateName when operator is |>
+            node.left,
+          ),
           node.right,
         ]),
       );
     },
   },
-};
+} as Visitor<PluginPass>;

--- a/packages/babel-plugin-proposal-pipeline-operator/src/hackVisitor.ts
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/hackVisitor.ts
@@ -2,10 +2,10 @@ import { types as t } from "@babel/core";
 import type { NodePath, Visitor } from "@babel/traverse";
 import type { PluginPass } from "@babel/core";
 
-interface State {
+type State = {
   topicReferences: NodePath<t.TopicReference>[];
   sideEffectsBeforeFirstTopicReference: boolean;
-}
+};
 
 const topicReferenceVisitor: Visitor<State> = {
   exit(path, state) {

--- a/packages/babel-plugin-proposal-pipeline-operator/src/index.ts
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/index.ts
@@ -4,6 +4,7 @@ import minimalVisitor from "./minimalVisitor";
 import hackVisitor from "./hackVisitor";
 import fsharpVisitor from "./fsharpVisitor";
 import smartVisitor from "./smartVisitor";
+import type { Options } from "@babel/plugin-syntax-pipeline-operator";
 
 const visitorsPerProposal = {
   minimal: minimalVisitor,
@@ -12,7 +13,7 @@ const visitorsPerProposal = {
   smart: smartVisitor,
 };
 
-export default declare((api, options) => {
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const { proposal } = options;

--- a/packages/babel-plugin-proposal-private-methods/src/index.ts
+++ b/packages/babel-plugin-proposal-private-methods/src/index.ts
@@ -6,7 +6,11 @@ import {
   FEATURES,
 } from "@babel/helper-create-class-features-plugin";
 
-export default declare((api, options) => {
+export interface Options {
+  loose?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   return createClassFeaturePlugin({

--- a/packages/babel-plugin-proposal-record-and-tuple/src/index.ts
+++ b/packages/babel-plugin-proposal-record-and-tuple/src/index.ts
@@ -30,9 +30,9 @@ export interface Options extends SyntaxOptions {
   importPolyfill?: boolean;
 }
 
-export interface State {
+type State = {
   programPath: NodePath<t.Program>;
-}
+};
 
 export default declare<State>((api, options: Options) => {
   api.assertVersion(7);

--- a/packages/babel-plugin-proposal-unicode-property-regex/src/index.ts
+++ b/packages/babel-plugin-proposal-unicode-property-regex/src/index.ts
@@ -2,7 +2,11 @@
 import { createRegExpFeaturePlugin } from "@babel/helper-create-regexp-features-plugin";
 import { declare } from "@babel/helper-plugin-utils";
 
-export default declare((api, options) => {
+export interface Options {
+  useUnicodeFlag?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const { useUnicodeFlag = true } = options;

--- a/packages/babel-plugin-syntax-decorators/src/index.ts
+++ b/packages/babel-plugin-syntax-decorators/src/index.ts
@@ -1,6 +1,12 @@
 import { declare } from "@babel/helper-plugin-utils";
 
-export default declare((api, options) => {
+export interface Options {
+  legacy?: boolean;
+  version?: "legacy" | "2018-09" | "2021-12";
+  decoratorsBeforeExport?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const {

--- a/packages/babel-plugin-syntax-destructuring-private/src/index.ts
+++ b/packages/babel-plugin-syntax-destructuring-private/src/index.ts
@@ -6,7 +6,7 @@ export default declare(api => {
   return {
     name: "syntax-destructuring-private",
 
-    manipulateOptions(_: any, parserOpts: { plugins: string[] }) {
+    manipulateOptions(_, parserOpts) {
       parserOpts.plugins.push("destructuringPrivate");
     },
   };

--- a/packages/babel-plugin-syntax-flow/src/index.ts
+++ b/packages/babel-plugin-syntax-flow/src/index.ts
@@ -1,6 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
+import type { FlowPluginOptions } from "@babel/parser";
 
-export default declare((api, options) => {
+export default declare((api, options: FlowPluginOptions) => {
   api.assertVersion(7);
 
   // When enabled and plugins includes flow, all files should be parsed as if

--- a/packages/babel-plugin-syntax-import-assertions/src/index.ts
+++ b/packages/babel-plugin-syntax-import-assertions/src/index.ts
@@ -7,7 +7,7 @@ export default declare(api => {
     name: "syntax-import-assertions",
 
     manipulateOptions(opts, parserOpts) {
-      parserOpts.plugins.push(["importAssertions"]);
+      parserOpts.plugins.push("importAssertions");
     },
   };
 });

--- a/packages/babel-plugin-syntax-pipeline-operator/src/index.ts
+++ b/packages/babel-plugin-syntax-pipeline-operator/src/index.ts
@@ -1,11 +1,16 @@
 import { declare } from "@babel/helper-plugin-utils";
 
-const PIPELINE_PROPOSALS = ["minimal", "fsharp", "hack", "smart"];
-const TOPIC_TOKENS = ["^^", "@@", "^", "%", "#"];
+const PIPELINE_PROPOSALS = ["minimal", "fsharp", "hack", "smart"] as const;
+const TOPIC_TOKENS = ["^^", "@@", "^", "%", "#"] as const;
 const documentationURL =
   "https://babeljs.io/docs/en/babel-plugin-proposal-pipeline-operator";
 
-export default declare((api, { proposal, topicToken }) => {
+export interface Options {
+  proposal: typeof PIPELINE_PROPOSALS[number];
+  topicToken?: typeof TOPIC_TOKENS[number];
+}
+
+export default declare((api, { proposal, topicToken }: Options) => {
   api.assertVersion(7);
 
   if (typeof proposal !== "string" || !PIPELINE_PROPOSALS.includes(proposal)) {

--- a/packages/babel-plugin-syntax-record-and-tuple/src/index.ts
+++ b/packages/babel-plugin-syntax-record-and-tuple/src/index.ts
@@ -1,6 +1,10 @@
 import { declare } from "@babel/helper-plugin-utils";
 
-export default declare((api, options) => {
+export interface Options {
+  syntaxType: "hash" | "bar";
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   return {

--- a/packages/babel-plugin-syntax-typescript/src/index.ts
+++ b/packages/babel-plugin-syntax-typescript/src/index.ts
@@ -15,7 +15,12 @@ function removePlugin(plugins, name) {
   }
 }
 
-export default declare((api, { isTSX, disallowAmbiguousJSXLike }) => {
+export interface Options {
+  disallowAmbiguousJSXLike?: boolean;
+  isTSX?: boolean;
+}
+
+export default declare((api, { isTSX, disallowAmbiguousJSXLike }: Options) => {
   api.assertVersion(7);
 
   return {

--- a/packages/babel-plugin-transform-arrow-functions/src/index.ts
+++ b/packages/babel-plugin-transform-arrow-functions/src/index.ts
@@ -7,7 +7,8 @@ export interface Options {
 export default declare((api, options: Options) => {
   api.assertVersion(7);
 
-  const noNewArrows = api.assumption("noNewArrows") ?? !options.spec;
+  const noNewArrows = (api.assumption("noNewArrows") ??
+    !options.spec) as boolean;
 
   return {
     name: "transform-arrow-functions",

--- a/packages/babel-plugin-transform-arrow-functions/src/index.ts
+++ b/packages/babel-plugin-transform-arrow-functions/src/index.ts
@@ -1,8 +1,10 @@
 import { declare } from "@babel/helper-plugin-utils";
-import type { NodePath } from "@babel/traverse";
-import type * as t from "@babel/types";
 
-export default declare((api, options) => {
+export interface Options {
+  spec?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const noNewArrows = api.assumption("noNewArrows") ?? !options.spec;
@@ -11,7 +13,7 @@ export default declare((api, options) => {
     name: "transform-arrow-functions",
 
     visitor: {
-      ArrowFunctionExpression(path: NodePath<t.ArrowFunctionExpression>) {
+      ArrowFunctionExpression(path) {
         // In some conversion cases, it may have already been converted to a function while this callback
         // was queued up.
         if (!path.isArrowFunctionExpression()) return;

--- a/packages/babel-plugin-transform-async-to-generator/src/index.ts
+++ b/packages/babel-plugin-transform-async-to-generator/src/index.ts
@@ -16,8 +16,9 @@ export default declare<State>((api, options: Options) => {
   api.assertVersion(7);
 
   const { method, module } = options;
-  const noNewArrows = api.assumption("noNewArrows");
-  const ignoreFunctionLength = api.assumption("ignoreFunctionLength");
+  const noNewArrows = (api.assumption("noNewArrows") ?? false) as boolean;
+  const ignoreFunctionLength = (api.assumption("ignoreFunctionLength") ??
+    false) as boolean;
 
   if (method && module) {
     return {

--- a/packages/babel-plugin-transform-async-to-generator/src/index.ts
+++ b/packages/babel-plugin-transform-async-to-generator/src/index.ts
@@ -16,7 +16,8 @@ export default declare<State>((api, options: Options) => {
   api.assertVersion(7);
 
   const { method, module } = options;
-  const noNewArrows = (api.assumption("noNewArrows") ?? false) as boolean;
+  // Todo(BABEL 8): Consider default it to false
+  const noNewArrows = (api.assumption("noNewArrows") ?? true) as boolean;
   const ignoreFunctionLength = (api.assumption("ignoreFunctionLength") ??
     false) as boolean;
 

--- a/packages/babel-plugin-transform-async-to-generator/src/index.ts
+++ b/packages/babel-plugin-transform-async-to-generator/src/index.ts
@@ -8,9 +8,9 @@ export interface Options {
   module?: string;
 }
 
-export interface State {
+type State = {
   methodWrapper?: t.Identifier | t.SequenceExpression;
-}
+};
 
 export default declare<State>((api, options: Options) => {
   api.assertVersion(7);

--- a/packages/babel-plugin-transform-async-to-generator/src/index.ts
+++ b/packages/babel-plugin-transform-async-to-generator/src/index.ts
@@ -3,7 +3,16 @@ import remapAsyncToGenerator from "@babel/helper-remap-async-to-generator";
 import { addNamed } from "@babel/helper-module-imports";
 import { types as t } from "@babel/core";
 
-export default declare((api, options) => {
+export interface Options {
+  method?: string;
+  module?: string;
+}
+
+export interface State {
+  methodWrapper?: t.Identifier | t.SequenceExpression;
+}
+
+export default declare<State>((api, options: Options) => {
   api.assertVersion(7);
 
   const { method, module } = options;

--- a/packages/babel-plugin-transform-block-scoping/src/index.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/index.ts
@@ -7,7 +7,12 @@ import type { File } from "@babel/core";
 
 const DONE = new WeakSet();
 
-export default declare((api, opts) => {
+export interface Options {
+  tdz?: boolean;
+  throwIfClosureRequired?: boolean;
+}
+
+export default declare((api, opts: Options) => {
   api.assertVersion(7);
 
   const { throwIfClosureRequired = false, tdz: tdzEnabled = false } = opts;

--- a/packages/babel-plugin-transform-classes/src/index.ts
+++ b/packages/babel-plugin-transform-classes/src/index.ts
@@ -15,7 +15,11 @@ const builtinClasses = new Set([
   ...getBuiltinClasses("browser"),
 ]);
 
-export default declare((api, options) => {
+export interface Options {
+  loose?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const { loose } = options;

--- a/packages/babel-plugin-transform-classes/src/index.ts
+++ b/packages/babel-plugin-transform-classes/src/index.ts
@@ -22,13 +22,15 @@ export interface Options {
 export default declare((api, options: Options) => {
   api.assertVersion(7);
 
-  const { loose } = options;
+  const { loose = false } = options;
 
-  const setClassMethods = api.assumption("setClassMethods") ?? options.loose;
-  const constantSuper = api.assumption("constantSuper") ?? options.loose;
-  const superIsCallableConstructor =
-    api.assumption("superIsCallableConstructor") ?? options.loose;
-  const noClassCalls = api.assumption("noClassCalls") ?? options.loose;
+  const setClassMethods = (api.assumption("setClassMethods") ??
+    loose) as boolean;
+  const constantSuper = (api.assumption("constantSuper") ?? loose) as boolean;
+  const superIsCallableConstructor = (api.assumption(
+    "superIsCallableConstructor",
+  ) ?? loose) as boolean;
+  const noClassCalls = (api.assumption("noClassCalls") ?? loose) as boolean;
 
   // todo: investigate traversal requeueing
   const VISITED = Symbol();

--- a/packages/babel-plugin-transform-computed-properties/src/index.ts
+++ b/packages/babel-plugin-transform-computed-properties/src/index.ts
@@ -1,7 +1,11 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { template, types as t } from "@babel/core";
 
-export default declare((api, options) => {
+export interface Options {
+  loose?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const setComputedProperties =
@@ -124,6 +128,7 @@ export default declare((api, options) => {
           const { node, parent, scope } = path;
           let hasComputed = false;
           for (const prop of node.properties) {
+            // @ts-ignore SpreadElement must not have computed property
             hasComputed = prop.computed === true;
             if (hasComputed) break;
           }
@@ -137,6 +142,7 @@ export default declare((api, options) => {
           let foundComputed = false;
 
           for (const prop of node.properties) {
+            // @ts-ignore SpreadElement must not have computed property
             if (prop.computed) {
               foundComputed = true;
             }

--- a/packages/babel-plugin-transform-destructuring/src/index.ts
+++ b/packages/babel-plugin-transform-destructuring/src/index.ts
@@ -30,11 +30,15 @@ export default declare((api, options: Options) => {
 
   const { useBuiltIns = false } = options;
 
-  const iterableIsArray = api.assumption("iterableIsArray") ?? options.loose;
-  const arrayLikeIsIterable =
-    options.allowArrayLike ?? api.assumption("arrayLikeIsIterable");
-  const objectRestNoSymbols =
-    api.assumption("objectRestNoSymbols") ?? options.loose;
+  const iterableIsArray = (api.assumption("iterableIsArray") ??
+    options.loose ??
+    false) as boolean;
+  const arrayLikeIsIterable = (options.allowArrayLike ??
+    api.assumption("arrayLikeIsIterable") ??
+    false) as boolean;
+  const objectRestNoSymbols = (api.assumption("objectRestNoSymbols") ??
+    options.loose ??
+    false) as boolean;
 
   return {
     name: "transform-destructuring",

--- a/packages/babel-plugin-transform-destructuring/src/index.ts
+++ b/packages/babel-plugin-transform-destructuring/src/index.ts
@@ -5,8 +5,6 @@ import {
   convertVariableDeclaration,
   convertAssignmentExpression,
 } from "./util";
-import type { PluginPass } from "@babel/core";
-import type { Visitor } from "@babel/traverse";
 
 /**
  * Test if a VariableDeclaration's declarations contains any Patterns.
@@ -21,7 +19,13 @@ function variableDeclarationHasPattern(node: t.VariableDeclaration) {
   return false;
 }
 
-export default declare((api, options) => {
+export interface Options {
+  allowArrayLike?: boolean;
+  loose?: boolean;
+  useBuiltIns?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const { useBuiltIns = false } = options;
@@ -167,6 +171,6 @@ export default declare((api, options) => {
           useBuiltIns,
         );
       },
-    } as Visitor<PluginPass>,
+    },
   };
 });

--- a/packages/babel-plugin-transform-duplicate-keys/src/index.ts
+++ b/packages/babel-plugin-transform-duplicate-keys/src/index.ts
@@ -19,7 +19,7 @@ export default declare(api => {
         const { node } = path;
         const plainProps = node.properties.filter(
           prop => !t.isSpreadElement(prop) && !prop.computed,
-        );
+        ) as (t.ObjectMethod | t.ObjectProperty)[];
 
         // A property is a duplicate key if:
         // * the property is a data property, and is preceded by a data,
@@ -36,6 +36,7 @@ export default declare(api => {
         for (const prop of plainProps) {
           const name = getName(prop.key);
           let isDuplicate = false;
+          // @ts-ignore prop.kind is not defined in ObjectProperty
           switch (prop.kind) {
             case "get":
               if (alreadySeenData[name] || alreadySeenGetters[name]) {

--- a/packages/babel-plugin-transform-flow-strip-types/src/index.ts
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.ts
@@ -145,7 +145,9 @@ export default declare((api, opts) => {
           }
         }
 
-        node.predicate = null;
+        if (!t.isMethod(node)) {
+          node.predicate = null;
+        }
       },
 
       TypeCastExpression(path) {

--- a/packages/babel-plugin-transform-for-of/src/index.ts
+++ b/packages/babel-plugin-transform-for-of/src/index.ts
@@ -3,7 +3,13 @@ import { template, types as t } from "@babel/core";
 
 import transformWithoutHelper from "./no-helper-implementation";
 
-export default declare((api, options) => {
+export interface Options {
+  allowArrayLike?: boolean;
+  assumeArray?: boolean;
+  loose?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   {
@@ -59,13 +65,14 @@ export default declare((api, options) => {
             return;
           }
           const i = scope.generateUidIdentifier("i");
-          let array = scope.maybeGenerateMemoised(right, true);
+          let array: t.Identifier | t.ThisExpression =
+            scope.maybeGenerateMemoised(right, true);
 
           const inits = [t.variableDeclarator(i, t.numericLiteral(0))];
           if (array) {
             inits.push(t.variableDeclarator(array, right));
           } else {
-            array = right;
+            array = right as t.Identifier | t.ThisExpression;
           }
 
           const item = t.memberExpression(
@@ -230,7 +237,7 @@ export default declare((api, options) => {
         // ensure that it's a block so we can take all its statements
         path.ensureBlock();
 
-        node.body.body.unshift(declar);
+        (node.body as t.BlockStatement).body.unshift(declar);
 
         const nodes = builder.build({
           CREATE_ITERATOR_HELPER: state.addHelper(builder.helper),

--- a/packages/babel-plugin-transform-instanceof/src/index.ts
+++ b/packages/babel-plugin-transform-instanceof/src/index.ts
@@ -24,7 +24,13 @@ export default declare(api => {
           if (isUnderHelper) {
             return;
           } else {
-            path.replaceWith(t.callExpression(helper, [node.left, node.right]));
+            path.replaceWith(
+              t.callExpression(helper, [
+                // @ts-ignore node.left can be PrivateName only when node.operator is "in"
+                node.left,
+                node.right,
+              ]),
+            );
           }
         }
       },

--- a/packages/babel-plugin-transform-jscript/src/index.ts
+++ b/packages/babel-plugin-transform-jscript/src/index.ts
@@ -19,6 +19,7 @@ export default declare(api => {
                 null,
                 [],
                 t.blockStatement([
+                  // @ts-ignore fixme: t.toStatement may return false
                   t.toStatement(node),
                   t.returnStatement(t.cloneNode(node.id)),
                 ]),

--- a/packages/babel-plugin-transform-literals/src/index.ts
+++ b/packages/babel-plugin-transform-literals/src/index.ts
@@ -9,6 +9,7 @@ export default declare(api => {
     visitor: {
       NumericLiteral({ node }) {
         // number octal like 0b10 or 0o70
+        // @ts-ignore Add node.extra typings
         if (node.extra && /^0[ob]/i.test(node.extra.raw)) {
           node.extra = undefined;
         }
@@ -16,6 +17,7 @@ export default declare(api => {
 
       StringLiteral({ node }) {
         // unicode escape
+        // @ts-ignore Add node.extra typings
         if (node.extra && /\\[u]/gi.test(node.extra.raw)) {
           node.extra = undefined;
         }

--- a/packages/babel-plugin-transform-modules-amd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-amd/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from "@babel/helper-module-transforms";
 import { template, types as t } from "@babel/core";
 import { getImportSource } from "babel-plugin-dynamic-import-node/utils";
+import type { PluginOptions } from "@babel/helper-module-transforms";
 
 const buildWrapper = template(`
   define(MODULE_NAME, AMD_ARGUMENTS, function(IMPORT_NAMES) {
@@ -35,7 +36,22 @@ function injectWrapper(path, wrapper) {
   amdFactory.pushContainer("body", body);
 }
 
-export default declare((api, options) => {
+export interface Options extends PluginOptions {
+  allowTopLevelThis?: boolean;
+  importInterop?: "babel" | "node";
+  loose?: boolean;
+  noInterop?: boolean;
+  strict?: boolean;
+  strictMode?: boolean;
+}
+
+export interface State {
+  requireId?: t.Identifier;
+  resolveId?: t.Identifier;
+  rejectId?: t.Identifier;
+}
+
+export default declare<State>((api, options: Options) => {
   api.assertVersion(7);
 
   const { allowTopLevelThis, strict, strictMode, importInterop, noInterop } =

--- a/packages/babel-plugin-transform-modules-amd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-amd/src/index.ts
@@ -45,11 +45,11 @@ export interface Options extends PluginOptions {
   strictMode?: boolean;
 }
 
-export interface State {
+type State = {
   requireId?: t.Identifier;
   resolveId?: t.Identifier;
   rejectId?: t.Identifier;
-}
+};
 
 export default declare<State>((api, options: Options) => {
   api.assertVersion(7);

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.ts
@@ -49,14 +49,14 @@ export default declare((api, options: Options) => {
     lazy = false,
     // Defaulting to 'true' for now. May change before 7.x major.
     allowCommonJSExports = true,
+    loose = false,
   } = options;
 
-  const constantReexports =
-    api.assumption("constantReexports") ?? options.loose;
-  const enumerableModuleMeta =
-    api.assumption("enumerableModuleMeta") ?? options.loose;
-  const noIncompleteNsImportDetection =
-    api.assumption("noIncompleteNsImportDetection") ?? false;
+  const constantReexports = api.assumption("constantReexports") ?? loose;
+  const enumerableModuleMeta = api.assumption("enumerableModuleMeta") ?? loose;
+  const noIncompleteNsImportDetection = (api.assumption(
+    "noIncompleteNsImportDetection",
+  ) ?? false) as boolean;
 
   if (
     typeof lazy !== "boolean" &&

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.ts
@@ -10,10 +10,24 @@ import {
 } from "@babel/helper-module-transforms";
 import simplifyAccess from "@babel/helper-simple-access";
 import { template, types as t } from "@babel/core";
+import type { PluginOptions } from "@babel/helper-module-transforms";
 
 import { createDynamicImportTransform } from "babel-plugin-dynamic-import-node/utils";
 
-export default declare((api, options) => {
+export interface Options extends PluginOptions {
+  allowCommonJSExports?: boolean;
+  allowTopLevelThis?: boolean;
+  importInterop?: "babel" | "node";
+  lazy?: boolean | string[] | ((string) => boolean);
+  loose?: boolean;
+  mjsStrictNamespace?: boolean;
+  noInterop?: boolean;
+  strict?: boolean;
+  strictMode?: boolean;
+  strictNamespace?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const transformImportCall = createDynamicImportTransform(api);

--- a/packages/babel-plugin-transform-modules-systemjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.ts
@@ -3,6 +3,7 @@ import hoistVariables from "@babel/helper-hoist-variables";
 import { template, types as t } from "@babel/core";
 import { getImportSource } from "babel-plugin-dynamic-import-node/utils";
 import { rewriteThis, getModuleName } from "@babel/helper-module-transforms";
+import type { PluginOptions } from "@babel/helper-module-transforms";
 import { isIdentifierName } from "@babel/helper-validator-identifier";
 import type { NodePath } from "@babel/traverse";
 
@@ -154,7 +155,12 @@ function constructExportCall(
   return statements;
 }
 
-export default declare((api, options) => {
+export interface Options extends PluginOptions {
+  allowTopLevelThis?: boolean;
+  systemGlobal?: string;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const { systemGlobal = "System", allowTopLevelThis = false } = options;

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
@@ -21,7 +21,8 @@
   },
   "bugs": "https://github.com/babel/babel/issues",
   "dependencies": {
-    "@babel/helper-create-regexp-features-plugin": "workspace:^"
+    "@babel/helper-create-regexp-features-plugin": "workspace:^",
+    "@babel/helper-plugin-utils": "workspace:^"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0"

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/src/index.ts
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/src/index.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @babel/development/plugin-name */
 import { createRegExpFeaturePlugin } from "@babel/helper-create-regexp-features-plugin";
+import { declare } from "@babel/helper-plugin-utils";
 
-export default function (core, options) {
+export interface Options {
+  runtime?: boolean;
+}
+
+export default declare((api, options: Options) => {
   const { runtime = true } = options;
   if (typeof runtime !== "boolean") {
     throw new Error("The 'runtime' option must be boolean");
@@ -12,4 +17,4 @@ export default function (core, options) {
     feature: "namedCaptureGroups",
     options: { runtime },
   });
-}
+});

--- a/packages/babel-plugin-transform-parameters/src/index.ts
+++ b/packages/babel-plugin-transform-parameters/src/index.ts
@@ -12,7 +12,8 @@ export default declare((api, options: Options) => {
 
   const ignoreFunctionLength =
     api.assumption("ignoreFunctionLength") ?? options.loose;
-  const noNewArrows = api.assumption("noNewArrows");
+  // Todo(BABEL 8): Consider default it to false
+  const noNewArrows = (api.assumption("noNewArrows") ?? true) as boolean;
 
   return {
     name: "transform-parameters",

--- a/packages/babel-plugin-transform-parameters/src/index.ts
+++ b/packages/babel-plugin-transform-parameters/src/index.ts
@@ -3,7 +3,11 @@ import convertFunctionParams from "./params";
 import convertFunctionRest from "./rest";
 export { convertFunctionParams };
 
-export default declare((api, options) => {
+export interface Options {
+  loose?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const ignoreFunctionLength =

--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
@@ -39,8 +39,19 @@ const get = (pass: PluginPass, name: string) =>
 const set = (pass: PluginPass, name: string, v: any) =>
   pass.set(`@babel/plugin-react-jsx/${name}`, v);
 
+export interface Options {
+  filter?: (node: t.Node, pass: PluginPass) => boolean;
+  importSource?: string;
+  pragma?: string;
+  pragmaFrag?: string;
+  pure?: string;
+  runtime?: "automatic" | "classic";
+  throwIfNamespace?: boolean;
+  useBuiltIns: boolean;
+  useSpread?: boolean;
+}
 export default function createPlugin({ name, development }) {
-  return declare((api, options) => {
+  return declare((api, options: Options) => {
     const {
       pure: PURE_ANNOTATION,
 

--- a/packages/babel-plugin-transform-react-jsx/src/index.ts
+++ b/packages/babel-plugin-transform-react-jsx/src/index.ts
@@ -6,3 +6,5 @@ export default createPlugin({
   name: "transform-react-jsx",
   development: false,
 });
+
+export type { Options } from "./create-plugin";

--- a/packages/babel-plugin-transform-reserved-words/src/index.ts
+++ b/packages/babel-plugin-transform-reserved-words/src/index.ts
@@ -1,5 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/traverse";
 
 export default declare(api => {
   api.assertVersion(7);
@@ -8,7 +9,7 @@ export default declare(api => {
     name: "transform-reserved-words",
 
     visitor: {
-      "BindingIdentifier|ReferencedIdentifier"(path) {
+      "BindingIdentifier|ReferencedIdentifier"(path: NodePath<t.Identifier>) {
         if (!t.isValidES3Identifier(path.node.name)) {
           path.scope.rename(path.node.name);
         }

--- a/packages/babel-plugin-transform-runtime/src/index.ts
+++ b/packages/babel-plugin-transform-runtime/src/index.ts
@@ -18,7 +18,16 @@ function supportsStaticESM(caller) {
   return !!caller?.supportsStaticESM;
 }
 
-export default declare((api, options, dirname) => {
+export interface Options {
+  absoluteRuntime?: boolean;
+  corejs?: string | number | { version: string | number; proposals?: boolean };
+  helpers?: boolean;
+  regenerator?: boolean;
+  useESModules?: boolean | "auto";
+  version?: string;
+}
+
+export default declare((api, options: Options, dirname) => {
   api.assertVersion(7);
 
   const {
@@ -99,7 +108,7 @@ export default declare((api, options, dirname) => {
   }
 
   if (has(options, "useBuiltIns")) {
-    if (options.useBuiltIns) {
+    if (options["useBuiltIns"]) {
       throw new Error(
         "The 'useBuiltIns' option has been removed. The @babel/runtime " +
           "module now uses builtins by default.",
@@ -113,7 +122,7 @@ export default declare((api, options, dirname) => {
   }
 
   if (has(options, "polyfill")) {
-    if (options.polyfill === false) {
+    if (options["polyfill"] === false) {
       throw new Error(
         "The 'polyfill' option has been removed. The @babel/runtime " +
           "module now skips polyfilling by default.",

--- a/packages/babel-plugin-transform-template-literals/src/index.ts
+++ b/packages/babel-plugin-transform-template-literals/src/index.ts
@@ -1,7 +1,11 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { template, types as t } from "@babel/core";
 
-export default declare((api, options) => {
+export interface Options {
+  loose?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(7);
 
   const ignoreToPrimitiveHint =
@@ -93,6 +97,7 @@ export default declare((api, options) => {
                 ${tmp} = ${this.addHelper(helperName)}(${helperArgs})
               )
             `,
+            //@ts-ignore Fixme: quasi.expressions may contain TSAnyKeyword
             ...quasi.expressions,
           ]),
         );

--- a/packages/babel-plugin-transform-typeof-symbol/src/index.ts
+++ b/packages/babel-plugin-transform-typeof-symbol/src/index.ts
@@ -22,13 +22,15 @@ export default declare(api => {
 
         if (
           path.parentPath.isBinaryExpression() &&
-          t.EQUALITY_BINARY_OPERATORS.indexOf(parent.operator) >= 0
+          t.EQUALITY_BINARY_OPERATORS.indexOf(
+            (parent as t.BinaryExpression).operator,
+          ) >= 0
         ) {
           // optimise `typeof foo === "string"` since we can determine that they'll never
           // need to handle symbols
           const opposite = path.getOpposite();
           if (
-            opposite.isLiteral() &&
+            opposite.isStringLiteral() &&
             opposite.node.value !== "symbol" &&
             opposite.node.value !== "object"
           ) {
@@ -39,6 +41,7 @@ export default declare(api => {
         let isUnderHelper = path.findParent(path => {
           if (path.isFunction()) {
             return (
+              // @ts-ignore the access is coupled with the shape of typeof helper
               path.get("body.directives.0")?.node.value.value ===
               "@babel/helpers - typeof"
             );

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -1,9 +1,9 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxTypeScript from "@babel/plugin-syntax-typescript";
 import { types as t, template } from "@babel/core";
-import type { PluginPass } from "@babel/core";
 import { injectInitialization } from "@babel/helper-create-class-features-plugin";
-import type { NodePath, Visitor } from "@babel/traverse";
+import type { NodePath } from "@babel/traverse";
+import type { Options as SyntaxOptions } from "@babel/plugin-syntax-typescript";
 
 import transpileConstEnum from "./const-enum";
 import type { NodePathConstEnum } from "./const-enum";
@@ -55,7 +55,7 @@ function isGlobalType(path: NodePath, name: string) {
 function registerGlobalType(programNode: t.Program, name: string) {
   GLOBAL_TYPES.get(programNode).add(name);
 }
-export interface Options {
+export interface Options extends SyntaxOptions {
   /** @default true */
   allowNamespaces?: boolean;
   /** @default "React.createElement" */
@@ -66,12 +66,6 @@ export interface Options {
   optimizeConstEnums?: boolean;
   allowDeclareFields?: boolean;
 }
-type ConfigAPI = { assertVersion: (range: string | number) => void };
-interface Plugin {
-  name: string;
-  visitor: Visitor<PluginPass>;
-  inherits: typeof syntaxTypeScript;
-}
 type ExtraNodeProps = {
   declare?: unknown;
   accessibility?: unknown;
@@ -79,7 +73,7 @@ type ExtraNodeProps = {
   optional?: unknown;
   override?: unknown;
 };
-export default declare((api: ConfigAPI, opts: Options): Plugin => {
+export default declare((api, opts: Options) => {
   api.assertVersion(7);
 
   const JSX_PRAGMA_REGEX = /\*?\s*@jsx((?:Frag)?)\s+([^\s]+)/;

--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -29,11 +29,11 @@ import getTargets, {
 } from "@babel/helper-compilation-targets";
 import type { Targets, InputTargets } from "@babel/helper-compilation-targets";
 import availablePlugins from "./available-plugins";
-import { declare } from "@babel/helper-plugin-utils";
+import { declarePreset } from "@babel/helper-plugin-utils";
 
 type ModuleTransformationsType =
   typeof import("./module-transformations").default;
-import type { BuiltInsOption, ModuleOption } from "./types";
+import type { BuiltInsOption, ModuleOption, Options } from "./types";
 
 // TODO: Remove in Babel 8
 export function isPluginRequired(targets: Targets, support: Targets) {
@@ -271,7 +271,7 @@ function supportsTopLevelAwait(caller) {
   return !!caller?.supportsTopLevelAwait;
 }
 
-export default declare((api, opts) => {
+export default declarePreset((api, opts: Options) => {
   api.assertVersion(7);
 
   const babelTargets = api.targets();
@@ -360,7 +360,8 @@ option \`forceAllTransforms: true\` instead.
     shouldTransformDynamicImport:
       modules !== "auto" || !api.caller?.(supportsDynamicImport),
     shouldTransformExportNamespaceFrom: !shouldSkipExportNamespaceFrom,
-    shouldParseTopLevelAwait: !api.caller || api.caller(supportsTopLevelAwait),
+    shouldParseTopLevelAwait:
+      !api.caller || (api.caller(supportsTopLevelAwait) as boolean),
   });
 
   const pluginNames = filterItems(

--- a/packages/babel-preset-flow/src/index.ts
+++ b/packages/babel-preset-flow/src/index.ts
@@ -1,8 +1,8 @@
-import { declare } from "@babel/helper-plugin-utils";
+import { declarePreset } from "@babel/helper-plugin-utils";
 import transformFlowStripTypes from "@babel/plugin-transform-flow-strip-types";
 import normalizeOptions from "./normalize-options";
 
-export default declare((api, opts) => {
+export default declarePreset((api, opts) => {
   api.assertVersion(7);
   const { all, allowDeclareFields } = normalizeOptions(opts);
 

--- a/packages/babel-preset-react/src/index.ts
+++ b/packages/babel-preset-react/src/index.ts
@@ -1,11 +1,23 @@
-import { declare } from "@babel/helper-plugin-utils";
+import { declarePreset } from "@babel/helper-plugin-utils";
 import transformReactJSX from "@babel/plugin-transform-react-jsx";
 import transformReactJSXDevelopment from "@babel/plugin-transform-react-jsx-development";
 import transformReactDisplayName from "@babel/plugin-transform-react-display-name";
 import transformReactPure from "@babel/plugin-transform-react-pure-annotations";
 import normalizeOptions from "./normalize-options";
 
-export default declare((api, opts) => {
+export interface Options {
+  development?: boolean;
+  importSource?: string;
+  pragma?: string;
+  pragmaFrag?: string;
+  pure?: string;
+  runtime?: "automatic" | "classic";
+  throwIfNamespace?: boolean;
+  useBuiltIns?: boolean;
+  useSpread?: boolean;
+}
+
+export default declarePreset((api, opts: Options) => {
   api.assertVersion(7);
 
   const {

--- a/packages/babel-preset-typescript/src/index.ts
+++ b/packages/babel-preset-typescript/src/index.ts
@@ -1,8 +1,9 @@
-import { declare } from "@babel/helper-plugin-utils";
+import { declarePreset } from "@babel/helper-plugin-utils";
 import transformTypeScript from "@babel/plugin-transform-typescript";
 import normalizeOptions from "./normalize-options";
+import type { Options } from "./normalize-options";
 
-export default declare((api, opts) => {
+export default declarePreset((api, opts: Options) => {
   api.assertVersion(7);
 
   const {

--- a/packages/babel-preset-typescript/src/normalize-options.ts
+++ b/packages/babel-preset-typescript/src/normalize-options.ts
@@ -1,7 +1,19 @@
 import { OptionValidator } from "@babel/helper-validator-option";
 const v = new OptionValidator("@babel/preset-typescript");
 
-export default function normalizeOptions(options = {} as any) {
+export interface Options {
+  allExtensions?: boolean;
+  allowDeclareFields?: boolean;
+  allowNamespaces?: boolean;
+  disallowAmbiguousJSXLike?: boolean;
+  isTSX?: boolean;
+  jsxPragma?: string;
+  jsxPragmaFrag?: string;
+  onlyRemoveTypeImports?: boolean;
+  optimizeConstEnums?: boolean;
+}
+
+export default function normalizeOptions(options: Options = {}) {
   let { allowNamespaces = true, jsxPragma, onlyRemoveTypeImports } = options;
 
   const TopLevelOptions = {

--- a/packages/babel-traverse/src/path/conversion.ts
+++ b/packages/babel-traverse/src/path/conversion.ts
@@ -143,6 +143,10 @@ export function arrowFunctionToExpression(
     specCompliant = false,
     // TODO(Babel 8): Consider defaulting to `false` for spec compliancy
     noNewArrows = !specCompliant,
+  }: {
+    allowInsertArrow?: boolean | void;
+    specCompliant?: boolean | void;
+    noNewArrows?: boolean | void;
   } = {},
 ) {
   if (!this.isArrowFunctionExpression()) {
@@ -217,8 +221,8 @@ const getSuperCallsVisitor = mergeVisitors<{
 function hoistFunctionEnvironment(
   fnPath: NodePath<t.Function>,
   // TODO(Babel 8): Consider defaulting to `false` for spec compliancy
-  noNewArrows = true,
-  allowInsertArrow = true,
+  noNewArrows: boolean | void = true,
+  allowInsertArrow: boolean | void = true,
 ): { thisBinding: string; fnPath: NodePath<t.Function> } {
   let arrowParent;
   let thisEnvFn = fnPath.findParent(p => {

--- a/packages/babel-traverse/src/path/conversion.ts
+++ b/packages/babel-traverse/src/path/conversion.ts
@@ -146,7 +146,7 @@ export function arrowFunctionToExpression(
   }: {
     allowInsertArrow?: boolean | void;
     specCompliant?: boolean | void;
-    noNewArrows?: boolean | void;
+    noNewArrows?: boolean;
   } = {},
 ) {
   if (!this.isArrowFunctionExpression()) {

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -640,7 +640,11 @@ export default class Scope {
   }
 
   // TODO: (Babel 8) Split i in two parameters, and use an object of flags
-  toArray(node: t.Node, i?: number | boolean, arrayLikeIsIterable?: boolean) {
+  toArray(
+    node: t.Node,
+    i?: number | boolean,
+    arrayLikeIsIterable?: boolean | void,
+  ) {
     if (isIdentifier(node)) {
       const binding = this.getBinding(node.name);
       if (binding?.constant && binding.path.isGenericType("Array")) {

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -444,6 +444,7 @@ export interface FunctionDeclaration extends BaseNode {
   generator?: boolean;
   async?: boolean;
   declare?: boolean | null;
+  predicate?: DeclaredPredicate | InferredPredicate | null;
   returnType?: TypeAnnotation | TSTypeAnnotation | Noop | null;
   typeParameters?:
     | TypeParameterDeclaration
@@ -459,6 +460,7 @@ export interface FunctionExpression extends BaseNode {
   body: BlockStatement;
   generator?: boolean;
   async?: boolean;
+  predicate?: DeclaredPredicate | InferredPredicate | null;
   returnType?: TypeAnnotation | TSTypeAnnotation | Noop | null;
   typeParameters?:
     | TypeParameterDeclaration
@@ -722,6 +724,7 @@ export interface ArrowFunctionExpression extends BaseNode {
   async?: boolean;
   expression: boolean;
   generator?: boolean;
+  predicate?: DeclaredPredicate | InferredPredicate | null;
   returnType?: TypeAnnotation | TSTypeAnnotation | Noop | null;
   typeParameters?:
     | TypeParameterDeclaration

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -334,7 +334,8 @@ export interface BinaryExpression extends BaseNode {
     | ">"
     | "<"
     | ">="
-    | "<=";
+    | "<="
+    | "|>";
   left: Expression | PrivateName;
   right: Expression;
 }

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -42,7 +42,8 @@ export function binaryExpression(
     | ">"
     | "<"
     | ">="
-    | "<=",
+    | "<="
+    | "|>",
   left: t.Expression | t.PrivateName,
   right: t.Expression,
 ): t.BinaryExpression {

--- a/packages/babel-types/src/constants/index.ts
+++ b/packages/babel-types/src/constants/index.ts
@@ -38,6 +38,7 @@ export const BINARY_OPERATORS = [
   "+",
   ...NUMBER_BINARY_OPERATORS,
   ...BOOLEAN_BINARY_OPERATORS,
+  "|>",
 ];
 
 export const ASSIGNMENT_OPERATORS = [

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -407,6 +407,10 @@ defineType("FunctionDeclaration", {
     body: {
       validate: assertNodeType("BlockStatement"),
     },
+    predicate: {
+      validate: assertNodeType("DeclaredPredicate", "InferredPredicate"),
+      optional: true,
+    },
   },
   aliases: [
     "Scopable",
@@ -449,6 +453,10 @@ defineType("FunctionExpression", {
     },
     body: {
       validate: assertNodeType("BlockStatement"),
+    },
+    predicate: {
+      validate: assertNodeType("DeclaredPredicate", "InferredPredicate"),
+      optional: true,
     },
   },
 });
@@ -1246,6 +1254,10 @@ defineType("ArrowFunctionExpression", {
     },
     body: {
       validate: assertNodeType("BlockStatement", "Expression"),
+    },
+    predicate: {
+      validate: assertNodeType("DeclaredPredicate", "InferredPredicate"),
+      optional: true,
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5956,7 +5956,7 @@ __metadata:
     semver: ^6.3.0
     test262-stream: ^1.4.0
     through2: ^4.0.0
-    typescript: ~4.5.0
+    typescript: ~4.6.3
   dependenciesMeta:
     core-js:
       built: false
@@ -15133,23 +15133,23 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.5.0":
-  version: 4.5.5
-  resolution: "typescript@npm:4.5.5"
+"typescript@npm:~4.6.3":
+  version: 4.6.3
+  resolution: "typescript@npm:4.6.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
+  checksum: 255bb26c8cb846ca689dd1c3a56587af4f69055907aa2c154796ea28ee0dea871535b1c78f85a6212c77f2657843a269c3a742d09d81495b97b914bf7920415b
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.5.0#~builtin<compat/typescript>":
-  version: 4.5.5
-  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=493e53"
+"typescript@patch:typescript@~4.6.3#~builtin<compat/typescript>":
+  version: 4.6.3
+  resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: c05c318d79c690f101d7ffb34cd6c7d6bbd884d3af9cefe7749ad0cd6be43c7082f098280982ca945dcba23fde34a08fed9602bb26540936baf8c0520727d3ba
+  checksum: fe6bdc1afb2f145ddb7b0a3a31f96352209f6a5704d97f038414ea22ff9d8dd42f32cfb6652e30458d7d958d2d4e85de2df11c574899c6f750a6b3c0e90a3a76
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2702,6 +2702,7 @@ __metadata:
     "@babel/core": "workspace:^"
     "@babel/helper-create-regexp-features-plugin": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
+    "@babel/helper-plugin-utils": "workspace:^"
     core-js: ^3.22.1
   peerDependencies:
     "@babel/core": ^7.0.0
@@ -15133,22 +15134,22 @@ fsevents@^1.2.7:
   linkType: hard
 
 "typescript@npm:~4.5.0":
-  version: 4.5.2
-  resolution: "typescript@npm:4.5.2"
+  version: 4.5.5
+  resolution: "typescript@npm:4.5.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 74f9ce65d532bdf5d0214b3f60cf37992180023388c87a11ee6f838a803067ef0b63c600fa501b0deb07f989257dce1e244c9635ed79feca40bbccf6e0aa1ebc
+  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@~4.5.0#~builtin<compat/typescript>":
-  version: 4.5.2
-  resolution: "typescript@patch:typescript@npm%3A4.5.2#~builtin<compat/typescript>::version=4.5.2&hash=493e53"
+  version: 4.5.5
+  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 53838d56aba6fcc947d63aa0771e5d966b1b648fddafed6e221d7f38c71219c4e036ece8cfe9e35ed80cf5a35ff4eb958934c993f99c3233773ec4f9ccd53f69
+  checksum: c05c318d79c690f101d7ffb34cd6c7d6bbd884d3af9cefe7749ad0cd6be43c7082f098280982ca945dcba23fde34a08fed9602bb26540936baf8c0520727d3ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Official Babel plugins finally have typing inference without manual typing annotations in most cases, also fixing bugs in partial-application caught by the type checker
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we provides typings from `declare` / `declarePreset` in `@babel/helper-plugin-utils`, which is used in every official Babel plugins.

For most plugins with type-only visitors, type inference works without manual annotations.

We introduce a `declarePreset` method for presets usage. I didn't figure out how to merge typing hints with `declare` so I end up with a new method.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14499"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

