### PR TITLE
fix: skip template literal transform for TSLiteralType

### DIFF
--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/ts-literal-type/input.ts
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/ts-literal-type/input.ts
@@ -1,0 +1,2 @@
+type World = "world";
+type Greeting = `hello ${World}`;

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/ts-literal-type/options.json
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/ts-literal-type/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-template-literals", "syntax-typescript"]
+}

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/ts-literal-type/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/ts-literal-type/output.js
@@ -1,0 +1,2 @@
+type World = "world";
+type Greeting = `hello ${World}`;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | template literal plugin incorrectly transforms TS template literal type
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The issue was caught by the type checker. In this PR we skip the transform when it is a TS template literal type. Other typing improvements are for the `noImplicitAny` option.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14582"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

