### PR TITLE
fix: guard against empty CPU return

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -223,7 +223,7 @@ function getFiles(glob, { include, exclude }) {
 }
 
 function createWorker(useWorker) {
-  const numWorkers = Math.ceil(cpus().length / 2) - 1;
+  const numWorkers = Math.ceil(Math.max(cpus().length, 1) / 2) - 1;
   if (numWorkers === 0 || !useWorker) {
     return require("./babel-worker.cjs");
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/pull/14720#discussion_r914008924
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This is a follow-up to #14720. As mentioned in the review comment, `cpus()` might return an empty array when `libuv` fails to retrieve CPU info. Here we ensure that `cpus().length` always return an integer not less than 1.