### PR TITLE
Reduce size of babel-highlight in browser

### DIFF
--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -14,6 +14,10 @@
     "directory": "packages/babel-highlight"
   },
   "main": "./lib/index.js",
+  "browser": {
+    "./lib/index.js": "./lib/index-browser.js",
+    "./src/index.ts": "./src/index-browser.ts"
+  },
   "dependencies": {
     "@babel/helper-validator-identifier": "workspace:^",
     "chalk": "^2.0.0",

--- a/packages/babel-highlight/src/index-browser.ts
+++ b/packages/babel-highlight/src/index-browser.ts
@@ -1,0 +1,34 @@
+/// <reference path="../../../lib/third-party-libs.d.ts" />
+
+import Chalk from "chalk";
+
+/**
+ * Highlight `text`.
+ */
+
+type Options = {
+  forceColor?: boolean;
+};
+
+/**
+ * Code cannot be highlighted in browser, will return false.
+ */
+export function shouldHighlight(): boolean {
+  return false;
+}
+
+/**
+ * The Chalk instance that should be used given the passed options.
+ */
+export function getChalk(options: Options) {
+  return options.forceColor
+    ? new Chalk.constructor({ enabled: true, level: 1 })
+    : Chalk;
+}
+
+/**
+ * Highlight `code`.
+ */
+export default function highlight(code: string): string {
+  return code;
+}


### PR DESCRIPTION
| Q                                                   | A 
| ------------------------------------ | ---
| Fixed Issues?                                 |
| Patch: Bug Fix?                              |  No
| Major: Breaking Change?              |  No
| Minor: New Feature?                     |  No
| Tests Added + Pass?                      |  No tests added
| Documentation PR Link                 |
| Any Dependency Changes?           |  No
| License                                           |  MIT

Syntax highlighting does not make sense for execution in the browser, because it uses Chalk, which only works with terminals, nevertheless it cannot be removed.

But it is possible to disable code highlighting in the browser, thereby reducing the weight of the code.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14555"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

