### PR TITLE
Add third party lib typings

### DIFF
--- a/lib/babel-plugin-dynamic-import-node.d.ts
+++ b/lib/babel-plugin-dynamic-import-node.d.ts
@@ -1,0 +1,16 @@
+import type { PluginAPI } from "@babel/core";
+import type * as t from "@babel/types";
+// https://github.com/airbnb/babel-plugin-dynamic-import-node/blob/master/src/utils.js
+declare module "babel-plugin-dynamic-import-node/utils" {
+  function getImportSource(
+    t: typeof import("@babel/types"),
+    callNode: t.CallExpression
+  ): t.Expression;
+
+  function createDynamicImportTransform({
+    template,
+    types: t,
+  }: PluginAPI): (context: PluginPass, path: NodePath) => void;
+
+  export { getImportSource, createDynamicImportTransform };
+}

--- a/lib/third-party-libs.d.ts
+++ b/lib/third-party-libs.d.ts
@@ -1,4 +1,6 @@
+import type { PluginPass } from "@babel/core";
 import { declare } from "@babel/helper-plugin-utils";
+import type * as t from "@babel/types";
 declare module "js-tokens" {
   // TODO(Babel 8): Remove this
   export { default } from "js-tokens-BABEL_8_BREAKING-true";
@@ -38,6 +40,11 @@ declare module "babel-plugin-polyfill-corejs3" {
   export = { default: plugin };
 }
 declare module "babel-plugin-polyfill-regenerator" {
+  let plugin: ReturnType<typeof declare>;
+  export = { default: plugin };
+}
+
+declare module "regenerator-transform" {
   let plugin: ReturnType<typeof declare>;
   export = { default: plugin };
 }

--- a/lib/third-party-libs.d.ts
+++ b/lib/third-party-libs.d.ts
@@ -1,5 +1,43 @@
+import { declare } from "@babel/helper-plugin-utils";
 declare module "js-tokens" {
   // TODO(Babel 8): Remove this
   export { default } from "js-tokens-BABEL_8_BREAKING-true";
   export * from "js-tokens-BABEL_8_BREAKING-true";
+}
+
+declare module "@babel/preset-modules/lib/plugins/transform-async-arrows-in-class" {
+  let plugin: ReturnType<typeof declare>;
+  export = { default: plugin };
+}
+declare module "@babel/preset-modules/lib/plugins/transform-edge-default-parameters" {
+  let plugin: ReturnType<typeof declare>;
+  export = { default: plugin };
+}
+declare module "@babel/preset-modules/lib/plugins/transform-edge-function-name" {
+  let plugin: ReturnType<typeof declare>;
+  export = { default: plugin };
+}
+declare module "@babel/preset-modules/lib/plugins/transform-tagged-template-caching" {
+  let plugin: ReturnType<typeof declare>;
+  export = { default: plugin };
+}
+declare module "@babel/preset-modules/lib/plugins/transform-safari-block-shadowing" {
+  let plugin: ReturnType<typeof declare>;
+  export = { default: plugin };
+}
+declare module "@babel/preset-modules/lib/plugins/transform-safari-for-shadowing" {
+  let plugin: ReturnType<typeof declare>;
+  export = { default: plugin };
+}
+declare module "babel-plugin-polyfill-corejs2" {
+  let plugin: ReturnType<typeof declare>;
+  export = { default: plugin };
+}
+declare module "babel-plugin-polyfill-corejs3" {
+  let plugin: ReturnType<typeof declare>;
+  export = { default: plugin };
+}
+declare module "babel-plugin-polyfill-regenerator" {
+  let plugin: ReturnType<typeof declare>;
+  export = { default: plugin };
 }

--- a/packages/babel-helper-compilation-targets/src/types.ts
+++ b/packages/babel-helper-compilation-targets/src/types.ts
@@ -13,7 +13,7 @@ export type Target =
   | "samsung";
 
 export type Targets = {
-  [target in Target]: string;
+  [target in Target]?: string;
 };
 
 export type TargetsTuple = {

--- a/packages/babel-plugin-transform-runtime/src/index.ts
+++ b/packages/babel-plugin-transform-runtime/src/index.ts
@@ -8,9 +8,12 @@ import getRuntimePath, { resolveFSPath } from "./get-runtime-path";
 import _pluginCorejs2 from "babel-plugin-polyfill-corejs2";
 import _pluginCorejs3 from "babel-plugin-polyfill-corejs3";
 import _pluginRegenerator from "babel-plugin-polyfill-regenerator";
-const pluginCorejs2 = _pluginCorejs2.default || _pluginCorejs2;
-const pluginCorejs3 = _pluginCorejs3.default || _pluginCorejs3;
-const pluginRegenerator = _pluginRegenerator.default || _pluginRegenerator;
+const pluginCorejs2 = (_pluginCorejs2.default ||
+  _pluginCorejs2) as typeof _pluginCorejs2.default;
+const pluginCorejs3 = (_pluginCorejs3.default ||
+  _pluginCorejs3) as typeof _pluginCorejs3.default;
+const pluginRegenerator = (_pluginRegenerator.default ||
+  _pluginRegenerator) as typeof _pluginRegenerator.default;
 
 const pluginsCompat = "#__secret_key__@babel/runtime__compatibility";
 

--- a/packages/babel-preset-env/src/normalize-options.ts
+++ b/packages/babel-preset-env/src/normalize-options.ts
@@ -116,7 +116,6 @@ export const checkDuplicateIncludeExcludes = (
 const normalizeTargets = (targets): Options["targets"] => {
   // TODO: Allow to use only query or strings as a targets from next breaking change.
   if (typeof targets === "string" || Array.isArray(targets)) {
-    // @ts-expect-error
     return { browsers: targets };
   }
   return { ...targets };

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -28,6 +28,14 @@ function getTsPkgs(subRoot) {
           if (name === "babel-standalone") {
             return [["", "/src"]];
           }
+          if (name === "babel-compat-data") {
+            // map ./plugins to ./data/plugins.json
+            const subExport = _export.slice(1);
+            const subExportPath = exportPath
+              .replace("./", "/data/")
+              .replace(/\.js$/, ".json");
+            return [[subExport, subExportPath]];
+          }
           // [{esm, default}, "./lib/index.js"]
           if (Array.isArray(exportPath)) {
             exportPath = exportPath[1];
@@ -55,8 +63,10 @@ function getTsPkgs(subRoot) {
     })
     .filter(
       ({ name, relative }) =>
-        // babel-register is special-cased because its entry point is a js file
+        // @babel/register is special-cased because its entry point is a js file
         name === "@babel/register" ||
+        // @babel/compat-data is used by preset-env
+        name === "@babel/compat-data" ||
         fs.existsSync(new URL(relative + "/src/index.ts", root))
     );
 }

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -18,6 +18,7 @@ const thirdPartyBabelPlugins = [
   "babel-plugin-polyfill-corejs2",
   "babel-plugin-polyfill-corejs3",
   "babel-plugin-polyfill-regenerator",
+  "regenerator-transform",
 ];
 
 const root = new URL("../../", import.meta.url);
@@ -111,6 +112,10 @@ fs.writeFileSync(
               name,
               ["./lib/third-party-libs.d.ts"],
             ]),
+            [
+              "babel-plugin-dynamic-import-node/utils",
+              ["./lib/babel-plugin-dynamic-import-node.d.ts"],
+            ],
           ]),
         },
       },

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -8,6 +8,18 @@ const archivedSyntaxPkgs = importJSON(
   new URL("./archived-syntax-pkgs.json", import.meta.url)
 );
 
