### PR TITLE
Enforce setting `type` in `package.json`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,8 @@
 conditions:
   BABEL_8_BREAKING:
     default: false
+  USE_ESM:
+    default: false
 
 enableGlobalCache: true
 

--- a/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
+++ b/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
+++ b/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/codemods/babel-plugin-codemod-optional-catch-binding/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/codemods/babel-plugin-codemod-optional-catch-binding/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/constraints.pro
+++ b/constraints.pro
@@ -86,3 +86,7 @@ gen_enforced_field(WorkspaceCwd, 'exports', '{ ".": "./lib/index.js", "./package
   WorkspaceIdent \= '@babel/standalone',
   \+ atom_concat('@babel/eslint-', _, WorkspaceIdent),
   \+ atom_concat('@babel/runtime', _, WorkspaceIdent).
+
+% Enforces the type field to be set
+gen_enforced_field(WorkspaceCwd, 'type', 'commonjs') :-
+  \+ workspace_field(WorkspaceCwd, 'type', 'module').

--- a/constraints.pro
+++ b/constraints.pro
@@ -90,3 +90,12 @@ gen_enforced_field(WorkspaceCwd, 'exports', '{ ".": "./lib/index.js", "./package
 % Enforces the type field to be set
 gen_enforced_field(WorkspaceCwd, 'type', 'commonjs') :-
   \+ workspace_field(WorkspaceCwd, 'type', 'module').
+
+% Enforce a default 'conditions', unless it's already specified
+gen_enforced_field(WorkspaceCwd, 'conditions', '{ "USE_ESM": [{ "type": "module" }, null] }') :-
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  \+ workspace_field(WorkspaceCwd, 'conditions', _),
+  \+ workspace_field(WorkspaceCwd, 'main', './lib/index.cjs'),
+  % Exclude some packages
+  workspace_ident(WorkspaceCwd, WorkspaceIdent),
+  WorkspaceIdent \= '@babel/compat-data'.

--- a/eslint/babel-eslint-plugin-development-internal/package.json
+++ b/eslint/babel-eslint-plugin-development-internal/package.json
@@ -21,5 +21,6 @@
   },
   "devDependencies": {
     "eslint": "^7.27.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/eslint/babel-eslint-shared-fixtures/package.json
+++ b/eslint/babel-eslint-shared-fixtures/package.json
@@ -16,5 +16,6 @@
     "@babel/preset-flow": "workspace:^",
     "@babel/preset-react": "workspace:^",
     "eslint": "^7.27.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/eslint/babel-eslint-tests/package.json
+++ b/eslint/babel-eslint-tests/package.json
@@ -11,5 +11,6 @@
     "eslint": "^7.27.0",
     "eslint-plugin-import": "^2.25.4",
     "npm-babel-parser": "npm:@babel/parser@^7.14.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -62,5 +62,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -57,6 +57,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -37,5 +37,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -32,6 +32,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-compat-data/package.json
+++ b/packages/babel-compat-data/package.json
@@ -35,5 +35,6 @@
   },
   "engines": {
     "node": ">=6.9.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -85,5 +85,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -80,6 +80,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -44,5 +44,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -39,6 +39,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-annotate-as-pure/package.json
+++ b/packages/babel-helper-annotate-as-pure/package.json
@@ -26,6 +26,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-annotate-as-pure/package.json
+++ b/packages/babel-helper-annotate-as-pure/package.json
@@ -31,5 +31,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -32,5 +32,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -27,6 +27,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -30,6 +30,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -35,5 +35,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-check-duplicate-nodes/package.json
+++ b/packages/babel-helper-check-duplicate-nodes/package.json
@@ -33,5 +33,13 @@
   "devDependencies": {
     "@babel/core": "workspace:^"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-helper-check-duplicate-nodes/package.json
+++ b/packages/babel-helper-check-duplicate-nodes/package.json
@@ -32,5 +32,6 @@
   },
   "devDependencies": {
     "@babel/core": "workspace:^"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -37,5 +37,6 @@
   },
   "engines": {
     "node": ">=6.9.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -38,5 +38,13 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -49,5 +49,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -44,6 +44,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -32,5 +32,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -27,6 +27,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-environment-visitor/package.json
+++ b/packages/babel-helper-environment-visitor/package.json
@@ -25,5 +25,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-helper-environment-visitor/package.json
+++ b/packages/babel-helper-environment-visitor/package.json
@@ -24,5 +24,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -34,5 +34,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -29,6 +29,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -34,5 +34,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -29,6 +29,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -32,5 +32,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -27,6 +27,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -30,6 +30,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -35,5 +35,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-member-expression-to-functions/package.json
+++ b/packages/babel-helper-member-expression-to-functions/package.json
@@ -34,5 +34,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-member-expression-to-functions/package.json
+++ b/packages/babel-helper-member-expression-to-functions/package.json
@@ -29,6 +29,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -30,6 +30,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -35,5 +35,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -33,6 +33,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -38,5 +38,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -30,6 +30,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -35,5 +35,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-plugin-test-runner/package.json
+++ b/packages/babel-helper-plugin-test-runner/package.json
@@ -49,5 +49,6 @@
         "exports": null
       }
     ]
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-plugin-utils/package.json
+++ b/packages/babel-helper-plugin-utils/package.json
@@ -23,6 +23,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-plugin-utils/package.json
+++ b/packages/babel-helper-plugin-utils/package.json
@@ -28,5 +28,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -31,6 +31,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -36,5 +36,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -30,6 +30,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -35,5 +35,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -34,5 +34,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -29,6 +29,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-skip-transparent-expression-wrappers/package.json
+++ b/packages/babel-helper-skip-transparent-expression-wrappers/package.json
@@ -26,5 +26,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-helper-skip-transparent-expression-wrappers/package.json
+++ b/packages/babel-helper-skip-transparent-expression-wrappers/package.json
@@ -25,5 +25,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-helper-split-export-declaration/package.json
+++ b/packages/babel-helper-split-export-declaration/package.json
@@ -26,6 +26,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-split-export-declaration/package.json
+++ b/packages/babel-helper-split-export-declaration/package.json
@@ -31,5 +31,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -39,5 +39,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -34,6 +34,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helper-validator-identifier/package.json
+++ b/packages/babel-helper-validator-identifier/package.json
@@ -24,5 +24,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-helper-validator-identifier/package.json
+++ b/packages/babel-helper-validator-identifier/package.json
@@ -23,5 +23,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-helper-validator-option/package.json
+++ b/packages/babel-helper-validator-option/package.json
@@ -19,5 +19,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-helper-validator-option/package.json
+++ b/packages/babel-helper-validator-option/package.json
@@ -20,5 +20,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -34,5 +34,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -29,6 +29,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -37,5 +37,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -32,6 +32,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -53,6 +53,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -58,5 +58,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -46,6 +46,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -51,5 +51,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/package.json
+++ b/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/package.json
@@ -37,5 +37,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/package.json
+++ b/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/package.json
@@ -36,5 +36,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/package.json
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/package.json
@@ -37,5 +37,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/package.json
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/package.json
@@ -38,5 +38,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-async-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-async-do-expressions/package.json
@@ -37,5 +37,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-async-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-async-do-expressions/package.json
@@ -38,5 +38,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/package.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/package.json
@@ -40,6 +40,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-async-generator-functions/package.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/package.json
@@ -45,5 +45,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-class-static-block/package.json
+++ b/packages/babel-plugin-proposal-class-static-block/package.json
@@ -37,5 +37,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-class-static-block/package.json
+++ b/packages/babel-plugin-proposal-class-static-block/package.json
@@ -38,5 +38,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -46,6 +46,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -51,5 +51,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-destructuring-private/package.json
+++ b/packages/babel-plugin-proposal-destructuring-private/package.json
@@ -39,5 +39,13 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-plugin-proposal-destructuring-private/package.json
+++ b/packages/babel-plugin-proposal-destructuring-private/package.json
@@ -38,5 +38,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-dynamic-import/package.json
+++ b/packages/babel-plugin-proposal-dynamic-import/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-dynamic-import/package.json
+++ b/packages/babel-plugin-proposal-dynamic-import/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-export-default-from/package.json
+++ b/packages/babel-plugin-proposal-export-default-from/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-export-default-from/package.json
+++ b/packages/babel-plugin-proposal-export-default-from/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-export-namespace-from/package.json
+++ b/packages/babel-plugin-proposal-export-namespace-from/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-export-namespace-from/package.json
+++ b/packages/babel-plugin-proposal-export-namespace-from/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -43,5 +43,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -38,6 +38,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-json-strings/package.json
+++ b/packages/babel-plugin-proposal-json-strings/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-json-strings/package.json
+++ b/packages/babel-plugin-proposal-json-strings/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/package.json
@@ -44,5 +44,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/package.json
@@ -39,6 +39,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-numeric-separator/package.json
+++ b/packages/babel-plugin-proposal-numeric-separator/package.json
@@ -44,5 +44,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-numeric-separator/package.json
+++ b/packages/babel-plugin-proposal-numeric-separator/package.json
@@ -39,6 +39,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-object-rest-spread/package.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/package.json
@@ -41,6 +41,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-object-rest-spread/package.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/package.json
@@ -46,5 +46,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-optional-catch-binding/package.json
+++ b/packages/babel-plugin-proposal-optional-catch-binding/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-optional-catch-binding/package.json
+++ b/packages/babel-plugin-proposal-optional-catch-binding/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -40,6 +40,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -45,5 +45,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-partial-application/package.json
+++ b/packages/babel-plugin-proposal-partial-application/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-partial-application/package.json
+++ b/packages/babel-plugin-proposal-partial-application/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-private-methods/package.json
+++ b/packages/babel-plugin-proposal-private-methods/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-private-methods/package.json
+++ b/packages/babel-plugin-proposal-private-methods/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-private-property-in-object/package.json
+++ b/packages/babel-plugin-proposal-private-property-in-object/package.json
@@ -44,5 +44,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-private-property-in-object/package.json
+++ b/packages/babel-plugin-proposal-private-property-in-object/package.json
@@ -39,6 +39,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-record-and-tuple/package.json
+++ b/packages/babel-plugin-proposal-record-and-tuple/package.json
@@ -35,5 +35,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-record-and-tuple/package.json
+++ b/packages/babel-plugin-proposal-record-and-tuple/package.json
@@ -36,5 +36,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -43,6 +43,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -48,5 +48,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-proposal-unicode-sets-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-sets-regex/package.json
@@ -45,5 +45,13 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-plugin-proposal-unicode-sets-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-sets-regex/package.json
@@ -44,5 +44,6 @@
   },
   "engines": {
     "node": ">=6.9.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-async-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-async-do-expressions/package.json
@@ -32,5 +32,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-async-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-async-do-expressions/package.json
@@ -33,5 +33,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-plugin-syntax-decimal/package.json
+++ b/packages/babel-plugin-syntax-decimal/package.json
@@ -28,5 +28,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-decimal/package.json
+++ b/packages/babel-plugin-syntax-decimal/package.json
@@ -29,5 +29,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-destructuring-private/package.json
+++ b/packages/babel-plugin-syntax-destructuring-private/package.json
@@ -37,5 +37,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-destructuring-private/package.json
+++ b/packages/babel-plugin-syntax-destructuring-private/package.json
@@ -32,6 +32,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-export-default-from/package.json
+++ b/packages/babel-plugin-syntax-export-default-from/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-export-default-from/package.json
+++ b/packages/babel-plugin-syntax-export-default-from/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-import-assertions/package.json
+++ b/packages/babel-plugin-syntax-import-assertions/package.json
@@ -39,5 +39,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-import-assertions/package.json
+++ b/packages/babel-plugin-syntax-import-assertions/package.json
@@ -34,6 +34,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-module-blocks/package.json
+++ b/packages/babel-plugin-syntax-module-blocks/package.json
@@ -28,5 +28,6 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "author": "The Babel Team (https://babel.dev/team)"
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-module-blocks/package.json
+++ b/packages/babel-plugin-syntax-module-blocks/package.json
@@ -29,5 +29,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-plugin-syntax-partial-application/package.json
+++ b/packages/babel-plugin-syntax-partial-application/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-partial-application/package.json
+++ b/packages/babel-plugin-syntax-partial-application/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-pipeline-operator/package.json
+++ b/packages/babel-plugin-syntax-pipeline-operator/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-pipeline-operator/package.json
+++ b/packages/babel-plugin-syntax-pipeline-operator/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-record-and-tuple/package.json
+++ b/packages/babel-plugin-syntax-record-and-tuple/package.json
@@ -39,5 +39,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-record-and-tuple/package.json
+++ b/packages/babel-plugin-syntax-record-and-tuple/package.json
@@ -34,6 +34,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-throw-expressions/package.json
+++ b/packages/babel-plugin-syntax-throw-expressions/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-throw-expressions/package.json
+++ b/packages/babel-plugin-syntax-throw-expressions/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-syntax-unicode-sets-regex/package.json
+++ b/packages/babel-plugin-syntax-unicode-sets-regex/package.json
@@ -45,5 +45,13 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-plugin-syntax-unicode-sets-regex/package.json
+++ b/packages/babel-plugin-syntax-unicode-sets-regex/package.json
@@ -44,5 +44,6 @@
   },
   "engines": {
     "node": ">=6.9.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -43,5 +43,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -38,6 +38,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -43,5 +43,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -38,6 +38,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -49,5 +49,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -44,6 +44,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-dotall-regex/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/package.json
@@ -42,6 +42,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-dotall-regex/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/package.json
@@ -47,5 +47,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -43,5 +43,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -38,6 +38,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -43,5 +43,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -38,6 +38,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -44,5 +44,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -39,6 +39,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -42,6 +42,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -47,5 +47,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -41,6 +41,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -46,5 +46,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -43,5 +43,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -38,6 +38,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
@@ -42,6 +42,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
@@ -47,5 +47,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -43,5 +43,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -38,6 +38,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-react-jsx-development/package.json
+++ b/packages/babel-plugin-transform-react-jsx-development/package.json
@@ -35,6 +35,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-react-jsx-development/package.json
+++ b/packages/babel-plugin-transform-react-jsx-development/package.json
@@ -40,5 +40,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -41,6 +41,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -47,5 +47,6 @@
     ".": "./lib/index.js",
     "./lib/development": "./lib/development.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-react-pure-annotations/package.json
+++ b/packages/babel-plugin-transform-react-pure-annotations/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-react-pure-annotations/package.json
+++ b/packages/babel-plugin-transform-react-pure-annotations/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -39,5 +39,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -34,6 +34,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -57,5 +57,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -52,6 +52,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -44,5 +44,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -39,6 +39,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -41,6 +41,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -46,5 +46,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-unicode-escapes/package.json
+++ b/packages/babel-plugin-transform-unicode-escapes/package.json
@@ -41,5 +41,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-unicode-escapes/package.json
+++ b/packages/babel-plugin-transform-unicode-escapes/package.json
@@ -36,6 +36,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -42,5 +42,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -37,6 +37,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -110,6 +110,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -115,5 +115,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -42,6 +42,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -47,5 +47,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -44,5 +44,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -39,6 +39,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -40,6 +40,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -45,5 +45,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -44,6 +44,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -967,5 +967,13 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -966,5 +966,6 @@
   },
   "engines": {
     "node": ">=6.9.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -1177,5 +1177,6 @@
   },
   "engines": {
     "node": ">=6.9.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -1178,5 +1178,13 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -872,5 +872,13 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
 }

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -871,5 +871,6 @@
   },
   "engines": {
     "node": ">=6.9.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -140,6 +140,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -147,5 +147,6 @@
     "./babel.js": "./babel.js",
     "./babel.min.js": "./babel.min.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -34,5 +34,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -29,6 +29,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -44,5 +44,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -39,6 +39,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -42,6 +42,12 @@
       {
         "exports": null
       }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
     ]
   },
   "exports": {

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -47,5 +47,6 @@
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
-  }
+  },
+  "type": "commonjs"
 }

