### PR TITLE
improve helper-create-class-features typings

### DIFF
--- a/packages/babel-core/src/config/validation/plugins.ts
+++ b/packages/babel-core/src/config/validation/plugins.ts
@@ -13,8 +13,8 @@ import type {
 } from "./option-assertions";
 import type { ParserOptions } from "@babel/parser";
 import type { Visitor } from "@babel/traverse";
-import type PluginPass from "../../transformation/plugin-pass";
 import type { ValidatedOptions } from "./options";
+import type { File, PluginPass } from "../../..";
 
 // Note: The casts here are just meant to be static assertions to make sure
 // that the assertion functions actually assert that the value's type matches
@@ -78,14 +78,14 @@ type VisitorHandler =
       exit?: Function;
     };
 
-export type PluginObject<S = PluginPass> = {
+export type PluginObject<S extends PluginPass = PluginPass> = {
   name?: string;
   manipulateOptions?: (
     options: ValidatedOptions,
     parserOpts: ParserOptions,
   ) => void;
-  pre?: Function;
-  post?: Function;
+  pre?: (this: S, file: File) => void;
+  post?: (this: S, file: File) => void;
   inherits?: Function;
   visitor?: Visitor<S>;
   parserOverride?: Function;

--- a/packages/babel-core/src/transformation/index.ts
+++ b/packages/babel-core/src/transformation/index.ts
@@ -3,7 +3,7 @@ import type * as t from "@babel/types";
 type SourceMap = any;
 import type { Handler } from "gensync";
 
-import type { ResolvedConfig, PluginPasses } from "../config";
+import type { ResolvedConfig, Plugin, PluginPasses } from "../config";
 
 import PluginPass from "./plugin-pass";
 import loadBlockHoistPlugin from "./block-hoist-plugin";
@@ -79,7 +79,7 @@ export function* run(
 
 function* transformFile(file: File, pluginPasses: PluginPasses): Handler<void> {
   for (const pluginPairs of pluginPasses) {
-    const passPairs = [];
+    const passPairs: [Plugin, PluginPass][] = [];
     const passes = [];
     const visitors = [];
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-integrations/class-accessor-property/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-integrations/class-accessor-property/input.js
@@ -1,0 +1,3 @@
+@f class C {
+  accessor x;
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-integrations/class-accessor-property/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-integrations/class-accessor-property/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    [
+      "proposal-decorators",
+      { "decoratorsBeforeExport": false, "version": "2018-09" }
+    ]
+  ],
+  "parserOpts": {
+    "plugins": ["decoratorAutoAccessors"]
+  },
+  "throws": "Accessor properties are not supported in 2018-09 decorator transform, please specify { \"version\": \"2021-12\" } instead."
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-integrations/static-block/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-integrations/static-block/input.js
@@ -1,0 +1,3 @@
+@f class C {
+  static {}
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-integrations/static-block/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-integrations/static-block/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "proposal-decorators",
+      { "decoratorsBeforeExport": false, "version": "2018-09" }
+    ],
+    "proposal-class-static-block"
+  ],
+  "throws": "Static blocks are not supported in 2018-09 decorator transform, please specify { \"version\": \"2021-12\" } instead."
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Throw an error when class auto accessors are used with 2018-09 decorators
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Improved `helper-create-class-features` typings. The type-checker found a bug that we didn't take into account some class members in the 2018-09 decorator transform.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14530"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

