### PR TITLE
Fix `import { types } from "@babel/core"` with native ESM

### DIFF
--- a/packages/babel-core/src/index.ts
+++ b/packages/babel-core/src/index.ts
@@ -8,9 +8,11 @@ export { resolvePlugin, resolvePreset } from "./config/files";
 
 export { getEnv } from "./config/helpers/environment";
 
+// NOTE: Lazy re-exports aren't detected by the Node.js CJS-ESM interop.
+// These are handled by pluginInjectNodeReexportsHints in our babel.config.js
+// so that they can work well.
 export * as types from "@babel/types";
 export { tokTypes } from "@babel/parser";
-
 export { default as traverse } from "@babel/traverse";
 export { default as template } from "@babel/template";
 

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -1,4 +1,4 @@
-import babel from "../lib/index.js";
+import * as babel from "../lib/index.js";
 import { TraceMap, originalPositionFor } from "@jridgewell/trace-mapping";
 import path from "path";
 import generator from "@babel/generator";

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -2,7 +2,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
-import babel from "../lib/index.js";
+import * as babel from "../lib/index.js";
 import rimraf from "rimraf";
 
 import _getTargets from "@babel/helper-compilation-targets";

--- a/packages/babel-core/test/fixtures/babel-compile-async.mjs
+++ b/packages/babel-core/test/fixtures/babel-compile-async.mjs
@@ -2,10 +2,8 @@
 
 // Usage:
 // babel-compile-async.js [filename]
-import babel from "../../lib/index.js";
+import { transformAsync } from "../../lib/index.js";
 
 (async () => {
-  process.stdout.write(
-    JSON.stringify(await babel.transformAsync(""))
-  );
+  process.stdout.write(JSON.stringify(await transformAsync("")));
 })();

--- a/packages/babel-core/test/fixtures/babel-compile-sync.mjs
+++ b/packages/babel-core/test/fixtures/babel-compile-sync.mjs
@@ -2,8 +2,6 @@
 
 // Usage:
 // babel-compile-async.js [filename]
-import babel from "../../lib/index.js";
+import { transformSync } from "../../lib/index.js";
 
-process.stdout.write(
-  JSON.stringify(babel.transformSync(""))
-);
+process.stdout.write(JSON.stringify(transformSync("")));

--- a/packages/babel-core/test/fixtures/babel-load-options-async.mjs
+++ b/packages/babel-core/test/fixtures/babel-load-options-async.mjs
@@ -2,12 +2,12 @@
 
 // Usage:
 // babel-load-options-async.js [filename]
-import babel from "../../lib/index.js";
+import { loadOptionsAsync } from "../../lib/index.js";
 
 const [, , filename, cwd] = process.argv;
 
 (async () => {
   process.stdout.write(
-    JSON.stringify(await babel.loadOptionsAsync({ filename, cwd }))
+    JSON.stringify(await loadOptionsAsync({ filename, cwd }))
   );
 })();

--- a/packages/babel-helper-check-duplicate-nodes/test/index.js
+++ b/packages/babel-helper-check-duplicate-nodes/test/index.js
@@ -1,6 +1,5 @@
 import _checkDuplicateNodes from "../lib/index.js";
-import babel from "@babel/core";
-const { parseSync, traverse, types: t } = babel;
+import { parseSync, traverse, types as t } from "@babel/core";
 const checkDuplicateNodes = _checkDuplicateNodes.default;
 
 describe("checkDuplicateNodes", () => {
@@ -53,7 +52,7 @@ describe("checkDuplicateNodes", () => {
   });
   it("should throw when more than one arguments are passed", () => {
     expect(() => {
-      checkDuplicateNodes(babel, {});
+      checkDuplicateNodes({}, {});
     }).toThrow("checkDuplicateNodes accepts only one argument: ast");
   });
 });

--- a/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/test/util.skip-bundled.js
+++ b/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/test/util.skip-bundled.js
@@ -1,6 +1,5 @@
 import { shouldTransform } from "../lib/util.js";