--- a/test/runtime-integration/rollup/package.json
+++ b/test/runtime-integration/rollup/package.json
@@ -6,5 +6,6 @@
     "@rollup/plugin-commonjs": "22.0.0",
     "@rollup/plugin-node-resolve": "^13.2.1",
     "rollup": "^2.70.2"
-  }
+  },
+  "type": "commonjs"
 }

--- a/test/runtime-integration/src/package.json
+++ b/test/runtime-integration/src/package.json
@@ -4,5 +4,6 @@
   "devDependencies": {
     "@babel/runtime": "workspace:^",
     "@babel/runtime-corejs3": "workspace:^"
-  }
+  },
+  "type": "commonjs"
 }

--- a/test/runtime-integration/webpack-3/package.json
+++ b/test/runtime-integration/webpack-3/package.json
@@ -4,5 +4,6 @@
   "devDependencies": {
     "@babel/runtime": "workspace:^",
     "webpack": "^3.12.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/test/runtime-integration/webpack-4/package.json
+++ b/test/runtime-integration/webpack-4/package.json
@@ -5,5 +5,6 @@
     "@babel/runtime": "workspace:^",
     "webpack": "^4.46.0",
     "webpack-cli": "^4.5.0"
-  }
+  },
+  "type": "commonjs"
 }

--- a/test/runtime-integration/webpack-5/package.json
+++ b/test/runtime-integration/webpack-5/package.json
@@ -6,5 +6,6 @@
     "@babel/runtime": "workspace:^",
     "webpack": "^5.24.1",
     "webpack-cli": "^4.5.0"
-  }
+  },
+  "type": "commonjs"
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Ref #13414.

This PR enforces a `"type": "commonjs"` in every package, so that we are explicit about it. Additionally, it introduces a new yarn condition (`USE_ESM`) to allow swapping it with `"type": "module"` on publish. The exception are commonjs packages (such as `@babel/eslint-parser`) and `@babel/compat-data` which is made of JSON files.

This PR does not change any behavior (it only explicitly sets the default type, and never uses the opt-in one), but it allows removing most of the noise from #13414.