### PR TITLE
Use full relative paths to plugins in tests

### DIFF
--- a/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR with multiple files-windows/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR with multiple files-windows/stdout.txt
@@ -16,12 +16,12 @@ config <CWD>/.babelrc
 programmatic options from @babel/cli
 {
   "presets": [
-    "<ROOTDIR>//packages//babel-preset-react"
+    "<ROOTDIR>//packages//babel-preset-react//lib//index.js"
   ],
   "plugins": [
-    "<ROOTDIR>//packages//babel-plugin-transform-arrow-functions",
-    "<ROOTDIR>//packages//babel-plugin-transform-strict-mode",
-    "<ROOTDIR>//packages//babel-plugin-transform-modules-commonjs"
+    "<ROOTDIR>//packages//babel-plugin-transform-arrow-functions//lib//index.js",
+    "<ROOTDIR>//packages//babel-plugin-transform-strict-mode//lib//index.js",
+    "<ROOTDIR>//packages//babel-plugin-transform-modules-commonjs//lib//index.js"
   ],
   "sourceFileName": "src/foo.js",
   "caller": {

--- a/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR with multiple files/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR with multiple files/stdout.txt
@@ -16,12 +16,12 @@ config <CWD>/.babelrc
 programmatic options from @babel/cli
 {
   "presets": [
-    "<ROOTDIR>/packages/babel-preset-react"
+    "<ROOTDIR>/packages/babel-preset-react/lib/index.js"
   ],
   "plugins": [
-    "<ROOTDIR>/packages/babel-plugin-transform-arrow-functions",
-    "<ROOTDIR>/packages/babel-plugin-transform-strict-mode",
-    "<ROOTDIR>/packages/babel-plugin-transform-modules-commonjs"
+    "<ROOTDIR>/packages/babel-plugin-transform-arrow-functions/lib/index.js",
+    "<ROOTDIR>/packages/babel-plugin-transform-strict-mode/lib/index.js",
+    "<ROOTDIR>/packages/babel-plugin-transform-modules-commonjs/lib/index.js"
   ],
   "sourceFileName": "src/foo.js",
   "caller": {

--- a/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR-windows/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR-windows/stdout.txt
@@ -16,12 +16,12 @@ config <CWD>/.babelrc
 programmatic options from @babel/cli
 {
   "presets": [
-    "<ROOTDIR>//packages//babel-preset-react"
+    "<ROOTDIR>//packages//babel-preset-react//lib//index.js"
   ],
   "plugins": [
-    "<ROOTDIR>//packages//babel-plugin-transform-arrow-functions",
-    "<ROOTDIR>//packages//babel-plugin-transform-strict-mode",
-    "<ROOTDIR>//packages//babel-plugin-transform-modules-commonjs"
+    "<ROOTDIR>//packages//babel-plugin-transform-arrow-functions//lib//index.js",
+    "<ROOTDIR>//packages//babel-plugin-transform-strict-mode//lib//index.js",
+    "<ROOTDIR>//packages//babel-plugin-transform-modules-commonjs//lib//index.js"
   ],
   "sourceFileName": "../src/foo.js",
   "caller": {

--- a/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR/stdout.txt
@@ -110,12 +110,12 @@ config <CWD>/.babelrc
 programmatic options from @babel/cli
 {
   "presets": [
-    "<ROOTDIR>/packages/babel-preset-react"
+    "<ROOTDIR>/packages/babel-preset-react/lib/index.js"
   ],
   "plugins": [
-    "<ROOTDIR>/packages/babel-plugin-transform-arrow-functions",
-    "<ROOTDIR>/packages/babel-plugin-transform-strict-mode",
-    "<ROOTDIR>/packages/babel-plugin-transform-modules-commonjs"
+    "<ROOTDIR>/packages/babel-plugin-transform-arrow-functions/lib/index.js",
+    "<ROOTDIR>/packages/babel-plugin-transform-strict-mode/lib/index.js",
+    "<ROOTDIR>/packages/babel-plugin-transform-modules-commonjs/lib/index.js"
   ],
   "configFile": "./my-config.js",
   "sourceFileName": "./src/index.js",

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -25,12 +25,14 @@ const outputFileSync = function (filePath, data) {
   fs.writeFileSync(filePath, data);
 };
 
-const presetLocs = [path.join(rootDir, "./packages/babel-preset-react")];
+const getPath = name => path.join(rootDir, "packages", name, "lib", "index.js");
+
+const presetLocs = [getPath("babel-preset-react")];
 
 const pluginLocs = [
-  path.join(rootDir, "./packages/babel-plugin-transform-arrow-functions"),
-  path.join(rootDir, "./packages/babel-plugin-transform-strict-mode"),
-  path.join(rootDir, "./packages/babel-plugin-transform-modules-commonjs"),
+  getPath("babel-plugin-transform-arrow-functions"),
+  getPath("babel-plugin-transform-strict-mode"),
+  getPath("babel-plugin-transform-modules-commonjs"),
 ].join(",");
 
 const readDir = function (loc, filter) {

--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -309,7 +309,7 @@ function wrapPackagesArray(type, names, optionsDir) {
         path.dirname(fileURLToPath(import.meta.url)),
         "../../..",
         name.startsWith("codemod") ? "codemods" : "packages",
-        `babel-${type}-${name}`,
+        `babel-${type}-${name}/lib/index.js`,
       );
 
       if (fs.existsSync(monorepoPath)) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Ref #13414. When loading files with an ESM import (either with a declaration or dynamically) using a relative path, Node.js doesn't check the `main` and `exports` fields: we must explicitly specify the full path.

This is not a problem for our users since they'll use something like `@babel/preset-env` and not `./packages/babel-preset-env`.