### PR TITLE
Run Babel asynchronously in our build process

### DIFF
--- a/babel-worker.cjs
+++ b/babel-worker.cjs
@@ -1,4 +1,4 @@
-const { transformSync } = require("@babel/core");
+const { transformAsync } = require("@babel/core");
 const { mkdirSync, statSync, readFileSync, writeFileSync } = require("fs");
 const { dirname } = require("path");
 const fancyLog = require("fancy-log");
@@ -23,8 +23,8 @@ function needCompile(src, dest) {
   return srcStat.mtimeMs > destStat.mtimeMs;
 }
 
-exports.transform = function transform(src, dest) {
-  if (!chalk) return chalkP.then(() => transform(src, dest));
+exports.transform = async function transform(src, dest) {
+  if (!chalk) await chalkP;
 
   mkdirSync(dirname(dest), { recursive: true });
   if (!needCompile(src, dest)) {
@@ -32,7 +32,7 @@ exports.transform = function transform(src, dest) {
   }
   fancyLog(`Compiling '${chalk.cyan(src)}'...`);
   const content = readFileSync(src, { encoding: "utf8" });
-  const { code } = transformSync(content, {
+  const { code } = await transformAsync(content, {
     filename: src,
     caller: {
       // We have wrapped packages/babel-core/src/config/files/configuration.js with feature detection


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is another piece extracted from #13414. Running Babel asynchronously lets us use native ESM for our config or for the internal plugins we use at build time.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14660"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

