### PR TITLE
fix: isFirstInContext doesn't handle postfix unary operators

### DIFF
--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -5,6 +5,7 @@ import {
   isAwaitExpression,
   isBinary,
   isBinaryExpression,
+  isUpdateExpression,
   isCallExpression,
   isClassDeclaration,
   isClassExpression,
@@ -414,6 +415,7 @@ function isFirstInContext(
     if (
       (hasPostfixPart(node, parent) && !isNewExpression(parent)) ||
       (isSequenceExpression(parent) && parent.expressions[0] === node) ||
+      (isUpdateExpression(parent) && !parent.prefix) ||
       isConditional(parent, { test: node }) ||
       isBinary(parent, { left: node }) ||
       isAssignmentExpression(parent, { left: node })

--- a/packages/babel-generator/test/fixtures/parentheses/unary-postfix/input.js
+++ b/packages/babel-generator/test/fixtures/parentheses/unary-postfix/input.js
@@ -1,0 +1,1 @@
+(function () { return {x: 24} }()).x++;

--- a/packages/babel-generator/test/fixtures/parentheses/unary-postfix/output.js
+++ b/packages/babel-generator/test/fixtures/parentheses/unary-postfix/output.js
@@ -1,0 +1,5 @@
+(function () {
+  return {
+    x: 24
+  };
+})().x++;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14401  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |  Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

fix the problem ```(function (){}).x++``` doesn't correctly generate parentheses, previously generate ```function () { return {x: 24} }().x++;```


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14532"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

