### PR TITLE
Rely on the call stack to clean up cache in `_guessExecutionStatusRel…

### DIFF
--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -230,6 +230,15 @@ Object.assign(
   NodePath_comments,
 );
 
+if (!process.env.BABEL_8_BREAKING) {
+  // The original _guessExecutionStatusRelativeToDifferentFunctions only worked for paths in
+  // different functions, but _guessExecutionStatusRelativeTo works as a replacement in those cases.
+
+  // @ts-ignore
+  NodePath.prototype._guessExecutionStatusRelativeToDifferentFunctions =
+    NodePath_introspection._guessExecutionStatusRelativeTo;
+}
+
 // we can not use `import { TYPES } from "@babel/types"` here
 // because the transformNamedBabelTypesImportToDestructuring plugin in babel.config.js
 // does not offer live bindings for `TYPES`


### PR DESCRIPTION
…ativeTo`

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Follow up to https://github.com/babel/babel/pull/14617 (cc @liuxingbaoyu)

This small refactor simplifies #14617 a bit so that we don't have to manually clean up `executionStatusCache` and track its "inited" status, but it's handled automatically by the engine. The number of lines of code in `introspection.ts` is still more or less the same, but the logic has been reduced.

Also, `NodePath#_guessExecutionStatusRelativeToDifferentFunctions` isn't used anymore so we can remove it in Babel 8.