### PR TITLE
fix: deep clone shared AST field definitions

### DIFF
--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -444,8 +444,8 @@ export interface FunctionDeclaration extends BaseNode {
   id?: Identifier | null;
   params: Array<Identifier | Pattern | RestElement>;
   body: BlockStatement;
-  generator?: boolean;
-  async?: boolean;
+  generator: boolean;
+  async: boolean;
   declare?: boolean | null;
   predicate?: DeclaredPredicate | InferredPredicate | null;
   returnType?: TypeAnnotation | TSTypeAnnotation | Noop | null;
@@ -461,8 +461,8 @@ export interface FunctionExpression extends BaseNode {
   id?: Identifier | null;
   params: Array<Identifier | Pattern | RestElement>;
   body: BlockStatement;
-  generator?: boolean;
-  async?: boolean;
+  generator: boolean;
+  async: boolean;
   predicate?: DeclaredPredicate | InferredPredicate | null;
   returnType?: TypeAnnotation | TSTypeAnnotation | Noop | null;
   typeParameters?:
@@ -582,8 +582,8 @@ export interface ObjectMethod extends BaseNode {
   params: Array<Identifier | Pattern | RestElement>;
   body: BlockStatement;
   computed: boolean;
-  generator?: boolean;
-  async?: boolean;
+  generator: boolean;
+  async: boolean;
   decorators?: Array<Decorator> | null;
   returnType?: TypeAnnotation | TSTypeAnnotation | Noop | null;
   typeParameters?:
@@ -738,7 +738,7 @@ export interface ArrowFunctionExpression extends BaseNode {
   type: "ArrowFunctionExpression";
   params: Array<Identifier | Pattern | RestElement>;
   body: BlockStatement | Expression;
-  async?: boolean;
+  async: boolean;
   expression: boolean;
   generator?: boolean;
   predicate?: DeclaredPredicate | InferredPredicate | null;
@@ -878,14 +878,14 @@ export interface MetaProperty extends BaseNode {
 
 export interface ClassMethod extends BaseNode {
   type: "ClassMethod";
-  kind?: "get" | "set" | "method" | "constructor";
+  kind: "get" | "set" | "method" | "constructor";
   key: Identifier | StringLiteral | NumericLiteral | BigIntLiteral | Expression;
   params: Array<Identifier | Pattern | RestElement | TSParameterProperty>;
   body: BlockStatement;
-  computed?: boolean;
-  static?: boolean;
-  generator?: boolean;
-  async?: boolean;
+  computed: boolean;
+  static: boolean;
+  generator: boolean;
+  async: boolean;
   abstract?: boolean | null;
   access?: "public" | "private" | "protected" | null;
   accessibility?: "public" | "private" | "protected" | null;
@@ -996,8 +996,8 @@ export interface ClassProperty extends BaseNode {
   value?: Expression | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
   decorators?: Array<Decorator> | null;
-  computed?: boolean;
-  static?: boolean;
+  computed: boolean;
+  static: boolean;
   abstract?: boolean | null;
   accessibility?: "public" | "private" | "protected" | null;
   declare?: boolean | null;
@@ -1020,8 +1020,8 @@ export interface ClassAccessorProperty extends BaseNode {
   value?: Expression | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
   decorators?: Array<Decorator> | null;
-  computed?: boolean;
-  static?: boolean;
+  computed: boolean;
+  static: boolean;
   abstract?: boolean | null;
   accessibility?: "public" | "private" | "protected" | null;
   declare?: boolean | null;
@@ -1050,7 +1050,7 @@ export interface ClassPrivateMethod extends BaseNode {
   key: PrivateName;
   params: Array<Identifier | Pattern | RestElement | TSParameterProperty>;
   body: BlockStatement;
-  static?: boolean;
+  static: boolean;
   abstract?: boolean | null;
   access?: "public" | "private" | "protected" | null;
   accessibility?: "public" | "private" | "protected" | null;
@@ -1725,7 +1725,7 @@ export interface TSPropertySignature extends BaseNode {
   key: Expression;
   typeAnnotation?: TSTypeAnnotation | null;
   initializer?: Expression | null;
-  computed?: boolean | null;
+  computed?: boolean;
   kind: "get" | "set";
   optional?: boolean | null;
   readonly?: boolean | null;
@@ -1737,7 +1737,7 @@ export interface TSMethodSignature extends BaseNode {
   typeParameters?: TSTypeParameterDeclaration | null;
   parameters: Array<Identifier | RestElement>;
   typeAnnotation?: TSTypeAnnotation | null;
-  computed?: boolean | null;
+  computed?: boolean;
   kind: "method" | "get" | "set";
   optional?: boolean | null;
 }

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -362,7 +362,7 @@ defineType("ForStatement", {
   },
 });
 
-export const functionCommon = {
+export const functionCommon = () => ({
   params: {
     validate: chain(
       assertValueType("array"),
@@ -375,9 +375,9 @@ export const functionCommon = {
   async: {
     default: false,
   },
-};
+});
 
-export const functionTypeAnnotationCommon = {
+export const functionTypeAnnotationCommon = () => ({
   returnType: {
     validate: process.env.BABEL_8_BREAKING
       ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
@@ -400,10 +400,10 @@ export const functionTypeAnnotationCommon = {
         ),
     optional: true,
   },
-};
+});
 
-export const functionDeclarationCommon = {
-  ...functionCommon,
+export const functionDeclarationCommon = () => ({
+  ...functionCommon(),
   declare: {
     validate: assertValueType("boolean"),
     optional: true,
@@ -412,14 +412,14 @@ export const functionDeclarationCommon = {
     validate: assertNodeType("Identifier"),
     optional: true, // May be null for `export default function`
   },
-};
+});
 
 defineType("FunctionDeclaration", {
   builder: ["id", "params", "body", "generator", "async"],
   visitor: ["id", "params", "body", "returnType", "typeParameters"],
   fields: {
-    ...functionDeclarationCommon,
-    ...functionTypeAnnotationCommon,
+    ...functionDeclarationCommon(),
+    ...functionTypeAnnotationCommon(),
     body: {
       validate: assertNodeType("BlockStatement"),
     },
@@ -461,8 +461,8 @@ defineType("FunctionExpression", {
     "Pureish",
   ],
   fields: {
-    ...functionCommon,
-    ...functionTypeAnnotationCommon,
+    ...functionCommon(),
+    ...functionTypeAnnotationCommon(),
     id: {
       validate: assertNodeType("Identifier"),
       optional: true,
@@ -477,7 +477,7 @@ defineType("FunctionExpression", {
   },
 });
 
-export const patternLikeCommon = {
+export const patternLikeCommon = () => ({
   typeAnnotation: {
     validate: process.env.BABEL_8_BREAKING
       ? assertNodeType("TypeAnnotation", "TSTypeAnnotation")
@@ -494,15 +494,16 @@ export const patternLikeCommon = {
       assertValueType("array"),
       assertEach(assertNodeType("Decorator")),
     ),
+    optional: true,
   },
-};
+});
 
 defineType("Identifier", {
   builder: ["name"],
   visitor: ["typeAnnotation", "decorators" /* for legacy param decorators */],
   aliases: ["Expression", "PatternLike", "LVal", "TSEntityName"],
   fields: {
-    ...patternLikeCommon,
+    ...patternLikeCommon(),
     name: {
       validate: chain(
         assertValueType("string"),
@@ -772,8 +773,8 @@ defineType("ObjectExpression", {
 defineType("ObjectMethod", {
   builder: ["kind", "key", "params", "body", "computed", "generator", "async"],
   fields: {
-    ...functionCommon,
-    ...functionTypeAnnotationCommon,
+    ...functionCommon(),
+    ...functionTypeAnnotationCommon(),
     kind: {
       validate: assertOneOf("method", "get", "set"),
       ...(!process.env.BABEL_TYPES_8_BREAKING ? { default: "method" } : {}),
@@ -948,7 +949,7 @@ defineType("RestElement", {
   aliases: ["LVal", "PatternLike"],
   deprecatedAlias: "RestProperty",
   fields: {
-    ...patternLikeCommon,
+    ...patternLikeCommon(),
     argument: {
       validate: !process.env.BABEL_TYPES_8_BREAKING
         ? assertNodeType("LVal")
@@ -1234,7 +1235,7 @@ defineType("AssignmentPattern", {
   builder: ["left", "right"],
   aliases: ["Pattern", "PatternLike", "LVal"],
   fields: {
-    ...patternLikeCommon,
+    ...patternLikeCommon(),
     left: {
       validate: assertNodeType(
         "Identifier",
@@ -1265,7 +1266,7 @@ defineType("ArrayPattern", {
   builder: ["elements"],
   aliases: ["Pattern", "PatternLike", "LVal"],
   fields: {
-    ...patternLikeCommon,
+    ...patternLikeCommon(),
     elements: {
       validate: chain(
         assertValueType("array"),
@@ -1299,8 +1300,8 @@ defineType("ArrowFunctionExpression", {
     "Pureish",
   ],
   fields: {
-    ...functionCommon,
-    ...functionTypeAnnotationCommon,
+    ...functionCommon(),
+    ...functionTypeAnnotationCommon(),
     expression: {
       // https://github.com/babel/babylon/issues/505
       validate: assertValueType("boolean"),
@@ -1786,7 +1787,7 @@ defineType("MetaProperty", {
   },
 });
 
-export const classMethodOrPropertyCommon = {
+export const classMethodOrPropertyCommon = () => ({
   abstract: {
     validate: assertValueType("boolean"),
     optional: true,
@@ -1832,11 +1833,11 @@ export const classMethodOrPropertyCommon = {
       ),
     ),
   },
-};
+});
 
-export const classMethodOrDeclareMethodCommon = {
-  ...functionCommon,
-  ...classMethodOrPropertyCommon,
+export const classMethodOrDeclareMethodCommon = () => ({
+  ...functionCommon(),
+  ...classMethodOrPropertyCommon(),
   params: {
     validate: chain(
       assertValueType("array"),
@@ -1868,7 +1869,7 @@ export const classMethodOrDeclareMethodCommon = {
     ),
     optional: true,
   },
-};
+});
 
 defineType("ClassMethod", {
   aliases: ["Function", "Scopable", "BlockParent", "FunctionParent", "Method"],
@@ -1891,8 +1892,8 @@ defineType("ClassMethod", {
     "typeParameters",
   ],
   fields: {
-    ...classMethodOrDeclareMethodCommon,
-    ...functionTypeAnnotationCommon,
+    ...classMethodOrDeclareMethodCommon(),
+    ...functionTypeAnnotationCommon(),
     body: {
       validate: assertNodeType("BlockStatement"),
     },
@@ -1908,7 +1909,7 @@ defineType("ObjectPattern", {
   builder: ["properties"],
   aliases: ["Pattern", "PatternLike", "LVal"],
   fields: {
-    ...patternLikeCommon,
+    ...patternLikeCommon(),
     properties: {
       validate: chain(
         assertValueType("array"),
@@ -2163,7 +2164,7 @@ defineType("ClassProperty", {
   ],
   aliases: ["Property"],
   fields: {
-    ...classMethodOrPropertyCommon,
+    ...classMethodOrPropertyCommon(),
     value: {
       validate: assertNodeType("Expression"),
       optional: true,
@@ -2217,7 +2218,7 @@ defineType("ClassAccessorProperty", {
   ],
   aliases: ["Property", "Accessor"],
   fields: {
-    ...classMethodOrPropertyCommon,
+    ...classMethodOrPropertyCommon(),
     key: {
       validate: chain(
         (function () {
@@ -2354,8 +2355,8 @@ defineType("ClassPrivateMethod", {
     "Private",
   ],
   fields: {
-    ...classMethodOrDeclareMethodCommon,
-    ...functionTypeAnnotationCommon,
+    ...classMethodOrDeclareMethodCommon(),
+    ...functionTypeAnnotationCommon(),
     kind: {
       validate: assertOneOf("get", "set", "method"),
       default: "method",

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -22,7 +22,7 @@ const defineType = defineAliasedType("TypeScript");
 
 const bool = assertValueType("boolean");
 
-const tSFunctionTypeAnnotationCommon = {
+const tSFunctionTypeAnnotationCommon = () => ({
   returnType: {
     validate: process.env.BABEL_8_BREAKING
       ? assertNodeType("TSTypeAnnotation")
@@ -37,7 +37,7 @@ const tSFunctionTypeAnnotationCommon = {
         assertNodeType("TSTypeParameterDeclaration", "Noop"),
     optional: true,
   },
-};
+});
 
 defineType("TSParameterProperty", {
   aliases: ["LVal"], // TODO: This isn't usable in general as an LVal. Should have a "Parameter" alias.
@@ -72,16 +72,16 @@ defineType("TSDeclareFunction", {
   aliases: ["Statement", "Declaration"],
   visitor: ["id", "typeParameters", "params", "returnType"],
   fields: {
-    ...functionDeclarationCommon,
-    ...tSFunctionTypeAnnotationCommon,
+    ...functionDeclarationCommon(),
+    ...tSFunctionTypeAnnotationCommon(),
   },
 });
 
 defineType("TSDeclareMethod", {
   visitor: ["decorators", "key", "typeParameters", "params", "returnType"],
   fields: {
-    ...classMethodOrDeclareMethodCommon,
-    ...tSFunctionTypeAnnotationCommon,
+    ...classMethodOrDeclareMethodCommon(),
+    ...tSFunctionTypeAnnotationCommon(),
   },
 });
 
@@ -94,14 +94,14 @@ defineType("TSQualifiedName", {
   },
 });
 
-const signatureDeclarationCommon = {
+const signatureDeclarationCommon = () => ({
   typeParameters: validateOptionalType("TSTypeParameterDeclaration"),
   [process.env.BABEL_8_BREAKING ? "params" : "parameters"]: validateArrayOfType(
     ["Identifier", "RestElement"],
   ),
   [process.env.BABEL_8_BREAKING ? "returnType" : "typeAnnotation"]:
     validateOptionalType("TSTypeAnnotation"),
-};
+});
 
 const callConstructSignatureDeclaration = {
   aliases: ["TSTypeElement"],
@@ -110,7 +110,7 @@ const callConstructSignatureDeclaration = {
     process.env.BABEL_8_BREAKING ? "params" : "parameters",
     process.env.BABEL_8_BREAKING ? "returnType" : "typeAnnotation",
   ],
-  fields: signatureDeclarationCommon,
+  fields: signatureDeclarationCommon(),
 };
 
 defineType("TSCallSignatureDeclaration", callConstructSignatureDeclaration);
@@ -119,17 +119,17 @@ defineType(
   callConstructSignatureDeclaration,
 );
 
-const namedTypeElementCommon = {
+const namedTypeElementCommon = () => ({
   key: validateType("Expression"),
-  computed: validate(bool),
+  computed: { default: false },
   optional: validateOptional(bool),
-};
+});
 
 defineType("TSPropertySignature", {
   aliases: ["TSTypeElement"],
   visitor: ["key", "typeAnnotation", "initializer"],
   fields: {
-    ...namedTypeElementCommon,
+    ...namedTypeElementCommon(),
     readonly: validateOptional(bool),
     typeAnnotation: validateOptionalType("TSTypeAnnotation"),
     initializer: validateOptionalType("Expression"),
@@ -148,8 +148,8 @@ defineType("TSMethodSignature", {
     process.env.BABEL_8_BREAKING ? "returnType" : "typeAnnotation",
   ],
   fields: {
-    ...signatureDeclarationCommon,
-    ...namedTypeElementCommon,
+    ...signatureDeclarationCommon(),
+    ...namedTypeElementCommon(),
     kind: {
       validate: assertOneOf("method", "get", "set"),
     },
@@ -208,12 +208,12 @@ const fnOrCtrBase = {
 
 defineType("TSFunctionType", {
   ...fnOrCtrBase,
-  fields: signatureDeclarationCommon,
+  fields: signatureDeclarationCommon(),
 });
 defineType("TSConstructorType", {
   ...fnOrCtrBase,
   fields: {
-    ...signatureDeclarationCommon,
+    ...signatureDeclarationCommon(),
     abstract: validateOptional(bool),
   },
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | See below
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The shared AST field definitions could be mutated by

https://github.com/babel/babel/blob/1c79224431ec13c04e157db125eb11632f070c6d/packages/babel-types/src/definitions/utils.ts#L344-L346

This issue surfaced when I am reviewing https://github.com/babel/babel/pull/14730/files#diff-85c1fccaeecd3c19b928ca56b3730ba55d198ce4e61717f56fc6a6aa62a7f85fL1043, where the `kind` of ClassPrivateMethod changed from an optional property to a non-optional property (expected). Here we deep clone the shared definitions such that, for example, mutating `TSPropertySignature`'s `computed` does not affect `ClassMethod`'s.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14737"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

