### PR TITLE
fix: remove TSDeclareFunction from ExportDefaultDeclaration

### DIFF
--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -811,11 +811,7 @@ export interface ExportAllDeclaration extends BaseNode {
 
 export interface ExportDefaultDeclaration extends BaseNode {
   type: "ExportDefaultDeclaration";
-  declaration:
-    | FunctionDeclaration
-    | TSDeclareFunction
-    | ClassDeclaration
-    | Expression;
+  declaration: FunctionDeclaration | ClassDeclaration | Expression;
   exportKind?: "value" | null;
 }
 

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -634,11 +634,7 @@ export function exportAllDeclaration(
   });
 }
 export function exportDefaultDeclaration(
-  declaration:
-    | t.FunctionDeclaration
-    | t.TSDeclareFunction
-    | t.ClassDeclaration
-    | t.Expression,
+  declaration: t.FunctionDeclaration | t.ClassDeclaration | t.Expression,
 ): t.ExportDefaultDeclaration {
   return validateNode<t.ExportDefaultDeclaration>({
     type: "ExportDefaultDeclaration",

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -1490,7 +1490,6 @@ defineType("ExportDefaultDeclaration", {
     declaration: {
       validate: assertNodeType(
         "FunctionDeclaration",
-        "TSDeclareFunction",
         "ClassDeclaration",
         "Expression",
       ),


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | ExportDefaultDeclaration incorrectly accept TSDeclareFunction as declaration
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Unlike `export declare function f()`, `export default declare function f()` is not valid TS and therefore we should remove it from `ExportDefaultDeclaration`.

Babel parser throws on `export default declare function f()`, too.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14591"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

