### PR TITLE
fix: skip flattening spread object with __proto__

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
@@ -42,7 +42,7 @@ const set = (pass: PluginPass, name: string, v: any) =>
 function hasProto(node: t.ObjectExpression) {
   return node.properties.some(
     value =>
-      t.isObjectProperty(value, { computed: false }) &&
+      t.isObjectProperty(value, { computed: false, shorthand: false }) &&
       (t.isIdentifier(value.key, { name: "__proto__" }) ||
         t.isStringLiteral(value.key, { value: "__proto__" })),
   );

--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
@@ -727,7 +727,17 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
           }
 
           if (objs.length === 1) {
-            return objs[0];
+            if (
+              !(
+                t.isSpreadElement(props[0]) &&
+                // If an object expression is spread element's argument
+                // it is very likely to contain __proto__ and we should stop
+                // optimizing spread element
+                t.isObjectExpression(props[0].argument)
+              )
+            ) {
+              return objs[0];
+            }
           }
 
           // looks like we have multiple objects
@@ -764,7 +774,12 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
         accumulateAttribute(props, attr);
       }
 
-      return props.length === 1 && t.isSpreadElement(props[0])
+      return props.length === 1 &&
+        t.isSpreadElement(props[0]) &&
+        // If an object expression is spread element's argument
+        // it is very likely to contain __proto__ and we should stop
+        // optimizing spread element
+        !t.isObjectExpression(props[0].argument)
         ? props[0].argument
         : props.length > 0
         ? t.objectExpression(props)

--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
@@ -39,6 +39,15 @@ const get = (pass: PluginPass, name: string) =>
 const set = (pass: PluginPass, name: string, v: any) =>
   pass.set(`@babel/plugin-react-jsx/${name}`, v);
 
