### PR TITLE
Restore es5 compatibility in `@babel/runtime/regenerator`

### DIFF
--- a/packages/babel-runtime-corejs2/regenerator/index.js
+++ b/packages/babel-runtime-corejs2/regenerator/index.js
@@ -1,6 +1,6 @@
 // TODO(Babel 8): Remove this file.
 
-const runtime = require("../helpers/regeneratorRuntime")();
+var runtime = require("../helpers/regeneratorRuntime")();
 module.exports = runtime;
 
 // Copied from https://github.com/facebook/regenerator/blob/main/packages/runtime/runtime.js#L736=

--- a/packages/babel-runtime-corejs3/regenerator/index.js
+++ b/packages/babel-runtime-corejs3/regenerator/index.js
@@ -1,6 +1,6 @@
 // TODO(Babel 8): Remove this file.
 
-const runtime = require("../helpers/regeneratorRuntime")();
+var runtime = require("../helpers/regeneratorRuntime")();
 module.exports = runtime;
 
 // Copied from https://github.com/facebook/regenerator/blob/main/packages/runtime/runtime.js#L736=

--- a/packages/babel-runtime/regenerator/index.js
+++ b/packages/babel-runtime/regenerator/index.js
@@ -1,6 +1,6 @@
 // TODO(Babel 8): Remove this file.
 
-const runtime = require("../helpers/regeneratorRuntime")();
+var runtime = require("../helpers/regeneratorRuntime")();
 module.exports = runtime;
 
 // Copied from https://github.com/facebook/regenerator/blob/main/packages/runtime/runtime.js#L736=


### PR DESCRIPTION
This aims to fix https://github.com/babel/babel/issues/14586.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14588"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

