### PR TITLE
Fix `jest-runner` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,17 +190,17 @@ jobs:
 
         # Todo(Babel 8): Jest execution path is hardcoded because Yarn 2 does not support node 6
         run: |
-          node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color
+          node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color --maxWorkers=4
         env:
           BABEL_ENV: test
           TEST_FUZZ: ${{ contains(fromJSON('["6","8","10"]'), matrix.node-version) && false || true }}
       - name: Test with jest-runner
-        if: ${{ !contains(fromJSON('["6","8","10"]'), matrix.node-version) }}
+        if: ${{ matrix.node-version == '16' }}
         run: |
-          yarn jest --ci --color
+          yarn jest --ci --color --maxWorkers=4
         env:
           BABEL_ENV: test
-          TEST_FUZZ: ${{ contains(fromJSON('["6","8","10"]'), matrix.node-version) && false || true }}
+          TEST_FUZZ: true
           BABEL_USE_JEST_LIGHT: false
       - name: Use Node.js latest # For `yarn version` in post actions of the first actions/setup-node
         if: contains(fromJSON('["6","8","10"]'), matrix.node-version)
@@ -236,7 +236,7 @@ jobs:
         # Hack: --color has supports-color@5 returned true for GitHub CI
         # Remove once `chalk` is bumped to 4.0.
         run: |
-          yarn jest --ci --color
+          yarn jest --ci --color --maxWorkers=4
           yarn test:esm
         env:
           BABEL_ENV: test
@@ -246,7 +246,7 @@ jobs:
         # Hack: --color has supports-color@5 returned true for GitHub CI
         # Remove once `chalk` is bumped to 4.0.
         run: |
-          yarn jest --ci --color
+          yarn jest --ci --color --maxWorkers=4
         env:
           BABEL_ENV: test
           BABEL_8_BREAKING: true
@@ -277,12 +277,12 @@ jobs:
         # Hack: --color has supports-color@5 returned true for GitHub CI
         # Remove once `chalk` is bumped to 4.0.
         run: |
-          yarn jest --ci --color
+          yarn jest --ci --color --maxWorkers=4
         env:
           BABEL_ENV: test
       - name: Test with jest-runner
         run: |
-          yarn jest --ci --color
+          yarn jest --ci --color --maxWorkers=4
         env:
           BABEL_ENV: test
           BABEL_USE_JEST_LIGHT: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
 
         # Todo(Babel 8): Jest execution path is hardcoded because Yarn 2 does not support node 6
         run: |
