### PR TITLE
Use `@ts-expect-error` instead of `@ts-ignore`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -43,6 +43,7 @@ module.exports = {
         "@typescript-eslint/no-dupe-class-members": "error",
         "no-undef": "off",
         "no-redeclare": "off",
+        "@babel/development-internal/disallow-ts-ignore": "error",
       },
     },
     {

--- a/eslint/babel-eslint-plugin-development-internal/src/index.cjs
+++ b/eslint/babel-eslint-plugin-development-internal/src/index.cjs
@@ -1,6 +1,7 @@
 const rules = {
   "report-error-message-format": require("./rules/report-error-message-format.cjs"),
   "require-default-import-fallback": require("./rules/require-default-import-fallback.cjs"),
+  "disallow-ts-ignore": require("./rules/disallow-ts-ignore.cjs"),
 };
 
 exports.rules = rules;

--- a/eslint/babel-eslint-plugin-development-internal/src/rules/disallow-ts-ignore.cjs
+++ b/eslint/babel-eslint-plugin-development-internal/src/rules/disallow-ts-ignore.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "",
+    },
+    fixable: "code",
+  },
+  create(ctx) {
+    const sourceCode = ctx.getSourceCode();
+
+    return {
+      Program() {
+        for (const comment of sourceCode.getAllComments()) {
+          if (
+            /^\s*@ts-ignore(?!\(Babel \d vs Babel \d\))/.test(comment.value)
+          ) {
+            ctx.report({
+              node: comment,
+              message:
+                "`@ts-ignore` is only allowed for differences between Babel 7 and Babel 8, and it must be marked" +
+                " as `@ts-ignore(Babel 7 vs Babel 8)`. Use `@ts-expect-error` instead.",
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/babel-core/src/config/files/plugins.ts
+++ b/packages/babel-core/src/config/files/plugins.ts
@@ -100,7 +100,7 @@ function* resolveAlternativesHelper(
   const { error, value } = yield standardizedName;
   if (!error) return value;
 
-  // @ts-ignore
+  // @ts-expect-error
   if (error.code !== "MODULE_NOT_FOUND") throw error;
 
   if (standardizedName !== name && !(yield name).error) {

--- a/packages/babel-core/src/config/validation/option-assertions.ts
+++ b/packages/babel-core/src/config/validation/option-assertions.ts
@@ -46,7 +46,7 @@ export function msg(loc: NestingPath | GeneralPath): string {
     case "access":
       return `${msg(loc.parent)}[${JSON.stringify(loc.name)}]`;
     default:
-      // @ts-ignore should not happen when code is type checked
+      // @ts-expect-error should not happen when code is type checked
       throw new Error(`Assertion failure: Unknown type ${loc.type}`);
   }
 }

--- a/packages/babel-core/src/config/validation/plugins.ts
+++ b/packages/babel-core/src/config/validation/plugins.ts
@@ -40,7 +40,6 @@ function assertVisitorMap(loc: OptionPath, value: unknown): Visitor {
   if (obj) {
     Object.keys(obj).forEach(prop => assertVisitorHandler(prop, obj[prop]));
 
-    // @ts-ignore
     if (obj.enter || obj.exit) {
       throw new Error(
         `${msg(

--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -57,7 +57,7 @@ export function DeclareFunction(
   this.word("function");
   this.space();
   this.print(node.id, node);
-  // @ts-ignore TODO(Babel 8) Remove this comment, since we'll remove the Noop node
+  // @ts-ignore(Babel 7 vs Babel 8) TODO(Babel 8) Remove this comment, since we'll remove the Noop node
   this.print(node.id.typeAnnotation.typeAnnotation, node);
 
   if (node.predicate) {

--- a/packages/babel-generator/src/generators/methods.ts
+++ b/packages/babel-generator/src/generators/methods.ts
@@ -80,7 +80,7 @@ export function _methodHead(this: Printer, node: t.Method | t.TSDeclareMethod) {
 
   if (
     kind === "method" ||
-    // @ts-ignore Fixme: kind: "init" is not defined
+    // @ts-expect-error Fixme: kind: "init" is not defined
     kind === "init"
   ) {
     if (node.generator) {

--- a/packages/babel-generator/src/generators/statements.ts
+++ b/packages/babel-generator/src/generators/statements.ts
@@ -51,7 +51,7 @@ export function IfStatement(this: Printer, node: t.IfStatement) {
 
 // Recursively get the last statement.
 function getLastStatement(statement: t.Statement): t.Statement {
-  // @ts-ignore: If statement.body is empty or not a Node, isStatement will return false
+  // @ts-expect-error: If statement.body is empty or not a Node, isStatement will return false
   const { body } = statement;
   if (isStatement(body) === false) {
     return statement;

--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -239,9 +239,9 @@ export function tsPrintFunctionOrConstructorType(
 ) {
   const { typeParameters } = node;
   const parameters = process.env.BABEL_8_BREAKING
-    ? // @ts-ignore Babel 8 AST shape
+    ? // @ts-ignore(Babel 7 vs Babel 8) Babel 8 AST shape
       node.params
-    : // @ts-ignore Babel 7 AST shape
+    : // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST shape
       node.parameters;
   this.print(typeParameters, node);
   this.token("(");
@@ -251,9 +251,9 @@ export function tsPrintFunctionOrConstructorType(
   this.token("=>");
   this.space();
   const returnType = process.env.BABEL_8_BREAKING
-    ? // @ts-ignore Babel 8 AST shape
+    ? // @ts-ignore(Babel 7 vs Babel 8) Babel 8 AST shape
       node.returnType
-    : // @ts-ignore Babel 7 AST shape
+    : // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST shape
       node.typeAnnotation;
   this.print(returnType.typeAnnotation, node);
 }

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -433,7 +433,7 @@ class Printer {
 
     const oldConcise = this.format.concise;
     if (
-      // @ts-ignore document _compact AST properties
+      // @ts-expect-error document _compact AST properties
       node._compact
     ) {
       this.format.concise = true;
@@ -766,7 +766,7 @@ class Printer {
 Object.assign(Printer.prototype, generatorFunctions);
 
 if (!process.env.BABEL_8_BREAKING) {
-  // @ts-ignore
+  // @ts-ignore(Babel 7 vs Babel 8)
   Printer.prototype.Noop = function Noop(this: Printer) {};
 }
 

--- a/packages/babel-helper-compilation-targets/src/index.ts
+++ b/packages/babel-helper-compilation-targets/src/index.ts
@@ -239,7 +239,7 @@ export default function getTargets(
       for (const browser of Object.keys(queryBrowsers) as Target[]) {
         const version = queryBrowsers[browser];
         const esmSupportVersion =
-          // @ts-ignore ie is not in ESM_SUPPORT
+          // @ts-expect-error ie is not in ESM_SUPPORT
           ESM_SUPPORT[browser];
 
         if (esmSupportVersion) {

--- a/packages/babel-helper-compilation-targets/src/utils.ts
+++ b/packages/babel-helper-compilation-targets/src/utils.ts
@@ -52,7 +52,7 @@ export function getLowestUnreleased(a: string, b: string, env: Target): string {
   const unreleasedLabel:
     | typeof unreleasedLabels[keyof typeof unreleasedLabels]
     | undefined =
-    // @ts-ignore unreleasedLabel is undefined when env is not safari
+    // @ts-expect-error unreleasedLabel is undefined when env is not safari
     unreleasedLabels[env];
   if (a === unreleasedLabel) {
     return b;

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -107,7 +107,7 @@ interface PrivateNameVisitorState {
 function privateNameVisitorFactory<S>(
   visitor: Visitor<PrivateNameVisitorState & S>,
 ) {
-  // @ts-ignore Fixme: TS complains _exploded: boolean does not satisfy visitor functions
+  // @ts-expect-error Fixme: TS complains _exploded: boolean does not satisfy visitor functions
   const privateNameVisitor: Visitor<PrivateNameVisitorState & S> = {
     ...visitor,
 

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -42,7 +42,7 @@ export function createClassFeaturePlugin({
   feature,
   loose,
   manipulateOptions,
-  // @ts-ignore TODO(Babel 8): Remove the default value
+  // @ts-ignore(Babel 7 vs Babel 8) TODO(Babel 8): Remove the default value
   api = { assumption: () => void 0 },
   inherits,
 }: Options): PluginObject {

--- a/packages/babel-helper-environment-visitor/src/index.ts
+++ b/packages/babel-helper-environment-visitor/src/index.ts
@@ -16,7 +16,7 @@ export function requeueComputedKeyAndDecorators(
   path: NodePath<t.Method | t.Property>,
 ) {
   const { context, node } = path;
-  //@ts-ignore ClassPrivateProperty does not have computed
+  // @ts-expect-error ClassPrivateProperty does not have computed
   if (node.computed) {
     // requeue the computed key
     context.maybeQueue(path.get("key"));

--- a/packages/babel-helper-function-name/src/index.ts
+++ b/packages/babel-helper-function-name/src/index.ts
@@ -276,7 +276,7 @@ export default function <N extends t.FunctionExpression | t.Class>(
   // The id shouldn't be considered a local binding to the function because
   // we are simply trying to set the function name and not actually create
   // a local binding.
-  // @ts-ignore Fixme: avoid mutating AST nodes
+  // @ts-expect-error Fixme: avoid mutating AST nodes
   newId[NOT_LOCAL_BINDING] = true;
 
   const state = visit(node, name, scope);

--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -145,7 +145,7 @@ export function rewriteModuleStatementsAndPrepareHeader(
 export function ensureStatementsHoisted(statements: t.Statement[]) {
   // Force all of the header fields to be at the top of the file.
   statements.forEach(header => {
-    // @ts-ignore Fixme: handle _blockHoist property
+    // @ts-expect-error Fixme: handle _blockHoist property
     header._blockHoist = 3;
   });
 }

--- a/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
+++ b/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
@@ -440,7 +440,7 @@ function getLocalExportMetadata(
       kind = "import";
     } else {
       if (child.isExportDefaultDeclaration()) {
-        // @ts-ignore
+        // @ts-expect-error
         child = child.get("declaration");
       }
       if (child.isExportNamedDeclaration()) {

--- a/packages/babel-helper-plugin-utils/src/index.ts
+++ b/packages/babel-helper-plugin-utils/src/index.ts
@@ -17,7 +17,6 @@ export function declare<State = {}, Option = {}>(
   options: Option,
   dirname: string,
 ) => PluginObject<State & PluginPass> {
-  // @ts-ignore
   return (api, options: Option, dirname: string) => {
     let clonedApi: PluginAPI;
 
@@ -32,7 +31,7 @@ export function declare<State = {}, Option = {}>(
       clonedApi[name] = apiPolyfills[name](clonedApi);
     }
 
-    // @ts-ignore
+    // @ts-expect-error
     return builder(clonedApi ?? api, options || {}, dirname);
   };
 }

--- a/packages/babel-helper-replace-supers/src/index.ts
+++ b/packages/babel-helper-replace-supers/src/index.ts
@@ -167,7 +167,7 @@ const specHandlers: SpecHandler = {
       this.isPrivateMethod,
     );
     return callExpression(this.file.addHelper("get"), [
-      // @ts-ignore memo does not exist when this.isDerivedConstructor is false
+      // @ts-expect-error memo does not exist when this.isDerivedConstructor is false
       thisRefs.memo ? sequenceExpression([thisRefs.memo, proto]) : proto,
       this.prop(superMember),
       thisRefs.this,
@@ -198,7 +198,7 @@ const specHandlers: SpecHandler = {
       this.isPrivateMethod,
     );
     return callExpression(this.file.addHelper("set"), [
-      // @ts-ignore memo does not exist when this.isDerivedConstructor is false
+      // @ts-expect-error memo does not exist when this.isDerivedConstructor is false
       thisRefs.memo ? sequenceExpression([thisRefs.memo, proto]) : proto,
       this.prop(superMember),
       value,

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -40,7 +40,7 @@ if (!process.env.BABEL_8_BREAKING) {
         await (typeof block === "function" ? block() : block);
         return Promise.reject(new Error("Promise not rejected"));
       } catch (error) {
-        // @ts-ignore Fixme: validateError can be a string | object
+        // @ts-expect-error Fixme: validateError can be a string | object
         // see https://nodejs.org/api/assert.html#assertrejectsasyncfn-error-message
         if (typeof validateError === "function" && !validateError(error)) {
           return Promise.reject(
@@ -538,7 +538,7 @@ export default function (
 
             if (task.externalHelpers) {
               (task.options.plugins ??= [])
-                // @ts-ignore manipulating input options
+                // @ts-expect-error manipulating input options
                 .push([
                   "external-helpers",
                   { helperVersion: EXTERNAL_HELPERS_VERSION },

--- a/packages/babel-plugin-proposal-destructuring-private/src/index.ts
+++ b/packages/babel-plugin-proposal-destructuring-private/src/index.ts
@@ -63,7 +63,7 @@ export default declare(function ({ assertVersion, assumption, types: t }) {
       // (b, p1 = void 0) => {}
       if (firstAssignmentPatternIndex >= firstPrivateIndex) {
         params[firstAssignmentPatternIndex] = assignmentPattern(
-          // @ts-ignore The transformed assignment pattern must not be a RestElement
+          // @ts-expect-error The transformed assignment pattern must not be a RestElement
           params[firstAssignmentPatternIndex],
           scope.buildUndefinedNode(),
         );

--- a/packages/babel-plugin-proposal-export-default-from/src/index.ts
+++ b/packages/babel-plugin-proposal-export-default-from/src/index.ts
@@ -18,7 +18,7 @@ export default declare(api => {
         const specifier = specifiers.shift();
         const { exported } = specifier;
         const uid = scope.generateUidIdentifier(
-          // @ts-ignore Identifier ?? StringLiteral
+          // @ts-expect-error Identifier ?? StringLiteral
           exported.name ?? exported.value,
         );
 

--- a/packages/babel-plugin-proposal-export-namespace-from/src/index.ts
+++ b/packages/babel-plugin-proposal-export-namespace-from/src/index.ts
@@ -28,7 +28,7 @@ export default declare(api => {
         const specifier = specifiers.shift();
         const { exported } = specifier;
         const uid = scope.generateUidIdentifier(
-          // @ts-ignore Identifier ?? StringLiteral
+          // @ts-expect-error Identifier ?? StringLiteral
           exported.name ?? exported.value,
         );
 

--- a/packages/babel-plugin-proposal-logical-assignment-operators/src/index.ts
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/src/index.ts
@@ -47,7 +47,7 @@ export default declare(api => {
 
         path.replaceWith(
           t.logicalExpression(
-            // @ts-ignore operatorTrunc has been tested by t.LOGICAL_OPERATORS
+            // @ts-expect-error operatorTrunc has been tested by t.LOGICAL_OPERATORS
             operatorTrunc,
             lhs,
             t.assignmentExpression("=", left, right),

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.ts
@@ -122,7 +122,7 @@ export default declare((api, opts: Options) => {
         keys.push(
           t.stringLiteral(
             String(
-              //@ts-ignore prop.key can not be a NullLiteral
+              // @ts-expect-error prop.key can not be a NullLiteral
               prop.key.value,
             ),
           ),

--- a/packages/babel-plugin-proposal-partial-application/src/index.ts
+++ b/packages/babel-plugin-proposal-partial-application/src/index.ts
@@ -40,7 +40,7 @@ export default declare(api => {
             t.assignmentExpression(
               "=",
               t.cloneNode(id),
-              // @ts-ignore Fixme: may need to handle JSXNamespacedName here
+              // @ts-expect-error Fixme: may need to handle JSXNamespacedName here
               node,
             ),
           );

--- a/packages/babel-plugin-proposal-pipeline-operator/src/hackVisitor.ts
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/hackVisitor.ts
@@ -85,7 +85,7 @@ const visitor: Visitor<PluginPass> = {
           t.assignmentExpression(
             "=",
             t.cloneNode(topicVariable),
-            // @ts-ignore node.left must not be a PrivateName when operator is |>
+            // @ts-expect-error node.left must not be a PrivateName when operator is |>
             node.left,
           ),
           node.right,

--- a/packages/babel-plugin-transform-classes/src/transformClass.ts
+++ b/packages/babel-plugin-transform-classes/src/transformClass.ts
@@ -506,7 +506,7 @@ export default function transformClass(
     if (t.isStringLiteral(key)) {
       // infer function name
       if (node.kind === "method") {
-        // @ts-ignore Fixme: we are passing a ClassMethod to nameFunction, but nameFunction
+        // @ts-expect-error Fixme: we are passing a ClassMethod to nameFunction, but nameFunction
         // does not seem to support it
         fn = nameFunction({ id: key, node: node, scope });
       }

--- a/packages/babel-plugin-transform-computed-properties/src/index.ts
+++ b/packages/babel-plugin-transform-computed-properties/src/index.ts
@@ -157,7 +157,7 @@ export default declare((api, options: Options) => {
           const { node, parent, scope } = path;
           let hasComputed = false;
           for (const prop of node.properties) {
-            // @ts-ignore SpreadElement must not have computed property
+            // @ts-expect-error SpreadElement must not have computed property
             hasComputed = prop.computed === true;
             if (hasComputed) break;
           }

--- a/packages/babel-plugin-transform-destructuring/src/util.ts
+++ b/packages/babel-plugin-transform-destructuring/src/util.ts
@@ -19,7 +19,6 @@ export function unshiftForXStatementBody(
     // var a = 0;for (const { #x: x, [a++]: y } of z) { const a = 1; }
     node.body = t.blockStatement([...newStatements, node.body]);
   } else {
-    // @ts-ignore statementPath.ensureBlock() has been called, node.body is always a BlockStatement
     node.body.body.unshift(...newStatements);
   }
 }

--- a/packages/babel-plugin-transform-duplicate-keys/src/index.ts
+++ b/packages/babel-plugin-transform-duplicate-keys/src/index.ts
@@ -45,7 +45,7 @@ export default declare(api => {
               | t.BigIntLiteral,
           );
           let isDuplicate = false;
-          // @ts-ignore prop.kind is not defined in ObjectProperty
+          // @ts-expect-error prop.kind is not defined in ObjectProperty
           switch (prop.kind) {
             case "get":
               if (alreadySeenData[name] || alreadySeenGetters[name]) {

--- a/packages/babel-plugin-transform-flow-comments/src/index.ts
+++ b/packages/babel-plugin-transform-flow-comments/src/index.ts
@@ -73,7 +73,7 @@ export default declare(api => {
       ofPath: path,
       comments: generateComment(
         path,
-        // @ts-ignore
+        // @ts-expect-error
         path.parent.optional,
       ),
     });
@@ -137,9 +137,9 @@ export default declare(api => {
       AssignmentPattern: {
         exit({ node }) {
           const { left } = node;
-          // @ts-ignore optional is not in ObjectPattern
+          // @ts-expect-error optional is not in ObjectPattern
           if (left.optional) {
-            // @ts-ignore optional is not in ObjectPattern
+            // @ts-expect-error optional is not in ObjectPattern
             left.optional = false;
           }
         },
@@ -153,7 +153,7 @@ export default declare(api => {
           attachComment({
             ofPath: path.get("typeParameters"),
             toPath: path.get("id"),
-            // @ts-ignore Fixme: optional is not in t.TypeParameterDeclaration
+            // @ts-expect-error Fixme: optional is not in t.TypeParameterDeclaration
             optional: node.typeParameters.optional,
           });
         }
@@ -162,7 +162,7 @@ export default declare(api => {
             ofPath: path.get("returnType"),
             toPath: path.get("body"),
             where: "leading",
-            // @ts-ignore Fixme: optional is not in t.TypeAnnotation
+            // @ts-expect-error Fixme: optional is not in t.TypeAnnotation
             optional: node.returnType.typeAnnotation.optional,
           });
         }
@@ -177,7 +177,7 @@ export default declare(api => {
           attachComment({
             ofPath: path.get("typeAnnotation"),
             toPath: path.get("key"),
-            // @ts-ignore Fixme: optional is not in t.TypeAnnotation
+            // @ts-expect-error Fixme: optional is not in t.TypeAnnotation
             optional: node.typeAnnotation.optional,
           });
         }
@@ -232,9 +232,9 @@ export default declare(api => {
             ofPath: path.get("typeAnnotation"),
             toPath: path,
             optional:
-              // @ts-ignore optional is not in ObjectPattern
+              // @ts-expect-error optional is not in ObjectPattern
               node.optional ||
-              // @ts-ignore Fixme: optional is not in t.TypeAnnotation
+              // @ts-expect-error Fixme: optional is not in t.TypeAnnotation
               node.typeAnnotation.optional,
           });
         }
@@ -254,7 +254,7 @@ export default declare(api => {
         if (node.typeParameters) {
           const typeParameters = path.get("typeParameters");
           comments.push(
-            // @ts-ignore optional is not in TypeParameterDeclaration
+            // @ts-expect-error optional is not in TypeParameterDeclaration
             generateComment(typeParameters, node.typeParameters.optional),
           );
           const trailingComments = node.typeParameters.trailingComments;
@@ -280,7 +280,7 @@ export default declare(api => {
             comments.push(
               generateComment(
                 superTypeParameters,
-                // @ts-ignore optional is not in TypeParameterInstantiation
+                // @ts-expect-error optional is not in TypeParameterInstantiation
                 superTypeParameters.node.optional,
               ),
             );

--- a/packages/babel-plugin-transform-flow-strip-types/src/index.ts
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.ts
@@ -64,7 +64,7 @@ export default declare((api, opts: Options) => {
 
         let typeCount = 0;
 
-        // @ts-ignore importKind is only in importSpecifier
+        // @ts-expect-error importKind is only in importSpecifier
         path.node.specifiers.forEach(({ importKind }) => {
           if (importKind === "type" || importKind === "typeof") {
             typeCount++;
@@ -155,7 +155,7 @@ export default declare((api, opts: Options) => {
         for (let i = 0; i < node.params.length; i++) {
           let param = node.params[i];
           if (param.type === "AssignmentPattern") {
-            // @ts-ignore
+            // @ts-expect-error
             param = param.left;
           }
           // @ts-expect-error optional is not in ObjectPattern
@@ -174,7 +174,7 @@ export default declare((api, opts: Options) => {
         if (skipStrip) return;
         let { node } = path;
         do {
-          // @ts-ignore node is a search pointer
+          // @ts-expect-error node is a search pointer
           node = node.expression;
         } while (t.isTypeCastExpression(node));
         path.replaceWith(node);

--- a/packages/babel-plugin-transform-function-name/src/index.ts
+++ b/packages/babel-plugin-transform-function-name/src/index.ts
@@ -26,7 +26,7 @@ export default declare(api => {
         const value = path.get("value");
         if (value.isFunction()) {
           const newNode = nameFunction(
-            // @ts-ignore Fixme: should check ArrowFunctionExpression
+            // @ts-expect-error Fixme: should check ArrowFunctionExpression
             value,
             false,
             supportUnicodeId,

--- a/packages/babel-plugin-transform-instanceof/src/index.ts
+++ b/packages/babel-plugin-transform-instanceof/src/index.ts
@@ -26,7 +26,7 @@ export default declare(api => {
           } else {
             path.replaceWith(
               t.callExpression(helper, [
-                // @ts-ignore node.left can be PrivateName only when node.operator is "in"
+                // @ts-expect-error node.left can be PrivateName only when node.operator is "in"
                 node.left,
                 node.right,
               ]),

--- a/packages/babel-plugin-transform-jscript/src/index.ts
+++ b/packages/babel-plugin-transform-jscript/src/index.ts
@@ -19,7 +19,7 @@ export default declare(api => {
                 null,
                 [],
                 t.blockStatement([
-                  // @ts-ignore fixme: t.toStatement may return false
+                  // @ts-expect-error fixme: t.toStatement may return false
                   t.toStatement(node),
                   t.returnStatement(t.cloneNode(node.id)),
                 ]),

--- a/packages/babel-plugin-transform-literals/src/index.ts
+++ b/packages/babel-plugin-transform-literals/src/index.ts
@@ -9,7 +9,7 @@ export default declare(api => {
     visitor: {
       NumericLiteral({ node }) {
         // number octal like 0b10 or 0o70
-        // @ts-ignore Add node.extra typings
+        // @ts-expect-error Add node.extra typings
         if (node.extra && /^0[ob]/i.test(node.extra.raw)) {
           node.extra = undefined;
         }
@@ -17,7 +17,7 @@ export default declare(api => {
 
       StringLiteral({ node }) {
         // unicode escape
-        // @ts-ignore Add node.extra typings
+        // @ts-expect-error Add node.extra typings
         if (node.extra && /\\[u]/gi.test(node.extra.raw)) {
           node.extra = undefined;
         }

--- a/packages/babel-plugin-transform-modules-systemjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.ts
@@ -232,7 +232,7 @@ export default declare<PluginState>((api, options: Options) => {
           t.unaryExpression(
             "+",
             t.cloneNode(
-              // @ts-ignore node is UpdateExpression
+              // @ts-expect-error node is UpdateExpression
               node.argument,
             ),
           ),

--- a/packages/babel-plugin-transform-react-constant-elements/src/index.ts
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.ts
@@ -193,7 +193,7 @@ export default declare((api, options: Options) => {
         let jsxScope;
         let current = path;
         while (!jsxScope && current.parentPath.isJSX()) {
-          // @ts-ignore current is a search pointer
+          // @ts-expect-error current is a search pointer
           current = current.parentPath;
           jsxScope = HOISTED.get(current.node);
         }

--- a/packages/babel-plugin-transform-runtime/src/index.ts
+++ b/packages/babel-plugin-transform-runtime/src/index.ts
@@ -19,7 +19,7 @@ const pluginRegenerator = (_pluginRegenerator.default ||
 const pluginsCompat = "#__secret_key__@babel/runtime__compatibility";
 
 function supportsStaticESM(caller: CallerMetadata | undefined) {
-  // @ts-ignore TS does not narrow down optional chaining
+  // @ts-expect-error TS does not narrow down optional chaining
   return !!caller?.supportsStaticESM;
 }
 

--- a/packages/babel-plugin-transform-template-literals/src/index.ts
+++ b/packages/babel-plugin-transform-template-literals/src/index.ts
@@ -99,7 +99,7 @@ export default declare((api, options: Options) => {
                 ${tmp} = ${this.addHelper(helperName)}(${helperArgs})
               )
             `,
-            //@ts-ignore Fixme: quasi.expressions may contain TSAnyKeyword
+            // @ts-expect-error Fixme: quasi.expressions may contain TSAnyKeyword
             ...quasi.expressions,
           ]),
         );

--- a/packages/babel-plugin-transform-typeof-symbol/src/index.ts
+++ b/packages/babel-plugin-transform-typeof-symbol/src/index.ts
@@ -41,7 +41,7 @@ export default declare(api => {
         let isUnderHelper = path.findParent(path => {
           if (path.isFunction()) {
             return (
-              // @ts-ignore the access is coupled with the shape of typeof helper
+              // @ts-expect-error the access is coupled with the shape of typeof helper
               path.get("body.directives.0")?.node.value.value ===
               "@babel/helpers - typeof"
             );

--- a/packages/babel-preset-env/src/debug.ts
+++ b/packages/babel-preset-env/src/debug.ts
@@ -24,7 +24,7 @@ export const logPlugin = (
     if (!first) formattedTargets += `,`;
     first = false;
     formattedTargets += ` ${target}`;
-    // @ts-ignore
+    // @ts-expect-error
     if (support[target]) formattedTargets += ` < ${support[target]}`;
   }
   formattedTargets += ` }`;

--- a/packages/babel-preset-env/src/filter-items.ts
+++ b/packages/babel-preset-env/src/filter-items.ts
@@ -29,7 +29,7 @@ export function removeUnsupportedItems(
       has(minVersions, item) &&
       semver.lt(
         babelVersion,
-        // @ts-ignore we have checked minVersions[item] in has call
+        // @ts-expect-error we have checked minVersions[item] in has call
         minVersions[item],
       )
     ) {

--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -57,7 +57,7 @@ function filterStageFromList(
 ) {
   return Object.keys(list).reduce((result, item) => {
     if (!stageList.has(item)) {
-      // @ts-ignore
+      // @ts-expect-error
       result[item] = list[item];
     }
 
@@ -91,7 +91,7 @@ function getPluginList(proposals: boolean, bugfixes: boolean) {
 
 const getPlugin = (pluginName: string) => {
   const plugin =
-    // @ts-ignore plugin name is constructed from available plugin list
+    // @ts-expect-error plugin name is constructed from available plugin list
     availablePlugins[pluginName]();
 
   if (!plugin) {

--- a/packages/babel-preset-env/src/normalize-options.ts
+++ b/packages/babel-preset-env/src/normalize-options.ts
@@ -1,6 +1,6 @@
 import semver, { type SemVer } from "semver";
 import corejs2Polyfills from "@babel/compat-data/corejs2-built-ins";
-// @ts-ignore Fixme: TS can not infer types from ../data/core-js-compat.js
+// @ts-expect-error Fixme: TS can not infer types from ../data/core-js-compat.js
 // but we can't import core-js-compat/data.json because JSON imports does
 // not work on Node 14
 import corejs3Polyfills from "../data/core-js-compat";
@@ -129,7 +129,7 @@ export const validateModulesOption = (
   modulesOpt: ModuleOption = ModulesOption.auto,
 ) => {
   v.invariant(
-    // @ts-ignore we have provided fallback for undefined keys
+    // @ts-expect-error we have provided fallback for undefined keys
     ModulesOption[modulesOpt.toString()] || modulesOpt === ModulesOption.false,
     `The 'modules' option must be one of \n` +
       ` - 'false' to indicate no module processing\n` +
@@ -145,7 +145,7 @@ export const validateUseBuiltInsOption = (
   builtInsOpt: BuiltInsOption = false,
 ) => {
   v.invariant(
-    // @ts-ignore we have provided fallback for undefined keys
+    // @ts-expect-error we have provided fallback for undefined keys
     UseBuiltInsOption[builtInsOpt.toString()] ||
       builtInsOpt === UseBuiltInsOption.false,
     `The 'useBuiltIns' option must be either

--- a/packages/babel-preset-env/src/plugins-compat-data.ts
+++ b/packages/babel-preset-env/src/plugins-compat-data.ts
@@ -7,14 +7,14 @@ const bugfixPluginsFiltered = {};
 
 for (const plugin of Object.keys(plugins)) {
   if (Object.hasOwnProperty.call(availablePlugins, plugin)) {
-    // @ts-ignore
+    // @ts-expect-error
     pluginsFiltered[plugin] = plugins[plugin];
   }
 }
 
 for (const plugin of Object.keys(bugfixPlugins)) {
   if (Object.hasOwnProperty.call(availablePlugins, plugin)) {
-    // @ts-ignore
+    // @ts-expect-error
     bugfixPluginsFiltered[plugin] = bugfixPlugins[plugin];
   }
 }

--- a/packages/babel-standalone/src/index.ts
+++ b/packages/babel-standalone/src/index.ts
@@ -205,7 +205,7 @@ export const availablePresets = {
   flow: presetFlow,
 };
 
-// @ts-ignore VERSION is to be replaced by rollup
+// @ts-expect-error VERSION is to be replaced by rollup
 export const version: string = VERSION;
 
 function onDOMContentLoaded() {

--- a/packages/babel-traverse/src/context.ts
+++ b/packages/babel-traverse/src/context.ts
@@ -44,7 +44,7 @@ export default class TraversalContext<S = unknown> {
     // we need to traverse into this node so ensure that it has children to traverse into!
     for (const key of keys) {
       if (
-        // @ts-ignore key is from visitor keys
+        // @ts-expect-error key is from visitor keys
         node[key]
       ) {
         return true;

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -51,7 +51,7 @@ function traverse(
 
 function traverse<Options extends TraverseOptions>(
   parent: t.Node,
-  // @ts-ignore provide {} as default value for Options
+  // @ts-expect-error provide {} as default value for Options
   opts: Options = {},
   scope?: Scope,
   state?: any,

--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -388,7 +388,7 @@ function _evaluate(path: NodePath, state: State): any {
         !isInvalidMethod(property.node.name)
       ) {
         context = global[object.node.name];
-        // @ts-ignore property may not exist in context object
+        // @ts-expect-error property may not exist in context object
         func = context[property.node.name];
       }
 

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -414,7 +414,7 @@ export function _getKey<T extends t.Node>(
 ): NodePath | NodePath[] {
   const node = this.node;
   const container =
-    // @ts-ignore
+    // @ts-expect-error
     node[key];
 
   if (Array.isArray(container)) {
@@ -450,7 +450,7 @@ export function _getPattern(
       path = path.parentPath;
     } else {
       if (Array.isArray(path)) {
-        // @ts-ignore
+        // @ts-expect-error
         path = path[part];
       } else {
         path = path.get(part, context);
@@ -519,7 +519,7 @@ export function getBindingIdentifierPaths(
     if (!id.node) continue;
 
     const keys =
-      // @ts-ignore
+      // @ts-expect-error
       _getBindingIdentifiers.keys[id.node.type];
 
     if (id.isIdentifier()) {

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -85,7 +85,7 @@ class NodePath<T extends t.Node = t.Node> {
     }
 
     const targetNode =
-      // @ts-ignore key must present in container
+      // @ts-expect-error key must present in container
       container[key];
 
     let paths = pathCache.get(parent);
@@ -238,7 +238,7 @@ if (!process.env.BABEL_8_BREAKING) {
   // The original _guessExecutionStatusRelativeToDifferentFunctions only worked for paths in
   // different functions, but _guessExecutionStatusRelativeTo works as a replacement in those cases.
 
-  // @ts-ignore
+  // @ts-expect-error
   NodePath.prototype._guessExecutionStatusRelativeToDifferentFunctions =
     NodePath_introspection._guessExecutionStatusRelativeTo;
 }
@@ -288,7 +288,7 @@ type NodePathMixins = typeof NodePath_ancestry &
   typeof NodePath_family &
   typeof NodePath_comments;
 
-// @ts-ignore TS throws because ensureBlock returns the body node path
+// @ts-expect-error TS throws because ensureBlock returns the body node path
 // however, we don't use the return value and treat it as a transform and
 // assertion utilities. For better type inference we annotate it as an
 // assertion method

--- a/packages/babel-traverse/src/path/inference/index.ts
+++ b/packages/babel-traverse/src/path/inference/index.ts
@@ -75,9 +75,9 @@ export function _getTypeAnnotation(this: NodePath): any {
     }
   }
 
-  // @ts-ignore
+  // @ts-expect-error
   if (node.typeAnnotation) {
-    // @ts-ignore
+    // @ts-expect-error
     return node.typeAnnotation;
   }
 

--- a/packages/babel-traverse/src/path/introspection.ts
+++ b/packages/babel-traverse/src/path/introspection.ts
@@ -37,7 +37,7 @@ export function matchesPattern(
 export function has(this: NodePath, key: string): boolean {
   const val =
     this.node &&
-    // @ts-ignore
+    // @ts-expect-error
     this.node[key];
   if (val && Array.isArray(val)) {
     return !!val.length;
@@ -73,7 +73,7 @@ export function isnt(this: NodePath, key: string): boolean {
  */
 
 export function equals(this: NodePath, key: string, value: any): boolean {
-  // @ts-ignore
+  // @ts-expect-error
   return this.node[key] === value;
 }
 

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -62,7 +62,7 @@ export function insertBefore(
     this.replaceWith(blockStatement(shouldInsertCurrentNode ? [node] : []));
     return (this as NodePath<t.BlockStatement>).unshiftContainer(
       "body",
-      // @ts-ignore Fixme: refine nodes to t.BlockStatement["body"] when this is a BlockStatement path
+      // @ts-expect-error Fixme: refine nodes to t.BlockStatement["body"] when this is a BlockStatement path
       nodes,
     );
   } else {
@@ -249,7 +249,7 @@ export function insertAfter(
         (node as t.ExpressionStatement).expression != null);
 
     this.replaceWith(blockStatement(shouldInsertCurrentNode ? [node] : []));
-    // @ts-ignore Fixme: refine nodes to t.BlockStatement["body"] when this is a BlockStatement path
+    // @ts-expect-error Fixme: refine nodes to t.BlockStatement["body"] when this is a BlockStatement path
     return this.pushContainer("body", nodes);
   } else {
     throw new Error(

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -354,7 +354,7 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
     if (
       path.isFunctionExpression() &&
       path.has("id") &&
-      // @ts-ignore Fixme: document symbol ast properties
+      // @ts-expect-error Fixme: document symbol ast properties
       !path.get("id").node[NOT_LOCAL_BINDING]
     ) {
       path.scope.registerBinding("local", path.get("id"), path);
@@ -364,7 +364,7 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
   ClassExpression(path) {
     if (
       path.has("id") &&
-      // @ts-ignore Fixme: document symbol ast properties
+      // @ts-expect-error Fixme: document symbol ast properties
       !path.get("id").node[NOT_LOCAL_BINDING]
     ) {
       path.scope.registerBinding("local", path);

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -233,7 +233,7 @@ function wrapWithStateOrWrapper<State>(
     // not an enter/exit array of callbacks
     if (!Array.isArray(fns)) continue;
 
-    // @ts-ignore manipulating visitors
+    // @ts-expect-error manipulating visitors
     fns = fns.map(function (fn) {
       let newFn = fn;
 
@@ -244,7 +244,7 @@ function wrapWithStateOrWrapper<State>(
       }
 
       if (wrapper) {
-        // @ts-ignore Fixme: document state.key
+        // @ts-expect-error Fixme: document state.key
         newFn = wrapper(state.key, key, newFn);
       }
 
@@ -274,9 +274,9 @@ function ensureEntranceObjects(obj: Visitor) {
 }
 
 function ensureCallbackArrays(obj: Visitor) {
-  // @ts-ignore normalizing enter property
+  // @ts-expect-error normalizing enter property
   if (obj.enter && !Array.isArray(obj.enter)) obj.enter = [obj.enter];
-  // @ts-ignore normalizing exit property
+  // @ts-expect-error normalizing exit property
   if (obj.exit && !Array.isArray(obj.exit)) obj.exit = [obj.exit];
 }
 

--- a/packages/babel-types/src/converters/ensureBlock.ts
+++ b/packages/babel-types/src/converters/ensureBlock.ts
@@ -11,9 +11,9 @@ export default function ensureBlock(
   node: t.Node,
   key: string = "body",
 ): t.BlockStatement {
-  // @ts-ignore Fixme: key may not exist in node, consider remove key = "body"
+  // @ts-expect-error Fixme: key may not exist in node, consider remove key = "body"
   const result = toBlock(node[key], node);
-  // @ts-ignore
+  // @ts-expect-error
   node[key] = result;
   return result;
 }

--- a/packages/babel-types/src/converters/toSequenceExpression.ts
+++ b/packages/babel-types/src/converters/toSequenceExpression.ts
@@ -24,6 +24,6 @@ export default function toSequenceExpression(
     scope.push(declar);
   }
 
-  // @ts-ignore fixme: gatherSequenceExpressions will return an Expression when there are only one element
+  // @ts-expect-error fixme: gatherSequenceExpressions will return an Expression when there are only one element
   return result;
 }

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -384,7 +384,7 @@ export const functionTypeAnnotationCommon = () => ({
       : assertNodeType(
           "TypeAnnotation",
           "TSTypeAnnotation",
-          // @ts-ignore Babel 7 AST
+          // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST
           "Noop",
         ),
     optional: true,
@@ -395,7 +395,7 @@ export const functionTypeAnnotationCommon = () => ({
       : assertNodeType(
           "TypeParameterDeclaration",
           "TSTypeParameterDeclaration",
-          // @ts-ignore Babel 7 AST
+          // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST
           "Noop",
         ),
     optional: true,
@@ -484,7 +484,7 @@ export const patternLikeCommon = () => ({
       : assertNodeType(
           "TypeAnnotation",
           "TSTypeAnnotation",
-          // @ts-ignore Babel 7 AST
+          // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST
           "Noop",
         ),
     optional: true,
@@ -1368,7 +1368,7 @@ defineType("ClassExpression", {
         : assertNodeType(
             "TypeParameterDeclaration",
             "TSTypeParameterDeclaration",
-            // @ts-ignore Babel 7 AST
+            // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST
             "Noop",
           ),
       optional: true,
@@ -1426,7 +1426,7 @@ defineType("ClassDeclaration", {
         : assertNodeType(
             "TypeParameterDeclaration",
             "TSTypeParameterDeclaration",
-            // @ts-ignore Babel 7 AST
+            // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST
             "Noop",
           ),
       optional: true,
@@ -2179,7 +2179,7 @@ defineType("ClassProperty", {
         : assertNodeType(
             "TypeAnnotation",
             "TSTypeAnnotation",
-            // @ts-ignore Babel 7 AST
+            // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST
             "Noop",
           ),
       optional: true,
@@ -2260,7 +2260,7 @@ defineType("ClassAccessorProperty", {
         : assertNodeType(
             "TypeAnnotation",
             "TSTypeAnnotation",
-            // @ts-ignore Babel 7 AST
+            // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST
             "Noop",
           ),
       optional: true,
@@ -2305,7 +2305,7 @@ defineType("ClassPrivateProperty", {
         : assertNodeType(
             "TypeAnnotation",
             "TSTypeAnnotation",
-            // @ts-ignore Babel 7 AST
+            // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST
             "Noop",
           ),
       optional: true,

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -26,14 +26,14 @@ const tSFunctionTypeAnnotationCommon = () => ({
   returnType: {
     validate: process.env.BABEL_8_BREAKING
       ? assertNodeType("TSTypeAnnotation")
-      : // @ts-ignore Babel 7 AST
+      : // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST
         assertNodeType("TSTypeAnnotation", "Noop"),
     optional: true,
   },
   typeParameters: {
     validate: process.env.BABEL_8_BREAKING
       ? assertNodeType("TSTypeParameterDeclaration")
-      : // @ts-ignore Babel 7 AST
+      : // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST
         assertNodeType("TSTypeParameterDeclaration", "Noop"),
     optional: true,
   },

--- a/packages/babel-types/src/modifications/removeProperties.ts
+++ b/packages/babel-types/src/modifications/removeProperties.ts
@@ -28,18 +28,18 @@ export default function removeProperties(
 ): void {
   const map = opts.preserveComments ? CLEAR_KEYS : CLEAR_KEYS_PLUS_COMMENTS;
   for (const key of map) {
-    // @ts-ignore
+    // @ts-expect-error
     if (node[key] != null) node[key] = undefined;
   }
 
   for (const key of Object.keys(node)) {
-    // @ts-ignore
+    // @ts-expect-error
     if (key[0] === "_" && node[key] != null) node[key] = undefined;
   }
 
   const symbols: Array<symbol> = Object.getOwnPropertySymbols(node);
   for (const sym of symbols) {
-    // @ts-ignore Fixme: document symbol properties
+    // @ts-expect-error Fixme: document symbol properties
     node[sym] = null;
   }
 }

--- a/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
+++ b/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
@@ -79,7 +79,7 @@ function getBindingIdentifiers(
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
         const nodes =
-          // @ts-ignore key must present in id
+          // @ts-expect-error key must present in id
           id[key] as t.Node[] | t.Node | undefined | null;
         if (nodes) {
           Array.isArray(nodes) ? search.push(...nodes) : search.push(nodes);

--- a/packages/babel-types/src/traverse/traverseFast.ts
+++ b/packages/babel-types/src/traverse/traverseFast.ts
@@ -20,7 +20,7 @@ export default function traverseFast<Options = {}>(
 
   for (const key of keys) {
     const subNode: t.Node | undefined | null =
-      // @ts-ignore key must present in node
+      // @ts-expect-error key must present in node
       node[key];
 
     if (Array.isArray(subNode)) {

--- a/packages/babel-types/src/utils/inherit.ts
+++ b/packages/babel-types/src/utils/inherit.ts
@@ -5,7 +5,7 @@ export default function inherit<
   P extends t.Node | undefined,
 >(key: keyof C & keyof P, child: C, parent: P): void {
   if (child && parent) {
-    // @ts-ignore Could further refine key definitions
+    // @ts-expect-error Could further refine key definitions
     child[key] = Array.from(
       new Set([].concat(child[key], parent[key]).filter(Boolean)),
     );

--- a/packages/babel-types/src/utils/shallowEqual.ts
+++ b/packages/babel-types/src/utils/shallowEqual.ts
@@ -6,7 +6,7 @@ export default function shallowEqual<T extends object>(
 
   for (const key of keys) {
     if (
-      // @ts-ignore maybe we should check whether key exists first
+      // @ts-expect-error maybe we should check whether key exists first
       actual[key] !== expected[key]
     ) {
       return false;

--- a/packages/babel-types/src/validators/isLet.ts
+++ b/packages/babel-types/src/validators/isLet.ts
@@ -9,7 +9,7 @@ export default function isLet(node: t.Node): boolean {
   return (
     isVariableDeclaration(node) &&
     (node.kind !== "var" ||
-      // @ts-ignore Fixme: document private properties
+      // @ts-expect-error Fixme: document private properties
       node[BLOCK_SCOPED_SYMBOL])
   );
 }

--- a/packages/babel-types/src/validators/isNodesEquivalent.ts
+++ b/packages/babel-types/src/validators/isNodesEquivalent.ts
@@ -26,7 +26,7 @@ export default function isNodesEquivalent<T extends Partial<t.Node>>(
 
   for (const field of fields) {
     const val_a =
-      // @ts-ignore field must present in a
+      // @ts-expect-error field must present in a
       a[field];
     const val_b = b[field];
     if (typeof val_a !== typeof val_b) {

--- a/packages/babel-types/src/validators/isVar.ts
+++ b/packages/babel-types/src/validators/isVar.ts
@@ -9,7 +9,7 @@ export default function isVar(node: t.Node): boolean {
   return (
     isVariableDeclaration(node, { kind: "var" }) &&
     !(
-      // @ts-ignore document private properties
+      // @ts-expect-error document private properties
       node[BLOCK_SCOPED_SYMBOL]
     )
   );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We cannot use `@ts-expect-error` for Babel 7 vs Babel 8 differences, because it errors only when building one version. However, we should use it for everything else so that we notice when they are not needed anymore (we already had 3 unnecessary `@ts-ignore`s).