### PR TITLE
fix: Ensure assertInputSourceMap understand sourcemap json

### DIFF
--- a/packages/babel-core/src/config/validation/option-assertions.ts
+++ b/packages/babel-core/src/config/validation/option-assertions.ts
@@ -168,17 +168,43 @@ export function assertCallerMetadata(
   return value;
 }
 
+function inputMayBeSourceMap(inputObj = {}) {
+  // https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.mofvlxcwqzej
+  // keys required in sourcemap format
+  const sourceMapKeys = ["version", "sources", "names", "mappings"];
+  let mayBeSourceMap = true;
+  for (let index = 0; index < sourceMapKeys.length; index++) {
+    const sourceMapKey = sourceMapKeys[index];
+    if (!inputObj[sourceMapKey]) {
+      mayBeSourceMap = false;
+      break;
+    }
+  }
+  return mayBeSourceMap;
+}
+
 export function assertInputSourceMap(
   loc: OptionPath,
   value: unknown,
 ): RootInputSourceMapOption | void {
+  if (typeof value == "string") {
+    try {
+      const parsedValue = JSON.parse(value);
+      if (inputMayBeSourceMap(parsedValue)) {
+        return parsedValue;
+      }
+    } catch {}
+  }
   if (
     value !== undefined &&
     typeof value !== "boolean" &&
     (typeof value !== "object" || !value)
   ) {
-    throw new Error(`${msg(loc)} must be a boolean, object, or undefined`);
+    throw new Error(
+      `${msg(loc)} must be a boolean, object, undefined or sourcemap json`,
+    );
   }
+
   return value;
 }
 

--- a/packages/babel-core/src/config/validation/option-assertions.ts
+++ b/packages/babel-core/src/config/validation/option-assertions.ts
@@ -168,32 +168,12 @@ export function assertCallerMetadata(
   return value;
 }
 
-function inputMayBeSourceMap(inputObj = {}) {
-  // https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.mofvlxcwqzej
-  // keys required in sourcemap format
-  const sourceMapKeys = ["version", "sources", "names", "mappings"];
-  let mayBeSourceMap = true;
-  for (let index = 0; index < sourceMapKeys.length; index++) {
-    const sourceMapKey = sourceMapKeys[index];
-    if (!inputObj[sourceMapKey]) {
-      mayBeSourceMap = false;
-      break;
-    }
-  }
-  return mayBeSourceMap;
-}
-
 export function assertInputSourceMap(
   loc: OptionPath,
   value: unknown,
 ): RootInputSourceMapOption | void {
   if (typeof value == "string") {
-    try {
-      const parsedValue = JSON.parse(value);
-      if (inputMayBeSourceMap(parsedValue)) {
-        return parsedValue;
-      }
-    } catch {}
+    value = JSON.parse(value);
   }
   if (
     value !== undefined &&

--- a/packages/babel-core/test/option-assertions.js
+++ b/packages/babel-core/test/option-assertions.js
@@ -1,0 +1,45 @@
+import { assertInputSourceMap } from "../lib/config/validation/option-assertions.js";
+
+const sampleSourceMapJson = {
+  version: 3,
+  sources: ["/home/aqua/coding/atri/src/app/app.tsx"],
+  names: [],
+  mappings: ";;;AAAA",
+  sourcesContent: [
+    'ReactDOM.render(, document.body.querySelector("#root"))\\n',
+  ],
+};
+
+const loc = {
+  name: "inputSourceMap",
+  parent: { type: "root", source: "arguments" },
+  type: "option",
+};
+
+const testAssetsPass = [
+  [JSON.stringify(sampleSourceMapJson), sampleSourceMapJson],
+  [undefined, undefined],
+  [false, false],
+  [{}, {}],
+];
+
+const sampleNoneSourceMapJson = { ...sampleSourceMapJson };
+delete sampleNoneSourceMapJson.version;
+
+const testAssetsFailed = [
+  JSON.stringify(sampleNoneSourceMapJson),
+  "kaljsdfkl",
+  42,
+];
+
+describe("assertInputSourceMap", () => {
+  it.each(testAssetsPass)("%p should work", (input, expected) => {
+    return expect(assertInputSourceMap(loc, input)).toEqual(expected);
+  });
+
+  it.each(testAssetsFailed)("%p should throw error", input => {
+    return expect(() => {
+      assertInputSourceMap(loc, input);
+    }).toThrowError();
+  });
+});

--- a/packages/babel-core/test/option-assertions.js
+++ b/packages/babel-core/test/option-assertions.js
@@ -23,14 +23,7 @@ const testAssetsPass = [
   [{}, {}],
 ];
 
-const sampleNoneSourceMapJson = { ...sampleSourceMapJson };
-delete sampleNoneSourceMapJson.version;
-
-const testAssetsFailed = [
-  JSON.stringify(sampleNoneSourceMapJson),
-  "kaljsdfkl",
-  42,
-];
+const testAssetsFailed = ["kaljsdfkl", 42];
 
 describe("assertInputSourceMap", () => {
   it.each(testAssetsPass)("%p should work", (input, expected) => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel-loader/issues/390 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Webpack loaders passing **sourcemap json** to babel, which will cause error

![image](https://user-images.githubusercontent.com/28096993/173186352-e742e690-949e-4ffc-9dac-fda09ccd84a2.png)

![image](https://user-images.githubusercontent.com/28096993/173186393-f7b3823a-02b3-4f3e-b453-2e9faf2e1ebd.png)

![image](https://user-images.githubusercontent.com/28096993/173186438-29039123-629a-4313-8b54-7c944a5f958a.png)

Solution is try to parse the json into a SourceMap object

`inputMayBeSourceMap` detects if the parsed json is a SourceMap object

Some simple tests are in `packages/babel-core/test/option-assertions.js`



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14658"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