-import babel from "@babel/core";
-const { parseSync, traverse } = babel;
+import { parseSync, traverse } from "@babel/core";
 
 function getPath(input, parserOpts = {}) {
   let targetPath;

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/util.skip-bundled.js
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/util.skip-bundled.js
@@ -1,6 +1,5 @@
 import { shouldTransform } from "../lib/util.js";
-import babel from "@babel/core";
-const { parseSync, traverse } = babel;
+import { parseSync, traverse } from "@babel/core";
 
 function getPath(input, parserOpts = {}) {
   let targetPath;

--- a/packages/babel-plugin-proposal-destructuring-private/test/plugin-ordering.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/plugin-ordering.js
@@ -1,4 +1,4 @@
-import babel from "@babel/core";
+import { transformSync } from "@babel/core";
 import proposalDestructuringPrivate from "../lib/index.js";
 
 describe("plugin ordering", () => {
@@ -12,7 +12,7 @@ describe("plugin ordering", () => {
     `;
     expect(
       () =>
-        babel.transformSync(source, {
+        transformSync(source, {
           filename: "example.js",
           highlightCode: false,
           configFile: false,

--- a/packages/babel-plugin-proposal-destructuring-private/test/util.skip-bundled.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/util.skip-bundled.js
@@ -1,8 +1,5 @@
-import babel from "@babel/core";
+import { parseSync, traverse, types as t } from "@babel/core";
 import { traversePattern, privateKeyPathIterator } from "../lib/util.js";
-const { isObjectProperty, isPrivateName } = babel.types;
-
-const { parseSync, traverse } = babel;
 
 function wrapSourceInClassEnvironment(input) {
   const usedPrivateNames = new Set();
@@ -44,9 +41,9 @@ describe("traversePattern", () => {
     );
     const keys = [
       ...traversePattern(patternPath.node, function* (node) {
-        if (isObjectProperty(node)) {
+        if (t.isObjectProperty(node)) {
           const propertyKey = node.key;
-          if (isPrivateName(propertyKey)) {
+          if (t.isPrivateName(propertyKey)) {
             yield propertyKey.id.name;
           }
         }

--- a/packages/babel-plugin-proposal-optional-chaining/test/util.skip-bundled.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/util.skip-bundled.js
@@ -1,6 +1,5 @@
 import { willPathCastToBoolean } from "../lib/util.js";
-import babel from "@babel/core";
-const { parseSync, traverse } = babel;
+import { parseSync, traverse } from "@babel/core";
 
 function getPath(input, parserOpts) {
   let targetPath;

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -2,7 +2,7 @@ import path from "path";
 import fs from "fs";
 import { createRequire } from "module";
 import helpers from "@babel/helpers";
-import babel from "@babel/core";
+import { transformFromAstSync, File } from "@babel/core";
 import template from "@babel/template";
 import t from "@babel/types";
 import { fileURLToPath } from "url";
@@ -217,7 +217,7 @@ function buildHelper(
 
   if (!esm) {
     bindings = [];
-    helpers.ensure(helperName, babel.File);
+    helpers.ensure(helperName, File);
     for (const dep of helpers.getDependencies(helperName)) {
       const id = (dependencies[dep] = t.identifier(t.toIdentifier(dep)));
       tree.body.push(template.statement.ast`
@@ -235,7 +235,7 @@ function buildHelper(
   );
   tree.body.push(...helper.nodes);
 
-  return babel.transformFromAstSync(tree, null, {
+  return transformFromAstSync(tree, null, {
     filename: helperFilename,
     presets: [["@babel/preset-env", { modules: false }]],
     plugins: [


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is another step in the direction of #13414. It makes it possible to use named imports for `types`, `tokTypes`, `traverse` and `template` from `@babel/core`, which were not available because the Node.js CJS-ESM interop doesn't recognize our lazy reexports.

Basically this code:
```js
Object.defineProperty(exports, "types", {
  enumerable: true,
  get: function () {
    return _types();
  }
});
```
Is replaced by this (which is detected by the Node.js interpo) by a custom plugin:
```js
Object.defineProperty((0, exports), "types", {
  enumerable: true,
  get: function () {
    return _types();
  }
});
0 && (exports.types = 0);
```

The second commit removes the usage of `@babel/core`'s `default` export in our tests, which in theory shouldn't exist.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14663"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