+const thirdPartyBabelPlugins = [
+  "@babel/preset-modules/lib/plugins/transform-async-arrows-in-class",
+  "@babel/preset-modules/lib/plugins/transform-edge-default-parameters",
+  "@babel/preset-modules/lib/plugins/transform-edge-function-name",
+  "@babel/preset-modules/lib/plugins/transform-tagged-template-caching",
+  "@babel/preset-modules/lib/plugins/transform-safari-block-shadowing",
+  "@babel/preset-modules/lib/plugins/transform-safari-for-shadowing",
+  "babel-plugin-polyfill-corejs2",
+  "babel-plugin-polyfill-corejs3",
+  "babel-plugin-polyfill-regenerator",
+];
+
 const root = new URL("../../", import.meta.url);
 
 function getTsPkgs(subRoot) {
@@ -94,6 +106,10 @@ fs.writeFileSync(
             ...archivedSyntaxPkgs.map(name => [
               name,
               ["./lib/archived-libs.d.ts"],
+            ]),
+            ...thirdPartyBabelPlugins.map(name => [
+              name,
+              ["./lib/third-party-libs.d.ts"],
             ]),
           ]),
         },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "extends": "./tsconfig.base.json",
   "include": [
     "./packages/babel-code-frame/src/**/*.ts",
+    "./packages/babel-compat-data/src/**/*.ts",
     "./packages/babel-core/src/**/*.ts",
     "./packages/babel-generator/src/**/*.ts",
     "./packages/babel-helper-annotate-as-pure/src/**/*.ts",
@@ -151,6 +152,24 @@
     "paths": {
       "@babel/code-frame": [
         "./packages/babel-code-frame/src"
+      ],
+      "@babel/compat-data/plugins": [
+        "./packages/babel-compat-data/data/plugins.json"
+      ],
+      "@babel/compat-data/native-modules": [
+        "./packages/babel-compat-data/data/native-modules.json"
+      ],
+      "@babel/compat-data/corejs2-built-ins": [
+        "./packages/babel-compat-data/data/corejs2-built-ins.json"
+      ],
+      "@babel/compat-data/corejs3-shipped-proposals": [
+        "./packages/babel-compat-data/data/corejs3-shipped-proposals.json"
+      ],
+      "@babel/compat-data/overlapping-plugins": [
+        "./packages/babel-compat-data/data/overlapping-plugins.json"
+      ],
+      "@babel/compat-data/plugin-bugfixes": [
+        "./packages/babel-compat-data/data/plugin-bugfixes.json"
       ],
       "@babel/core": [
         "./packages/babel-core/src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -665,6 +665,33 @@
       ],
       "@babel/plugin-syntax-trailing-function-commas": [
         "./lib/archived-libs.d.ts"
+      ],
+      "@babel/preset-modules/lib/plugins/transform-async-arrows-in-class": [
+        "./lib/third-party-libs.d.ts"
+      ],
+      "@babel/preset-modules/lib/plugins/transform-edge-default-parameters": [
+        "./lib/third-party-libs.d.ts"
+      ],
+      "@babel/preset-modules/lib/plugins/transform-edge-function-name": [
+        "./lib/third-party-libs.d.ts"
+      ],
+      "@babel/preset-modules/lib/plugins/transform-tagged-template-caching": [
+        "./lib/third-party-libs.d.ts"
+      ],
+      "@babel/preset-modules/lib/plugins/transform-safari-block-shadowing": [
+        "./lib/third-party-libs.d.ts"
+      ],
+      "@babel/preset-modules/lib/plugins/transform-safari-for-shadowing": [
+        "./lib/third-party-libs.d.ts"
+      ],
+      "babel-plugin-polyfill-corejs2": [
+        "./lib/third-party-libs.d.ts"
+      ],
+      "babel-plugin-polyfill-corejs3": [
+        "./lib/third-party-libs.d.ts"
+      ],
+      "babel-plugin-polyfill-regenerator": [
+        "./lib/third-party-libs.d.ts"
       ]
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -692,6 +692,12 @@
       ],
       "babel-plugin-polyfill-regenerator": [
         "./lib/third-party-libs.d.ts"
+      ],
+      "regenerator-transform": [
+        "./lib/third-party-libs.d.ts"
+      ],
+      "babel-plugin-dynamic-import-node/utils": [
+        "./lib/babel-plugin-dynamic-import-node.d.ts"
       ]
     }
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR adds path mappings for `@babel/compat-data` and third-party Babel plugins typings, such as `@babel/preset-modules` and `babel-plugin-polyfill-provider-*`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14580"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

