### PR TITLE
fix: Cannot add property __esModule, object is not extensible on @babel/helpers

### DIFF
--- a/packages/babel-helpers/src/helpers.ts
+++ b/packages/babel-helpers/src/helpers.ts
@@ -360,9 +360,10 @@ helpers.inheritsLoose = helper("7.0.0-beta.0")`
   }
 `;
 
+// need a bind because https://github.com/babel/babel/issues/14527
 helpers.getPrototypeOf = helper("7.0.0-beta.0")`
   export default function _getPrototypeOf(o) {
-    _getPrototypeOf = Object.setPrototypeOf
+    _getPrototypeOf = Object.setPrototypeOf.bind()
       ? Object.getPrototypeOf
       : function _getPrototypeOf(o) {
           return o.__proto__ || Object.getPrototypeOf(o);
@@ -373,7 +374,7 @@ helpers.getPrototypeOf = helper("7.0.0-beta.0")`
 
 helpers.setPrototypeOf = helper("7.0.0-beta.0")`
   export default function _setPrototypeOf(o, p) {
-    _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) {
+    _setPrototypeOf = Object.setPrototypeOf.bind() || function _setPrototypeOf(o, p) {
       o.__proto__ = p;
       return o;
     };


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14527
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
