### PR TITLE
fix: babel-plugin-proposal-function-bind: ts-ignore

### DIFF
--- a/packages/babel-plugin-proposal-function-bind/src/index.ts
+++ b/packages/babel-plugin-proposal-function-bind/src/index.ts
@@ -14,11 +14,16 @@ export default declare(api => {
     return scope.path.setData("functionBind", id);
   }
 
+  function getObject(bind: t.BindExpression) {
+    if (t.isExpression(bind.object)) {
+      return bind.object;
+    }
+
+    return (bind.callee as t.MemberExpression).object;
+  }
+
   function getStaticContext(bind: t.BindExpression, scope: Scope) {
-    const object =
-      bind.object ||
-      // @ts-ignore Fixme: should check bind.callee type first
-      bind.callee.object;
+    const object = getObject(bind);
     return (
       scope.isStatic(object) &&
       (t.isSuper(object) ? t.thisExpression() : object)
@@ -35,12 +40,10 @@ export default declare(api => {
         t.assignmentExpression("=", tempId, bind.object),
         bind.callee,
       ]);
-    } else {
-      // @ts-ignore Fixme: should check bind.callee type first
+    } else if (t.isMemberExpression(bind.callee)) {
       bind.callee.object = t.assignmentExpression(
         "=",
         tempId,
-        // @ts-ignore Fixme: should check bind.callee type first
         bind.callee.object,
       );
     }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | `ts-ignore`
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Get rid of `ts-ignore` in `babel-plugin-proposal-function-bind`. Added `isMemberExpression` check, since when there is no `object`, `callee` of `BindExpression` is Always `MemberExpression`, otherwise we see:

```
Binding should be performed on object property. (1:2)
```

for such code:

```
::console
```

So it should always used as `MemberExpression`:

```
::console.log
```

And produce:

```
BindExpression {
    callee: MemberExpression
}
```

In cases when we have `object`:

```js
console::log
```

We have such signature:

```
BindExpression {
    callee: Expression,
    object: Expression
}
```

And both `callee` and `object` can be any `Expression`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14707"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

