### PR TITLE
Fix e2e-old-babel test to always use old core/helpers/traverse

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -320,6 +320,8 @@ const privateNameHandlerSpec: Handler<PrivateNameState & Receiver> & Receiver =
       const isAccessor = getId || setId;
 
       if (isStatic) {
+        // NOTE: This package has a peerDependency on @babel/core@^7.0.0, but these
+        // helpers have been introduced in @babel/helpers@7.1.0.
         const helperName =
           isMethod && !isAccessor
             ? "classStaticPrivateMethodGet"

--- a/scripts/integration-tests/e2e-babel-old-version.sh
+++ b/scripts/integration-tests/e2e-babel-old-version.sh
@@ -67,7 +67,6 @@ node -e "
 rm packages/babel-standalone/test/built-into-es5.js
 
 # Update deps, build and test
-rm yarn.lock
 YARN_ENABLE_IMMUTABLE_INSTALLS=false make -j test-ci
 
 cleanup

--- a/scripts/integration-tests/e2e-babel-old-version.sh
+++ b/scripts/integration-tests/e2e-babel-old-version.sh
@@ -56,6 +56,7 @@ node -e "
 rm packages/babel-standalone/test/built-into-es5.js
 
 # Update deps, build and test
+rm yarn.lock
 YARN_ENABLE_IMMUTABLE_INSTALLS=false make -j test-ci
 
 cleanup

--- a/scripts/integration-tests/e2e-babel-old-version.sh
+++ b/scripts/integration-tests/e2e-babel-old-version.sh
@@ -28,9 +28,10 @@ node -e "\
   var pkg = require('./package.json');\
   pkg.devDependencies['@babel/core'] = '7.0.0';\
   Object.assign(pkg.resolutions, {\
-    '@babel/core': '7.0.0',\
-    '@babel/helpers': '7.0.2',\
-    '@babel/traverse': '7.0.0'\
+    '@babel/core@npm:*': '7.0.0',\
+    '@babel/core@npm:7.0.0/@babel/traverse': '7.0.0',\
+    '@babel/core@npm:7.0.0/@babel/helpers': '7.0.0',\
+    '@babel/helpers@npm:7.0.0/@babel/traverse': '7.0.0',\
   });\
   fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2));\
 "

--- a/scripts/integration-tests/e2e-babel-old-version.sh
+++ b/scripts/integration-tests/e2e-babel-old-version.sh
@@ -29,7 +29,7 @@ node -e "\
   pkg.devDependencies['@babel/core'] = '7.0.0';\
   Object.assign(pkg.resolutions, {\
     '@babel/core': '7.0.0',\
-    '@babel/helpers': '7.0.0',\
+    '@babel/helpers': '7.0.2',\
     '@babel/traverse': '7.0.0'\
   });\
   fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2));\

--- a/scripts/integration-tests/e2e-babel-old-version.sh
+++ b/scripts/integration-tests/e2e-babel-old-version.sh
@@ -30,8 +30,8 @@ node -e "\
   Object.assign(pkg.resolutions, {\
     '@babel/core@npm:*': '7.0.0',\
     '@babel/core@npm:7.0.0/@babel/traverse': '7.0.0',\
-    '@babel/core@npm:7.0.0/@babel/helpers': '7.0.0',\
-    '@babel/helpers@npm:7.0.0/@babel/traverse': '7.0.0',\
+    '@babel/core@npm:7.0.0/@babel/helpers': '7.1.0',\
+    '@babel/helpers@npm:7.1.0/@babel/traverse': '7.0.0',\
   });\
   fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2));\
 "

--- a/scripts/integration-tests/e2e-babel-old-version.sh
+++ b/scripts/integration-tests/e2e-babel-old-version.sh
@@ -24,16 +24,16 @@ startLocalRegistry "$PWD"/scripts/integration-tests/verdaccio-config.yml
 
 node "$PWD"/scripts/integration-tests/utils/bump-babel-dependencies.js
 
-node -e "\
-  var pkg = require('./package.json');\
-  pkg.devDependencies['@babel/core'] = '7.0.0';\
-  Object.assign(pkg.resolutions, {\
-    '@babel/core@npm:*': '7.0.0',\
-    '@babel/core@npm:7.0.0/@babel/traverse': '7.0.0',\
-    '@babel/core@npm:7.0.0/@babel/helpers': '7.1.0',\
-    '@babel/helpers@npm:7.1.0/@babel/traverse': '7.0.0',\
-  });\
-  fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2));\
+node -e "
+  var pkg = require('./package.json');
+  pkg.devDependencies['@babel/core'] = '7.0.0';
+  Object.assign(pkg.resolutions, {
+    '@babel/core@npm:*': '7.0.0',
+    '@babel/core@npm:7.0.0/@babel/traverse': '7.0.0',
+    '@babel/core@npm:7.0.0/@babel/helpers': '7.1.0',
+    '@babel/helpers@npm:7.1.0/@babel/traverse': '7.0.0',
+  });
+  fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2));
 "
 
 # Older @babel/core versions don't support "targets" and "assumptions"