+function hasProto(node: t.ObjectExpression) {
+  return node.properties.some(
+    value =>
+      t.isObjectProperty(value, { computed: false }) &&
+      (t.isIdentifier(value.key, { name: "__proto__" }) ||
+        t.isStringLiteral(value.key, { value: "__proto__" })),
+  );
+}
+
 export interface Options {
   filter?: (node: t.Node, pass: PluginPass) => boolean;
   importSource?: string;
@@ -422,7 +431,7 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
       if (t.isJSXSpreadAttribute(attribute.node)) {
         const arg = attribute.node.argument;
         // Collect properties into props array if spreading object expression
-        if (t.isObjectExpression(arg)) {
+        if (t.isObjectExpression(arg) && !hasProto(arg)) {
           array.push(...arg.properties);
         } else {
           array.push(t.spreadElement(arg));

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/input.js
@@ -5,3 +5,7 @@
 <img alt="" {...{src, title}} />;
 
 <blockquote {...{cite}}>{items}</blockquote>;
+
+<pre {...{["__proto__"]: null }}></pre>;
+
+<code {...{[__proto__]: null }}></code>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/input.js
@@ -2,7 +2,7 @@
 
 <div {...props}>{contents}</div>;
 
-<img alt="" {...{src, title}} />;
+<img alt="" {...{src, title, __proto__}} />;
 
 <blockquote {...{cite}}>{items}</blockquote>;
 

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/output.mjs
@@ -22,3 +22,13 @@ _jsx("blockquote", {
   cite,
   children: items
 });
+
+/*#__PURE__*/
+_jsx("pre", {
+  ["__proto__"]: null
+});
+
+/*#__PURE__*/
+_jsx("code", {
+  [__proto__]: null
+});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/flattens-spread/output.mjs
@@ -14,7 +14,8 @@ _jsx("div", { ...props,
 _jsx("img", {
   alt: "",
   src,
-  title
+  title,
+  __proto__
 });
 
 /*#__PURE__*/

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-spread-with-proto/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-spread-with-proto/input.js
@@ -1,7 +1,3 @@
-var __proto__ = null;
-
 <p {...{__proto__: null}}>text</p>;
 
 <div {...{"__proto__": null}}>{contents}</div>;
-
-<img alt="" {...{__proto__}} />;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-spread-with-proto/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-spread-with-proto/input.js
@@ -1,0 +1,7 @@
+var __proto__ = null;
+
+<p {...{__proto__: null}}>text</p>;
+
+<div {...{"__proto__": null}}>{contents}</div>;
+
+<img alt="" {...{__proto__}} />;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-spread-with-proto/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-spread-with-proto/output.mjs
@@ -1,0 +1,24 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+var __proto__ = null;
+
+/*#__PURE__*/
+_jsx("p", { ...{
+    __proto__: null
+  },
+  children: "text"
+});
+
+/*#__PURE__*/
+_jsx("div", { ...{
+    "__proto__": null
+  },
+  children: contents
+});
+
+/*#__PURE__*/
+_jsx("img", {
+  alt: "",
+  ...{
+    __proto__
+  }
+});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-spread-with-proto/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react-automatic/handle-spread-with-proto/output.mjs
@@ -1,5 +1,4 @@
 import { jsx as _jsx } from "react/jsx-runtime";
-var __proto__ = null;
 
 /*#__PURE__*/
 _jsx("p", { ...{
@@ -13,12 +12,4 @@ _jsx("div", { ...{
     "__proto__": null
   },
   children: contents
-});
-
-/*#__PURE__*/
-_jsx("img", {
-  alt: "",
-  ...{
-    __proto__
-  }
 });

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/input.js
@@ -5,3 +5,7 @@
 <img alt="" {...{src, title}} />;
 
 <blockquote {...{cite}}>{items}</blockquote>;
+
+<pre {...{["__proto__"]: null }}></pre>;
+
+<code {...{[__proto__]: null }}></code>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/input.js
@@ -2,7 +2,7 @@
 
 <div {...props}>{contents}</div>;
 
-<img alt="" {...{src, title}} />;
+<img alt="" {...{src, title, __proto__}} />;
 
 <blockquote {...{cite}}>{items}</blockquote>;
 

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/output.js
@@ -8,7 +8,8 @@ React.createElement("div", props, contents);
 React.createElement("img", {
   alt: "",
   src,
-  title
+  title,
+  __proto__
 });
 
 /*#__PURE__*/

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/flattens-spread/output.js
@@ -15,3 +15,13 @@ React.createElement("img", {
 React.createElement("blockquote", {
   cite
 }, items);
+
+/*#__PURE__*/
+React.createElement("pre", {
+  ["__proto__"]: null
+});
+
+/*#__PURE__*/
+React.createElement("code", {
+  [__proto__]: null
+});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/input.js
@@ -1,7 +1,3 @@
-var __proto__ = null;
-
 <p {...{__proto__: null}}>text</p>;
 
 <div {...{"__proto__": null}}>{contents}</div>;
-
-<img alt="" {...{__proto__}} />;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/input.js
@@ -1,0 +1,7 @@
+var __proto__ = null;
+
+<p {...{__proto__: null}}>text</p>;
+
+<div {...{"__proto__": null}}>{contents}</div>;
+
+<img alt="" {...{__proto__}} />;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/options.json
@@ -1,0 +1,3 @@
+{
+  "BABEL_8_BREAKING": false
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/output.js
@@ -1,5 +1,3 @@
-var __proto__ = null;
-
 /*#__PURE__*/
 React.createElement("p", babelHelpers.extends({
   __proto__: null
@@ -9,10 +7,3 @@ React.createElement("p", babelHelpers.extends({
 React.createElement("div", babelHelpers.extends({
   "__proto__": null
 }), contents);
-
-/*#__PURE__*/
-React.createElement("img", babelHelpers.extends({
-  alt: ""
-}, {
-  __proto__
-}));

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/output.js
@@ -1,14 +1,14 @@
 var __proto__ = null;
 
 /*#__PURE__*/
-React.createElement("p", {
+React.createElement("p", babelHelpers.extends({
   __proto__: null
-}, "text");
+}), "text");
 
 /*#__PURE__*/
-React.createElement("div", {
+React.createElement("div", babelHelpers.extends({
   "__proto__": null
-}, contents);
+}), contents);
 
 /*#__PURE__*/
 React.createElement("img", babelHelpers.extends({

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto-babel-7/output.js
@@ -11,9 +11,8 @@ React.createElement("div", {
 }, contents);
 
 /*#__PURE__*/
-React.createElement("img", {
-  alt: "",
-  ...{
-    __proto__
-  }
-});
+React.createElement("img", babelHelpers.extends({
+  alt: ""
+}, {
+  __proto__
+}));

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/input.js
@@ -1,7 +1,3 @@
-var __proto__ = null;
-
 <p {...{__proto__: null}}>text</p>;
 
 <div {...{"__proto__": null}}>{contents}</div>;
-
-<img alt="" {...{__proto__}} />;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/input.js
@@ -1,0 +1,7 @@
+var __proto__ = null;
+
+<p {...{__proto__: null}}>text</p>;
+
+<div {...{"__proto__": null}}>{contents}</div>;
+
+<img alt="" {...{__proto__}} />;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/options.json
@@ -1,0 +1,3 @@
+{
+  "BABEL_8_BREAKING": true
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/output.js
@@ -1,13 +1,15 @@
 var __proto__ = null;
 
 /*#__PURE__*/
-React.createElement("p", {
-  __proto__: null
+React.createElement("p", { ...{
+    __proto__: null
+  }
 }, "text");
 
 /*#__PURE__*/
-React.createElement("div", {
-  "__proto__": null
+React.createElement("div", { ...{
+    "__proto__": null
+  }
 }, contents);
 
 /*#__PURE__*/

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/output.js
@@ -1,0 +1,18 @@
+var __proto__ = null;
+
+/*#__PURE__*/
+React.createElement("p", {
+  __proto__: null
+}, "text");
+
+/*#__PURE__*/
+React.createElement("div", {
+  "__proto__": null
+}, contents);
+
+/*#__PURE__*/
+React.createElement("img", babelHelpers.extends({
+  alt: ""
+}, {
+  __proto__
+}));

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/handle-spread-with-proto/output.js
@@ -1,5 +1,3 @@
-var __proto__ = null;
-
 /*#__PURE__*/
 React.createElement("p", { ...{
     __proto__: null
@@ -11,11 +9,3 @@ React.createElement("div", { ...{
     "__proto__": null
   }
 }, contents);
-
-/*#__PURE__*/
-React.createElement("img", {
-  alt: "",
-  ...{
-    __proto__
-  }
-});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/proto-in-jsx-attribute/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/proto-in-jsx-attribute/input.js
@@ -1,0 +1,1 @@
+<p __proto__={null} class="bar">text</p>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/proto-in-jsx-attribute/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/proto-in-jsx-attribute/output.js
@@ -1,0 +1,5 @@
+/*#__PURE__*/
+React.createElement("p", {
+  __proto__: null,
+  class: "bar"
+}, "text");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14756
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we avoid optimizing the JSX pattern `{ ... { __proto__: foo }` to `{ __proto__: foo }` as JSX spread element evaluates to a plain object created by the global `Object` function.

This PR is a follow-up to #12557.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14759"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

