### PR TITLE
feat: add import-assertions to shippedProposals

### DIFF
--- a/packages/babel-preset-env/data/shipped-proposals.js
+++ b/packages/babel-preset-env/data/shipped-proposals.js
@@ -2,7 +2,9 @@
 // These mappings represent the syntax proposals that have been
 // shipped by browsers, and are enabled by the `shippedProposals` option.
 
-const proposalPlugins = new Set();
+const proposalPlugins = new Set([
+  "syntax-import-assertions"
+]);
 
 // use intermediary object to enforce alphabetical key order
 const pluginSyntaxObject = {

--- a/packages/babel-preset-env/data/shipped-proposals.js
+++ b/packages/babel-preset-env/data/shipped-proposals.js
@@ -1,10 +1,14 @@
 /* eslint sort-keys: "error" */
-// These mappings represent the syntax proposals that have been
+// These mappings represent the transform plugins that have been
 // shipped by browsers, and are enabled by the `shippedProposals` option.
 
-const proposalPlugins = new Set([
+const proposalPlugins = new Set();
+
+// proposal syntax plugins enabled by the `shippedProposals` option.
+// Unlike proposalPlugins above, they are independent of compiler targets.
+const proposalSyntaxPlugins = [
   "syntax-import-assertions"
-]);
+]
 
 // use intermediary object to enforce alphabetical key order
 const pluginSyntaxObject = {
@@ -29,4 +33,4 @@ const pluginSyntaxEntries = Object.keys(pluginSyntaxObject).map(function (key) {
 
 const pluginSyntaxMap = new Map(pluginSyntaxEntries);
 
-module.exports = { pluginSyntaxMap, proposalPlugins };
+module.exports = { pluginSyntaxMap, proposalPlugins, proposalSyntaxPlugins };

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -42,6 +42,7 @@
     "@babel/plugin-syntax-class-static-block": "^7.14.5",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+    "@babel/plugin-syntax-import-assertions": "workspace:^",
     "@babel/plugin-syntax-json-strings": "^7.8.3",
     "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
     "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",

--- a/packages/babel-preset-env/src/available-plugins.ts
+++ b/packages/babel-preset-env/src/available-plugins.ts
@@ -5,6 +5,7 @@ import syntaxClassProperties from "@babel/plugin-syntax-class-properties";
 import syntaxClassStaticBlock from "@babel/plugin-syntax-class-static-block";
 import syntaxDynamicImport from "@babel/plugin-syntax-dynamic-import";
 import syntaxExportNamespaceFrom from "@babel/plugin-syntax-export-namespace-from";
+import syntaxImportAssertions from "@babel/plugin-syntax-import-assertions";
 import syntaxJsonStrings from "@babel/plugin-syntax-json-strings";
 import syntaxLogicalAssignmentOperators from "@babel/plugin-syntax-logical-assignment-operators";
 import syntaxNullishCoalescingOperator from "@babel/plugin-syntax-nullish-coalescing-operator";
@@ -104,6 +105,7 @@ export default {
   "syntax-class-static-block": () => syntaxClassStaticBlock,
   "syntax-dynamic-import": () => syntaxDynamicImport,
   "syntax-export-namespace-from": () => syntaxExportNamespaceFrom,
+  "syntax-import-assertions": () => syntaxImportAssertions,
   "syntax-json-strings": () => syntaxJsonStrings,
   "syntax-logical-assignment-operators": () => syntaxLogicalAssignmentOperators,
   "syntax-nullish-coalescing-operator": () => syntaxNullishCoalescingOperator,

--- a/packages/babel-preset-env/src/filter-items.ts
+++ b/packages/babel-preset-env/src/filter-items.ts
@@ -4,6 +4,14 @@ import { minVersions } from "./available-plugins";
 // $FlowIgnore
 const has = Function.call.bind(Object.hasOwnProperty);
 
+export function addProposalSyntaxPlugins(
+  items: Set<string>,
+  proposalSyntaxPlugins: string[],
+) {
+  proposalSyntaxPlugins.forEach(plugin => {
+    items.add(plugin);
+  });
+}
 export function removeUnnecessaryItems(
   items: Set<string>,
   overlapping: { [name: string]: string[] },

--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -2,10 +2,18 @@ import { lt } from "semver";
 import type { SemVer } from "semver";
 import { logPlugin } from "./debug";
 import getOptionSpecificExcludesFor from "./get-option-specific-excludes";
-import { removeUnnecessaryItems, removeUnsupportedItems } from "./filter-items";
+import {
+  addProposalSyntaxPlugins,
+  removeUnnecessaryItems,
+  removeUnsupportedItems,
+} from "./filter-items";
 import moduleTransformations from "./module-transformations";
 import normalizeOptions from "./normalize-options";
-import { proposalPlugins, pluginSyntaxMap } from "../data/shipped-proposals";
+import {
+  pluginSyntaxMap,
+  proposalPlugins,
+  proposalSyntaxPlugins,
+} from "../data/shipped-proposals";
 import {
   plugins as pluginsList,
   pluginsBugfixes as pluginsBugfixesList,
@@ -375,6 +383,9 @@ option \`forceAllTransforms: true\` instead.
   );
   removeUnnecessaryItems(pluginNames, overlappingPlugins);
   removeUnsupportedItems(pluginNames, api.version);
+  if (shippedProposals) {
+    addProposalSyntaxPlugins(pluginNames, proposalSyntaxPlugins);
+  }
 
   const polyfillPlugins = getPolyfillPlugins({
     useBuiltIns,

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-babel-polyfill/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -25,6 +25,7 @@ Using plugins:
   proposal-export-namespace-from { samsung < 11.0 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-shippedProposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
@@ -23,5 +23,6 @@ Using plugins:
   transform-modules-commonjs
   proposal-dynamic-import
   proposal-export-namespace-from { }
+  syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
@@ -22,5 +22,6 @@ Using plugins:
   transform-modules-commonjs
   proposal-dynamic-import
   proposal-export-namespace-from { }
+  syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -25,6 +25,7 @@ Using plugins:
   proposal-export-namespace-from { samsung < 11.0 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   proposal-export-namespace-from { ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
@@ -24,5 +24,6 @@ Using plugins:
   transform-modules-commonjs
   proposal-dynamic-import
   proposal-export-namespace-from { }
+  syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
@@ -23,5 +23,6 @@ Using plugins:
   transform-modules-commonjs
   proposal-dynamic-import
   proposal-export-namespace-from { }
+  syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   proposal-dynamic-import
+  syntax-import-assertions
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/shipped-proposals/import-assertions/input.mjs
+++ b/packages/babel-preset-env/test/fixtures/shipped-proposals/import-assertions/input.mjs
@@ -1,0 +1,1 @@
+import { version } from "./package.json" assert { type: "json" }

--- a/packages/babel-preset-env/test/fixtures/shipped-proposals/import-assertions/options.json
+++ b/packages/babel-preset-env/test/fixtures/shipped-proposals/import-assertions/options.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["env", { "shippedProposals": true }]]
+}

--- a/packages/babel-preset-env/test/fixtures/shipped-proposals/import-assertions/output.js
+++ b/packages/babel-preset-env/test/fixtures/shipped-proposals/import-assertions/output.js
@@ -1,0 +1,3 @@
+"use strict";
+
+var _package = require("./package.json");

--- a/yarn.lock
+++ b/yarn.lock
@@ -3372,6 +3372,7 @@ __metadata:
     "@babel/plugin-syntax-class-static-block": ^7.14.5
     "@babel/plugin-syntax-dynamic-import": ^7.8.3
     "@babel/plugin-syntax-export-namespace-from": ^7.8.3
+    "@babel/plugin-syntax-import-assertions": "workspace:^"
     "@babel/plugin-syntax-json-strings": ^7.8.3
     "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
     "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The import assertions proposal has been shipped in Chrome 91 and Node.js 17.1. Therefore we should add the syntax plugin to `shippedProposals`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14556"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

