### PR TITLE
Define the global `regeneratorRuntime` in `@babel/runtime/regenerator`

### DIFF
--- a/packages/babel-runtime-corejs2/regenerator/index.js
+++ b/packages/babel-runtime-corejs2/regenerator/index.js
@@ -1,1 +1,15 @@
-module.exports = require("../helpers/regeneratorRuntime")();
+// TODO(Babel 8): Remove this file.
+
+const runtime = require("../helpers/regeneratorRuntime")();
+module.exports = runtime;
+
+// Copied from https://github.com/facebook/regenerator/blob/main/packages/runtime/runtime.js#L736=
+try {
+  regeneratorRuntime = runtime;
+} catch (accidentalStrictMode) {
+  if (typeof globalThis === "object") {
+    globalThis.regeneratorRuntime = runtime;
+  } else {
+    Function("r", "regeneratorRuntime = r")(runtime);
+  }
+}

--- a/packages/babel-runtime-corejs3/regenerator/index.js
+++ b/packages/babel-runtime-corejs3/regenerator/index.js
@@ -1,1 +1,15 @@
-module.exports = require("../helpers/regeneratorRuntime")();
+// TODO(Babel 8): Remove this file.
+
+const runtime = require("../helpers/regeneratorRuntime")();
+module.exports = runtime;
+
+// Copied from https://github.com/facebook/regenerator/blob/main/packages/runtime/runtime.js#L736=
+try {
+  regeneratorRuntime = runtime;
+} catch (accidentalStrictMode) {
+  if (typeof globalThis === "object") {
+    globalThis.regeneratorRuntime = runtime;
+  } else {
+    Function("r", "regeneratorRuntime = r")(runtime);
+  }
+}

--- a/packages/babel-runtime/regenerator/index.js
+++ b/packages/babel-runtime/regenerator/index.js
@@ -1,1 +1,15 @@
-module.exports = require("../helpers/regeneratorRuntime")();
+// TODO(Babel 8): Remove this file.
+
+const runtime = require("../helpers/regeneratorRuntime")();
+module.exports = runtime;
+
+// Copied from https://github.com/facebook/regenerator/blob/main/packages/runtime/runtime.js#L736=
+try {
+  regeneratorRuntime = runtime;
+} catch (accidentalStrictMode) {
+  if (typeof globalThis === "object") {
+    globalThis.regeneratorRuntime = runtime;
+  } else {
+    Function("r", "regeneratorRuntime = r")(runtime);
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/14576
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Even if `@babel/runtime' was documented as being a pure set of helpers and the `@babel/runtime/regenerator` entry point exported the `regeneratorRuntime` helper, it also accientally used to define a `regeneratorRuntime` global due to its depenency on `regenerator-runtime`.

Many packages relied on this global being "accidentally" present due to something else in the dependencies tree loading `@babel/runtime/regenerator`. I'm annoyed by this, but let's restore the old (accidental and undocumented) behavior because I have already seen multiple repositories with this problem. We'll remove this legacy entry point in Babel 8.

Closes #14576.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14581"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

