### PR TITLE
Use `maybeAddMapping` to add sourcemap markings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,9 +7,13 @@ const supportsESMAndJestLightRunner = semver.satisfies(
   "^12.22 || ^13.7 || >=14.17"
 );
 const isPublishBundle = process.env.IS_PUBLISH;
+const debug = process.env.TEST_DEBUG;
 
 module.exports = {
-  runner: supportsESMAndJestLightRunner ? "jest-light-runner" : "jest-runner",
+  runner:
+    supportsESMAndJestLightRunner && !debug
+      ? "jest-light-runner"
+      : "jest-runner",
 
   collectCoverageFrom: [
     "packages/*/src/**/*.{js,mjs,ts}",

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,13 +7,9 @@ const supportsESMAndJestLightRunner = semver.satisfies(
   "^12.22 || ^13.7 || >=14.17"
 );
 const isPublishBundle = process.env.IS_PUBLISH;
-const debug = process.env.TEST_DEBUG;
 
 module.exports = {
-  runner:
-    supportsESMAndJestLightRunner && !debug
-      ? "jest-light-runner"
-      : "jest-runner",
+  runner: supportsESMAndJestLightRunner ? "jest-light-runner" : "jest-runner",
 
   collectCoverageFrom: [
     "packages/*/src/**/*.{js,mjs,ts}",

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-multiple-output-sources-complete-replace/source-map.json
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-multiple-output-sources-complete-replace/source-map.json
@@ -1,13 +1,15 @@
 {
-  "mappings": "AAAC;ACAD,K",
+  "version": 3,
+  "mappings": "AAAC,KCAD;ACAA,K",
   "names": [],
   "sources": [
     "bar.js",
+    "input.tsx",
     "baz.js"
   ],
   "sourcesContent": [
     "<bar />",
+    "foo(1);\nfunction foo(bar: number): never {\n    throw new Error('Intentional.');\n}",
     "baz();"
-  ],
-  "version": 3
+  ]
 }

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-multiple-output-sources/source-map.json
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-multiple-output-sources/source-map.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
-  "mappings": "AAAC;;ACCD,SAASA,GAAT,CAAaC,GAAb,EAAwB;EACpB,MAAM,IAAIC,KAAJ,CAAU,cAAV,CAAN;AACH",
+  "mappings": "AAAC,KCAD;;AACA,SAASA,GAAT,CAAaC,GAAb,EAAwB;EACpB,MAAM,IAAIC,KAAJ,CAAU,cAAV,CAAN;AACH",
   "names": [
     "foo",
     "bar",

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-sources-complete-replace/source-map.json
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-sources-complete-replace/source-map.json
@@ -1,7 +1,13 @@
 {
-  "mappings": "AAAC",
+  "version": 3,
+  "mappings": "AAAC,KCAD",
   "names": [],
-  "sources": ["test.js"],
-  "sourcesContent": ["<bar />"],
-  "version": 3
+  "sources": [
+    "test.js",
+    "input.tsx"
+  ],
+  "sourcesContent": [
+    "<bar />",
+    "foo(1);\nfunction foo(bar: number): never {\n    throw new Error('Intentional.');\n}"
+  ]
 }

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "@babel/types": "workspace:^",
-    "@jridgewell/gen-mapping": "^0.1.0",
+    "@jridgewell/gen-mapping": "^0.3.0",
     "jsesc": "condition: BABEL_8_BREAKING ? ^3.0.2 : ^2.5.1"
   },
   "devDependencies": {

--- a/packages/babel-generator/src/source-map.ts
+++ b/packages/babel-generator/src/source-map.ts
@@ -1,10 +1,10 @@
 import {
   GenMapping,
-  addMapping,
+  maybeAddMapping,
   setSourceContent,
   allMappings,
-  encodedMap,
-  decodedMap,
+  toEncodedMap,
+  toDecodedMap,
 } from "@jridgewell/gen-mapping";
 
 import type {
@@ -55,11 +55,11 @@ export default class SourceMap {
    * Get the sourcemap.
    */
   get(): EncodedSourceMap {
-    return encodedMap(this._map);
+    return toEncodedMap(this._map);
   }
 
   getDecoded(): DecodedSourceMap {
-    return decodedMap(this._map);
+    return toDecodedMap(this._map);
   }
 
   getRawMappings(): Mapping[] {
@@ -77,30 +77,10 @@ export default class SourceMap {
     column: number,
     identifierName?: string | null,
     filename?: string | null,
-    force?: boolean,
   ) {
-    const generatedLine = generated.line;
-
-    // Adding an empty mapping at the start of a generated line just clutters the map.
-    if (this._lastGenLine !== generatedLine && line == null) return;
-
-    // If this mapping points to the same source location as the last one, we can ignore it since
-    // the previous one covers it.
-    if (
-      !force &&
-      this._lastGenLine === generatedLine &&
-      this._lastSourceLine === line &&
-      this._lastSourceColumn === column
-    ) {
-      return;
-    }
-
     this._rawMappings = undefined;
-    this._lastGenLine = generatedLine;
-    this._lastSourceLine = line;
-    this._lastSourceColumn = column;
 
-    addMapping(this._map, {
+    maybeAddMapping(this._map, {
       name: identifierName,
       generated,
       source:

--- a/yarn.lock
+++ b/yarn.lock
@@ -456,7 +456,7 @@ __metadata:
     "@babel/helper-fixtures": "workspace:^"
     "@babel/parser": "workspace:^"
     "@babel/types": "workspace:^"
-    "@jridgewell/gen-mapping": ^0.1.0
+    "@jridgewell/gen-mapping": ^0.3.0
     "@jridgewell/trace-mapping": ^0.3.8
     "@types/jsesc": ^2.5.0
     charcodes: ^0.2.0
@@ -4070,13 +4070,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@jridgewell/gen-mapping@npm:0.1.0"
+"@jridgewell/gen-mapping@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@jridgewell/gen-mapping@npm:0.3.0"
   dependencies:
-    "@jridgewell/set-array": 1.0.0
+    "@jridgewell/set-array": ^1.0.0
     "@jridgewell/sourcemap-codec": ^1.4.10
-  checksum: 8611de5acbea55fa84bcde0d6f803e006560f7a8ce618ba427e20a76913d18308fc14d5cfb324e30d0051556a96527fbc4e64cf65d68f121170776243387dcce
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: ccc9b288d2bbf09d81a85cd07b0e0dd461f2a8d2fd0d46eefc1c04e994e9f95a51bb9e1c8718f4182e87a21c11d2f5ed687a789024cbd160c8e5421de8b011f6
   languageName: node
   linkType: hard
 
@@ -4087,10 +4088,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/set-array@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@jridgewell/set-array@npm:1.0.0"
-  checksum: 35dd48a205099839fa8b9e9b7138d382d1f33457404c4e96c95ad1cd9aea99904737b351d4dea8b21fa17b50fcd0dc2fdbf4c04fc4bcd3c1a42d079217261444
+"@jridgewell/set-array@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@jridgewell/set-array@npm:1.1.0"
+  checksum: 86ddd72ce7d2f7756dfb69804b35d0e760a85dcef30ed72e8610bf2c5e843f8878d977a0c77c4fdfa6a0e3d5b18e5bde4a1f1dd73fd2db06b200c998e9b5a6c5
   languageName: node
   linkType: hard
 
@@ -4101,13 +4102,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.0, @jridgewell/trace-mapping@npm:^0.3.8":
-  version: 0.3.8
-  resolution: "@jridgewell/trace-mapping@npm:0.3.8"
+"@jridgewell/trace-mapping@npm:^0.3.0, @jridgewell/trace-mapping@npm:^0.3.8, @jridgewell/trace-mapping@npm:^0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
   dependencies:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
-  checksum: 4b46f28c785133773de521677983186dfe7ed80872bee57b73624527e345954139ea45dfb7551a5f04de1773dc9501b896554a8f1c9e1c44ab2146a3c66b6fda
+  checksum: d89597752fd88d3f3480845691a05a44bd21faac18e2185b6f436c3b0fd0c5a859fbbd9aaa92050c4052caf325ad3e10e2e1d1b64327517471b7d51babc0ddef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

Projects trying to create sourcemaps shouldn't have to concern themselves with whether adding a mapping is useful or just clutters the mappings. `gen-mapping` has [newly introduced](https://github.com/jridgewell/gen-mapping/releases/tag/v0.3.0) `maybeAddMapping` which will determine if a mapping is useful, or skip it.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14510"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

