### PR TITLE
refactor: avoid mutating AST nodes

### DIFF
--- a/packages/babel-plugin-transform-modules-systemjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.ts
@@ -170,14 +170,14 @@ export default declare<PluginState>((api, options: Options) => {
   api.assertVersion(7);
 
   const { systemGlobal = "System", allowTopLevelThis = false } = options;
-  const IGNORE_REASSIGNMENT_SYMBOL = Symbol();
+  const reassignmentVisited = new WeakSet();
 
   const reassignmentVisitor: Visitor<ReassignmentVisitorState> = {
     "AssignmentExpression|UpdateExpression"(
       path: NodePath<t.AssignmentExpression | t.UpdateExpression>,
     ) {
-      if (path.node[IGNORE_REASSIGNMENT_SYMBOL]) return;
-      path.node[IGNORE_REASSIGNMENT_SYMBOL] = true;
+      if (reassignmentVisited.has(path.node)) return;
+      reassignmentVisited.add(path.node);
 
       const arg = path.isAssignmentExpression()
         ? path.get("left")


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we migrate plugin-introduced AST node properties to a weak set, which prevents V8 from creating new shapes for different AST types and renders typings easier.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14599"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

