### PR TITLE
Add `fail-fast: false` to CI tests matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [16, 14, 12, 10, 8, 6]
     steps:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Our tests often fail because some of them are flaky (on CI). With this flag, if the suite fail on a Node.js version it won't automatically stop all the other versions. We already have this flag for e2e tests.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14523"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

