### PR TITLE
[ts] FIx parsing of nested `extends` type in arrow type

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1163,7 +1163,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         if (abstract) this.next();
         this.next(); // eat `new`
       }
-      this.tsFillSignature(tt.arrow, node);
+      this.tsInAllowConditionalTypesContext(() =>
+        this.tsFillSignature(tt.arrow, node),
+      );
       return this.finishNode(node, type);
     }
 

--- a/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/input.ts
@@ -1,0 +1,1 @@
+type Equals = A extends (x: B extends C ? D : E) => 0 ? F : G;

--- a/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["typescript"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/output.json
@@ -1,0 +1,125 @@
+{
+  "type": "File",
+  "start":0,"end":62,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":62,"index":62}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":62,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":62,"index":62}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start":0,"end":62,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":62,"index":62}},
+        "id": {
+          "type": "Identifier",
+          "start":5,"end":11,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":11,"index":11},"identifierName":"Equals"},
+          "name": "Equals"
+        },
+        "typeAnnotation": {
+          "type": "TSConditionalType",
+          "start":14,"end":61,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":61,"index":61}},
+          "checkType": {
+            "type": "TSTypeReference",
+            "start":14,"end":15,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":15,"index":15}},
+            "typeName": {
+              "type": "Identifier",
+              "start":14,"end":15,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":15,"index":15},"identifierName":"A"},
+              "name": "A"
+            }
+          },
+          "extendsType": {
+            "type": "TSFunctionType",
+            "start":24,"end":53,"loc":{"start":{"line":1,"column":24,"index":24},"end":{"line":1,"column":53,"index":53}},
+            "parameters": [
+              {
+                "type": "Identifier",
+                "start":25,"end":47,"loc":{"start":{"line":1,"column":25,"index":25},"end":{"line":1,"column":47,"index":47},"identifierName":"x"},
+                "name": "x",
+                "typeAnnotation": {
+                  "type": "TSTypeAnnotation",
+                  "start":26,"end":47,"loc":{"start":{"line":1,"column":26,"index":26},"end":{"line":1,"column":47,"index":47}},
+                  "typeAnnotation": {
+                    "type": "TSConditionalType",
+                    "start":28,"end":47,"loc":{"start":{"line":1,"column":28,"index":28},"end":{"line":1,"column":47,"index":47}},
+                    "checkType": {
+                      "type": "TSTypeReference",
+                      "start":28,"end":29,"loc":{"start":{"line":1,"column":28,"index":28},"end":{"line":1,"column":29,"index":29}},
+                      "typeName": {
+                        "type": "Identifier",
+                        "start":28,"end":29,"loc":{"start":{"line":1,"column":28,"index":28},"end":{"line":1,"column":29,"index":29},"identifierName":"B"},
+                        "name": "B"
+                      }
+                    },
+                    "extendsType": {
+                      "type": "TSTypeReference",
+                      "start":38,"end":39,"loc":{"start":{"line":1,"column":38,"index":38},"end":{"line":1,"column":39,"index":39}},
+                      "typeName": {
+                        "type": "Identifier",
+                        "start":38,"end":39,"loc":{"start":{"line":1,"column":38,"index":38},"end":{"line":1,"column":39,"index":39},"identifierName":"C"},
+                        "name": "C"
+                      }
+                    },
+                    "trueType": {
+                      "type": "TSTypeReference",
+                      "start":42,"end":43,"loc":{"start":{"line":1,"column":42,"index":42},"end":{"line":1,"column":43,"index":43}},
+                      "typeName": {
+                        "type": "Identifier",
+                        "start":42,"end":43,"loc":{"start":{"line":1,"column":42,"index":42},"end":{"line":1,"column":43,"index":43},"identifierName":"D"},
+                        "name": "D"
+                      }
+                    },
+                    "falseType": {
+                      "type": "TSTypeReference",
+                      "start":46,"end":47,"loc":{"start":{"line":1,"column":46,"index":46},"end":{"line":1,"column":47,"index":47}},
+                      "typeName": {
+                        "type": "Identifier",
+                        "start":46,"end":47,"loc":{"start":{"line":1,"column":46,"index":46},"end":{"line":1,"column":47,"index":47},"identifierName":"E"},
+                        "name": "E"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start":49,"end":53,"loc":{"start":{"line":1,"column":49,"index":49},"end":{"line":1,"column":53,"index":53}},
+              "typeAnnotation": {
+                "type": "TSLiteralType",
+                "start":52,"end":53,"loc":{"start":{"line":1,"column":52,"index":52},"end":{"line":1,"column":53,"index":53}},
+                "literal": {
+                  "type": "NumericLiteral",
+                  "start":52,"end":53,"loc":{"start":{"line":1,"column":52,"index":52},"end":{"line":1,"column":53,"index":53}},
+                  "extra": {
+                    "rawValue": 0,
+                    "raw": "0"
+                  },
+                  "value": 0
+                }
+              }
+            }
+          },
+          "trueType": {
+            "type": "TSTypeReference",
+            "start":56,"end":57,"loc":{"start":{"line":1,"column":56,"index":56},"end":{"line":1,"column":57,"index":57}},
+            "typeName": {
+              "type": "Identifier",
+              "start":56,"end":57,"loc":{"start":{"line":1,"column":56,"index":56},"end":{"line":1,"column":57,"index":57},"identifierName":"F"},
+              "name": "F"
+            }
+          },
+          "falseType": {
+            "type": "TSTypeReference",
+            "start":60,"end":61,"loc":{"start":{"line":1,"column":60,"index":60},"end":{"line":1,"column":61,"index":61}},
+            "typeName": {
+              "type": "Identifier",
+              "start":60,"end":61,"loc":{"start":{"line":1,"column":60,"index":60},"end":{"line":1,"column":61,"index":61},"identifierName":"G"},
+              "name": "G"
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-return/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-return/input.ts
@@ -1,0 +1,1 @@
+type Equals = A extends () => B extends C ? D : E ? F : G;

--- a/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-return/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-return/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["typescript"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-return/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-return/output.json
@@ -1,0 +1,102 @@
+{
+  "type": "File",
+  "start":0,"end":58,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":58,"index":58}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":58,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":58,"index":58}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start":0,"end":58,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":58,"index":58}},
+        "id": {
+          "type": "Identifier",
+          "start":5,"end":11,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":11,"index":11},"identifierName":"Equals"},
+          "name": "Equals"
+        },
+        "typeAnnotation": {
+          "type": "TSConditionalType",
+          "start":14,"end":57,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":57,"index":57}},
+          "checkType": {
+            "type": "TSTypeReference",
+            "start":14,"end":15,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":15,"index":15}},
+            "typeName": {
+              "type": "Identifier",
+              "start":14,"end":15,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":15,"index":15},"identifierName":"A"},
+              "name": "A"
+            }
+          },
+          "extendsType": {
+            "type": "TSFunctionType",
+            "start":24,"end":49,"loc":{"start":{"line":1,"column":24,"index":24},"end":{"line":1,"column":49,"index":49}},
+            "parameters": [],
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start":27,"end":49,"loc":{"start":{"line":1,"column":27,"index":27},"end":{"line":1,"column":49,"index":49}},
+              "typeAnnotation": {
+                "type": "TSConditionalType",
+                "start":30,"end":49,"loc":{"start":{"line":1,"column":30,"index":30},"end":{"line":1,"column":49,"index":49}},
+                "checkType": {
+                  "type": "TSTypeReference",
+                  "start":30,"end":31,"loc":{"start":{"line":1,"column":30,"index":30},"end":{"line":1,"column":31,"index":31}},
+                  "typeName": {
+                    "type": "Identifier",
+                    "start":30,"end":31,"loc":{"start":{"line":1,"column":30,"index":30},"end":{"line":1,"column":31,"index":31},"identifierName":"B"},
+                    "name": "B"
+                  }
+                },
+                "extendsType": {
+                  "type": "TSTypeReference",
+                  "start":40,"end":41,"loc":{"start":{"line":1,"column":40,"index":40},"end":{"line":1,"column":41,"index":41}},
+                  "typeName": {
+                    "type": "Identifier",
+                    "start":40,"end":41,"loc":{"start":{"line":1,"column":40,"index":40},"end":{"line":1,"column":41,"index":41},"identifierName":"C"},
+                    "name": "C"
+                  }
+                },
+                "trueType": {
+                  "type": "TSTypeReference",
+                  "start":44,"end":45,"loc":{"start":{"line":1,"column":44,"index":44},"end":{"line":1,"column":45,"index":45}},
+                  "typeName": {
+                    "type": "Identifier",
+                    "start":44,"end":45,"loc":{"start":{"line":1,"column":44,"index":44},"end":{"line":1,"column":45,"index":45},"identifierName":"D"},
+                    "name": "D"
+                  }
+                },
+                "falseType": {
+                  "type": "TSTypeReference",
+                  "start":48,"end":49,"loc":{"start":{"line":1,"column":48,"index":48},"end":{"line":1,"column":49,"index":49}},
+                  "typeName": {
+                    "type": "Identifier",
+                    "start":48,"end":49,"loc":{"start":{"line":1,"column":48,"index":48},"end":{"line":1,"column":49,"index":49},"identifierName":"E"},
+                    "name": "E"
+                  }
+                }
+              }
+            }
+          },
+          "trueType": {
+            "type": "TSTypeReference",
+            "start":52,"end":53,"loc":{"start":{"line":1,"column":52,"index":52},"end":{"line":1,"column":53,"index":53}},
+            "typeName": {
+              "type": "Identifier",
+              "start":52,"end":53,"loc":{"start":{"line":1,"column":52,"index":52},"end":{"line":1,"column":53,"index":53},"identifierName":"F"},
+              "name": "F"
+            }
+          },
+          "falseType": {
+            "type": "TSTypeReference",
+            "start":56,"end":57,"loc":{"start":{"line":1,"column":56,"index":56},"end":{"line":1,"column":57,"index":57}},
+            "typeName": {
+              "type": "Identifier",
+              "start":56,"end":57,"loc":{"start":{"line":1,"column":56,"index":56},"end":{"line":1,"column":57,"index":57},"identifierName":"G"},
+              "name": "G"
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14600
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14604"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

