### PR TITLE
fix: support compiling monorepo on single-core CPU machines

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -1,5 +1,6 @@
 import path from "path";
 import fs from "fs";
+import { cpus } from "os";
 import { createRequire } from "module";
 import { fileURLToPath } from "url";
 import plumber from "gulp-plumber";
@@ -222,7 +223,8 @@ function getFiles(glob, { include, exclude }) {
 }
 
 function createWorker(useWorker) {
-  const numWorkers = require("os").cpus().length / 2 - 1;
+  // jest-worker defaults
+  const numWorkers = cpus().length - 1;
   if (numWorkers === 0 || !useWorker) {
     return require("./babel-worker.cjs");
   }

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -223,8 +223,7 @@ function getFiles(glob, { include, exclude }) {
 }
 
 function createWorker(useWorker) {
-  // jest-worker defaults
-  const numWorkers = cpus().length - 1;
+  const numWorkers = Math.ceil(cpus().length / 2) - 1;
   if (numWorkers === 0 || !useWorker) {
     return require("./babel-worker.cjs");
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14715 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Fixed building errors on single-core CPU machines, here we use the default value (CPU length - 1) for `numWorkers`. I mark the PR as internal because this issue does not affect end users.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14720"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

