### PR TITLE
Enable the `noImplicitThis` tsc option

### DIFF
--- a/packages/babel-core/src/config/full.ts
+++ b/packages/babel-core/src/config/full.ts
@@ -494,7 +494,7 @@ function chain(a, b) {
   const fns = [a, b].filter(Boolean);
   if (fns.length <= 1) return fns[0];
 
-  return function (...args) {
+  return function (this: unknown, ...args) {
     for (const fn of fns) {
       fn.apply(this, args);
     }

--- a/packages/babel-generator/src/generators/classes.ts
+++ b/packages/babel-generator/src/generators/classes.ts
@@ -199,7 +199,7 @@ export function _classMethodHead(this: Printer, node) {
   this._methodHead(node);
 }
 
-export function StaticBlock(node: t.StaticBlock) {
+export function StaticBlock(this: Printer, node: t.StaticBlock) {
   this.word("static");
   this.space();
   this.token("{");

--- a/packages/babel-generator/src/generators/expressions.ts
+++ b/packages/babel-generator/src/generators/expressions.ts
@@ -219,7 +219,7 @@ export function Import(this: Printer) {
 }
 
 function buildYieldAwait(keyword: string) {
-  return function (node: any) {
+  return function (this: Printer, node: any) {
     this.word(keyword);
 
     if (node.delegate) {
@@ -348,7 +348,7 @@ export function V8IntrinsicIdentifier(
   this.word(node.name);
 }
 
-export function ModuleExpression(node: t.ModuleExpression) {
+export function ModuleExpression(this: Printer, node: t.ModuleExpression) {
   this.word("module");
   this.space();
   this.token("{");

--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -68,7 +68,7 @@ export function DeclareFunction(
   this.semicolon();
 }
 
-export function InferredPredicate(/*node: Object*/) {
+export function InferredPredicate(this: Printer) {
   this.token("%");
   this.word("checks");
 }
@@ -159,7 +159,7 @@ export function DeclareExportDeclaration(
   FlowExportDeclaration.apply(this, arguments);
 }
 
-export function DeclareExportAllDeclaration(/*node: Object*/) {
+export function DeclareExportAllDeclaration(this: Printer) {
   this.word("declare");
   this.space();
   ExportAllDeclaration.apply(this, arguments);
@@ -258,7 +258,7 @@ export function EnumStringMember(this: Printer, node: t.EnumStringMember) {
   enumInitializedMember(this, node);
 }
 
-function FlowExportDeclaration(node: any) {
+function FlowExportDeclaration(this: Printer, node: any) {
   if (node.declaration) {
     const declar = node.declaration;
     this.print(declar, node);
@@ -403,7 +403,7 @@ export function InterfaceDeclaration(
   this._interfaceish(node);
 }
 
-function andSeparator() {
+function andSeparator(this: Printer) {
   this.space();
   this.token("&");
   this.space();
@@ -707,7 +707,7 @@ export function SymbolTypeAnnotation(this: Printer) {
   this.word("symbol");
 }
 
-function orSeparator() {
+function orSeparator(this: Printer) {
   this.space();
   this.token("|");
   this.space();

--- a/packages/babel-generator/src/generators/jsx.ts
+++ b/packages/babel-generator/src/generators/jsx.ts
@@ -75,7 +75,7 @@ export function JSXElement(this: Printer, node: t.JSXElement) {
   this.print(node.closingElement, node);
 }
 
-function spaceSeparator() {
+function spaceSeparator(this: Printer) {
   this.space();
 }
 

--- a/packages/babel-generator/src/generators/modules.ts
+++ b/packages/babel-generator/src/generators/modules.ts
@@ -119,7 +119,7 @@ export function ExportDefaultDeclaration(
   ExportDeclaration.apply(this, arguments);
 }
 
-function ExportDeclaration(node: any) {
+function ExportDeclaration(this: Printer, node: any) {
   if (node.declaration) {
     const declar = node.declaration;
     this.print(declar, node);

--- a/packages/babel-generator/src/generators/statements.ts
+++ b/packages/babel-generator/src/generators/statements.ts
@@ -90,7 +90,7 @@ export function WhileStatement(this: Printer, node: t.WhileStatement) {
 }
 
 const buildForXStatement = function (op) {
-  return function (node: any) {
+  return function (this: Printer, node: any) {
     this.word("for");
     this.space();
     if (op === "of" && node.await) {
@@ -125,7 +125,7 @@ export function DoWhileStatement(this: Printer, node: t.DoWhileStatement) {
 }
 
 function buildLabelStatement(prefix, key = "label") {
-  return function (node: any) {
+  return function (this: Printer, node: any) {
     this.word(prefix);
 
     const label = node[key];
@@ -232,7 +232,7 @@ export function DebuggerStatement(this: Printer) {
   this.semicolon();
 }
 
-function variableDeclarationIndent() {
+function variableDeclarationIndent(this: Printer) {
   // "let " or "var " indentation.
   this.token(",");
   this.newline();
@@ -241,7 +241,7 @@ function variableDeclarationIndent() {
   }
 }
 
-function constDeclarationIndent() {
+function constDeclarationIndent(this: Printer) {
   // "const " indentation.
   this.token(",");
   this.newline();

--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -208,7 +208,7 @@ export function TSNullKeyword(this: Printer) {
 export function TSNeverKeyword(this: Printer) {
   this.word("never");
 }
-export function TSIntrinsicKeyword() {
+export function TSIntrinsicKeyword(this: Printer) {
   this.word("intrinsic");
 }
 

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -720,7 +720,7 @@ type GeneratorFunctions = typeof generatorFunctions;
 interface Printer extends GeneratorFunctions {}
 export default Printer;
 
-function commaSeparator() {
+function commaSeparator(this: Printer) {
   this.token(",");
   this.space();
 }

--- a/packages/babel-helper-replace-supers/src/index.ts
+++ b/packages/babel-helper-replace-supers/src/index.ts
@@ -16,6 +16,7 @@ import {
   thisExpression,
 } from "@babel/types";
 import type * as t from "@babel/types";
+import type { File } from "@babel/core";
 
 // TODO (Babel 8): Don't export this.
 export {
@@ -70,8 +71,32 @@ const unshadowSuperBindingVisitor = traverse.visitors.merge([
   },
 ]);
 
+type SharedState = {
+  file: File;
+  scope: Scope;
+  isDerivedConstructor: boolean;
+  isStatic: boolean;
+  isPrivateMethod: boolean;
+  getObjectRef: Function;
+  getSuperRef: Function;
+  // we dont need boundGet here, but memberExpressionToFunctions handler needs it.
+  boundGet: HandlerState["get"];
+};
+
+type Handler = HandlerState<SharedState> & SharedState;
+type SuperMember = NodePath<
+  | t.MemberExpression & {
+      object: t.Super;
+      property: Exclude<t.MemberExpression["property"], t.PrivateName>;
+    }
+>;
+
 const specHandlers = {
-  memoise(superMember, count) {
+  memoise(
+    this: Handler & typeof specHandlers,
+    superMember: SuperMember,
+    count,
+  ) {
     const { scope, node } = superMember;
     const { computed, property } = node;
     if (!computed) {
@@ -86,7 +111,7 @@ const specHandlers = {
     this.memoiser.set(property, memo, count);
   },
 
-  prop(superMember) {
+  prop(this: Handler & typeof specHandlers, superMember: SuperMember) {
     const { computed, property } = superMember.node;
     if (this.memoiser.has(property)) {
       return cloneNode(this.memoiser.get(property));
@@ -96,14 +121,18 @@ const specHandlers = {
       return cloneNode(property);
     }
 
-    return stringLiteral(property.name);
+    return stringLiteral((property as t.Identifier).name);
   },
 
-  get(superMember) {
+  get(this: Handler & typeof specHandlers, superMember: SuperMember) {
     return this._get(superMember, this._getThisRefs());
   },
 
-  _get(superMember, thisRefs) {
+  _get(
+    this: Handler & typeof specHandlers,
+    superMember: SuperMember,
+    thisRefs,
+  ) {
     const proto = getPrototypeOfExpression(
       this.getObjectRef(),
       this.isStatic,
@@ -117,7 +146,7 @@ const specHandlers = {
     ]);
   },
 
-  _getThisRefs() {
+  _getThisRefs(this: Handler & typeof specHandlers) {
     if (!this.isDerivedConstructor) {
       return { this: thisExpression() };
     }
@@ -128,7 +157,7 @@ const specHandlers = {
     };
   },
 
-  set(superMember, value) {
+  set(this: Handler & typeof specHandlers, superMember: SuperMember, value) {
     const thisRefs = this._getThisRefs();
     const proto = getPrototypeOfExpression(
       this.getObjectRef(),
@@ -145,13 +174,16 @@ const specHandlers = {
     ]);
   },
 
-  destructureSet(superMember) {
+  destructureSet(
+    this: Handler & typeof specHandlers,
+    superMember: SuperMember,
+  ) {
     throw superMember.buildCodeFrameError(
       `Destructuring to a super field is not supported yet.`,
     );
   },
 
-  call(superMember, args) {
+  call(this: Handler & typeof specHandlers, superMember: SuperMember, args) {
     const thisRefs = this._getThisRefs();
     return optimiseCall(
       this._get(superMember, thisRefs),
@@ -161,7 +193,11 @@ const specHandlers = {
     );
   },
 
-  optionalCall(superMember, args) {
+  optionalCall(
+    this: Handler & typeof specHandlers,
+    superMember: SuperMember,
+    args,
+  ) {
     const thisRefs = this._getThisRefs();
     return optimiseCall(
       this._get(superMember, thisRefs),
@@ -175,7 +211,7 @@ const specHandlers = {
 const looseHandlers = {
   ...specHandlers,
 
-  prop(superMember) {
+  prop(this: Handler & typeof specHandlers, superMember: SuperMember) {
     const { property } = superMember.node;
     if (this.memoiser.has(property)) {
       return cloneNode(this.memoiser.get(property));
@@ -184,7 +220,7 @@ const looseHandlers = {
     return cloneNode(property);
   },
 
-  get(superMember) {
+  get(this: Handler & typeof specHandlers, superMember: SuperMember) {
     const { isStatic, getSuperRef } = this;
     const { computed } = superMember.node;
     const prop = this.prop(superMember);
@@ -204,7 +240,7 @@ const looseHandlers = {
     return memberExpression(object, prop, computed);
   },
 
-  set(superMember, value) {
+  set(this: Handler & typeof specHandlers, superMember: SuperMember, value) {
     const { computed } = superMember.node;
     const prop = this.prop(superMember);
 
@@ -215,18 +251,25 @@ const looseHandlers = {
     );
   },
 
-  destructureSet(superMember) {
+  destructureSet(
+    this: Handler & typeof specHandlers,
+    superMember: SuperMember,
+  ) {
     const { computed } = superMember.node;
     const prop = this.prop(superMember);
 
     return memberExpression(thisExpression(), prop, computed);
   },
 
-  call(superMember, args) {
+  call(this: Handler & typeof specHandlers, superMember: SuperMember, args) {
     return optimiseCall(this.get(superMember), thisExpression(), args, false);
   },
 
-  optionalCall(superMember, args) {
+  optionalCall(
+    this: Handler & typeof specHandlers,
+    superMember: SuperMember,
+    args,
+  ) {
     return optimiseCall(this.get(superMember), thisExpression(), args, true);
   },
 };

--- a/packages/babel-helper-simple-access/src/index.ts
+++ b/packages/babel-helper-simple-access/src/index.ts
@@ -134,7 +134,7 @@ const simpleAssignmentVisitor: Visitor<State> = {
         // (foo &&= bar) => (foo && foo = bar)
         path.replaceWith(
           logicalExpression(
-            // @ts-expect-error Guarded by
+            // @ts-expect-error Guarded by LOGICAL_OPERATORS.includes
             operator,
             path.node.left,
             assignmentExpression(

--- a/packages/babel-plugin-proposal-function-sent/src/index.ts
+++ b/packages/babel-plugin-proposal-function-sent/src/index.ts
@@ -2,6 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import syntaxFunctionSent from "@babel/plugin-syntax-function-sent";
 import wrapFunction from "@babel/helper-wrap-function";
 import { types as t } from "@babel/core";
+import type { Visitor } from "@babel/traverse";
 
 export default declare(api => {
   api.assertVersion(7);
@@ -14,7 +15,7 @@ export default declare(api => {
     t.isAssignmentExpression(node) &&
     t.isIdentifier(node.left, { name: sentId });
 
-  const yieldVisitor = {
+  const yieldVisitor: Visitor<{ sentId: string }> = {
     Function(path) {
       path.skip();
     },

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.ts
@@ -11,6 +11,7 @@ import {
 import simplifyAccess from "@babel/helper-simple-access";
 import { template, types as t } from "@babel/core";
 import type { PluginOptions } from "@babel/helper-module-transforms";
+import type { Visitor, Scope } from "@babel/traverse";
 
 import { createDynamicImportTransform } from "babel-plugin-dynamic-import-node/utils";
 
@@ -82,7 +83,7 @@ export default declare((api, options: Options) => {
     })()
   `;
 
-  const moduleExportsVisitor = {
+  const moduleExportsVisitor: Visitor<{ scope: Scope }> = {
     ReferencedIdentifier(path) {
       const localName = path.node.name;
       if (localName !== "module" && localName !== "exports") return;
@@ -106,6 +107,7 @@ export default declare((api, options: Options) => {
 
     UpdateExpression(path) {
       const arg = path.get("argument");
+      if (!arg.isIdentifier()) return;
       const localName = arg.node.name;
       if (localName !== "module" && localName !== "exports") return;
 
@@ -127,7 +129,7 @@ export default declare((api, options: Options) => {
     AssignmentExpression(path) {
       const left = path.get("left");
       if (left.isIdentifier()) {
-        const localName = path.node.name;
+        const localName = left.node.name;
         if (localName !== "module" && localName !== "exports") return;
 
         const localBinding = path.scope.getBinding(localName);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/module-exports/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/module-exports/output.js
@@ -8,15 +8,16 @@ console.log(function () {
 console.log(function () {
   throw new Error("The CommonJS '" + "exports" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
 }().prop);
-
-exports += function () {
+exports += (function () {
   throw new Error("The CommonJS '" + "exports" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
-}();
-
-exports = function () {
+}(), function () {
   throw new Error("The CommonJS '" + "exports" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
-}() + 4;
-
+}());
+exports = (function () {
+  throw new Error("The CommonJS '" + "exports" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
+}() + 4, function () {
+  throw new Error("The CommonJS '" + "exports" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
+}());
 ({
   exports
 } = ({}, function () {
@@ -25,7 +26,9 @@ exports = function () {
 [exports] = ([], function () {
   throw new Error("The CommonJS '" + "exports" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
 }());
-exports = {};
+exports = ({}, function () {
+  throw new Error("The CommonJS '" + "exports" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
+}());
 (function () {
   throw new Error("The CommonJS '" + "exports" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
 })().prop = "";
@@ -35,15 +38,16 @@ console.log(function () {
 console.log(function () {
   throw new Error("The CommonJS '" + "module" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
 }().exports);
-
-module += function () {
+module += (function () {
   throw new Error("The CommonJS '" + "module" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
-}();
-
-module = function () {
+}(), function () {
   throw new Error("The CommonJS '" + "module" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
-}() + 4;
-
+}());
+module = (function () {
+  throw new Error("The CommonJS '" + "module" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
+}() + 4, function () {
+  throw new Error("The CommonJS '" + "module" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
+}());
 ({
   module
 } = ({}, function () {
@@ -52,7 +56,9 @@ module = function () {
 [module] = ([], function () {
   throw new Error("The CommonJS '" + "module" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
 }());
-module = {};
+module = ({}, function () {
+  throw new Error("The CommonJS '" + "module" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
+}());
 (function () {
   throw new Error("The CommonJS '" + "module" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
 })().prop = "";

--- a/packages/babel-preset-env/src/polyfills/regenerator.ts
+++ b/packages/babel-preset-env/src/polyfills/regenerator.ts
@@ -1,5 +1,6 @@
 import { getImportSource, getRequireSource } from "./utils";
 import type { Visitor } from "@babel/traverse";
+import type { PluginObject, PluginPass } from "@babel/core";
 
 function isRegeneratorSource(source) {
   return (
@@ -8,8 +9,12 @@ function isRegeneratorSource(source) {
   );
 }
 
-export default function () {
-  const visitor: Visitor<{ regeneratorImportExcluded: boolean }> = {
+type State = {
+  regeneratorImportExcluded: boolean;
+};
+
+export default function (): PluginObject<State & PluginPass> {
+  const visitor: Visitor<State & PluginPass> = {
     ImportDeclaration(path) {
       if (isRegeneratorSource(getImportSource(path))) {
         this.regeneratorImportExcluded = true;

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -468,6 +468,7 @@ function getBindingIdentifiers(
 ): Record<string, t.Identifier[] | t.Identifier>;
 
 function getBindingIdentifiers(
+  this: NodePath,
   duplicates?: boolean,
 ): Record<string, t.Identifier[] | t.Identifier> {
   return _getBindingIdentifiers(this.node, duplicates);
@@ -486,6 +487,7 @@ function getOuterBindingIdentifiers(
 ): Record<string, t.Identifier[] | t.Identifier>;
 
 function getOuterBindingIdentifiers(
+  this: NodePath,
   duplicates?: boolean,
 ): Record<string, t.Identifier[] | t.Identifier> {
   return _getOuterBindingIdentifiers(this.node, duplicates);

--- a/packages/babel-traverse/src/path/inference/index.ts
+++ b/packages/babel-traverse/src/path/inference/index.ts
@@ -23,7 +23,7 @@ import type * as t from "@babel/types";
  * Infer the type of the current `NodePath`.
  */
 
-export function getTypeAnnotation(): t.FlowType {
+export function getTypeAnnotation(this: NodePath): t.FlowType {
   if (this.typeAnnotation) return this.typeAnnotation;
 
   let type = this._getTypeAnnotation() || anyTypeAnnotation();
@@ -40,7 +40,7 @@ const typeAnnotationInferringNodes = new WeakSet();
  * todo: split up this method
  */
 
-export function _getTypeAnnotation(): any {
+export function _getTypeAnnotation(this: NodePath): any {
   const node = this.node;
 
   if (!node) {
@@ -90,7 +90,11 @@ export function _getTypeAnnotation(): any {
   }
 }
 
-export function isBaseType(baseName: string, soft?: boolean): boolean {
+export function isBaseType(
+  this: NodePath,
+  baseName: string,
+  soft?: boolean,
+): boolean {
   return _isBaseType(baseName, this.getTypeAnnotation(), soft);
 }
 
@@ -118,7 +122,7 @@ function _isBaseType(baseName: string, type?, soft?): boolean {
   }
 }
 
-export function couldBeBaseType(name: string): boolean {
+export function couldBeBaseType(this: NodePath, name: string): boolean {
   const type = this.getTypeAnnotation();
   if (isAnyTypeAnnotation(type)) return true;
 
@@ -134,7 +138,10 @@ export function couldBeBaseType(name: string): boolean {
   }
 }
 
-export function baseTypeStrictlyMatches(rightArg: NodePath): boolean {
+export function baseTypeStrictlyMatches(
+  this: NodePath,
+  rightArg: NodePath,
+): boolean {
   const left = this.getTypeAnnotation();
   const right = rightArg.getTypeAnnotation();
 
@@ -144,7 +151,7 @@ export function baseTypeStrictlyMatches(rightArg: NodePath): boolean {
   return false;
 }
 
-export function isGenericType(genericName: string): boolean {
+export function isGenericType(this: NodePath, genericName: string): boolean {
   const type = this.getTypeAnnotation();
   return (
     isGenericTypeAnnotation(type) &&

--- a/packages/babel-traverse/src/path/inference/index.ts
+++ b/packages/babel-traverse/src/path/inference/index.ts
@@ -24,11 +24,14 @@ import type * as t from "@babel/types";
  */
 
 export function getTypeAnnotation(this: NodePath): t.FlowType {
-  if (this.typeAnnotation) return this.typeAnnotation;
-
-  let type = this._getTypeAnnotation() || anyTypeAnnotation();
+  let type = this.getData("typeAnnotation");
+  if (type != null) {
+    return type;
+  }
+  type = this._getTypeAnnotation() || anyTypeAnnotation();
   if (isTypeAnnotation(type)) type = type.typeAnnotation;
-  return (this.typeAnnotation = type);
+  this.setData("typeAnnotation", type);
+  return type;
 }
 
 // Used to avoid infinite recursion in cases like
@@ -65,7 +68,9 @@ export function _getTypeAnnotation(this: NodePath): any {
     }
   }
 
+  // @ts-ignore
   if (node.typeAnnotation) {
+    // @ts-ignore
     return node.typeAnnotation;
   }
 

--- a/packages/babel-traverse/src/path/inference/inferer-reference.ts
+++ b/packages/babel-traverse/src/path/inference/inferer-reference.ts
@@ -12,7 +12,7 @@ import {
 import type * as t from "@babel/types";
 import type Binding from "../../scope/binding";
 
-export default function (node: any) {
+export default function (this: NodePath, node: any) {
   if (!this.isReferenced()) return;
 
   // check if a binding exists of this value and if so then return a union type of all

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -299,12 +299,14 @@ export function _verifyNodeList(
 }
 
 export function unshiftContainer<Nodes extends t.Node | t.Node[]>(
+  this: NodePath,
   listKey: string,
   nodes: Nodes,
 ): NodePath[] {
   // todo: NodePaths<Nodes>
   this._assertUnremoved();
 
+  // @ts-expect-error fixme
   nodes = this._verifyNodeList(nodes);
 
   // get the first path and insert our nodes before it, if it doesn't exist then it

--- a/packages/babel-traverse/src/path/replacement.ts
+++ b/packages/babel-traverse/src/path/replacement.ts
@@ -38,10 +38,10 @@ import hoistVariables from "@babel/helper-hoist-variables";
  *  - Remove the current node.
  */
 
-export function replaceWithMultiple<Nodes extends Array<t.Node>>(
-  nodes: Nodes,
+export function replaceWithMultiple(
+  this: NodePath,
+  nodes: t.Node[],
 ): NodePath[] {
-  // todo NodePaths
   this.resync();
 
   nodes = this._verifyNodeList(nodes);

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -264,7 +264,7 @@ function ensureCallbackArrays(obj) {
 }
 
 function wrapCheck(wrapper, fn) {
-  const newFn = function (path) {
+  const newFn = function (this: unknown, path) {
     if (wrapper.checkPath(path)) {
       return fn.apply(this, arguments);
     }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,9 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-    "lib": [
-      "esnext"
-    ],
+    "lib": ["esnext"],
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
@@ -13,6 +11,7 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noImplicitThis": true
   }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we enable the `noImplicitThis` compiler option and fixes all the new typing errors.

This PR is based on #14530, whose changes implicitly fix `noImplicitThis` errors.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14545"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

