### PR TITLE
Fix prettier test compat with Babel 8

### DIFF
--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -40,7 +40,7 @@ yarn install
 
 if [ "$BABEL_8_BREAKING" = true ] ; then
   # Prettier's tests use `>` in JSX, which is invalid syntax
-  sed -i 's§<in T>() => {}</in>;§<in T>() = {}</in>;§g' tests/format/typescript/optional-variance/{with-jsx.tsx,__snapshots__/jsfmt.spec.js.snap}
+  sed -i 's$<in T>() => {}</in>;$<in T>() = {}</in>;$g' tests/format/typescript/optional-variance/{with-jsx.tsx,__snapshots__/jsfmt.spec.js.snap}
   node -e '
     const filepath = "jsfmt.spec.js.snap";
     const file = fs.readFileSync(filepath, "utf8");

--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -38,6 +38,24 @@ export YARN_IGNORE_PATH=1
 startLocalRegistry "$root"/verdaccio-config.yml
 yarn install
 
+if [ "$BABEL_8_BREAKING" = true ] ; then
+  # Prettier's tests use `>` in JSX, which is invalid syntax
+  sed -i 's§<in T>() => {}</in>;§<in T>() = {}</in>;§g' tests/format/typescript/optional-variance/{with-jsx.tsx,__snapshots__/jsfmt.spec.js.snap}
+  node -e '
+    const filepath = "jsfmt.spec.js.snap";
+    const file = fs.readFileSync(filepath, "utf8");
+    const BEFORE_READ = "exports[`with-jsx.tsx [babel-ts] format 1`] = `";
+    const END_READ = "`;";
+    const BEFORE_WRITE = "exports[`with-jsx.tsx [typescript] format 1`] = `";
+    const read_start = file.indexOf(BEFORE_READ) + BEFORE_READ.length;
+    const read_end = file.indexOf(END_READ, read_start) + END_READ.length;
+    const write_start = file.indexOf(BEFORE_WRITE) + BEFORE_WRITE.length;
+
+    const newFile = file.slice(0, write_start) + file.slice(read_start, read_end);
+    fs.writeFileSync(filepath, newFile);
+  '
+fi
+
 # Only run js,jsx,misc format tests
 # Without --runInBand CircleCI hangs.
 yarn test "tests/format/(jsx?|misc)/" --update-snapshot --runInBand

--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -42,7 +42,7 @@ if [ "$BABEL_8_BREAKING" = true ] ; then
   # Prettier's tests use `>` in JSX, which is invalid syntax
   sed -i 's$<in T>() => {}</in>;$<in T>() = {}</in>;$g' tests/format/typescript/optional-variance/{with-jsx.tsx,__snapshots__/jsfmt.spec.js.snap}
   node -e '
-    const filepath = "jsfmt.spec.js.snap";
+    const filepath = "tests/format/typescript/optional-variance/__snapshots__/jsfmt.spec.js.snap";
     const file = fs.readFileSync(filepath, "utf8");
     const BEFORE_READ = "exports[`with-jsx.tsx [babel-ts] format 1`] = `";
     const END_READ = "`;";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This tests contains invalid JSX that is disallowed in Babel 8. https://github.com/prettier/prettier/blob/main/tests/format/typescript/optional-variance/with-jsx.tsx

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14612"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

