### PR TITLE
Fix `@babel/transform-typescript` compatibility with Next.js

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -575,8 +575,16 @@ export default declare((api, opts: Options) => {
 
       [process.env.BABEL_8_BREAKING
         ? "TSNonNullExpression|TSInstantiationExpression"
-        : // This has been introduced in Babel 7.18.0
-        t.tsInstantiationExpression
+        : /* This has been introduced in Babel 7.18.0
+             We use api.types.* and not t.* for feature detection,
+             because the Babel version that is running this plugin
+             (where we check if the visitor is valid) might be different
+             from the Babel version that we resolve with `import "@babel/core"`.
+             This happens, for example, with Next.js that bundled `@babel/core`
+             but allows loading unbundled plugin (which cannot obviously import
+             the bundled `@babel/core` version).
+           */
+        api.types.tsInstantiationExpression
         ? "TSNonNullExpression|TSInstantiationExpression"
         : "TSNonNullExpression"](
         path: NodePath<t.TSNonNullExpression | t.TSExpressionWithTypeArguments>,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/vercel/next.js/issues/37080
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This was a quite annoying discovery, I'm pasting here the comment I also wrote in the code:
> We use api.types.* and not t.* (imported from `@babel/core`) for feature detection,
             because the Babel version that is running this plugin
             (where we check if the visitor is valid) might be different
             from the Babel version that we resolve with `import "@babel/core"`.
             This happens, for example, with Next.js that bundled `@babel/core`
             but allows loading unbundled plugin (which cannot obviously import
             the bundled `@babel/core` version).

I verified that this works using https://github.com/babel/babel/issues/14587#issuecomment-1139732466.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14610"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