-          node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color --maxWorkers=2
+          node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color --maxWorkers=${{ (matrix.node-version == '8') && 1 || 2 }}
         env:
           BABEL_ENV: test
           TEST_FUZZ: ${{ contains(fromJSON('["6","8","10"]'), matrix.node-version) && false || true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
 
         # Todo(Babel 8): Jest execution path is hardcoded because Yarn 2 does not support node 6
         run: |
-          node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color --maxWorkers=4
+          node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color --maxWorkers=3
         env:
           BABEL_ENV: test
           TEST_FUZZ: ${{ contains(fromJSON('["6","8","10"]'), matrix.node-version) && false || true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,10 +190,10 @@ jobs:
 
         # Todo(Babel 8): Jest execution path is hardcoded because Yarn 2 does not support node 6
         run: |
-          node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color --maxWorkers=${{ (matrix.node-version == '8') && 1 || 2 }}
+          node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color --maxWorkers=2
         env:
           BABEL_ENV: test
-          TEST_FUZZ: ${{ contains(fromJSON('["6","8","10"]'), matrix.node-version) && false || true }}
+          TEST_FUZZ: ${{ contains(fromJSON('["6","8","10"]'), matrix.node-version) && 'false' || 'true' }}
       - name: Test with jest-runner
         if: ${{ matrix.node-version == '16' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,14 +190,14 @@ jobs:
 
         # Todo(Babel 8): Jest execution path is hardcoded because Yarn 2 does not support node 6
         run: |
-          node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color --maxWorkers=3
+          node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color --maxWorkers=2
         env:
           BABEL_ENV: test
           TEST_FUZZ: ${{ contains(fromJSON('["6","8","10"]'), matrix.node-version) && false || true }}
       - name: Test with jest-runner
         if: ${{ matrix.node-version == '16' }}
         run: |
-          yarn jest --ci --color --maxWorkers=4
+          yarn jest --ci --color --maxWorkers=2
         env:
           BABEL_ENV: test
           TEST_FUZZ: true
@@ -236,7 +236,7 @@ jobs:
         # Hack: --color has supports-color@5 returned true for GitHub CI
         # Remove once `chalk` is bumped to 4.0.
         run: |
-          yarn jest --ci --color --maxWorkers=4
+          yarn jest --ci --color --maxWorkers=2
           yarn test:esm
         env:
           BABEL_ENV: test
@@ -246,7 +246,7 @@ jobs:
         # Hack: --color has supports-color@5 returned true for GitHub CI
         # Remove once `chalk` is bumped to 4.0.
         run: |
-          yarn jest --ci --color --maxWorkers=4
+          yarn jest --ci --color --maxWorkers=2
         env:
           BABEL_ENV: test
           BABEL_8_BREAKING: true
@@ -277,12 +277,12 @@ jobs:
         # Hack: --color has supports-color@5 returned true for GitHub CI
         # Remove once `chalk` is bumped to 4.0.
         run: |
-          yarn jest --ci --color --maxWorkers=4
+          yarn jest --ci --color --maxWorkers=2
         env:
           BABEL_ENV: test
       - name: Test with jest-runner
         run: |
-          yarn jest --ci --color --maxWorkers=4
+          yarn jest --ci --color --maxWorkers=2
         env:
           BABEL_ENV: test
           BABEL_USE_JEST_LIGHT: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,9 @@ jobs:
           cache: "yarn"
       - name: Build babel artifacts
         run: |
-          BABEL_ENV=test-legacy make -j build-standalone-ci
+          make -j build-standalone-ci
         env:
+          BABEL_ENV: test-legacy
           BABEL_8_BREAKING: false
           STRIP_BABEL_8_FLAG: true
       - name: Ensure cwd does not contain uncommitted changes
@@ -116,8 +117,9 @@ jobs:
       - name: Build babel artifacts
         shell: bash
         run: |
-          BABEL_ENV=test-legacy make -j build-standalone-ci
+          make -j build-standalone-ci
         env:
+          BABEL_ENV: test-legacy
           BABEL_8_BREAKING: false
           STRIP_BABEL_8_FLAG: true
       - name: Ensure cwd does not contain uncommitted changes
@@ -165,7 +167,7 @@ jobs:
         run: |
           yarn install
       - name: Downgrade Jest for node <= 10
-        if: matrix.node-version == '6' || matrix.node-version == '8' || matrix.node-version == '10'
+        if: contains(fromJSON('["6","8","10"]'), matrix.node-version)
         run: |
           yarn remove jest
           yarn add --dev jest@24
@@ -182,17 +184,26 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Test on node.js ${{ matrix.node-version }}
+      - name: Test
         # Hack: --color has supports-color@5 returned true for GitHub CI
         # Remove once `chalk` is bumped to 4.0.
 
         # Todo(Babel 8): Jest execution path is hardcoded because Yarn 2 does not support node 6
         run: |
-          BABEL_ENV=test node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color
+          node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color
         env:
-          TEST_FUZZ: "${{ (matrix.node-version == '6' || matrix.node-version == '8' || matrix.node-version == '10') && 'false' || 'true' }}"
+          BABEL_ENV: test
+          TEST_FUZZ: ${{ contains(fromJSON('["6","8","10"]'), matrix.node-version) && false || true }}
+      - name: Test with jest-runner
+        if: ${{ !contains(fromJSON('["6","8","10"]'), matrix.node-version) }}
+        run: |
+          yarn jest --ci --color
+        env:
+          BABEL_ENV: test
+          TEST_FUZZ: ${{ contains(fromJSON('["6","8","10"]'), matrix.node-version) && false || true }}
+          BABEL_USE_JEST_LIGHT: false
       - name: Use Node.js latest # For `yarn version` in post actions of the first actions/setup-node
-        if: matrix.node-version == '6' || matrix.node-version == '8' || matrix.node-version == '10'
+        if: contains(fromJSON('["6","8","10"]'), matrix.node-version)
         uses: actions/setup-node@v3
         with:
           node-version: "*"
@@ -231,6 +242,16 @@ jobs:
           BABEL_ENV: test
           BABEL_8_BREAKING: true
           BABEL_TYPES_8_BREAKING: true
+      - name: Test with jest-runner
+        # Hack: --color has supports-color@5 returned true for GitHub CI
+        # Remove once `chalk` is bumped to 4.0.
+        run: |
+          yarn jest --ci --color
+        env:
+          BABEL_ENV: test
+          BABEL_8_BREAKING: true
+          BABEL_TYPES_8_BREAKING: true
+          BABEL_USE_JEST_LIGHT: false
 
   test-windows:
     name: Test on Windows
@@ -252,12 +273,19 @@ jobs:
       - name: Generate runtime helpers
         run: |
           make build-plugin-transform-runtime-dist
-      - name: Test on Windows
+      - name: Test
         # Hack: --color has supports-color@5 returned true for GitHub CI
         # Remove once `chalk` is bumped to 4.0.
-        run: yarn jest --ci --color
+        run: |
+          yarn jest --ci --color
         env:
           BABEL_ENV: test
+      - name: Test with jest-runner
+        run: |
+          yarn jest --ci --color
+        env:
+          BABEL_ENV: test
+          BABEL_USE_JEST_LIGHT: false
 
   external-parser-tests:
     name: Third-party Parser Tests

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ test-only:
 test: lint test-only
 
 test-ci: build-standalone-ci
-	BABEL_ENV=test $(YARN) jest --maxWorkers=4 --ci
+	BABEL_ENV=test $(YARN) jest --maxWorkers=2 --ci
 	$(MAKE) test-clean
 
 # Does not work on Windows

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,21 @@
 const semver = require("semver");
 const nodeVersion = process.versions.node;
-const supportsESMAndJestLightRunner = semver.satisfies(
-  nodeVersion,
-  // ^12.22 || >=14.17 : Node will throw "t.isIdentifier is not a function" when test is running in worker threads.
-  // ^13.7: `resolve.exports` specifies conditional exports in package.json
-  "^12.22 || ^13.7 || >=14.17"
-);
+const supportsESMAndJestLightRunner =
+  process.env.BABEL_USE_JEST_LIGHT !== undefined
+    ? bool(process.env.BABEL_USE_JEST_LIGHT)
+    : semver.satisfies(
+        nodeVersion,
+        // ^12.22 || >=14.17 : Node will throw "t.isIdentifier is not a function" when test is running in worker threads.
+        // ^13.7: `resolve.exports` specifies conditional exports in package.json
+        "^12.22 || ^13.7 || >=14.17"
+      );
 const isPublishBundle = process.env.IS_PUBLISH;
+
+console.log(`useJestLightRunner: ${supportsESMAndJestLightRunner}`);
+
+function bool(value) {
+  return value && value !== "false" && value !== "0";
+}
 
 module.exports = {
   runner: supportsESMAndJestLightRunner ? "jest-light-runner" : "jest-runner",

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -4,6 +4,16 @@ import stripAnsi from "strip-ansi";
 import _codeFrame, { codeFrameColumns } from "../lib/index.js";
 const codeFrame = _codeFrame.default;
 
+const FORCE_COLOR = process.env["FORCE_COLOR"];
+
+beforeAll(() => {
+  process.env["FORCE_COLOR"] = "true";
+});
+
+afterAll(() => {
+  process.env["FORCE_COLOR"] = FORCE_COLOR;
+});
+
 describe("@babel/code-frame", function () {
   test("basic usage", function () {
     const rawLines = ["class Foo {", "  constructor()", "};"].join("\n");

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -464,9 +464,9 @@ describe("addon resolution", function () {
     }).toThrow(/Cannot (?:find|resolve) module 'babel-plugin-foo'/);
   });
 
-  const nodeGte12 = parseInt(process.versions.node, 10) >= 12 ? it : it.skip;
+  const itNodeGte12 = parseInt(process.versions.node, 10) >= 12 ? it : it.skip;
 
-  nodeGte12("should respect package.json#exports", async function () {
+  itNodeGte12("should respect package.json#exports for CJS", function () {
     process.chdir("pkg-exports");
 
     expect(
@@ -477,16 +477,29 @@ describe("addon resolution", function () {
         plugins: ["babel-plugin-dual"],
       }).code,
     ).toBe(`"CJS"`);
-
-    expect(
-      (
-        await babel.transformAsync("", {
-          filename: "filename.js",
-          babelrc: false,
-          configFile: false,
-          plugins: ["babel-plugin-dual"],
-        })
-      ).code,
-    ).toBe(`"ESM"`);
   });
+
+  // only jest-light-runner support ESM
+  const itSupportESM =
+    itNodeGte12 == it && new Error().stack.includes("jest-light-runner")
+      ? it
+      : it.skip;
+
+  itSupportESM(
+    "should respect package.json#exports for ESM",
+    async function () {
+      process.chdir("pkg-exports");
+
+      expect(
+        (
+          await babel.transformAsync("", {
+            filename: "filename.js",
+            babelrc: false,
+            configFile: false,
+            plugins: ["babel-plugin-dual"],
+          })
+        ).code,
+      ).toBe(`"ESM"`);
+    },
+  );
 });

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -4,6 +4,16 @@ import stripAnsi from "strip-ansi";
 import _highlight, { shouldHighlight, getChalk } from "../lib/index.js";
 const highlight = _highlight.default;
 
+const FORCE_COLOR = process.env["FORCE_COLOR"];
+
+beforeAll(() => {
+  process.env["FORCE_COLOR"] = "true";
+});
+
+afterAll(() => {
+  process.env["FORCE_COLOR"] = FORCE_COLOR;
+});
+
 describe("@babel/highlight", function () {
   function stubColorSupport(supported) {
     let originalSupportsColor;

--- a/packages/babel-register/test/browserify.js
+++ b/packages/babel-register/test/browserify.js
@@ -21,5 +21,5 @@ describe("browserify", function () {
         resolve();
       });
     });
-  });
+  }, 15000);
 });

--- a/scripts/test-cov.sh
+++ b/scripts/test-cov.sh
@@ -5,7 +5,7 @@ node="yarn node"
 jestArgs="--coverage"
 
 if [ -n "$CI" ]; then
-  jestArgs="${jestArgs} --maxWorkers=4 --ci"
+  jestArgs="${jestArgs} --maxWorkers=2 --ci"
 fi
 
 $node "$(yarn bin jest)" $jestArgs

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,7 +10,7 @@ if [ "$TEST_DEBUG" ]; then
 fi
 
 if [ -n "$CI" ]; then
-  jestArgs+=("--maxWorkers=4")
+  jestArgs+=("--maxWorkers=2")
   jestArgs+=("--ci")
 fi
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |√
| Major: Breaking Change?  |×
| Minor: New Feature?      |×
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I suspect the ci failure in the main branch has something to do with the `worker_threads` used by `jest-light-runner`.

I'm worried it will get worse in the future.

Let's keep `jest-runner` available as a backup.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14572"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

