### PR TITLE
fix: perserve parentheses of lhs id with rhs unamed fn

### DIFF
--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -350,7 +350,7 @@ export function Identifier(
   if (
     node.extra?.parenthesized &&
     isAssignmentExpression(parent, { left: node }) &&
-    isFunctionExpression(parent.right) &&
+    (isFunctionExpression(parent.right) || isClassExpression(parent.right)) &&
     parent.right.id == null
   ) {
     return true;

--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -17,6 +17,7 @@ import {
   isForInStatement,
   isForOfStatement,
   isForStatement,
+  isFunctionExpression,
   isIfStatement,
   isIndexedAccessType,
   isIntersectionTypeAnnotation,
@@ -344,6 +345,16 @@ export function Identifier(
   parent: t.Node,
   printStack: Array<t.Node>,
 ): boolean {
+  // 13.15.2 AssignmentExpression RS: Evaluation
+  // (fn) = function () {};
+  if (
+    node.extra?.parenthesized &&
+    isAssignmentExpression(parent, { left: node }) &&
+    isFunctionExpression(parent.right) &&
+    parent.right.id == null
+  ) {
+    return true;
+  }
   // Non-strict code allows the identifier `let`, but it cannot occur as-is in
   // certain contexts to avoid ambiguity with contextual keyword `let`.
   if (node.name === "let") {

--- a/packages/babel-generator/test/fixtures/parentheses/identifier-lhs/input.js
+++ b/packages/babel-generator/test/fixtures/parentheses/identifier-lhs/input.js
@@ -1,0 +1,4 @@
+var f, g, h;
+(f) = function () {};
+g = function () {};
+(h) = function noParen() {}

--- a/packages/babel-generator/test/fixtures/parentheses/identifier-lhs/input.js
+++ b/packages/babel-generator/test/fixtures/parentheses/identifier-lhs/input.js
@@ -1,4 +1,7 @@
 var f, g, h;
 (f) = function () {};
+(f) = class {};
 g = function () {};
-(h) = function noParen() {}
+g = class {};
+(h) = function noParen() {};
+(h) = class noParen {}

--- a/packages/babel-generator/test/fixtures/parentheses/identifier-lhs/output.js
+++ b/packages/babel-generator/test/fixtures/parentheses/identifier-lhs/output.js
@@ -1,0 +1,7 @@
+var f, g, h;
+
+(f) = function () {};
+
+g = function () {};
+
+h = function noParen() {};

--- a/packages/babel-generator/test/fixtures/parentheses/identifier-lhs/output.js
+++ b/packages/babel-generator/test/fixtures/parentheses/identifier-lhs/output.js
@@ -2,6 +2,12 @@ var f, g, h;
 
 (f) = function () {};
 
+(f) = class {};
+
 g = function () {};
 
+g = class {};
+
 h = function noParen() {};
+
+h = class noParen {};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14514
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Detect the pattern `(f) = function () {}` and preserve the parentheses around `f`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14524"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

