### PR TITLE
Improve @babel/helper-* typings

### DIFF
--- a/packages/babel-helper-annotate-as-pure/src/index.ts
+++ b/packages/babel-helper-annotate-as-pure/src/index.ts
@@ -1,5 +1,5 @@
-import { addComment } from "@babel/types";
-import type { Node } from "@babel/types";
+import { addComment, type Node } from "@babel/types";
+import type { NodePath } from "@babel/traverse";
 
 const PURE_ANNOTATION = "#__PURE__";
 
@@ -7,12 +7,10 @@ const isPureAnnotated = ({ leadingComments }: Node): boolean =>
   !!leadingComments &&
   leadingComments.some(comment => /[@#]__PURE__/.test(comment.value));
 
-export default function annotateAsPure(
-  pathOrNode: Node | { node: Node },
-): void {
+export default function annotateAsPure(pathOrNode: Node | NodePath): void {
   const node =
     // @ts-expect-error Node will not have `node` property
-    pathOrNode["node"] || pathOrNode;
+    (pathOrNode["node"] || pathOrNode) as Node;
   if (isPureAnnotated(node)) {
     return;
   }

--- a/packages/babel-helper-annotate-as-pure/src/index.ts
+++ b/packages/babel-helper-annotate-as-pure/src/index.ts
@@ -10,7 +10,9 @@ const isPureAnnotated = ({ leadingComments }: Node): boolean =>
 export default function annotateAsPure(
   pathOrNode: Node | { node: Node },
 ): void {
-  const node = pathOrNode["node"] || pathOrNode;
+  const node =
+    // @ts-expect-error Node will not have `node` property
+    pathOrNode["node"] || pathOrNode;
   if (isPureAnnotated(node)) {
     return;
   }

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.ts
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.ts
@@ -1,6 +1,7 @@
 import explode from "@babel/helper-explode-assignable-expression";
 import { assignmentExpression, sequenceExpression } from "@babel/types";
 import type { Visitor } from "@babel/traverse";
+import * as t from "@babel/types";
 
 export default function (opts: { build: Function; operator: string }) {
   const { build, operator } = opts;
@@ -10,7 +11,7 @@ export default function (opts: { build: Function; operator: string }) {
       const { node, scope } = path;
       if (node.operator !== operator + "=") return;
 
-      const nodes = [];
+      const nodes: t.AssignmentExpression[] = [];
       // @ts-expect-error todo(flow->ts)
       const exploded = explode(node.left, nodes, this, scope);
       nodes.push(

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.ts
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.ts
@@ -1,7 +1,7 @@
 import explode from "@babel/helper-explode-assignable-expression";
 import { assignmentExpression, sequenceExpression } from "@babel/types";
 import type { Visitor } from "@babel/traverse";
-import * as t from "@babel/types";
+import type * as t from "@babel/types";
 
 export default function (opts: { build: Function; operator: string }) {
   const { build, operator } = opts;

--- a/packages/babel-helper-check-duplicate-nodes/src/index.ts
+++ b/packages/babel-helper-check-duplicate-nodes/src/index.ts
@@ -1,20 +1,25 @@
 import { VISITOR_KEYS } from "@babel/types";
+import type * as t from "@babel/types";
 
-export default function checkDuplicateNodes(ast) {
+type StackItem = {
+  node: t.Node;
+  parent: t.Node | null;
+};
+export default function checkDuplicateNodes(ast: t.Node) {
   if (arguments.length !== 1) {
     throw new Error("checkDuplicateNodes accepts only one argument: ast");
   }
   // A Map from node to its parent
   const parentsMap = new Map();
 
-  const hidePrivateProperties = (key, val) => {
+  const hidePrivateProperties = (key: string, val: unknown) => {
     // Hides properties like _shadowedFunctionLiteral,
     // which makes the AST circular
     if (key[0] === "_") return "[Private]";
     return val;
   };
 
-  const stack = [{ node: ast, parent: null }];
+  const stack: StackItem[] = [{ node: ast, parent: null }];
   let item;
 
   while ((item = stack.pop()) !== undefined) {
@@ -36,7 +41,9 @@ export default function checkDuplicateNodes(ast) {
     parentsMap.set(node, parent);
 
     for (const key of keys) {
-      const subNode = node[key];
+      const subNode =
+        // @ts-expect-error visitor keys must present in node
+        node[key];
 
       if (Array.isArray(subNode)) {
         for (const child of subNode) {

--- a/packages/babel-helper-define-map/src/index.ts
+++ b/packages/babel-helper-define-map/src/index.ts
@@ -45,8 +45,10 @@ type DefineMap = {
   kind: "get" | "set" | "value" | "initializer";
 };
 
+export type MutatorMap = Record<string, DefineMap>;
+
 export function push(
-  mutatorMap: any,
+  mutatorMap: MutatorMap,
   node: t.Property | t.Method,
   kind: DefineMap["kind"],
   file: File,

--- a/packages/babel-helper-hoist-variables/src/index.ts
+++ b/packages/babel-helper-hoist-variables/src/index.ts
@@ -4,7 +4,7 @@ import {
   identifier,
 } from "@babel/types";
 import type * as t from "@babel/types";
-import type { NodePath } from "@babel/traverse";
+import type { NodePath, Visitor } from "@babel/traverse";
 
 export type EmitFunction = (
   id: t.Identifier,
@@ -19,16 +19,16 @@ type State = {
 
 type Unpacked<T> = T extends (infer U)[] ? U : T;
 
-const visitor = {
-  Scope(path: NodePath, state: State) {
+const visitor: Visitor<State> = {
+  Scope(path, state) {
     if (state.kind === "let") path.skip();
   },
 
-  FunctionParent(path: NodePath) {
+  FunctionParent(path) {
     path.skip();
   },
 
-  VariableDeclaration(path: NodePath<t.VariableDeclaration>, state: State) {
+  VariableDeclaration(path, state) {
     if (state.kind && path.node.kind !== state.kind) return;
 
     const nodes = [];

--- a/packages/babel-helper-remap-async-to-generator/src/index.ts
+++ b/packages/babel-helper-remap-async-to-generator/src/index.ts
@@ -1,6 +1,6 @@
 /* @noflow */
 
-import type { NodePath } from "@babel/traverse";
+import type { NodePath, Visitor } from "@babel/traverse";
 import wrapFunction from "@babel/helper-wrap-function";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 import {
@@ -10,8 +10,9 @@ import {
   isThisExpression,
   yieldExpression,
 } from "@babel/types";
+import type * as t from "@babel/types";
 
-const awaitVisitor = {
+const awaitVisitor: Visitor<{ wrapAwait: t.Expression }> = {
   Function(path) {
     path.skip();
   },
@@ -32,8 +33,8 @@ const awaitVisitor = {
 export default function (
   path: NodePath<any>,
   helpers: {
-    wrapAsync: any;
-    wrapAwait?: any;
+    wrapAsync: t.Expression;
+    wrapAwait?: t.Expression;
   },
   noNewArrows?: boolean,
   ignoreFunctionLength?: boolean,

--- a/packages/babel-helper-simple-access/src/index.ts
+++ b/packages/babel-helper-simple-access/src/index.ts
@@ -20,7 +20,7 @@ type State = {
 };
 export default function simplifyAccess(
   path: NodePath,
-  bindingNames,
+  bindingNames: Set<string>,
   // TODO(Babel 8): Remove this
   includeUpdateExpression: boolean = true,
 ) {

--- a/packages/babel-helper-split-export-declaration/src/index.ts
+++ b/packages/babel-helper-split-export-declaration/src/index.ts
@@ -10,6 +10,8 @@ import {
 export default function splitExportDeclaration(exportDeclaration) {
   if (!exportDeclaration.isExportDeclaration()) {
     throw new Error("Only export declarations can be split.");
+  } else if (exportDeclaration.isExportAllDeclaration()) {
+    return;
   }
 
   // build specifiers that point back to this export declaration

--- a/packages/babel-helper-split-export-declaration/src/index.ts
+++ b/packages/babel-helper-split-export-declaration/src/index.ts
@@ -14,10 +14,11 @@ export default function splitExportDeclaration(
     t.ExportDefaultDeclaration | t.ExportNamedDeclaration
   >,
 ) {
-  if (!exportDeclaration.isExportDeclaration()) {
-    throw new Error("Only export declarations can be split.");
-  } else if (exportDeclaration.isExportAllDeclaration()) {
-    return;
+  if (
+    !exportDeclaration.isExportDeclaration() ||
+    exportDeclaration.isExportAllDeclaration()
+  ) {
+    throw new Error("Only default and named export declarations can be split.");
   }
 
   // build specifiers that point back to this export declaration

--- a/packages/babel-plugin-transform-property-mutators/src/index.ts
+++ b/packages/babel-plugin-transform-property-mutators/src/index.ts
@@ -9,9 +9,9 @@ export default declare(api => {
     name: "transform-property-mutators",
 
     visitor: {
-      ObjectExpression(path, file) {
+      ObjectExpression(path, { file }) {
         const { node } = path;
-        let mutatorMap;
+        let mutatorMap: defineMap.MutatorMap | void;
         const newProperties = node.properties.filter(function (prop) {
           if (t.isObjectMethod(prop)) {
             if (prop.kind === "get" || prop.kind === "set") {

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -380,9 +380,9 @@ export default class Scope {
   inited;
 
   bindings: { [name: string]: Binding };
-  references: object;
-  globals: object;
-  uids: object;
+  references: { [name: string]: true };
+  globals: { [name: string]: t.Identifier | t.JSXIdentifier };
+  uids: { [name: string]: true };
   data: object;
   crawling: boolean;
 
@@ -798,8 +798,7 @@ export default class Scope {
     }
   }
 
-  // todo: flow->ts maybe add more specific type
-  addGlobal(node: Extract<t.Node, { name: string }>) {
+  addGlobal(node: t.Identifier | t.JSXIdentifier) {
     this.globals[node.name] = node;
   }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes `@babel/helper-*` typing errors when `noImplicitAny` is enabled. See #14601 for more info.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14620"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

