### PR TITLE
Speedup e2e test on github

### DIFF
--- a/.github/workflows/e2e-tests-breaking.yml
+++ b/.github/workflows/e2e-tests-breaking.yml
@@ -45,12 +45,34 @@ jobs:
           - react-native
           - prettier
     steps:
+      - name: Get yarn1 cache directory path
+        id: yarn1-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
           node-version: "*"
+      - name: Get yarn3 cache directory path
+        id: yarn3-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - name: Use yarn1 cache
+        uses: actions/cache@v3
+        id: yarn1-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn1-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn1-e2e-breaking-${{ matrix.project }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn1-e2e-breaking-${{ matrix.project }}-
+      - name: Use yarn3 cache
+        uses: actions/cache@v3
+        id: yarn3-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn3-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn3-e2e-breaking-${{ matrix.project }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn3-e2e-breaking-${{ matrix.project }}-
       - uses: actions/download-artifact@v3
         with:
           name: verdaccio-workspace

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,13 +44,34 @@ jobs:
           - react-native
           - prettier
     steps:
+      - name: Get yarn1 cache directory path
+        id: yarn1-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
           node-version: "*"
-          cache: "yarn"
+      - name: Get yarn3 cache directory path
+        id: yarn3-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - name: Use yarn1 cache
+        uses: actions/cache@v3
+        id: yarn1-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn1-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn1-e2e-${{ matrix.project }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn1-e2e-${{ matrix.project }}-
+      - name: Use yarn3 cache
+        uses: actions/cache@v3
+        id: yarn3-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn3-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn3-e2e-${{ matrix.project }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn3-e2e-${{ matrix.project }}-
       - uses: actions/download-artifact@v3
         with:
           name: verdaccio-workspace

--- a/scripts/integration-tests/e2e-jest.sh
+++ b/scripts/integration-tests/e2e-jest.sh
@@ -58,6 +58,8 @@ if [ "$BABEL_8_BREAKING" = true ] ; then
   "
 fi
 
+sed -i 's/"skipLibCheck": false,/"skipLibCheck": true,/g' tsconfig.json # Speedup
+
 yarn build
 
 # The full test suite takes about 20mins on CircleCI. We run only a few of them


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Speed up all e2e tests on github.
The jest is the most obvious, going from 16-18 minutes to 7 minutes.
The total time went from 20-25 minutes to 11-12 minutes.

1. Enable yarn caching for all tests
2. Enable `skipLibCheck` in jest.

We can produce less CO2!