### PR TITLE
[parser] Make `decoratorsBeforeExport` default to `false`

### DIFF
--- a/packages/babel-parser/src/plugin-utils.ts
+++ b/packages/babel-parser/src/plugin-utils.ts
@@ -85,14 +85,10 @@ export function validatePlugins(plugins: PluginList) {
       "decorators",
       "decoratorsBeforeExport",
     );
-    if (decoratorsBeforeExport == null) {
-      throw new Error(
-        "The 'decorators' plugin requires a 'decoratorsBeforeExport' option," +
-          " whose value must be a boolean. If you are migrating from" +
-          " Babylon/Babel 6 or want to use the old decorators proposal, you" +
-          " should use the 'decorators-legacy' plugin instead of 'decorators'.",
-      );
-    } else if (typeof decoratorsBeforeExport !== "boolean") {
+    if (
+      decoratorsBeforeExport != null &&
+      typeof decoratorsBeforeExport !== "boolean"
+    ) {
       throw new Error("'decoratorsBeforeExport' must be a boolean.");
     }
   }

--- a/packages/babel-parser/src/plugin-utils.ts
+++ b/packages/babel-parser/src/plugin-utils.ts
@@ -1,5 +1,9 @@
 import type Parser from "./parser";
-import type { PluginConfig } from "./typings";
+import type {
+  PluginConfig,
+  ParserPluginWithOptions,
+  PluginOptions,
+} from "./typings";
 
 export type Plugin = PluginConfig;
 
@@ -47,11 +51,14 @@ export function hasPlugin(
   });
 }
 
-export function getPluginOption(
+export function getPluginOption<
+  PluginName extends ParserPluginWithOptions[0],
+  OptionName extends keyof PluginOptions<PluginName>,
+>(
   plugins: PluginList,
-  name: string,
-  option: string,
-) {
+  name: PluginName,
+  option: OptionName,
+): PluginOptions<PluginName>[OptionName] | null {
   const plugin = plugins.find(plugin => {
     if (Array.isArray(plugin)) {
       return plugin[0] === name;
@@ -60,9 +67,8 @@ export function getPluginOption(
     }
   });
 
-  if (plugin && Array.isArray(plugin)) {
-    // @ts-expect-error Fixme: should check whether option is defined
-    return plugin[1][option];
+  if (plugin && Array.isArray(plugin) && plugin.length >= 2) {
+    return (plugin[1] as PluginOptions<PluginName>)[option];
   }
 
   return null;
@@ -168,6 +174,7 @@ export function validatePlugins(plugins: PluginList) {
       }
       const moduleAttributesVersionPluginOption = getPluginOption(
         plugins,
+        // @ts-expect-error TODO: moduleAttributes's type definitions don't have options
         "moduleAttributes",
         "version",
       );

--- a/packages/babel-parser/src/typings.ts
+++ b/packages/babel-parser/src/typings.ts
@@ -53,6 +53,9 @@ export type ParserPluginWithOptions =
   | ["flow", FlowPluginOptions]
   | ["typescript", TypeScriptPluginOptions];
 
+export type PluginOptions<PluginName extends ParserPluginWithOptions[0]> =
+  Extract<ParserPluginWithOptions, [PluginName, any]>[1];
+
 export interface DecoratorsPluginOptions {
   decoratorsBeforeExport?: boolean;
 }

--- a/packages/babel-parser/test/fixtures/es2022/class-properties/arguments-in-nested-class-decorator-call-expression/options.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-properties/arguments-in-nested-class-decorator-call-expression/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/class-property/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/class-property/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/compued-property/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/compued-property/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/decoratorsBeforeExport-required/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/decoratorsBeforeExport-required/options.json
@@ -1,4 +1,0 @@
-{
-  "plugins": ["decorators"],
-  "throws": "The 'decorators' plugin requires a 'decoratorsBeforeExport' option, whose value must be a boolean. If you are migrating from Babylon/Babel 6 or want to use the old decorators proposal, you should use the 'decorators-legacy' plugin instead of 'decorators'."
-}

--- a/packages/babel-parser/test/fixtures/experimental/decorators/no-object-methods/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/no-object-methods/options.json
@@ -1,10 +1,3 @@
 {
-  "plugins": [
-    [
-      "decorators",
-      {
-        "decoratorsBeforeExport": false
-      }
-    ]
-  ]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/no-semi/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/no-semi/options.json
@@ -1,11 +1,4 @@
 {
-  "plugins": [
-    [
-      "decorators",
-      {
-        "decoratorsBeforeExport": false
-      }
-    ]
-  ],
+  "plugins": ["decorators"],
   "throws": "Decorators must not be followed by a semicolon. (2:5)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/parenthesized-createParenthesizedExpressions/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/parenthesized-createParenthesizedExpressions/options.json
@@ -1,4 +1,4 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]],
+  "plugins": ["decorators"],
   "createParenthesizedExpressions": true
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/private-property/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/private-property/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/restricted-1/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/restricted-1/options.json
@@ -1,11 +1,4 @@
 {
-  "plugins": [
-    [
-      "decorators",
-      {
-        "decoratorsBeforeExport": false
-      }
-    ]
-  ],
+  "plugins": ["decorators"],
   "throws": "Leading decorators must be attached to a class declaration. (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/restricted-2/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/restricted-2/options.json
@@ -1,11 +1,4 @@
 {
-  "plugins": [
-    [
-      "decorators",
-      {
-        "decoratorsBeforeExport": false
-      }
-    ]
-  ],
+  "plugins": ["decorators"],
   "throws": "Leading decorators must be attached to a class declaration. (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-bare-identifier/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-bare-identifier/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "@@" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-parenthesized-identifier/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-parenthesized-identifier/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "@@" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-parenthesized-topic/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-parenthesized-topic/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "@@" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-bare-identifier/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-bare-identifier/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "^^" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-parenthesized-identifier/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-parenthesized-identifier/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "^^" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-parenthesized-topic/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-parenthesized-topic/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "^^" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/flow/class-properties/declare-after-decorators/options.json
+++ b/packages/babel-parser/test/fixtures/flow/class-properties/declare-after-decorators/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "plugins": ["flow", ["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["flow", "decorators"]
 }

--- a/packages/babel-parser/test/fixtures/flow/class-properties/declare-before-decorators/options.json
+++ b/packages/babel-parser/test/fixtures/flow/class-properties/declare-before-decorators/options.json
@@ -1,5 +1,5 @@
 {
   "sourceType": "module",
-  "plugins": ["flow", ["decorators", { "decoratorsBeforeExport": false }]],
+  "plugins": ["flow", "decorators"],
   "throws": "Unexpected token (2:10)"
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Minor: New Feature?      | Y
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Ref https://github.com/babel/babel/pull/12712#issuecomment-1166231875=

It already defaults to false in the transform plugin and in the generator.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14695"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

