### PR TITLE
perf: Improve generator perf

### DIFF
--- a/benchmark/babel-generator/real-case/jquery.mjs
+++ b/benchmark/babel-generator/real-case/jquery.mjs
@@ -31,7 +31,4 @@ function benchCases(name, implementation, options) {
 benchCases("current", current.default);
 benchCases("baseline", baseline.default);
 
-benchCases("baseline", baseline.default);
-benchCases("current", current.default);
-
 suite.on("cycle", report).run();

--- a/benchmark/babel-generator/real-case/jquery.mjs
+++ b/benchmark/babel-generator/real-case/jquery.mjs
@@ -15,14 +15,21 @@ function createInput(length) {
   );
 }
 
+const inputs = [1, 4, 16, 64].map(length => ({
+  tag: length,
+  body: createInput(length),
+}));
+
 function benchCases(name, implementation, options) {
-  for (const length of [1, 2]) {
-    const input = createInput(length);
-    suite.add(`${name} ${length} jquery 3.6`, () => {
-      implementation(input, options);
+  for (const input of inputs) {
+    suite.add(`${name} ${input.tag} jquery 3.6`, () => {
+      implementation(input.body, options);
     });
   }
 }
+
+benchCases("current", current.default);
+benchCases("baseline", baseline.default);
 
 benchCases("baseline", baseline.default);
 benchCases("current", current.default);

--- a/packages/babel-generator/src/buffer.ts
+++ b/packages/babel-generator/src/buffer.ts
@@ -18,7 +18,7 @@ type SourcePos = {
   filename: string | undefined;
 };
 
-type queueObj = {
+type queueItem = {
   char: number;
   repeat: number;
   line: number | undefined;
@@ -48,7 +48,7 @@ export default class Buffer {
   _str = "";
   _appendCount = 0;
   _last = 0;
-  _queue: queueObj[] = [];
+  _queue: queueItem[] = [];
   _queueCursor = 0;
 
   _position = {
@@ -91,18 +91,18 @@ export default class Buffer {
     if (cursor === this._queue.length) {
       this._allocQueue();
     }
-    const obj = this._queue[cursor];
-    obj.char = char;
-    obj.repeat = repeat;
-    obj.line = line;
-    obj.column = column;
-    obj.identifierName = identifierName;
-    obj.filename = filename;
+    const item = this._queue[cursor];
+    item.char = char;
+    item.repeat = repeat;
+    item.line = line;
+    item.column = column;
+    item.identifierName = identifierName;
+    item.filename = filename;
 
     this._queueCursor++;
   }
 
-  _popQueue(): queueObj {
+  _popQueue(): queueItem {
     if (this._queueCursor === 0) {
       throw new Error("Cannot pop from empty queue");
     }
@@ -200,7 +200,7 @@ export default class Buffer {
     const queueCursor = this._queueCursor;
     const queue = this._queue;
     for (let i = 0; i < queueCursor; i++) {
-      const item: queueObj = queue[i];
+      const item: queueItem = queue[i];
       this._appendChar(item.char, item.repeat, item);
     }
     this._queueCursor = 0;
@@ -235,7 +235,7 @@ export default class Buffer {
 
     if (++this._appendCount > 4096) {
       // @ts-ignore
-      this._str | 0; // Unexplainable huge performance boost. Ref: https://github.com/davidmarkclements/flatstr License: MIT
+      +this._str; // Unexplainable huge performance boost. Ref: https://github.com/davidmarkclements/flatstr License: MIT
       this._buf += this._str;
       this._str = str;
       this._appendCount = 0;

--- a/packages/babel-generator/src/generators/base.ts
+++ b/packages/babel-generator/src/generators/base.ts
@@ -85,7 +85,7 @@ export function InterpreterDirective(
   this: Printer,
   node: t.InterpreterDirective,
 ) {
-  this.token(`#!${node.value}\n`);
+  this.token(`#!${node.value}\n`, true);
 }
 
 export function Placeholder(this: Printer, node: t.Placeholder) {

--- a/packages/babel-generator/src/generators/template-literals.ts
+++ b/packages/babel-generator/src/generators/template-literals.ts
@@ -20,7 +20,7 @@ export function TemplateElement(
 
   const value = (isFirst ? "`" : "}") + node.value.raw + (isLast ? "`" : "${");
 
-  this.token(value);
+  this.token(value, true);
 }
 
 export function TemplateLiteral(this: Printer, node: t.TemplateLiteral) {

--- a/packages/babel-generator/src/index.ts
+++ b/packages/babel-generator/src/index.ts
@@ -91,8 +91,8 @@ function normalizeOptions(
       format.shouldPrintComment ||
       (value =>
         format.comments ||
-        value.indexOf("@license") >= 0 ||
-        value.indexOf("@preserve") >= 0);
+        value.includes("@license") ||
+        value.includes("@preserve"));
   }
 
   if (format.compact === "auto") {

--- a/packages/babel-generator/src/node/index.ts
+++ b/packages/babel-generator/src/node/index.ts
@@ -87,20 +87,17 @@ export function needsWhitespace(
     node = node.expression;
   }
 
-  let linesInfo: any = find(expandedWhitespaceNodes, node, parent);
-
-  if (!linesInfo) {
-    const items = find(expandedWhitespaceList, node, parent);
-    if (items) {
-      for (let i = 0; i < items.length; i++) {
-        linesInfo = needsWhitespace(items[i], node, type);
-        if (linesInfo) break;
-      }
-    }
+  if ((find(expandedWhitespaceNodes, node, parent) & type) !== 0) {
+    return true;
   }
 
-  if (typeof linesInfo === "number") {
-    return (linesInfo & type) !== 0;
+  const items = find(expandedWhitespaceList, node, parent);
+  if (items) {
+    for (let i = 0; i < items.length; i++) {
+      if (needsWhitespace(items[i], node, type)) {
+        return true;
+      }
+    }
   }
 
   return false;

--- a/packages/babel-generator/src/node/index.ts
+++ b/packages/babel-generator/src/node/index.ts
@@ -9,6 +9,8 @@ import {
 } from "@babel/types";
 import type * as t from "@babel/types";
 
+import type { WhitespaceFlag } from "./whitespace";
+
 export type NodeHandlers<R> = {
   [K in string]?: (
     node: K extends t.Node["type"] ? Extract<t.Node, { type: K }> : t.Node,
@@ -56,7 +58,6 @@ function expandAliases<R>(obj: NodeHandlers<R>) {
 // into concrete types so that the 'find' call below can be as fast as possible.
 const expandedParens = expandAliases(parens);
 const expandedWhitespaceNodes = expandAliases(whitespace.nodes);
-//const expandedWhitespaceList = expandAliases(whitespace.list);
 
 function find<R>(
   obj: NodeHandlers<R>,
@@ -79,7 +80,7 @@ function isOrHasCallExpression(node: t.Node): boolean {
 export function needsWhitespace(
   node: t.Node,
   parent: t.Node,
-  type: number,
+  type: WhitespaceFlag,
 ): boolean {
   if (!node) return false;
 
@@ -92,17 +93,6 @@ export function needsWhitespace(
   if (typeof flag === "number") {
     return (flag & type) !== 0;
   }
-
-  // A bug that existed before, commenting out it will cause the test to fail.
-
-  // const items = find(expandedWhitespaceList, node, parent);
-  // if (items) {
-  //   for (let i = 0; i < items.length; i++) {
-  //     if (needsWhitespace(items[i], node, type)) {
-  //       return true;
-  //     }
-  //   }
-  // }
 
   return false;
 }

--- a/packages/babel-generator/src/node/index.ts
+++ b/packages/babel-generator/src/node/index.ts
@@ -56,7 +56,7 @@ function expandAliases<R>(obj: NodeHandlers<R>) {
 // into concrete types so that the 'find' call below can be as fast as possible.
 const expandedParens = expandAliases(parens);
 const expandedWhitespaceNodes = expandAliases(whitespace.nodes);
-const expandedWhitespaceList = expandAliases(whitespace.list);
+//const expandedWhitespaceList = expandAliases(whitespace.list);
 
 function find<R>(
   obj: NodeHandlers<R>,
@@ -87,18 +87,22 @@ export function needsWhitespace(
     node = node.expression;
   }
 
-  if ((find(expandedWhitespaceNodes, node, parent) & type) !== 0) {
-    return true;
+  const flag = find(expandedWhitespaceNodes, node, parent);
+
+  if (typeof flag === "number") {
+    return (flag & type) !== 0;
   }
 
-  const items = find(expandedWhitespaceList, node, parent);
-  if (items) {
-    for (let i = 0; i < items.length; i++) {
-      if (needsWhitespace(items[i], node, type)) {
-        return true;
-      }
-    }
-  }
+  // A bug that existed before, commenting out it will cause the test to fail.
+
+  // const items = find(expandedWhitespaceList, node, parent);
+  // if (items) {
+  //   for (let i = 0; i < items.length; i++) {
+  //     if (needsWhitespace(items[i], node, type)) {
+  //       return true;
+  //     }
+  //   }
+  // }
 
   return false;
 }

--- a/packages/babel-generator/src/node/index.ts
+++ b/packages/babel-generator/src/node/index.ts
@@ -8,7 +8,6 @@ import {
   isNewExpression,
 } from "@babel/types";
 import type * as t from "@babel/types";
-import type { WhitespaceObject } from "./whitespace";
 
 export type NodeHandlers<R> = {
   [K in string]?: (
@@ -80,7 +79,7 @@ function isOrHasCallExpression(node: t.Node): boolean {
 export function needsWhitespace(
   node: t.Node,
   parent: t.Node,
-  type: "before" | "after",
+  type: number,
 ): boolean {
   if (!node) return false;
 
@@ -88,11 +87,7 @@ export function needsWhitespace(
     node = node.expression;
   }
 
-  let linesInfo: WhitespaceObject | null | boolean = find(
-    expandedWhitespaceNodes,
-    node,
-    parent,
-  );
+  let linesInfo: any = find(expandedWhitespaceNodes, node, parent);
 
   if (!linesInfo) {
     const items = find(expandedWhitespaceList, node, parent);
@@ -104,19 +99,19 @@ export function needsWhitespace(
     }
   }
 
-  if (typeof linesInfo === "object" && linesInfo !== null) {
-    return linesInfo[type] || false;
+  if (typeof linesInfo === "number") {
+    return (linesInfo & type) !== 0;
   }
 
   return false;
 }
 
 export function needsWhitespaceBefore(node: t.Node, parent: t.Node) {
-  return needsWhitespace(node, parent, "before");
+  return needsWhitespace(node, parent, 1);
 }
 
 export function needsWhitespaceAfter(node: t.Node, parent: t.Node) {
-  return needsWhitespace(node, parent, "after");
+  return needsWhitespace(node, parent, 2);
 }
 
 export function needsParens(

--- a/packages/babel-generator/src/node/whitespace.ts
+++ b/packages/babel-generator/src/node/whitespace.ts
@@ -18,10 +18,37 @@ import {
 import type { NodeHandlers } from "./index";
 
 import type * as t from "@babel/types";
-export type WhitespaceObject = {
-  before?: boolean;
-  after?: boolean;
-};
+
+const enum WhitespaceFlag {
+  before = 1 << 0,
+  after = 1 << 1,
+}
+
+function crawlInternal(
+  node: t.Node,
+  state: { hasCall: boolean; hasFunction: boolean; hasHelper: boolean },
+) {
+  if (!node) return state;
+
+  if (isMemberExpression(node) || isOptionalMemberExpression(node)) {
+    crawlInternal(node.object, state);
+    if (node.computed) crawlInternal(node.property, state);
+  } else if (isBinary(node) || isAssignmentExpression(node)) {
+    crawlInternal(node.left, state);
+    crawlInternal(node.right, state);
+  } else if (isCallExpression(node) || isOptionalCallExpression(node)) {
+    state.hasCall = true;
+    crawlInternal(node.callee, state);
+  } else if (isFunction(node)) {
+    state.hasFunction = true;
+  } else if (isIdentifier(node)) {
+    state.hasHelper =
+      // @ts-expect-error todo(flow->ts): node.callee is not really expected here…
+      state.hasHelper || (node.callee && isHelper(node.callee));
+  }
+
+  return state;
+}
 
 /**
  * Crawl a node to test if it contains a CallExpression, a Function, or a Helper.
@@ -31,27 +58,12 @@ export type WhitespaceObject = {
  * // { hasCall: false, hasFunction: true, hasHelper: false }
  */
 
-function crawl(
-  node: t.Node,
-  state: { hasCall?: boolean; hasFunction?: boolean; hasHelper?: boolean } = {},
-) {
-  if (isMemberExpression(node) || isOptionalMemberExpression(node)) {
-    crawl(node.object, state);
-    if (node.computed) crawl(node.property, state);
-  } else if (isBinary(node) || isAssignmentExpression(node)) {
-    crawl(node.left, state);
-    crawl(node.right, state);
-  } else if (isCallExpression(node) || isOptionalCallExpression(node)) {
-    state.hasCall = true;
-    crawl(node.callee, state);
-  } else if (isFunction(node)) {
-    state.hasFunction = true;
-  } else if (isIdentifier(node)) {
-    // @ts-expect-error todo(flow->ts): node.callee is not really expected here…
-    state.hasHelper = state.hasHelper || isHelper(node.callee);
-  }
-
-  return state;
+function crawl(node: t.Node) {
+  return crawlInternal(node, {
+    hasCall: false,
+    hasFunction: false,
+    hasHelper: false,
+  });
 }
 
 /**
@@ -59,10 +71,12 @@ function crawl(
  */
 
 function isHelper(node: t.Node): boolean {
+  if (!node) return false;
+
   if (isMemberExpression(node)) {
     return isHelper(node.object) || isHelper(node.property);
   } else if (isIdentifier(node)) {
-    return node.name === "require" || node.name[0] === "_";
+    return node.name === "require" || node.name.charCodeAt(0) === 95; //node.name[0] === "_";
   } else if (isCallExpression(node)) {
     return isHelper(node.callee);
   } else if (isBinary(node) || isAssignmentExpression(node)) {
@@ -88,20 +102,17 @@ function isType(node: t.Node) {
  * Tests for node types that need whitespace.
  */
 
-export const nodes: NodeHandlers<WhitespaceObject | undefined | null> = {
+export const nodes: NodeHandlers<WhitespaceFlag> = {
   /**
    * Test if AssignmentExpression needs whitespace.
    */
 
-  AssignmentExpression(
-    node: t.AssignmentExpression,
-  ): WhitespaceObject | undefined | null {
+  AssignmentExpression(node: t.AssignmentExpression): WhitespaceFlag {
     const state = crawl(node.right);
     if ((state.hasCall && state.hasHelper) || state.hasFunction) {
-      return {
-        before: state.hasFunction,
-        after: true,
-      };
+      return state.hasFunction
+        ? WhitespaceFlag.before | WhitespaceFlag.after
+        : WhitespaceFlag.after;
     }
   },
 
@@ -109,24 +120,24 @@ export const nodes: NodeHandlers<WhitespaceObject | undefined | null> = {
    * Test if SwitchCase needs whitespace.
    */
 
-  SwitchCase(node: t.SwitchCase, parent: t.SwitchStatement): WhitespaceObject {
-    return {
-      before: !!node.consequent.length || parent.cases[0] === node,
-      after:
-        !node.consequent.length &&
-        parent.cases[parent.cases.length - 1] === node,
-    };
+  SwitchCase(node: t.SwitchCase, parent: t.SwitchStatement): WhitespaceFlag {
+    return (
+      (!!node.consequent.length || parent.cases[0] === node
+        ? WhitespaceFlag.before
+        : 0) |
+      (!node.consequent.length && parent.cases[parent.cases.length - 1] === node
+        ? WhitespaceFlag.after
+        : 0)
+    );
   },
 
   /**
    * Test if LogicalExpression needs whitespace.
    */
 
-  LogicalExpression(node: t.LogicalExpression): WhitespaceObject | undefined {
+  LogicalExpression(node: t.LogicalExpression): WhitespaceFlag {
     if (isFunction(node.left) || isFunction(node.right)) {
-      return {
-        after: true,
-      };
+      return WhitespaceFlag.after;
     }
   },
 
@@ -134,11 +145,9 @@ export const nodes: NodeHandlers<WhitespaceObject | undefined | null> = {
    * Test if Literal needs whitespace.
    */
 
-  Literal(node: t.Literal): WhitespaceObject | undefined | null {
+  Literal(node: t.Literal): WhitespaceFlag {
     if (isStringLiteral(node) && node.value === "use strict") {
-      return {
-        after: true,
-      };
+      return WhitespaceFlag.after;
     }
   },
 
@@ -146,23 +155,15 @@ export const nodes: NodeHandlers<WhitespaceObject | undefined | null> = {
    * Test if CallExpressionish needs whitespace.
    */
 
-  CallExpression(node: t.CallExpression): WhitespaceObject | undefined | null {
+  CallExpression(node: t.CallExpression): WhitespaceFlag {
     if (isFunction(node.callee) || isHelper(node)) {
-      return {
-        before: true,
-        after: true,
-      };
+      return WhitespaceFlag.before | WhitespaceFlag.after;
     }
   },
 
-  OptionalCallExpression(
-    node: t.OptionalCallExpression,
-  ): WhitespaceObject | undefined | null {
+  OptionalCallExpression(node: t.OptionalCallExpression): WhitespaceFlag {
     if (isFunction(node.callee)) {
-      return {
-        before: true,
-        after: true,
-      };
+      return WhitespaceFlag.before | WhitespaceFlag.after;
     }
   },
 
@@ -170,23 +171,18 @@ export const nodes: NodeHandlers<WhitespaceObject | undefined | null> = {
    * Test if VariableDeclaration needs whitespace.
    */
 
-  VariableDeclaration(
-    node: t.VariableDeclaration,
-  ): WhitespaceObject | undefined | null {
+  VariableDeclaration(node: t.VariableDeclaration): WhitespaceFlag {
     for (let i = 0; i < node.declarations.length; i++) {
       const declar = node.declarations[i];
 
       let enabled = isHelper(declar.id) && !isType(declar.init);
-      if (!enabled) {
+      if (!enabled && declar.init) {
         const state = crawl(declar.init);
         enabled = (isHelper(declar.init) && state.hasCall) || state.hasFunction;
       }
 
       if (enabled) {
-        return {
-          before: true,
-          after: true,
-        };
+        return WhitespaceFlag.before | WhitespaceFlag.after;
       }
     }
   },
@@ -195,12 +191,9 @@ export const nodes: NodeHandlers<WhitespaceObject | undefined | null> = {
    * Test if IfStatement needs whitespace.
    */
 
-  IfStatement(node: t.IfStatement): WhitespaceObject | undefined | null {
+  IfStatement(node: t.IfStatement): WhitespaceFlag {
     if (isBlockStatement(node.consequent)) {
-      return {
-        before: true,
-        after: true,
-      };
+      return WhitespaceFlag.before | WhitespaceFlag.after;
     }
   },
 };
@@ -215,53 +208,45 @@ nodes.ObjectProperty =
     function (
       node: t.ObjectProperty | t.ObjectTypeProperty | t.ObjectMethod,
       parent: t.ObjectExpression,
-    ): WhitespaceObject | undefined | null {
+    ): WhitespaceFlag {
       if (parent.properties[0] === node) {
-        return {
-          before: true,
-        };
+        return WhitespaceFlag.before;
       }
     };
 
 nodes.ObjectTypeCallProperty = function (
   node: t.ObjectTypeCallProperty,
   parent: t.ObjectTypeAnnotation,
-): WhitespaceObject | undefined | null {
+): WhitespaceFlag {
   if (parent.callProperties[0] === node && !parent.properties?.length) {
-    return {
-      before: true,
-    };
+    return WhitespaceFlag.before;
   }
 };
 
 nodes.ObjectTypeIndexer = function (
   node: t.ObjectTypeIndexer,
   parent: t.ObjectTypeAnnotation,
-): WhitespaceObject | undefined | null {
+): WhitespaceFlag {
   if (
     parent.indexers[0] === node &&
     !parent.properties?.length &&
     !parent.callProperties?.length
   ) {
-    return {
-      before: true,
-    };
+    return WhitespaceFlag.before;
   }
 };
 
 nodes.ObjectTypeInternalSlot = function (
   node: t.ObjectTypeInternalSlot,
   parent: t.ObjectTypeAnnotation,
-): WhitespaceObject | undefined | null {
+): WhitespaceFlag {
   if (
     parent.internalSlots[0] === node &&
     !parent.properties?.length &&
     !parent.callProperties?.length &&
     !parent.indexers?.length
   ) {
-    return {
-      before: true,
-    };
+    return WhitespaceFlag.before;
   }
 };
 
@@ -312,8 +297,8 @@ export const list: NodeHandlers<t.Node[]> = {
   [type as string]
     .concat(FLIPPED_ALIAS_KEYS[type] || [])
     .forEach(function (type) {
-      nodes[type] = function () {
-        return { after: amounts, before: amounts };
-      };
+      nodes[type] = function (ret: number) {
+        return ret;
+      }.bind(null, amounts ? WhitespaceFlag.before | WhitespaceFlag.after : 0);
     });
 });

--- a/packages/babel-generator/src/node/whitespace.ts
+++ b/packages/babel-generator/src/node/whitespace.ts
@@ -25,6 +25,8 @@ const enum WhitespaceFlag {
   after = 1 << 1,
 }
 
+export type { WhitespaceFlag };
+
 function crawlInternal(
   node: t.Node,
   state: { hasCall: boolean; hasFunction: boolean; hasHelper: boolean },
@@ -252,36 +254,6 @@ nodes.ObjectTypeInternalSlot = function (
   ) {
     return WhitespaceFlag.before;
   }
-};
-
-/**
- * Returns lists from node types that need whitespace.
- */
-
-export const list: NodeHandlers<t.Node[]> = {
-  /**
-   * Return VariableDeclaration declarations init properties.
-   */
-
-  VariableDeclaration(node: t.VariableDeclaration) {
-    return node.declarations.map(decl => decl.init);
-  },
-
-  /**
-   * Return VariableDeclaration elements.
-   */
-
-  ArrayExpression(node: t.ArrayExpression) {
-    return node.elements;
-  },
-
-  /**
-   * Return VariableDeclaration properties.
-   */
-
-  ObjectExpression(node: t.ObjectExpression) {
-    return node.properties;
-  },
 };
 
 /**

--- a/packages/babel-generator/src/node/whitespace.ts
+++ b/packages/babel-generator/src/node/whitespace.ts
@@ -118,7 +118,6 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
         ? WhitespaceFlag.before | WhitespaceFlag.after
         : WhitespaceFlag.after;
     }
-    return 0;
   },
 
   /**
@@ -144,7 +143,6 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
     if (isFunction(node.left) || isFunction(node.right)) {
       return WhitespaceFlag.after;
     }
-    return 0;
   },
 
   /**
@@ -155,7 +153,6 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
     if (isStringLiteral(node) && node.value === "use strict") {
       return WhitespaceFlag.after;
     }
-    return 0;
   },
 
   /**
@@ -166,14 +163,12 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
     if (isFunction(node.callee) || isHelper(node)) {
       return WhitespaceFlag.before | WhitespaceFlag.after;
     }
-    return 0;
   },
 
   OptionalCallExpression(node: t.OptionalCallExpression): WhitespaceFlag {
     if (isFunction(node.callee)) {
       return WhitespaceFlag.before | WhitespaceFlag.after;
     }
-    return 0;
   },
 
   /**
@@ -194,7 +189,6 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
         return WhitespaceFlag.before | WhitespaceFlag.after;
       }
     }
-    return 0;
   },
 
   /**
@@ -205,7 +199,6 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
     if (isBlockStatement(node.consequent)) {
       return WhitespaceFlag.before | WhitespaceFlag.after;
     }
-    return 0;
   },
 };
 
@@ -223,7 +216,6 @@ nodes.ObjectProperty =
       if (parent.properties[0] === node) {
         return WhitespaceFlag.before;
       }
-      return 0;
     };
 
 nodes.ObjectTypeCallProperty = function (
@@ -233,7 +225,6 @@ nodes.ObjectTypeCallProperty = function (
   if (parent.callProperties[0] === node && !parent.properties?.length) {
     return WhitespaceFlag.before;
   }
-  return 0;
 };
 
 nodes.ObjectTypeIndexer = function (
@@ -247,7 +238,6 @@ nodes.ObjectTypeIndexer = function (
   ) {
     return WhitespaceFlag.before;
   }
-  return 0;
 };
 
 nodes.ObjectTypeInternalSlot = function (
@@ -262,7 +252,6 @@ nodes.ObjectTypeInternalSlot = function (
   ) {
     return WhitespaceFlag.before;
   }
-  return 0;
 };
 
 /**

--- a/packages/babel-generator/src/node/whitespace.ts
+++ b/packages/babel-generator/src/node/whitespace.ts
@@ -301,8 +301,7 @@ export const list: NodeHandlers<t.Node[]> = {
   [type as string]
     .concat(FLIPPED_ALIAS_KEYS[type] || [])
     .forEach(function (type) {
-      nodes[type] = function (ret: number) {
-        return ret;
-      }.bind(null, amounts ? WhitespaceFlag.before | WhitespaceFlag.after : 0);
+      const ret = amounts ? WhitespaceFlag.before | WhitespaceFlag.after : 0;
+      nodes[type] = () => ret;
     });
 });

--- a/packages/babel-generator/src/node/whitespace.ts
+++ b/packages/babel-generator/src/node/whitespace.ts
@@ -14,6 +14,7 @@ import {
   isOptionalMemberExpression,
   isStringLiteral,
 } from "@babel/types";
+import * as charCodes from "charcodes";
 
 import type { NodeHandlers } from "./index";
 
@@ -76,7 +77,10 @@ function isHelper(node: t.Node): boolean {
   if (isMemberExpression(node)) {
     return isHelper(node.object) || isHelper(node.property);
   } else if (isIdentifier(node)) {
-    return node.name === "require" || node.name.charCodeAt(0) === 95; //node.name[0] === "_";
+    return (
+      node.name === "require" ||
+      node.name.charCodeAt(0) === charCodes.underscore
+    );
   } else if (isCallExpression(node)) {
     return isHelper(node.callee);
   } else if (isBinary(node) || isAssignmentExpression(node)) {
@@ -114,6 +118,7 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
         ? WhitespaceFlag.before | WhitespaceFlag.after
         : WhitespaceFlag.after;
     }
+    return 0;
   },
 
   /**
@@ -139,6 +144,7 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
     if (isFunction(node.left) || isFunction(node.right)) {
       return WhitespaceFlag.after;
     }
+    return 0;
   },
 
   /**
@@ -149,6 +155,7 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
     if (isStringLiteral(node) && node.value === "use strict") {
       return WhitespaceFlag.after;
     }
+    return 0;
   },
 
   /**
@@ -159,12 +166,14 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
     if (isFunction(node.callee) || isHelper(node)) {
       return WhitespaceFlag.before | WhitespaceFlag.after;
     }
+    return 0;
   },
 
   OptionalCallExpression(node: t.OptionalCallExpression): WhitespaceFlag {
     if (isFunction(node.callee)) {
       return WhitespaceFlag.before | WhitespaceFlag.after;
     }
+    return 0;
   },
 
   /**
@@ -185,6 +194,7 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
         return WhitespaceFlag.before | WhitespaceFlag.after;
       }
     }
+    return 0;
   },
 
   /**
@@ -195,6 +205,7 @@ export const nodes: NodeHandlers<WhitespaceFlag> = {
     if (isBlockStatement(node.consequent)) {
       return WhitespaceFlag.before | WhitespaceFlag.after;
     }
+    return 0;
   },
 };
 
@@ -212,6 +223,7 @@ nodes.ObjectProperty =
       if (parent.properties[0] === node) {
         return WhitespaceFlag.before;
       }
+      return 0;
     };
 
 nodes.ObjectTypeCallProperty = function (
@@ -221,6 +233,7 @@ nodes.ObjectTypeCallProperty = function (
   if (parent.callProperties[0] === node && !parent.properties?.length) {
     return WhitespaceFlag.before;
   }
+  return 0;
 };
 
 nodes.ObjectTypeIndexer = function (
@@ -234,6 +247,7 @@ nodes.ObjectTypeIndexer = function (
   ) {
     return WhitespaceFlag.before;
   }
+  return 0;
 };
 
 nodes.ObjectTypeInternalSlot = function (
@@ -248,6 +262,7 @@ nodes.ObjectTypeInternalSlot = function (
   ) {
     return WhitespaceFlag.before;
   }
+  return 0;
 };
 
 /**

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -539,7 +539,7 @@ class Printer {
     this._insideAux = !node.loc;
     this._maybeAddAuxComment(this._insideAux && !oldInAux);
 
-    let shouldPrintParens;
+    let shouldPrintParens: boolean;
     if (
       this.format.retainFunctionParens &&
       node.type === "FunctionExpression" &&

--- a/scripts/integration-tests/utils/local-registry.sh
+++ b/scripts/integration-tests/utils/local-registry.sh
@@ -9,8 +9,7 @@ function startLocalRegistry {
   # Start local registry
   tmp_registry_log=`mktemp`
   echo "Registry output file: $tmp_registry_log"
-  (cd && nohup npx verdaccio@~5.1.2 -c $1 &>$tmp_registry_log &)
-  YARN_IGNORE_PATH=1 yarn global add verdaccio-memory@~10.0.0
+  (cd && nohup npx verdaccio@~5.13.1 -c $1 &>$tmp_registry_log &)
   # Wait for Verdaccio to boot
   grep -q "http address" <(tail -f $tmp_registry_log)
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I love this PR, and I'm sure you do too!

This PR improves the performance of the generator by 100%, which is equivalent to a 50% reduction in time consumption.

Benchmark results are from the real world (jquery 3.6).
The running environment is nodejs 18.3 and Windows 11.


```
current 1 jquery 3.6: 45.99 ops/sec ±0.83% (22ms)
current 4 jquery 3.6: 11.31 ops/sec ±0.44% (88ms)
current 16 jquery 3.6: 2.74 ops/sec ±0.52% (364ms)
current 64 jquery 3.6: 0.67 ops/sec ±0.34% (1490ms)
baseline 1 jquery 3.6: 25.99 ops/sec ±3.81% (38ms)
baseline 4 jquery 3.6: 5.57 ops/sec ±0.88% (180ms)
baseline 16 jquery 3.6: 1.33 ops/sec ±2.17% (750ms)
baseline 64 jquery 3.6: 0.32 ops/sec ±6.15% (3090ms)
baseline 1 jquery 3.6: 26.15 ops/sec ±0.65% (38ms)
baseline 4 jquery 3.6: 5.55 ops/sec ±0.85% (180ms)
baseline 16 jquery 3.6: 1.3 ops/sec ±3.79% (770ms)
baseline 64 jquery 3.6: 0.33 ops/sec ±2.08% (3013ms)
current 1 jquery 3.6: 45.51 ops/sec ±0.38% (22ms)
current 4 jquery 3.6: 11.19 ops/sec ±0.49% (89ms)
current 16 jquery 3.6: 2.71 ops/sec ±0.38% (369ms)
current 64 jquery 3.6: 0.67 ops/sec ±0.29% (1495ms)
```


I made the following changes.

Significant performance improvements:

1. Optimize the string merging logic. When merging into a large string, it seems that some strange operations will greatly improve the performance. It is difficult to explain clearly with words. You can directly view the code.

2. Optimize the queue of printers to avoid frequent creation and destruction of objects.

3. Modify the row and column calculation logic to avoid searching for newlines in most cases.
Note: Now we need to add a parameter to check for newlines on elements that may wrap, but this is rare, I only found two in the current code.

4. In `parentheses.ts` and `whitespace.ts`, change the objects to bitwise operations. And add bounds checking to avoid reading elements outside the array and useless type judgment.


Minor performance improvements:

5. Add the `tokenChar` method, which can save some checks, and automatically modify the single-character text to the character code and call `tokenChar` through the compile-time plugin.

6. Treat the queue elements uniformly as a single character or the same character.
Note: There is an externally observable change here.
That is, we assume that indentation characters must contain only one character.
E.g:
"space+space", or "tab+tab"
instead of "space+tab".


There are also some minor modifications that may not have been mentioned, but that shouldn't matter.


It's worth mentioning that none of the tests were modified and all passed, so this should be safe overall.


What might be possible in the future:

1. Current bit operations cannot be optimized by constant folding, this should have little impact, but we can improve it in the future.

2. We can inline `types.isXXX` with a plugin, I don't know how much performance improvement this will bring, but maybe try.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14701"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

