### PR TITLE
Change limit of source map 3MB

### DIFF
--- a/packages/babel-core/src/transformation/normalize-file.ts
+++ b/packages/babel-core/src/transformation/normalize-file.ts
@@ -12,7 +12,7 @@ import parser from "../parser";
 import cloneDeep from "./util/clone-deep";
 
 const debug = buildDebug("babel:transform:file");
-const LARGE_INPUT_SOURCEMAP_THRESHOLD = 1_000_000;
+const LARGE_INPUT_SOURCEMAP_THRESHOLD = 3_000_000;
 
 export type NormalizedFile = {
   code: string;


### PR DESCRIPTION
Workaround for https://github.com/babel/babel/issues/14635

Changes limit of source map size to 3MB