### PR TITLE
fix: allow exporting `TSDeclareFunction` as default

### DIFF
--- a/packages/babel-plugin-transform-modules-systemjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.ts
@@ -436,6 +436,7 @@ export default declare<PluginState>((api, options: Options) => {
                 }
                 removedPaths.push(path);
               } else {
+                // @ts-expect-error TSDeclareFunction is not expected here
                 path.replaceWith(buildExportCall("default", declar));
               }
             } else if (path.isExportNamedDeclaration()) {

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -813,7 +813,11 @@ export interface ExportAllDeclaration extends BaseNode {
 
 export interface ExportDefaultDeclaration extends BaseNode {
   type: "ExportDefaultDeclaration";
-  declaration: FunctionDeclaration | ClassDeclaration | Expression;
+  declaration:
+    | TSDeclareFunction
+    | FunctionDeclaration
+    | ClassDeclaration
+    | Expression;
   exportKind?: "value" | null;
 }
 
@@ -6722,6 +6726,7 @@ export interface ParentMaps {
   TSDeclareFunction:
     | BlockStatement
     | DoWhileStatement
+    | ExportDefaultDeclaration
     | ExportNamedDeclaration
     | ForInStatement
     | ForOfStatement

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -639,7 +639,11 @@ export function exportAllDeclaration(
   });
 }
 export function exportDefaultDeclaration(
-  declaration: t.FunctionDeclaration | t.ClassDeclaration | t.Expression,
+  declaration:
+    | t.TSDeclareFunction
+    | t.FunctionDeclaration
+    | t.ClassDeclaration
+    | t.Expression,
 ): t.ExportDefaultDeclaration {
   return validateNode<t.ExportDefaultDeclaration>({
     type: "ExportDefaultDeclaration",

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -1521,6 +1521,7 @@ defineType("ExportDefaultDeclaration", {
   fields: {
     declaration: {
       validate: assertNodeType(
+        "TSDeclareFunction",
         "FunctionDeclaration",
         "ClassDeclaration",
         "Expression",

--- a/packages/babel-types/test/builders/typescript/exportDefaultDeclaration.js
+++ b/packages/babel-types/test/builders/typescript/exportDefaultDeclaration.js
@@ -1,0 +1,23 @@
+import * as t from "../../../lib/index.js";
+
+describe("builders", function () {
+  describe("typescript", function () {
+    describe("exportDefaultDeclaration", function () {
+      it("accept TSDeclareFunction as argument for exportDefaultDeclaration", function () {
+        // this can be used when having function overrides for function exported as default
+        // export default function test();
+        // export default function test() {};
+        expect(() => {
+          t.exportDefaultDeclaration(
+            t.tsDeclareFunction(
+              t.identifier("test"),
+              null,
+              [],
+              t.tsTypeAnnotation(t.tsVoidKeyword()),
+            ),
+          );
+        }).not.toThrow();
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Updating `@babel/types` to allow `TSDeclareFunction` in default export.
It was working earlier, but stopped somewhere in between `7.18.2` and current (`7.18.8`) version

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14763"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

