### PR TITLE
fix: `@babel/runtime-corejs2` should depend on core-js 2

### DIFF
--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://babel.dev/docs/en/next/babel-runtime-corejs2",
   "author": "The Babel Team (https://babel.dev/team)",
   "dependencies": {
-    "core-js": "^3.22.1",
+    "core-js": "^2.6.12",
     "regenerator-runtime": "^0.13.4"
   },
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,7 +3543,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/runtime-corejs2@workspace:packages/babel-runtime-corejs2"
   dependencies:
-    core-js: ^3.22.1
+    core-js: ^2.6.12
     regenerator-runtime: ^0.13.4
   languageName: unknown
   linkType: soft
@@ -7029,6 +7029,13 @@ __metadata:
   version: 3.20.2
   resolution: "core-js-pure@npm:3.20.2"
   checksum: d6b3f6782e3f2fc27eb2335917d5c5d0e7621e424c25da67429e9b48b7708b76fdc4a178b245421eeb8342c0ea9b0ca636ece002db3d0e68246a9d395d461ca7
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^2.6.12":
+  version: 2.6.12
+  resolution: "core-js@npm:2.6.12"
+  checksum: 44fa9934a85f8c78d61e0c8b7b22436330471ffe59ec5076fe7f324d6e8cf7f824b14b1c81ca73608b13bdb0fef035bd820989bf059767ad6fa13123bb8bd016
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14508
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | @babel/runtime-corejs2 should depend on core-js 2
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Fixed a regression introduced in #14474 when I bumped the `core-js` versions. I should have checked the package.json changes more carefully.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14509"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