@@ -55,6 +55,13 @@ node -e "
 # https://github.com/babel/babel/pull/14124 - This test is fixed in Babel 7.17;
 # Todo(Babel 8): enable this test
 rm packages/babel-standalone/test/built-into-es5.js
+
+# Our 'WorkerClient' implementation uses static private getters, that are only supported
+# when using '@babel/helpers@^7.6.0'
+# NOTE: When running this command on MacOS, use gsed from 'brew install gnu-sed'
+sed -i 's/describe, "worker"/describe.skip, "worker"/g' packages/babel-register/test/index.js
+sed -i 's/babel7node12(/babel7node12.skip(/g' eslint/babel-eslint-tests/test/integration/parser-override.js
+sed -i 's/itNode12upNoESM(/itNode12upNoESM.skip(/g' eslint/babel-eslint-tests/test/integration/config-files.js
 
 # Update deps, build and test
 rm yarn.lock

--- a/scripts/integration-tests/e2e-babel-old-version.sh
+++ b/scripts/integration-tests/e2e-babel-old-version.sh
@@ -24,26 +24,15 @@ startLocalRegistry "$PWD"/scripts/integration-tests/verdaccio-config.yml
 
 node "$PWD"/scripts/integration-tests/utils/bump-babel-dependencies.js
 
-(
-  # Yarn prints colors on GH actions even if it's piped, unless explicitly disabled
-  # https://github.com/yarnpkg/berry/pull/659
-  YARN_ENABLE_COLORS=0 yarn why @babel/core | grep -o "@babel/core@npm:.* (via npm:.*)";
-  YARN_ENABLE_COLORS=0 yarn why @babel/helpers | grep -o "@babel/helpers@npm:.* (via npm:.*)";
-  YARN_ENABLE_COLORS=0 yarn why @babel/traverse | grep -o "@babel/traverse@npm:.* (via npm:.*)"
-) | uniq | node -e "
-  var pkg = require('./package.json');
-  var packages = fs.readFileSync(0, 'utf8').trim().split('\n');
-
-  pkg.devDependencies['@babel/core'] = '7.0.0';
-
-  packages.forEach(desc => {
-    const { name, specifier } = desc
-      .match(/(?<name>@babel\/[a-z]+).*\(via (?<specifier>npm:[^)]+)\)/)
-      .groups;
-    pkg.resolutions[name + '@' + specifier] = '7.0.0';
-  });
-
-  fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2));
+node -e "\
+  var pkg = require('./package.json');\
+  pkg.devDependencies['@babel/core'] = '7.0.0';\
+  Object.assign(pkg.resolutions, {\
+    '@babel/core': '7.0.0',\
+    '@babel/helpers': '7.0.0',\
+    '@babel/traverse': '7.0.0'\
+  });\
+  fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2));\
 "
 
 # Older @babel/core versions don't support "targets" and "assumptions"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14794"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

