### PR TITLE
Improve `@babel/types` typings

### DIFF
--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@babel/helper-validator-identifier": "workspace:^",
-    "to-fast-properties": "^2.0.0"
+    "to-fast-properties": "condition:BABEL_8_BREAKING ? ^4.0.0 : ^2.0.0"
   },
   "devDependencies": {
     "@babel/generator": "workspace:^",

--- a/packages/babel-types/scripts/generators/ast-types.js
+++ b/packages/babel-types/scripts/generators/ast-types.js
@@ -37,9 +37,9 @@ export interface SourceLocation {
 
 interface BaseNode {
   type: Node["type"];
-  leadingComments?: ReadonlyArray<Comment> | null;
-  innerComments?: ReadonlyArray<Comment> | null;
-  trailingComments?: ReadonlyArray<Comment> | null;
+  leadingComments?: Comment[] | null;
+  innerComments?: Comment[] | null;
+  trailingComments?: Comment[] | null;
   start?: number | null;
   end?: number | null;
   loc?: SourceLocation | null;

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -33,9 +33,9 @@ export interface SourceLocation {
 
 interface BaseNode {
   type: Node["type"];
-  leadingComments?: ReadonlyArray<Comment> | null;
-  innerComments?: ReadonlyArray<Comment> | null;
-  trailingComments?: ReadonlyArray<Comment> | null;
+  leadingComments?: Comment[] | null;
+  innerComments?: Comment[] | null;
+  trailingComments?: Comment[] | null;
   start?: number | null;
   end?: number | null;
   loc?: SourceLocation | null;

--- a/packages/babel-types/src/builders/validateNode.ts
+++ b/packages/babel-types/src/builders/validateNode.ts
@@ -4,7 +4,7 @@ import { BUILDER_KEYS } from "..";
 
 export default function validateNode<N extends t.Node>(node: N) {
   // todo: because keys not in BUILDER_KEYS are not validated - this actually allows invalid nodes in some cases
-  const keys = BUILDER_KEYS[node.type];
+  const keys = BUILDER_KEYS[node.type] as (keyof N & string)[];
   for (const key of keys) {
     validate(node, key, node[key]);
   }

--- a/packages/babel-types/src/clone/cloneNode.ts
+++ b/packages/babel-types/src/clone/cloneNode.ts
@@ -4,8 +4,15 @@ import { isFile, isIdentifier } from "../validators/generated";
 
 const has = Function.call.bind(Object.prototype.hasOwnProperty);
 
+type CommentCache = Map<t.Comment, t.Comment>;
+
 // This function will never be called for comments, only for real nodes.
-function cloneIfNode(obj, deep, withoutLoc, commentsCache) {
+function cloneIfNode(
+  obj: t.Node | undefined | null,
+  deep: boolean,
+  withoutLoc: boolean,
+  commentsCache: CommentCache,
+) {
   if (obj && typeof obj.type === "string") {
     return cloneNodeInternal(obj, deep, withoutLoc, commentsCache);
   }
@@ -13,7 +20,12 @@ function cloneIfNode(obj, deep, withoutLoc, commentsCache) {
   return obj;
 }
 
-function cloneIfNodeOrArray(obj, deep, withoutLoc, commentsCache) {
+function cloneIfNodeOrArray(
+  obj: t.Node | undefined | null | (t.Node | undefined | null)[],
+  deep: boolean,
+  withoutLoc: boolean,
+  commentsCache: CommentCache,
+) {
   if (Array.isArray(obj)) {
     return obj.map(node => cloneIfNode(node, deep, withoutLoc, commentsCache));
   }
@@ -37,7 +49,7 @@ function cloneNodeInternal<T extends t.Node>(
   node: T,
   deep: boolean = true,
   withoutLoc: boolean = false,
-  commentsCache: Map<t.Comment, t.Comment>,
+  commentsCache: CommentCache,
 ): T {
   if (!node) return node;
 
@@ -77,13 +89,16 @@ function cloneNodeInternal<T extends t.Node>(
                   commentsCache,
                 )
               : cloneIfNodeOrArray(
+                  // @ts-expect-error node[field] has been guarded by has check
                   node[field],
                   true,
                   withoutLoc,
                   commentsCache,
                 );
         } else {
-          newNode[field] = node[field];
+          newNode[field] =
+            // @ts-expect-error node[field] has been guarded by has check
+            node[field];
         }
       }
     }

--- a/packages/babel-types/src/comments/addComments.ts
+++ b/packages/babel-types/src/comments/addComments.ts
@@ -6,11 +6,11 @@ import type * as t from "..";
 export default function addComments<T extends t.Node>(
   node: T,
   type: t.CommentTypeShorthand,
-  comments: ReadonlyArray<t.Comment>,
+  comments: Array<t.Comment>,
 ): T {
   if (!comments || !node) return node;
 
-  const key = `${type}Comments`;
+  const key = `${type}Comments` as const;
 
   if (node[key]) {
     if (type === "leading") {

--- a/packages/babel-types/src/constants/index.ts
+++ b/packages/babel-types/src/constants/index.ts
@@ -5,7 +5,7 @@ export const COMMENT_KEYS = [
   "leadingComments",
   "trailingComments",
   "innerComments",
-];
+] as const;
 
 export const LOGICAL_OPERATORS = ["||", "&&", "??"];
 export const UPDATE_OPERATORS = ["++", "--"];
@@ -62,7 +62,7 @@ export const UNARY_OPERATORS = [
 export const INHERIT_KEYS = {
   optional: ["typeAnnotation", "typeParameters", "returnType"],
   force: ["start", "loc", "end"],
-};
+} as const;
 
 export const BLOCK_SCOPED_SYMBOL = Symbol.for("var used to be block scoped");
 export const NOT_LOCAL_BINDING = Symbol.for(

--- a/packages/babel-types/src/converters/Scope.ts
+++ b/packages/babel-types/src/converters/Scope.ts
@@ -1,8 +1,0 @@
-// NOTE: this actually uses Scope from @babel/traverse, but we can't add a dependency on its types,
-// because this would be cyclic dependency. Declare the structural subset that is required.
-import type * as t from "..";
-
-export type Scope = {
-  push(value: { id: t.LVal; kind: "var"; init?: t.Expression }): void;
-  buildUndefinedNode(): t.Node;
-};

--- a/packages/babel-types/src/converters/ensureBlock.ts
+++ b/packages/babel-types/src/converters/ensureBlock.ts
@@ -11,5 +11,9 @@ export default function ensureBlock(
   node: t.Node,
   key: string = "body",
 ): t.BlockStatement {
-  return (node[key] = toBlock(node[key], node));
+  // @ts-ignore Fixme: key may not exist in node, consider remove key = "body"
+  const result = toBlock(node[key], node);
+  // @ts-ignore
+  node[key] = result;
+  return result;
 }

--- a/packages/babel-types/src/converters/gatherSequenceExpressions.ts
+++ b/packages/babel-types/src/converters/gatherSequenceExpressions.ts
@@ -14,14 +14,19 @@ import {
 } from "../builders/generated";
 import cloneNode from "../clone/cloneNode";
 import type * as t from "..";
-import type { Scope } from "./Scope";
+import type { Scope } from "@babel/traverse";
+
+export type DeclarationInfo = {
+  kind: t.VariableDeclaration["kind"];
+  id: t.Identifier;
+};
 
 export default function gatherSequenceExpressions(
   nodes: ReadonlyArray<t.Node>,
   scope: Scope,
-  declars: Array<any>,
-): t.SequenceExpression {
-  const exprs = [];
+  declars: Array<DeclarationInfo>,
+) {
+  const exprs: t.Expression[] = [];
   let ensureLastUndefined = true;
 
   for (const node of nodes) {
@@ -62,7 +67,6 @@ export default function gatherSequenceExpressions(
         : scope.buildUndefinedNode();
       if (!consequent || !alternate) return; // bailed
 
-      // @ts-expect-error todo(flow->ts) consequent - Argument of type 'Node' is not assignable to parameter of type 'Expression'
       exprs.push(conditionalExpression(node.test, consequent, alternate));
     } else if (isBlockStatement(node)) {
       const body = gatherSequenceExpressions(node.body, scope, declars);

--- a/packages/babel-types/src/converters/toBlock.ts
+++ b/packages/babel-types/src/converters/toBlock.ts
@@ -19,7 +19,7 @@ export default function toBlock(
     return node;
   }
 
-  let blockNodes = [];
+  let blockNodes: t.Statement[] = [];
 
   if (isEmptyStatement(node)) {
     blockNodes = [];

--- a/packages/babel-types/src/converters/toSequenceExpression.ts
+++ b/packages/babel-types/src/converters/toSequenceExpression.ts
@@ -1,6 +1,7 @@
 import gatherSequenceExpressions from "./gatherSequenceExpressions";
 import type * as t from "..";
-import type { Scope } from "./Scope";
+import type { Scope } from "@babel/traverse";
+import type { DeclarationInfo } from "./gatherSequenceExpressions";
 
 /**
  * Turn an array of statement `nodes` into a `SequenceExpression`.
@@ -16,7 +17,7 @@ export default function toSequenceExpression(
 ): t.SequenceExpression | undefined {
   if (!nodes?.length) return;
 
-  const declars = [];
+  const declars: DeclarationInfo[] = [];
   const result = gatherSequenceExpressions(nodes, scope, declars);
   if (!result) return;
 
@@ -24,5 +25,6 @@ export default function toSequenceExpression(
     scope.push(declar);
   }
 
+  // @ts-ignore fixme: gatherSequenceExpressions will return an Expression when there are only one element
   return result;
 }

--- a/packages/babel-types/src/converters/toStatement.ts
+++ b/packages/babel-types/src/converters/toStatement.ts
@@ -33,17 +33,17 @@ function toStatement(node: t.Node, ignore?: boolean): t.Statement | false {
 
   if (isClass(node)) {
     mustHaveId = true;
-    newType = "ClassDeclaration";
+    newType = "ClassDeclaration" as const;
   } else if (isFunction(node)) {
     mustHaveId = true;
-    newType = "FunctionDeclaration";
+    newType = "FunctionDeclaration" as const;
   } else if (isAssignmentExpression(node)) {
     return expressionStatement(node);
   }
 
   // @ts-expect-error todo(flow->ts): node.id might be missing
   if (mustHaveId && !node.id) {
-    newType = false;
+    newType = false as false;
   }
 
   if (!newType) {
@@ -54,6 +54,7 @@ function toStatement(node: t.Node, ignore?: boolean): t.Statement | false {
     }
   }
 
+  // @ts-expect-error manipulating node.type
   node.type = newType;
 
   // @ts-expect-error todo(flow->ts) refactor to avoid type unsafe mutations like reassigning node type above

--- a/packages/babel-types/src/converters/valueToNode.ts
+++ b/packages/babel-types/src/converters/valueToNode.ts
@@ -31,15 +31,15 @@ export default valueToNode as {
   (value: unknown): t.Expression;
 };
 
-const objectToString: (value: object) => string = Function.call.bind(
+const objectToString: (value: unknown) => string = Function.call.bind(
   Object.prototype.toString,
 );
 
-function isRegExp(value): value is RegExp {
+function isRegExp(value: unknown): value is RegExp {
   return objectToString(value) === "[object RegExp]";
 }
 
-function isPlainObject(value): value is object {
+function isPlainObject(value: unknown): value is object {
   if (
     typeof value !== "object" ||
     value === null ||
@@ -122,7 +122,15 @@ function valueToNode(value: unknown): t.Expression {
       } else {
         nodeKey = stringLiteral(key);
       }
-      props.push(objectProperty(nodeKey, valueToNode(value[key])));
+      props.push(
+        objectProperty(
+          nodeKey,
+          valueToNode(
+            // @ts-expect-error key must present in value
+            value[key],
+          ),
+        ),
+      );
     }
     return objectExpression(props);
   }

--- a/packages/babel-types/src/definitions/flow.ts
+++ b/packages/babel-types/src/definitions/flow.ts
@@ -13,8 +13,7 @@ import {
 const defineType = defineAliasedType("Flow");
 
 const defineInterfaceishType = (
-  name: string,
-  typeParameterType: string = "TypeParameterDeclaration",
+  name: "DeclareClass" | "DeclareInterface" | "InterfaceDeclaration",
 ) => {
   defineType(name, {
     builder: ["id", "typeParameters", "extends", "body"],
@@ -29,7 +28,7 @@ const defineInterfaceishType = (
     aliases: ["FlowDeclaration", "Statement", "Declaration"],
     fields: {
       id: validateType("Identifier"),
-      typeParameters: validateOptionalType(typeParameterType),
+      typeParameters: validateOptionalType("TypeParameterDeclaration"),
       extends: validateOptional(arrayOfType("InterfaceExtends")),
       mixins: validateOptional(arrayOfType("InterfaceExtends")),
       implements: validateOptional(arrayOfType("ClassImplements")),

--- a/packages/babel-types/src/definitions/index.ts
+++ b/packages/babel-types/src/definitions/index.ts
@@ -50,3 +50,5 @@ export {
   PLACEHOLDERS_FLIPPED_ALIAS,
   TYPES,
 };
+
+export type { FieldOptions } from "./utils";

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -179,7 +179,7 @@ const tsKeywordTypes = [
   "TSUndefinedKeyword",
   "TSUnknownKeyword",
   "TSVoidKeyword",
-];
+] as const;
 
 for (const type of tsKeywordTypes) {
   defineType(type, {
@@ -384,7 +384,7 @@ defineType("TSLiteralType", {
           "BooleanLiteral",
           "BigIntLiteral",
         );
-        function validator(parent, key: string, node) {
+        function validator(parent: any, key: string, node: any) {
           // type A = -1 | 1;
           if (is("UnaryExpression", node)) {
             // check operator first

--- a/packages/babel-types/src/modifications/flow/removeTypeDuplicates.ts
+++ b/packages/babel-types/src/modifications/flow/removeTypeDuplicates.ts
@@ -7,7 +7,7 @@ import {
 } from "../../validators/generated";
 import type * as t from "../..";
 
-function getQualifiedName(node: t.GenericTypeAnnotation["id"]) {
+function getQualifiedName(node: t.GenericTypeAnnotation["id"]): string {
   return isIdentifier(node)
     ? node.name
     : `${node.id.name}.${getQualifiedName(node.qualification)}`;
@@ -20,13 +20,16 @@ export default function removeTypeDuplicates(
   // todo(babel-8): change type to Array<...>
   nodes: ReadonlyArray<t.FlowType | false | null | undefined>,
 ): t.FlowType[] {
-  const generics = {};
-  const bases = {};
+  const generics: Record<string, t.GenericTypeAnnotation> = {};
+  const bases = {} as Record<
+    t.FlowBaseAnnotation["type"],
+    t.FlowBaseAnnotation
+  >;
 
   // store union type groups to circular references
   const typeGroups = new Set<t.FlowType[]>();
 
-  const types = [];
+  const types: t.FlowType[] = [];
 
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
@@ -61,7 +64,7 @@ export default function removeTypeDuplicates(
       const name = getQualifiedName(node.id);
 
       if (generics[name]) {
-        let existing = generics[name];
+        let existing: t.Flow = generics[name];
         if (existing.typeParameters) {
           if (node.typeParameters) {
             existing.typeParameters.params = removeTypeDuplicates(
@@ -82,7 +85,7 @@ export default function removeTypeDuplicates(
   }
 
   // add back in bases
-  for (const type of Object.keys(bases)) {
+  for (const type of Object.keys(bases) as (keyof typeof bases)[]) {
     types.push(bases[type]);
   }
 

--- a/packages/babel-types/src/modifications/inherits.ts
+++ b/packages/babel-types/src/modifications/inherits.ts
@@ -13,18 +13,24 @@ export default function inherits<T extends t.Node | null | undefined>(
 
   // optionally inherit specific properties if not null
   for (const key of INHERIT_KEYS.optional) {
+    // @ts-expect-error Fixme: refine parent types
     if (child[key] == null) {
+      // @ts-expect-error Fixme: refine parent types
       child[key] = parent[key];
     }
   }
 
   // force inherit "private" properties
   for (const key of Object.keys(parent)) {
-    if (key[0] === "_" && key !== "__clone") child[key] = parent[key];
+    if (key[0] === "_" && key !== "__clone") {
+      // @ts-expect-error Fixme: refine parent types
+      child[key] = parent[key];
+    }
   }
 
   // force inherit select properties
   for (const key of INHERIT_KEYS.force) {
+    // @ts-expect-error Fixme: refine parent types
     child[key] = parent[key];
   }
 

--- a/packages/babel-types/src/modifications/removeProperties.ts
+++ b/packages/babel-types/src/modifications/removeProperties.ts
@@ -1,11 +1,21 @@
 import { COMMENT_KEYS } from "../constants";
 import type * as t from "..";
 
-const CLEAR_KEYS = ["tokens", "start", "end", "loc", "raw", "rawValue"];
+const CLEAR_KEYS = [
+  "tokens", // only exist in t.File
+  "start",
+  "end",
+  "loc",
+  // Fixme: should be extra.raw / extra.rawValue?
+  "raw",
+  "rawValue",
+] as const;
 
-const CLEAR_KEYS_PLUS_COMMENTS = COMMENT_KEYS.concat(["comments"]).concat(
-  CLEAR_KEYS,
-);
+const CLEAR_KEYS_PLUS_COMMENTS = [
+  ...COMMENT_KEYS,
+  "comments",
+  ...CLEAR_KEYS,
+] as const;
 
 /**
  * Remove all of the _* properties from a node along with the additional metadata
@@ -17,15 +27,18 @@ export default function removeProperties(
 ): void {
   const map = opts.preserveComments ? CLEAR_KEYS : CLEAR_KEYS_PLUS_COMMENTS;
   for (const key of map) {
+    // @ts-ignore
     if (node[key] != null) node[key] = undefined;
   }
 
   for (const key of Object.keys(node)) {
+    // @ts-ignore
     if (key[0] === "_" && node[key] != null) node[key] = undefined;
   }
 
   const symbols: Array<symbol> = Object.getOwnPropertySymbols(node);
   for (const sym of symbols) {
+    // @ts-ignore Fixme: document symbol properties
     node[sym] = null;
   }
 }

--- a/packages/babel-types/src/modifications/typescript/removeTypeDuplicates.ts
+++ b/packages/babel-types/src/modifications/typescript/removeTypeDuplicates.ts
@@ -12,12 +12,12 @@ export default function removeTypeDuplicates(
   nodes: Array<t.TSType>,
 ): Array<t.TSType> {
   const generics = {};
-  const bases = {};
+  const bases = {} as Record<t.TSBaseType["type"], t.TSBaseType>;
 
   // store union type groups to circular references
   const typeGroups = new Set<t.TSType[]>();
 
-  const types = [];
+  const types: t.TSType[] = [];
 
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
@@ -53,13 +53,16 @@ export default function removeTypeDuplicates(
   }
 
   // add back in bases
-  for (const type of Object.keys(bases)) {
+  for (const type of Object.keys(bases) as (keyof typeof bases)[]) {
     types.push(bases[type]);
   }
 
   // add back in generics
   for (const name of Object.keys(generics)) {
-    types.push(generics[name]);
+    types.push(
+      // @ts-ignore generics are not implemented
+      generics[name],
+    );
   }
 
   return types;

--- a/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
+++ b/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
@@ -36,14 +36,16 @@ function getBindingIdentifiers(
   duplicates?: boolean,
   outerOnly?: boolean,
 ): Record<string, t.Identifier> | Record<string, Array<t.Identifier>> {
-  let search = [].concat(node);
+  const search: t.Node[] = [].concat(node);
   const ids = Object.create(null);
 
   while (search.length) {
     const id = search.shift();
     if (!id) continue;
 
-    const keys = getBindingIdentifiers.keys[id.type];
+    const keys =
+      // @ts-expect-error getBindingIdentifiers.keys do not cover all AST types
+      getBindingIdentifiers.keys[id.type];
 
     if (isIdentifier(id)) {
       if (duplicates) {
@@ -76,8 +78,11 @@ function getBindingIdentifiers(
     if (keys) {
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
-        if (id[key]) {
-          search = search.concat(id[key]);
+        const nodes =
+          // @ts-ignore key must present in id
+          id[key] as t.Node[] | t.Node | undefined | null;
+        if (nodes) {
+          Array.isArray(nodes) ? search.push(...nodes) : search.push(nodes);
         }
       }
     }

--- a/packages/babel-types/src/traverse/traverseFast.ts
+++ b/packages/babel-types/src/traverse/traverseFast.ts
@@ -5,22 +5,23 @@ import type * as t from "..";
  * A prefix AST traversal implementation meant for simple searching
  * and processing.
  */
-export default function traverseFast(
+export default function traverseFast<Options = {}>(
   node: t.Node | null | undefined,
-  enter: (node: t.Node, opts?: any) => void,
-  // todo(flow->ts) We could parametrize opts to T rather than any, so that the type is "forwarded" to the callback.
-  opts?: any,
+  enter: (node: t.Node, opts?: Options) => void,
+  opts?: Options,
 ): void {
   if (!node) return;
 
   const keys = VISITOR_KEYS[node.type];
   if (!keys) return;
 
-  opts = opts || {};
+  opts = opts || ({} as Options);
   enter(node, opts);
 
   for (const key of keys) {
-    const subNode = node[key];
+    const subNode: t.Node | undefined | null =
+      // @ts-ignore key must present in node
+      node[key];
 
     if (Array.isArray(subNode)) {
       for (const node of subNode) {

--- a/packages/babel-types/src/utils/inherit.ts
+++ b/packages/babel-types/src/utils/inherit.ts
@@ -1,11 +1,11 @@
 import type * as t from "..";
 
-export default function inherit(
-  key: string,
-  child: t.Node,
-  parent: t.Node,
-): void {
+export default function inherit<
+  C extends t.Node | undefined,
+  P extends t.Node | undefined,
+>(key: keyof C & keyof P, child: C, parent: P): void {
   if (child && parent) {
+    // @ts-ignore Could further refine key definitions
     child[key] = Array.from(
       new Set([].concat(child[key], parent[key]).filter(Boolean)),
     );

--- a/packages/babel-types/src/utils/shallowEqual.ts
+++ b/packages/babel-types/src/utils/shallowEqual.ts
@@ -2,10 +2,13 @@ export default function shallowEqual<T extends object>(
   actual: object,
   expected: T,
 ): actual is T {
-  const keys = Object.keys(expected);
+  const keys = Object.keys(expected) as (keyof T)[];
 
   for (const key of keys) {
-    if (actual[key] !== expected[key]) {
+    if (
+      // @ts-ignore maybe we should check whether key exists first
+      actual[key] !== expected[key]
+    ) {
       return false;
     }
   }

--- a/packages/babel-types/src/validators/isBinding.ts
+++ b/packages/babel-types/src/validators/isBinding.ts
@@ -19,11 +19,15 @@ export default function isBinding(
     return false;
   }
 
-  const keys = getBindingIdentifiers.keys[parent.type];
+  const keys =
+    // @ts-expect-error getBindingIdentifiers.keys does not cover all AST types
+    getBindingIdentifiers.keys[parent.type];
   if (keys) {
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
-      const val = parent[key];
+      const val =
+        // @ts-expect-error key must present in parent
+        parent[key];
       if (Array.isArray(val)) {
         if (val.indexOf(node) >= 0) return true;
       } else {

--- a/packages/babel-types/src/validators/isLet.ts
+++ b/packages/babel-types/src/validators/isLet.ts
@@ -8,6 +8,8 @@ import type * as t from "..";
 export default function isLet(node: t.Node): boolean {
   return (
     isVariableDeclaration(node) &&
-    (node.kind !== "var" || node[BLOCK_SCOPED_SYMBOL])
+    (node.kind !== "var" ||
+      // @ts-ignore Fixme: document private properties
+      node[BLOCK_SCOPED_SYMBOL])
   );
 }

--- a/packages/babel-types/src/validators/isNodesEquivalent.ts
+++ b/packages/babel-types/src/validators/isNodesEquivalent.ts
@@ -25,41 +25,45 @@ export default function isNodesEquivalent<T extends Partial<t.Node>>(
   const visitorKeys = VISITOR_KEYS[a.type];
 
   for (const field of fields) {
-    if (typeof a[field] !== typeof b[field]) {
+    const val_a =
+      // @ts-ignore field must present in a
+      a[field];
+    const val_b = b[field];
+    if (typeof val_a !== typeof val_b) {
       return false;
     }
-    if (a[field] == null && b[field] == null) {
+    if (val_a == null && val_b == null) {
       continue;
-    } else if (a[field] == null || b[field] == null) {
+    } else if (val_a == null || val_b == null) {
       return false;
     }
 
-    if (Array.isArray(a[field])) {
-      if (!Array.isArray(b[field])) {
+    if (Array.isArray(val_a)) {
+      if (!Array.isArray(val_b)) {
         return false;
       }
-      if (a[field].length !== b[field].length) {
+      if (val_a.length !== val_b.length) {
         return false;
       }
 
-      for (let i = 0; i < a[field].length; i++) {
-        if (!isNodesEquivalent(a[field][i], b[field][i])) {
+      for (let i = 0; i < val_a.length; i++) {
+        if (!isNodesEquivalent(val_a[i], val_b[i])) {
           return false;
         }
       }
       continue;
     }
 
-    if (typeof a[field] === "object" && !visitorKeys?.includes(field)) {
-      for (const key of Object.keys(a[field])) {
-        if (a[field][key] !== b[field][key]) {
+    if (typeof val_a === "object" && !visitorKeys?.includes(field)) {
+      for (const key of Object.keys(val_a)) {
+        if (val_a[key] !== val_b[key]) {
           return false;
         }
       }
       continue;
     }
 
-    if (!isNodesEquivalent(a[field], b[field])) {
+    if (!isNodesEquivalent(val_a, val_b)) {
       return false;
     }
   }

--- a/packages/babel-types/src/validators/isVar.ts
+++ b/packages/babel-types/src/validators/isVar.ts
@@ -7,6 +7,10 @@ import type * as t from "..";
  */
 export default function isVar(node: t.Node): boolean {
   return (
-    isVariableDeclaration(node, { kind: "var" }) && !node[BLOCK_SCOPED_SYMBOL]
+    isVariableDeclaration(node, { kind: "var" }) &&
+    !(
+      // @ts-ignore document private properties
+      node[BLOCK_SCOPED_SYMBOL]
+    )
   );
 }

--- a/packages/babel-types/src/validators/validate.ts
+++ b/packages/babel-types/src/validators/validate.ts
@@ -1,4 +1,8 @@
-import { NODE_FIELDS, NODE_PARENT_VALIDATIONS } from "../definitions";
+import {
+  NODE_FIELDS,
+  NODE_PARENT_VALIDATIONS,
+  type FieldOptions,
+} from "../definitions";
 import type * as t from "..";
 
 export default function validate(
@@ -20,7 +24,7 @@ export function validateField(
   node: t.Node | undefined | null,
   key: string,
   val: any,
-  field: any,
+  field: FieldOptions | undefined | null,
 ): void {
   if (!field?.validate) return;
   if (field.optional && val == null) return;
@@ -31,7 +35,7 @@ export function validateField(
 export function validateChild(
   node: t.Node | undefined | null,
   key: string,
-  val?: any,
+  val?: t.Node | undefined | null,
 ) {
   if (val == null) return;
   const validate = NODE_PARENT_VALIDATIONS[val.type];

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -118,6 +118,10 @@ fs.writeFileSync(
             ],
             ["globals", ["./node_modules/globals-BABEL_8_BREAKING-true"]],
             ["regexpu-core", ["./lib/regexpu-core.d.ts"]],
+            [
+              "to-fast-properties",
+              ["./node_modules/to-fast-properties-BABEL_8_BREAKING-true"],
+            ],
           ]),
         },
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -704,6 +704,9 @@
       ],
       "regexpu-core": [
         "./lib/regexpu-core.d.ts"
+      ],
+      "to-fast-properties": [
+        "./node_modules/to-fast-properties-BABEL_8_BREAKING-true"
       ]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,7 +3794,7 @@ __metadata:
     "@babel/parser": "workspace:^"
     chalk: ^4.1.0
     glob: ^7.1.7
-    to-fast-properties: ^2.0.0
+    to-fast-properties: "condition:BABEL_8_BREAKING ? ^4.0.0 : ^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -14704,10 +14704,27 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"to-fast-properties@npm:^2.0.0":
+"to-fast-properties-BABEL_8_BREAKING-false@npm:to-fast-properties@^2.0.0, to-fast-properties@npm:^2.0.0":
   version: 2.0.0
   resolution: "to-fast-properties@npm:2.0.0"
   checksum: be2de62fe58ead94e3e592680052683b1ec986c72d589e7b21e5697f8744cdbf48c266fa72f6c15932894c10187b5f54573a3bcf7da0bfd964d5caf23d436168
+  languageName: node
+  linkType: hard
+
+"to-fast-properties-BABEL_8_BREAKING-true@npm:to-fast-properties@^4.0.0":
+  version: 4.0.0
+  resolution: "to-fast-properties@npm:4.0.0"
+  checksum: c72297bdd126a7e7ffe9cc6230eee60182f0439a7abb19d281e73137880d87d12fc971a47ff4bd1e0dc68e17262344fbf98499400ff5e341db431715c3620346
+  languageName: node
+  linkType: hard
+
+"to-fast-properties@condition:BABEL_8_BREAKING ? ^4.0.0 : ^2.0.0":
+  version: 0.0.0-condition-ce57b6
+  resolution: "to-fast-properties@condition:BABEL_8_BREAKING?^4.0.0:^2.0.0#ce57b6"
+  dependencies:
+    to-fast-properties-BABEL_8_BREAKING-false: "npm:to-fast-properties@^2.0.0"
+    to-fast-properties-BABEL_8_BREAKING-true: "npm:to-fast-properties@^4.0.0"
+  checksum: e301950506020ee20ad9ebdf7da40174c08f441a9ac0fe89d0efeb70a7fcedefdb3079433eae3d5a840ee38d589c0c2c9e27774d93fb60cd5af9b22b8b95df67
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | `to-fast-properties` is bumped to v4 (requires Node>=12.20) for Babel 8
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
See https://github.com/babel/babel/pull/14601 for more info. This PR improves `@babel/types` typings. `to-fast-properties` is bumped to v4 for Babel 8 since to-fast-properties@>=3.0 provides typings.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14645"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

