### PR TITLE
Run Babel asynchronously in fixtures

### DIFF
--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -3,16 +3,22 @@ import type { Handler } from "gensync";
 import path from "path";
 import { pathToFileURL } from "url";
 import { createRequire } from "module";
+import semver from "semver";
 
 const require = createRequire(import.meta.url);
 
 let import_;
 try {
-  // Node < 13.3 doesn't support import() syntax.
+  // Old Node.js versions don't support import() syntax.
   import_ = require("./import").default;
 } catch {}
 
-export const supportsESM = !!import_;
+export const supportsESM = semver.satisfies(
+  process.versions.node,
+  // older versions, starting from 10, support the dynamic
+  // import syntax but always return a rejected promise.
+  "^12.17 || >=13.2",
+);
 
 export default function* loadCjsOrMjsDefault(
   filepath: string,

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -20,6 +20,24 @@ const require = createRequire(import.meta.url);
 
 import checkDuplicateNodes from "@babel/helper-check-duplicate-nodes";
 
+if (!process.env.BABEL_8_BREAKING) {
+  // Introduced in Node.js 10
+  if (!assert.rejects) {
+    assert.rejects = async function (promise, validateError) {
+      try {
+        await promise;
+        return Promise.reject(new Error("Promise not rejected"));
+      } catch (error) {
+        if (!validateError(error)) {
+          return Promise.reject(
+            new Error("Promise rejected with invalid error"),
+          );
+        }
+      }
+    };
+  }
+}
+
 const EXTERNAL_HELPERS_VERSION = "7.100.0";
 
 const cachedScripts = new QuickLRU<
@@ -40,12 +58,20 @@ function transformWithoutConfigFile(code, opts) {
     ...opts,
   });
 }
+function transformAsyncWithoutConfigFile(code, opts) {
+  return babel.transformAsync(code, {
+    configFile: false,
+    babelrc: false,
+    ...opts,
+  });
+}
 
 function createContext() {
   const context = vm.createContext({
     ...helpers,
     process: process,
     transform: transformWithoutConfigFile,
+    transformAsync: transformAsyncWithoutConfigFile,
     setTimeout: setTimeout,
     setImmediate: setImmediate,
     expect,
@@ -194,10 +220,10 @@ export function runCodeInTestContext(
   }
 }
 
-function maybeMockConsole(validateLogs, run) {
+async function maybeMockConsole(validateLogs, run) {
   const actualLogs = { stdout: "", stderr: "" };
 
-  if (!validateLogs) return { result: run(), actualLogs };
+  if (!validateLogs) return { result: await run(), actualLogs };
 
   const spy1 = jest.spyOn(console, "log").mockImplementation(msg => {
     actualLogs.stdout += `${msg}\n`;
@@ -207,14 +233,14 @@ function maybeMockConsole(validateLogs, run) {
   });
 
   try {
-    return { result: run(), actualLogs };
+    return { result: await run(), actualLogs };
   } finally {
     spy1.mockRestore();
     spy2.mockRestore();
   }
 }
 
-function run(task) {
+async function run(task) {
   const {
     actual,
     expect: expected,
@@ -256,8 +282,8 @@ function run(task) {
 
     // Ignore Babel logs of exec.js files.
     // They will be validated in input/output files.
-    ({ result } = maybeMockConsole(validateLogs, () =>
-      babel.transformSync(execCode, execOpts),
+    ({ result } = await maybeMockConsole(validateLogs, () =>
+      babel.transformAsync(execCode, execOpts),
     ));
 
     checkDuplicateNodes(result.ast);
@@ -278,8 +304,8 @@ function run(task) {
   if (!execCode || inputCode) {
     let actualLogs;
 
-    ({ result, actualLogs } = maybeMockConsole(validateLogs, () =>
-      babel.transformSync(inputCode, getOpts(actual)),
+    ({ result, actualLogs } = await maybeMockConsole(validateLogs, () =>
+      babel.transformAsync(inputCode, getOpts(actual)),
     ));
 
     const outputCode = normalizeOutput(result.code);
@@ -470,11 +496,7 @@ export default function (
         testFn(
           task.title,
 
-          function () {
-            function runTask() {
-              run(task);
-            }
-
+          async function () {
             if ("sourceMap" in task.options === false) {
               task.options.sourceMap = !!(
                 task.sourceMappings || task.sourceMap
@@ -499,7 +521,7 @@ export default function (
               // the options object with useless options
               delete task.options.throws;
 
-              assert.throws(runTask, function (err: Error) {
+              await assert.rejects(run(task), function (err: Error) {
                 assert.ok(
                   throwMsg === true || err.message.includes(throwMsg),
                   `
@@ -509,13 +531,11 @@ Actual Error: ${err.message}`,
                 return true;
               });
             } else {
+              const result = await run(task);
               if (task.exec.code) {
-                const result = run(task);
                 if (result && typeof result.then === "function") {
                   return result;
                 }
-              } else {
-                runTask();
               }
             }
           },

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/allowArrayLike/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/allowArrayLike/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["../../../res/checkScopeInfo.js"]
+  "plugins": ["../../helpers/checkScopeInfo.js"]
 }

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/assumption-arrayLikeIsIterable/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/assumption-arrayLikeIsIterable/options.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["transform-destructuring", "../../../res/checkScopeInfo.js"],
+  "plugins": ["transform-destructuring", "../../helpers/checkScopeInfo.js"],
   "assumptions": {
     "arrayLikeIsIterable": true
   }

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/assumption-iterableIsArray/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/assumption-iterableIsArray/options.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["transform-destructuring", "../../../res/checkScopeInfo.js"],
+  "plugins": ["transform-destructuring", "../../helpers/checkScopeInfo.js"],
   "assumptions": {
     "iterableIsArray": true
   }

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/assumption-objectRestNoSymbols/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/assumption-objectRestNoSymbols/options.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["transform-destructuring", "../../../res/checkScopeInfo.js"],
+  "plugins": ["transform-destructuring", "../../helpers/checkScopeInfo.js"],
   "assumptions": {
     "objectRestNoSymbols": true
   }

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/options.json
@@ -6,6 +6,6 @@
     "transform-block-scoping",
     "proposal-object-rest-spread",
     "transform-regenerator",
-    "../../../res/checkScopeInfo.js"
+    "../../helpers/checkScopeInfo.js"
   ]
 }

--- a/packages/babel-plugin-transform-destructuring/test/helpers/checkScopeInfo.js
+++ b/packages/babel-plugin-transform-destructuring/test/helpers/checkScopeInfo.js
@@ -1,5 +1,4 @@
-// checkScopeInfo.js
-module.exports = () => {
+export default () => {
   return {
     visitor: {
       Program: {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This was extracted from #13414: by running our tests asynchronously, they can also run ESM plugins. The second commit verifies that it works by converting an existing test-only plugin from CJS to ESM.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14659"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

