### PR TITLE
babel parser type improvements

### DIFF
--- a/packages/babel-parser/src/index.ts
+++ b/packages/babel-parser/src/index.ts
@@ -113,6 +113,7 @@ function getParserClass(pluginsFromOptions: PluginList): {
   if (!cls) {
     cls = Parser;
     for (const plugin of pluginList) {
+      // @ts-expect-error todo(flow->ts)
       cls = mixinPlugins[plugin](cls);
     }
     parserClassCache[key] = cls;

--- a/packages/babel-parser/src/parser/comments.ts
+++ b/packages/babel-parser/src/parser/comments.ts
@@ -66,7 +66,7 @@ function setLeadingComments(node: Undone<Node>, comments: Array<Comment>) {
  * @param {Undone<Node>} node
  * @param {Array<Comment>} comments
  */
-export function setInnerComments(node: Undone<Node>, comments: Array<Comment>) {
+export function setInnerComments(node: Undone<Node>, comments?: Array<Comment>) {
   if (node.innerComments === undefined) {
     node.innerComments = comments;
   } else {

--- a/packages/babel-parser/src/parser/comments.ts
+++ b/packages/babel-parser/src/parser/comments.ts
@@ -66,7 +66,10 @@ function setLeadingComments(node: Undone<Node>, comments: Array<Comment>) {
  * @param {Undone<Node>} node
  * @param {Array<Comment>} comments
  */
-export function setInnerComments(node: Undone<Node>, comments?: Array<Comment>) {
+export function setInnerComments(
+  node: Undone<Node>,
+  comments?: Array<Comment>,
+) {
   if (node.innerComments === undefined) {
     node.innerComments = comments;
   } else {

--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -60,6 +60,7 @@ import {
   PARAM_RETURN,
   functionFlags,
 } from "../util/production-parameter";
+import type { ParamKind } from "../util/production-parameter";
 import {
   newArrowHeadScope,
   newAsyncArrowScope,
@@ -71,44 +72,44 @@ import { setInnerComments } from "./comments";
 import { cloneIdentifier, type Undone } from "./node";
 import type Parser from ".";
 
-/*::
 import type { SourceType } from "../options";
-declare var invariant;
-*/
 
-export default class ExpressionParser extends LValParser {
+export default abstract class ExpressionParser extends LValParser {
   // Forward-declaration: defined in statement.js
-  /*::
-  +parseBlock: (
+  abstract parseBlock(
     allowDirectives?: boolean,
     createNewLexicalScope?: boolean,
     afterBlockParse?: (hasStrictModeDirective: boolean) => void,
-  ) => N.BlockStatement;
-  +parseClass: (
+  ): N.BlockStatement;
+  abstract parseClass(
     node: N.Class,
     isStatement: boolean,
     optionalId?: boolean,
-  ) => N.Class;
-  +parseDecorators: (allowExport?: boolean) => void;
-  +parseFunction: <T: N.NormalFunction>(
+  ): N.Class;
+  abstract parseDecorators(allowExport?: boolean): void;
+  abstract parseFunction<T extends N.NormalFunction>(
     node: T,
     statement?: number,
     allowExpressionBody?: boolean,
     isAsync?: boolean,
-  ) => T;
-  +parseFunctionParams: (node: N.Function, allowModifiers?: boolean) => void;
-  +takeDecorators: (node: N.HasDecorators) => void;
-  +parseBlockOrModuleBlockBody: (
+  ): T;
+  abstract parseFunctionParams(
+    node: N.Function,
+    allowModifiers?: boolean,
+  ): void;
+  abstract takeDecorators(node: N.HasDecorators): void;
+  abstract parseBlockOrModuleBlockBody(
     body: N.Statement[],
-    directives: ?(N.Directive[]),
+    directives: N.Directive[] | null | undefined,
     topLevel: boolean,
     end: TokenType,
-    afterBlockParse?: (hasStrictModeDirective: boolean) => void
-  ) => void
-  +parseProgram: (
-    program: N.Program, end: TokenType, sourceType?: SourceType
-  ) => N.Program
-  */
+    afterBlockParse?: (hasStrictModeDirective: boolean) => void,
+  ): void;
+  abstract parseProgram(
+    program: N.Program,
+    end: TokenType,
+    sourceType?: SourceType,
+  ): N.Program;
 
   // For object literal, check if property __proto__ has been used more than once.
   // If the expression is a destructuring assignment, then __proto__ may appear
@@ -2629,7 +2630,9 @@ export default class ExpressionParser extends LValParser {
 
       // FunctionBody[Yield, Await]:
       //   StatementList[?Yield, ?Await, +Return] opt
-      this.prodParam.enter(this.prodParam.currentFlags() | PARAM_RETURN);
+      this.prodParam.enter(
+        (this.prodParam.currentFlags() | PARAM_RETURN) as ParamKind,
+      );
       node.body = this.parseBlock(
         true,
         false,

--- a/packages/babel-parser/src/parser/index.ts
+++ b/packages/babel-parser/src/parser/index.ts
@@ -1,5 +1,5 @@
 import type { Options } from "../options";
-import type { File, Program /*::, JSXOpeningElement */ } from "../types";
+import type * as N from "../types";
 import type { PluginList } from "../plugin-utils";
 import { getOptions } from "../options";
 import StatementParser from "./statement";
@@ -14,11 +14,10 @@ export type PluginsMap = Map<
 
 export default class Parser extends StatementParser {
   // Forward-declaration so typescript plugin can override jsx plugin
-  /*::
-  +jsxParseOpeningElementAfterName: (
-    node: JSXOpeningElement,
-  ) => JSXOpeningElement;
-  */
+  // todo(flow->ts) - this probably can be removed
+  // abstract jsxParseOpeningElementAfterName(
+  //   node: N.JSXOpeningElement,
+  // ): N.JSXOpeningElement;
 
   constructor(options: Options | undefined | null, input: string) {
     options = getOptions(options);
@@ -32,15 +31,15 @@ export default class Parser extends StatementParser {
 
   // This can be overwritten, for example, by the TypeScript plugin.
   getScopeHandler(): {
-    new (...args: any): ScopeHandler<any>;
+    new (...args: any): ScopeHandler;
   } {
     return ScopeHandler;
   }
 
-  parse(): File {
+  parse(): N.File {
     this.enterInitialScopes();
-    const file = this.startNode() as File;
-    const program = this.startNode() as Program;
+    const file = this.startNode() as N.File;
+    const program = this.startNode() as N.Program;
     this.nextToken();
     file.errors = null;
     this.parseTopLevel(file, program);

--- a/packages/babel-parser/src/parser/lval.ts
+++ b/packages/babel-parser/src/parser/lval.ts
@@ -1,4 +1,3 @@
-/*:: declare var invariant; */
 import * as charCodes from "charcodes";
 import { tt, type TokenType } from "../tokenizer/types";
 import type {
@@ -11,18 +10,17 @@ import type {
   Pattern,
   RestElement,
   SpreadElement,
-  /*:: ObjectOrClassMember, */
-  /*:: ClassMember, */
+  ObjectOrClassMember,
+  ClassMember,
   ObjectMember,
+  TsNamedTypeElementBase,
+  PrivateName,
   ObjectExpression,
+  ObjectPattern,
   ArrayExpression,
   ArrayPattern,
-  /*:: TsNamedTypeElementBase, */
-  /*:: PrivateName, */
-  /*:: ObjectExpression, */
-  /*:: ObjectPattern, */
 } from "../types";
-import type { Position } from "../util/location";
+import type { Pos, Position } from "../util/location";
 import {
   isStrictBindOnlyReservedWord,
   isStrictBindReservedWord,
@@ -46,39 +44,43 @@ const unwrapParenthesizedExpression = (node: Node): Node => {
     : node;
 };
 
-export default class LValParser extends NodeUtils {
+export default abstract class LValParser extends NodeUtils {
   // Forward-declaration: defined in expression.js
-  /*::
-  +parseIdentifier: (liberal?: boolean) => Identifier;
-  +parseMaybeAssignAllowIn: (
-    refExpressionErrors?: ?ExpressionErrors,
+  abstract parseIdentifier(liberal?: boolean): Identifier;
+  abstract parseMaybeAssign(
+    refExpressionErrors?: ExpressionErrors | null,
     afterLeftParse?: Function,
-  ) => Expression;
-  +parseObjectLike: <T: ObjectPattern | ObjectExpression>(
+    refNeedsArrowPos?: Pos | null,
+  ): Expression;
+
+  abstract parseMaybeAssignAllowIn(
+    refExpressionErrors?: ExpressionErrors | null,
+    afterLeftParse?: Function,
+    refNeedsArrowPos?: Pos | null,
+  ): Expression;
+
+  abstract parseObjectLike<T extends ObjectPattern | ObjectExpression>(
     close: TokenType,
     isPattern: boolean,
-    isRecord?: ?boolean,
-    refExpressionErrors?: ?ExpressionErrors,
-  ) => T;
-  +parseObjPropValue: (
+    isRecord?: boolean,
+    refExpressionErrors?: ExpressionErrors,
+  ): T;
+  abstract parseObjPropValue(
     prop: any,
-    startPos: ?number,
-    startLoc: ?Position,
+    startPos: number | null,
+    startLoc: Position | null,
     isGenerator: boolean,
     isAsync: boolean,
     isPattern: boolean,
     isAccessor: boolean,
-    refExpressionErrors?: ?ExpressionErrors,
-  ) => void;
-  +parsePropertyName: (
+    refExpressionErrors?: ExpressionErrors | null,
+  ): void;
+  abstract parsePropertyName(
     prop: ObjectOrClassMember | ClassMember | TsNamedTypeElementBase,
-  ) => Expression | Identifier;
-  +parsePrivateName: () => PrivateName
-  */
+  ): Expression | Identifier;
+  abstract parsePrivateName(): PrivateName;
   // Forward-declaration: defined in statement.js
-  /*::
-  +parseDecorator: () => Decorator;
-  */
+  abstract parseDecorator(): Decorator;
 
   /**
    * Convert existing expression atom to assignable pattern

--- a/packages/babel-parser/src/parser/node.ts
+++ b/packages/babel-parser/src/parser/node.ts
@@ -98,7 +98,7 @@ export function cloneStringLiteral(node: any): any {
 
 export type Undone<T extends NodeType> = Omit<T, "type">;
 
-export class NodeUtils extends UtilParser {
+export abstract class NodeUtils extends UtilParser {
   startNode<T extends NodeType>(): Undone<T> {
     // @ts-expect-error
     return new Node(this, this.state.start, this.state.startLoc);

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -184,7 +184,7 @@ function babel7CompatTokens(tokens: (Token | N.Comment)[], input: string) {
   }
   return tokens;
 }
-export default class StatementParser extends ExpressionParser {
+export default abstract class StatementParser extends ExpressionParser {
   // ### Statement parsing
 
   // Parse a program. Initializes the parser, reads any number of
@@ -1627,16 +1627,11 @@ export default class StatementParser extends ExpressionParser {
     state: N.ParseClassMemberState,
     isStatic: boolean,
   ) {
-    // @ts-expect-error: Fixme: convert $FlowSubtype to TS
-    const publicMethod: $FlowSubtype<N.ClassMethod> = member;
-    // @ts-expect-error: Fixme: convert $FlowSubtype to TS
-    const privateMethod: $FlowSubtype<N.ClassPrivateMethod> = member;
-    // @ts-expect-error: Fixme: convert $FlowSubtype to TS
-    const publicProp: $FlowSubtype<N.ClassProperty> = member;
-    // @ts-expect-error: Fixme: convert $FlowSubtype to TS
-    const privateProp: $FlowSubtype<N.ClassPrivateProperty> = member;
-    // @ts-expect-error: Fixme: convert $FlowSubtype to TS
-    const accessorProp: $FlowSubtype<N.ClassAccessorProperty> = member;
+    const publicMethod = member as N.ClassMethod;
+    const privateMethod = member as N.ClassPrivateMethod;
+    const publicProp = member as N.ClassProperty;
+    const privateProp = member as N.ClassPrivateProperty;
+    const accessorProp = member as N.ClassAccessorProperty;
 
     const method: typeof publicMethod | typeof privateMethod = publicMethod;
     const publicMember: typeof publicMethod | typeof publicProp = publicMethod;

--- a/packages/babel-parser/src/parser/util.ts
+++ b/packages/babel-parser/src/parser/util.ts
@@ -23,9 +23,7 @@ import {
 } from "../parse-error";
 import type Parser from ".";
 
-/*::
 import type ScopeHandler from "../util/scope";
-*/
 
 type TryParse<Node, Error, Thrown, Aborted, FailState> = {
   node: Node;
@@ -37,11 +35,9 @@ type TryParse<Node, Error, Thrown, Aborted, FailState> = {
 
 // ## Parser utilities
 
-export default class UtilParser extends Tokenizer {
+export default abstract class UtilParser extends Tokenizer {
   // Forward-declaration: defined in parser/index.js
-  /*::
-  +getScopeHandler: () => Class<ScopeHandler<*>>;
-  */
+  abstract getScopeHandler(): { new (...args: any): ScopeHandler };
 
   // TODO
 

--- a/packages/babel-parser/src/plugin-utils.ts
+++ b/packages/babel-parser/src/plugin-utils.ts
@@ -220,9 +220,7 @@ import placeholders from "./plugins/placeholders";
 import v8intrinsic from "./plugins/v8intrinsic";
 
 // NOTE: order is important. estree must come first; placeholders must come last.
-export const mixinPlugins: {
-  [name: string]: MixinPlugin;
-} = {
+export const mixinPlugins = {
   estree,
   jsx,
   flow,

--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -3346,7 +3346,7 @@ export default (superClass: typeof Parser) =>
       return fileNode;
     }
 
-    skipBlockComment(): N.CommentBlock | void {
+    skipBlockComment(): N.CommentBlock | undefined {
       if (this.hasPlugin("flowComments") && this.skipFlowComment()) {
         if (this.state.hasFlowComment) {
           throw this.raise(FlowErrors.NestedFlowComment, {

--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -304,12 +304,8 @@ type EnumMemberInit =
       loc: Position;
     };
 
-export default (superClass: {
-  new (...args: any): Parser;
-}): {
-  new (...args: any): Parser;
-} =>
-  class extends superClass {
+export default (superClass: typeof Parser) =>
+  class FlowParserMixin extends superClass implements Parser {
     // The value of the @flow/@noflow pragma. Initially undefined, transitions
     // to "@flow" or "@noflow" if we see a pragma. Transitions to null if we are
     // past the initial comment.
@@ -2492,8 +2488,11 @@ export default (superClass: {
       return node;
     }
 
-    isValidLVal(type: string, ...rest: [boolean, BindingTypes]) {
-      return type === "TypeCastExpression" || super.isValidLVal(type, ...rest);
+    isValidLVal(type: string, isParenthesized: boolean, binding: BindingTypes) {
+      return (
+        type === "TypeCastExpression" ||
+        super.isValidLVal(type, isParenthesized, binding)
+      );
     }
 
     // parse class property type annotations
@@ -3131,6 +3130,7 @@ export default (superClass: {
       node: N.Function,
       allowDuplicates: boolean,
       isArrowFunction?: boolean | null,
+      strictModeChanged: boolean = true,
     ): void {
       if (
         isArrowFunction &&
@@ -3146,7 +3146,12 @@ export default (superClass: {
         }
       }
 
-      return super.checkParams(node, allowDuplicates, isArrowFunction);
+      return super.checkParams(
+        node,
+        allowDuplicates,
+        isArrowFunction,
+        strictModeChanged,
+      );
     }
 
     parseParenAndDistinguishExpression(canBeArrow: boolean): N.Expression {
@@ -3522,8 +3527,7 @@ export default (superClass: {
       const id = this.parseIdentifier(true);
       const init = this.eat(tt.eq)
         ? this.flowEnumMemberInit()
-        : { type: "none", loc };
-      // @ts-expect-error: fixme
+        : { type: "none" as const, loc };
       return { id, init };
     }
 

--- a/packages/babel-parser/src/plugins/jsx/index.ts
+++ b/packages/babel-parser/src/plugins/jsx/index.ts
@@ -77,12 +77,14 @@ function getQualifiedJSXName(
   throw new Error("Node had unexpected type: " + object.type);
 }
 
-export default (superClass: {
-  new (...args: any): Parser;
-}): {
-  new (...args: any): Parser;
-} =>
-  class extends superClass {
+export interface IJSXParserMixin {
+  jsxParseOpeningElementAfterName(
+    node: N.JSXOpeningElement,
+  ): N.JSXOpeningElement;
+}
+
+export default (superClass: typeof Parser) =>
+  class JSXParserMixin extends superClass implements Parser, IJSXParserMixin {
     // Reads inline JSX contents token.
 
     jsxReadToken(): void {

--- a/packages/babel-parser/src/plugins/jsx/xhtml.ts
+++ b/packages/babel-parser/src/plugins/jsx/xhtml.ts
@@ -256,5 +256,5 @@ const entities: {
   clubs: "\u2663",
   hearts: "\u2665",
   diams: "\u2666",
-};
+} as const;
 export default entities;

--- a/packages/babel-parser/src/plugins/placeholders.ts
+++ b/packages/babel-parser/src/plugins/placeholders.ts
@@ -5,9 +5,9 @@ import type Parser from "../parser";
 import * as N from "../types";
 import { ParseErrorEnum } from "../parse-error";
 import type { Undone } from "../parser/node";
-import { ExpressionErrors } from "../parser/util";
-import { BindingTypes } from "../util/scopeflags";
-import { Position } from "../util/location";
+import type { ExpressionErrors } from "../parser/util";
+import type { BindingTypes } from "../util/scopeflags";
+import type { Position } from "../util/location";
 
 type PossiblePlaceholedrs = {
   Identifier: N.Identifier;

--- a/packages/babel-parser/src/plugins/placeholders.ts
+++ b/packages/babel-parser/src/plugins/placeholders.ts
@@ -20,16 +20,6 @@ type PossiblePlaceholedrs = {
   Pattern: N.Pattern;
 };
 export type PlaceholderTypes = keyof PossiblePlaceholedrs;
-// todo:
-// export type PlaceholderTypes =
-//   | "Identifier"
-//   | "StringLiteral"
-//   | "Expression"
-//   | "Statement"
-//   | "Declaration"
-//   | "BlockStatement"
-//   | "ClassBody"
-//   | "Pattern";
 
 type NodeOf<T extends keyof PossiblePlaceholedrs> = PossiblePlaceholedrs[T];
 // todo: when there  is proper union type for Node

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -28,6 +28,7 @@ import {
   BIND_TS_NAMESPACE,
   BIND_CLASS,
   BIND_LEXICAL,
+  BIND_NONE,
 } from "../../util/scopeflags";
 import TypeScriptScopeHandler from "./scope";
 import * as charCodes from "charcodes";

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -28,7 +28,6 @@ import {
   BIND_TS_NAMESPACE,
   BIND_CLASS,
   BIND_LEXICAL,
-  BIND_NONE,
 } from "../../util/scopeflags";
 import TypeScriptScopeHandler from "./scope";
 import * as charCodes from "charcodes";
@@ -36,6 +35,9 @@ import type { ExpressionErrors } from "../../parser/util";
 import { PARAM } from "../../util/production-parameter";
 import { Errors, ParseErrorEnum } from "../../parse-error";
 import { cloneIdentifier, type Undone } from "../../parser/node";
+import type { Pattern } from "../../types";
+import type { Expression } from "../../types";
+import type { IJSXParserMixin } from "../jsx";
 
 const getOwn = <T extends {}>(object: T, key: keyof T) =>
   Object.hasOwnProperty.call(object, key) && object[key];
@@ -269,13 +271,15 @@ function tsIsVarianceAnnotations(
   return modifier === "in" || modifier === "out";
 }
 
-export default (superClass: {
-  new (...args: any): Parser;
-}): {
-  new (...args: any): Parser;
-} =>
-  // @ts-expect-error plugin may override interfaces
-  class extends superClass {
+type ClassWithMixin<
+  T extends new (...args: any) => any,
+  M extends object,
+> = T extends new (...args: infer P) => infer I
+  ? new (...args: P) => I & M
+  : never;
+
+export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
+  class TypeScriptParserMixin extends superClass implements Parser {
     getScopeHandler(): {
       new (...args: any): TypeScriptScopeHandler;
     } {
@@ -2385,9 +2389,17 @@ export default (superClass: {
     }
 
     parseArrayLike(
-      ...args: [TokenType, boolean, boolean, ExpressionErrors | null]
+      close: TokenType,
+      canBePattern: boolean,
+      isTuple: boolean,
+      refExpressionErrors?: ExpressionErrors | null,
     ): N.ArrayExpression | N.TupleExpression {
-      const node = super.parseArrayLike(...args);
+      const node = super.parseArrayLike(
+        close,
+        canBePattern,
+        isTuple,
+        refExpressionErrors,
+      );
 
       if (node.type === "ArrayExpression") {
         this.tsCheckForInvalidTypeCasts(node.elements);
@@ -3087,6 +3099,8 @@ export default (superClass: {
       node: N.Class,
       isStatement: boolean,
       optionalId?: boolean | null,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      bindingType?: BindingTypes,
     ): void {
       if ((!isStatement || optionalId) && this.isContextual(tt._implements)) {
         return;
@@ -3225,21 +3239,28 @@ export default (superClass: {
     }
 
     parseObjPropValue(
-      prop: Undone<N.ObjectMember>,
-      ...args: [
-        number | undefined | null,
-        Position | undefined | null,
-        boolean,
-        boolean,
-        boolean,
-        boolean,
-        ExpressionErrors | null,
-      ]
-    ): N.ObjectMethod | N.ObjectProperty {
+      prop: Undone<N.ObjectMethod | N.ObjectProperty>,
+      startPos: number | undefined | null,
+      startLoc: Position | undefined | null,
+      isGenerator: boolean,
+      isAsync: boolean,
+      isPattern: boolean,
+      isAccessor: boolean,
+      refExpressionErrors?: ExpressionErrors | null,
+    ) {
       const typeParameters = this.tsTryParseTypeParameters();
       if (typeParameters) prop.typeParameters = typeParameters;
 
-      return super.parseObjPropValue(prop, ...args);
+      return super.parseObjPropValue(
+        prop,
+        startPos,
+        startLoc,
+        isGenerator,
+        isAsync,
+        isPattern,
+        isAccessor,
+        refExpressionErrors,
+      );
     }
 
     parseFunctionParams(node: N.Function, allowModifiers?: boolean): void {
@@ -3281,7 +3302,8 @@ export default (superClass: {
     }
 
     parseMaybeAssign(
-      ...args: [ExpressionErrors | null, Function]
+      refExpressionErrors?: ExpressionErrors | null,
+      afterLeftParse?: Function,
     ): N.Expression {
       // Note: When the JSX plugin is on, type assertions (`<T> x`) aren't valid syntax.
 
@@ -3296,7 +3318,10 @@ export default (superClass: {
         // Prefer to parse JSX if possible. But may be an arrow fn.
         state = this.state.clone();
 
-        jsx = this.tryParse(() => super.parseMaybeAssign(...args), state);
+        jsx = this.tryParse(
+          () => super.parseMaybeAssign(refExpressionErrors, afterLeftParse),
+          state,
+        );
 
         /*:: invariant(!jsx.aborted) */
         /*:: invariant(jsx.node != null) */
@@ -3313,7 +3338,7 @@ export default (superClass: {
       }
 
       if (!jsx?.error && !this.match(tt.lt)) {
-        return super.parseMaybeAssign(...args);
+        return super.parseMaybeAssign(refExpressionErrors, afterLeftParse);
       }
 
       // Either way, we're looking at a '<': tt.jsxTagStart or relational.
@@ -3327,7 +3352,10 @@ export default (superClass: {
       const arrow = this.tryParse(abort => {
         // This is similar to TypeScript's `tryParseParenthesizedArrowFunctionExpression`.
         typeParameters = this.tsParseTypeParameters();
-        const expr = super.parseMaybeAssign(...args);
+        const expr = super.parseMaybeAssign(
+          refExpressionErrors,
+          afterLeftParse,
+        );
 
         if (
           expr.type !== "ArrowFunctionExpression" ||
@@ -3382,7 +3410,10 @@ export default (superClass: {
 
         // This will start with a type assertion (via parseMaybeUnary).
         // But don't directly call `this.tsParseTypeAssertion` because we want to handle any binary after it.
-        typeCast = this.tryParse(() => super.parseMaybeAssign(...args), state);
+        typeCast = this.tryParse(
+          () => super.parseMaybeAssign(refExpressionErrors, afterLeftParse),
+          state,
+        );
         /*:: invariant(!typeCast.aborted) */
         /*:: invariant(typeCast.node != null) */
         if (!typeCast.error) return typeCast.node;
@@ -3428,11 +3459,12 @@ export default (superClass: {
     // Handle type assertions
     parseMaybeUnary(
       refExpressionErrors?: ExpressionErrors | null,
+      sawUnary?: boolean,
     ): N.Expression {
       if (!this.hasPlugin("jsx") && this.match(tt.lt)) {
         return this.tsParseTypeAssertion();
       } else {
-        return super.parseMaybeUnary(refExpressionErrors);
+        return super.parseMaybeUnary(refExpressionErrors, sawUnary);
       }
     }
 
@@ -3635,13 +3667,11 @@ export default (superClass: {
     }
 
     parseMaybeDefault(
-      ...args: [
-        startPos?: number | null,
-        startLoc?: Position | null,
-        left?: N.Pattern | null,
-      ]
+      startPos?: number | null,
+      startLoc?: Position | null,
+      left?: Pattern | null,
     ): N.Pattern {
-      const node = super.parseMaybeDefault(...args);
+      const node = super.parseMaybeDefault(startPos, startLoc, left);
 
       if (
         node.type === "AssignmentPattern" &&
@@ -3692,8 +3722,9 @@ export default (superClass: {
     }
 
     toAssignableList(
-      exprList: N.Expression[],
-      ...args: [Position | undefined | null, boolean]
+      exprList: Expression[],
+      trailingCommaLoc: Position | undefined | null,
+      isLHS: boolean,
     ): void {
       for (let i = 0; i < exprList.length; i++) {
         const expr = exprList[i];
@@ -3703,7 +3734,7 @@ export default (superClass: {
           );
         }
       }
-      super.toAssignableList(exprList, ...args);
+      super.toAssignableList(exprList, trailingCommaLoc, isLHS);
     }
 
     typeCastToParameter(node: N.TsTypeCastExpression): N.Node {
@@ -3742,7 +3773,6 @@ export default (superClass: {
         // @ts-expect-error: refine typings
         if (typeArguments) node.typeParameters = typeArguments;
       }
-      // @ts-expect-error calling JSX methods
       return super.jsxParseOpeningElementAfterName(node);
     }
 
@@ -3781,12 +3811,13 @@ export default (superClass: {
 
     parseClass<T extends N.Class>(
       node: Undone<T>,
-      ...args: [boolean, boolean]
+      isStatement: boolean,
+      optionalId?: boolean,
     ): T {
       const oldInAbstractClass = this.state.inAbstractClass;
       this.state.inAbstractClass = !!(node as any).abstract;
       try {
-        return super.parseClass(node, ...args);
+        return super.parseClass(node, isStatement, optionalId);
       } finally {
         this.state.inAbstractClass = oldInAbstractClass;
       }
@@ -3825,18 +3856,24 @@ export default (superClass: {
     parseMethod<
       T extends N.ObjectMethod | N.ClassMethod | N.ClassPrivateMethod,
     >(
-      ...args: [
-        Undone<T>,
-        boolean,
-        boolean,
-        boolean,
-        boolean,
-        T["type"],
-        boolean,
-      ]
+      node: Undone<T>,
+      isGenerator: boolean,
+      isAsync: boolean,
+      isConstructor: boolean,
+      allowDirectSuper: boolean,
+      type: T["type"],
+      inClassScope?: boolean,
     ) {
-      const method = super.parseMethod(...args);
-      // @ts-expect-error abstract is not in ObjectMethod
+      const method = super.parseMethod<T>(
+        node,
+        isGenerator,
+        isAsync,
+        isConstructor,
+        allowDirectSuper,
+        type,
+        inClassScope,
+      );
+      // @ts-expect-error todo(flow->ts) property not defined for all types in union
       if (method.abstract) {
         const hasBody = this.hasPlugin("estree")
           ? // @ts-expect-error estree typings

--- a/packages/babel-parser/src/plugins/v8intrinsic.ts
+++ b/packages/babel-parser/src/plugins/v8intrinsic.ts
@@ -1,14 +1,11 @@
 import type Parser from "../parser";
 import { tokenIsIdentifier, tt } from "../tokenizer/types";
 import * as N from "../types";
+import type { ExpressionErrors } from "../parser/util";
 
-export default (superClass: {
-  new (...args: any): Parser;
-}): {
-  new (...args: any): Parser;
-} =>
-  class extends superClass {
-    parseV8Intrinsic(): N.Expression | void {
+export default (superClass: typeof Parser) =>
+  class V8IntrinsicMixin extends superClass implements Parser {
+    parseV8Intrinsic(): N.Expression {
       if (this.match(tt.modulo)) {
         const v8IntrinsicStartLoc = this.state.startLoc;
         // let the `loc` of Identifier starts from `%`
@@ -31,7 +28,9 @@ export default (superClass: {
      * parser/expression.js                                         *
      * ============================================================ */
 
-    parseExprAtom(): N.Expression {
-      return this.parseV8Intrinsic() || super.parseExprAtom(...arguments);
+    parseExprAtom(refExpressionErrors?: ExpressionErrors | null): N.Expression {
+      return (
+        this.parseV8Intrinsic() || super.parseExprAtom(refExpressionErrors)
+      );
     }
   };

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -361,7 +361,6 @@ export default abstract class Tokenizer extends CommentsParser {
             case charCodes.asterisk: {
               const comment = this.skipBlockComment();
               if (comment !== undefined) {
-                // @ts-expect-error strictNullCheck is not enabled
                 this.addComment(comment);
                 if (this.options.attachComment) comments.push(comment);
               }
@@ -371,7 +370,6 @@ export default abstract class Tokenizer extends CommentsParser {
             case charCodes.slash: {
               const comment = this.skipLineComment(2);
               if (comment !== undefined) {
-                // @ts-expect-error strictNullCheck is not enabled
                 this.addComment(comment);
                 if (this.options.attachComment) comments.push(comment);
               }
@@ -396,7 +394,6 @@ export default abstract class Tokenizer extends CommentsParser {
               // A `-->` line comment
               const comment = this.skipLineComment(3);
               if (comment !== undefined) {
-                // @ts-expect-error strictNullCheck is not enabled
                 this.addComment(comment);
                 if (this.options.attachComment) comments.push(comment);
               }
@@ -413,7 +410,6 @@ export default abstract class Tokenizer extends CommentsParser {
               // `<!--`, an XML-style comment that should be interpreted as a line comment
               const comment = this.skipLineComment(4);
               if (comment !== undefined) {
-                // @ts-expect-error strictNullCheck is not enabled
                 this.addComment(comment);
                 if (this.options.attachComment) comments.push(comment);
               }
@@ -431,7 +427,6 @@ export default abstract class Tokenizer extends CommentsParser {
       const commentWhitespace: CommentWhitespace = {
         start: spaceStart,
         end,
-        // @ts-expect-error strictNullCheck is not enabled
         comments,
         leadingNode: null,
         trailingNode: null,

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -82,7 +82,7 @@ export class Token {
 
 // ## Tokenizer
 
-export default class Tokenizer extends CommentsParser {
+export default abstract class Tokenizer extends CommentsParser {
   isLookahead: boolean;
 
   // Token store.

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -260,7 +260,7 @@ export default abstract class Tokenizer extends CommentsParser {
     this.getTokenFromCode(this.codePointAtPos(this.state.pos));
   }
 
-  skipBlockComment(): N.CommentBlock | void {
+  skipBlockComment(): N.CommentBlock | undefined {
     let startLoc;
     if (!this.isLookahead) startLoc = this.state.curPosition();
     const start = this.state.pos;
@@ -297,7 +297,7 @@ export default abstract class Tokenizer extends CommentsParser {
     return comment;
   }
 
-  skipLineComment(startSkip: number): N.CommentLine | void {
+  skipLineComment(startSkip: number): N.CommentLine | undefined {
     const start = this.state.pos;
     let startLoc;
     if (!this.isLookahead) startLoc = this.state.curPosition();
@@ -1374,7 +1374,7 @@ export default abstract class Tokenizer extends CommentsParser {
   // When `firstCode` is given, it assumes it is always an identifier start and
   // will skip reading start position again
 
-  readWord1(firstCode: number | void): string {
+  readWord1(firstCode?: number): string {
     this.state.containsEsc = false;
     let word = "";
     const start = this.state.pos;
@@ -1423,7 +1423,7 @@ export default abstract class Tokenizer extends CommentsParser {
   // Read an identifier or keyword token. Will check for reserved
   // words when necessary.
 
-  readWord(firstCode: number | void): void {
+  readWord(firstCode?: number): void {
     const word = this.readWord1(firstCode);
     const type = keywordTypes.get(word);
     if (type !== undefined) {

--- a/packages/babel-parser/src/util/production-parameter.ts
+++ b/packages/babel-parser/src/util/production-parameter.ts
@@ -29,12 +29,16 @@ export const // Initial Parameter flags
 // 6. parse function body
 // 7. exit current stack
 
-export type ParamKind =
-  | typeof PARAM
-  | typeof PARAM_AWAIT
-  | typeof PARAM_IN
-  | typeof PARAM_RETURN
-  | typeof PARAM_YIELD;
+export type ParamKind = number;
+
+// todo(flow->ts) - check if more granular type can be used,
+//  type below is not good because things like PARAM_AWAIT|PARAM_YIELD are not included
+// export type ParamKind =
+//   | typeof PARAM
+//   | typeof PARAM_AWAIT
+//   | typeof PARAM_IN
+//   | typeof PARAM_RETURN
+//   | typeof PARAM_YIELD;
 
 export default class ProductionParameterHandler {
   stacks: Array<number> = [];

--- a/packages/babel-parser/tsconfig.json
+++ b/packages/babel-parser/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": [
-    "./typings"
+    "./typings/**/*.ts",
+    "./src/**/*.ts"
   ]
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Type improvements for babel parser:
 - uncommenting flow comments, converting them to typescript
 - making some classes abstract (effectively they were already abstract)
 - better types for parser plugins
 - avoid using `...args` in class methods, replacing it with actual arguments
 - other type error fixes

(rebasing remaining type fixes from https://github.com/babel/babel/pull/13370)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14801"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

