### PR TITLE
fix(parser): allow TS declare readonly fields with initializers

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -3118,7 +3118,11 @@ export default (superClass: {
     parseClassProperty(node: N.ClassProperty): N.ClassProperty {
       this.parseClassPropertyAnnotation(node);
 
-      if (this.state.isAmbientContext && this.match(tt.eq)) {
+      if (
+        this.state.isAmbientContext &&
+        !(node.readonly && !node.typeAnnotation) &&
+        this.match(tt.eq)
+      ) {
         this.raise(TSErrors.DeclareClassFieldHasInitializer, {
           at: this.state.startLoc,
         });

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-readonly-field-initializer-w-annotation/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-readonly-field-initializer-w-annotation/input.ts
@@ -1,0 +1,4 @@
+class A {
+  declare readonly bar: string = "test";
+  declare baz: string = "test";
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-readonly-field-initializer-w-annotation/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-readonly-field-initializer-w-annotation/output.json
@@ -1,0 +1,92 @@
+{
+  "type": "File",
+  "start":0,"end":84,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":1,"index":84}},
+  "errors": [
+    "SyntaxError: Initializers are not allowed in ambient contexts. (2:31)",
+    "SyntaxError: Initializers are not allowed in ambient contexts. (3:22)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":84,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":1,"index":84}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":84,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":1,"index":84}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"A"},
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":8,"end":84,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":4,"column":1,"index":84}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":12,"end":50,"loc":{"start":{"line":2,"column":2,"index":12},"end":{"line":2,"column":40,"index":50}},
+              "declare": true,
+              "readonly": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":29,"end":32,"loc":{"start":{"line":2,"column":19,"index":29},"end":{"line":2,"column":22,"index":32},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":32,"end":40,"loc":{"start":{"line":2,"column":22,"index":32},"end":{"line":2,"column":30,"index":40}},
+                "typeAnnotation": {
+                  "type": "TSStringKeyword",
+                  "start":34,"end":40,"loc":{"start":{"line":2,"column":24,"index":34},"end":{"line":2,"column":30,"index":40}}
+                }
+              },
+              "value": {
+                "type": "StringLiteral",
+                "start":43,"end":49,"loc":{"start":{"line":2,"column":33,"index":43},"end":{"line":2,"column":39,"index":49}},
+                "extra": {
+                  "rawValue": "test",
+                  "raw": "\"test\""
+                },
+                "value": "test"
+              }
+            },
+            {
+              "type": "ClassProperty",
+              "start":53,"end":82,"loc":{"start":{"line":3,"column":2,"index":53},"end":{"line":3,"column":31,"index":82}},
+              "declare": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":61,"end":64,"loc":{"start":{"line":3,"column":10,"index":61},"end":{"line":3,"column":13,"index":64},"identifierName":"baz"},
+                "name": "baz"
+              },
+              "computed": false,
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":64,"end":72,"loc":{"start":{"line":3,"column":13,"index":64},"end":{"line":3,"column":21,"index":72}},
+                "typeAnnotation": {
+                  "type": "TSStringKeyword",
+                  "start":66,"end":72,"loc":{"start":{"line":3,"column":15,"index":66},"end":{"line":3,"column":21,"index":72}}
+                }
+              },
+              "value": {
+                "type": "StringLiteral",
+                "start":75,"end":81,"loc":{"start":{"line":3,"column":24,"index":75},"end":{"line":3,"column":30,"index":81}},
+                "extra": {
+                  "rawValue": "test",
+                  "raw": "\"test\""
+                },
+                "value": "test"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-readonly-field-initializer/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-readonly-field-initializer/input.ts
@@ -1,0 +1,5 @@
+class A {
+  declare readonly bar = "test";
+  declare readonly foo = 1;
+  declare readonly baz = a.b;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-readonly-field-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-readonly-field-initializer/output.json
@@ -1,0 +1,101 @@
+{
+  "type": "File",
+  "start":0,"end":102,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":5,"column":1,"index":102}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":102,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":5,"column":1,"index":102}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":102,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":5,"column":1,"index":102}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"A"},
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":8,"end":102,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":5,"column":1,"index":102}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":12,"end":42,"loc":{"start":{"line":2,"column":2,"index":12},"end":{"line":2,"column":32,"index":42}},
+              "declare": true,
+              "readonly": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":29,"end":32,"loc":{"start":{"line":2,"column":19,"index":29},"end":{"line":2,"column":22,"index":32},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "value": {
+                "type": "StringLiteral",
+                "start":35,"end":41,"loc":{"start":{"line":2,"column":25,"index":35},"end":{"line":2,"column":31,"index":41}},
+                "extra": {
+                  "rawValue": "test",
+                  "raw": "\"test\""
+                },
+                "value": "test"
+              }
+            },
+            {
+              "type": "ClassProperty",
+              "start":45,"end":70,"loc":{"start":{"line":3,"column":2,"index":45},"end":{"line":3,"column":27,"index":70}},
+              "declare": true,
+              "readonly": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":62,"end":65,"loc":{"start":{"line":3,"column":19,"index":62},"end":{"line":3,"column":22,"index":65},"identifierName":"foo"},
+                "name": "foo"
+              },
+              "computed": false,
+              "value": {
+                "type": "NumericLiteral",
+                "start":68,"end":69,"loc":{"start":{"line":3,"column":25,"index":68},"end":{"line":3,"column":26,"index":69}},
+                "extra": {
+                  "rawValue": 1,
+                  "raw": "1"
+                },
+                "value": 1
+              }
+            },
+            {
+              "type": "ClassProperty",
+              "start":73,"end":100,"loc":{"start":{"line":4,"column":2,"index":73},"end":{"line":4,"column":29,"index":100}},
+              "declare": true,
+              "readonly": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":90,"end":93,"loc":{"start":{"line":4,"column":19,"index":90},"end":{"line":4,"column":22,"index":93},"identifierName":"baz"},
+                "name": "baz"
+              },
+              "computed": false,
+              "value": {
+                "type": "MemberExpression",
+                "start":96,"end":99,"loc":{"start":{"line":4,"column":25,"index":96},"end":{"line":4,"column":28,"index":99}},
+                "object": {
+                  "type": "Identifier",
+                  "start":96,"end":97,"loc":{"start":{"line":4,"column":25,"index":96},"end":{"line":4,"column":26,"index":97},"identifierName":"a"},
+                  "name": "a"
+                },
+                "computed": false,
+                "property": {
+                  "type": "Identifier",
+                  "start":98,"end":99,"loc":{"start":{"line":4,"column":27,"index":98},"end":{"line":4,"column":28,"index":99},"identifierName":"b"},
+                  "name": "b"
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14812
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This aligns Babel's behavior with https://github.com/microsoft/TypeScript/pull/26313 for class fields. Specifically:

```ts
if (isConstOrReadonly && !node.type) {
    if (isInvalidInitializer) {
        return grammarErrorOnNode(node.initializer!, Diagnostics.A_const_initializer_in_an_ambient_context_must_be_a_string_or_numeric_literal);
    }
}
else {
    return grammarErrorOnNode(node.initializer!, Diagnostics.Initializers_are_not_allowed_in_ambient_contexts);
}
if (!isConstOrReadonly || isInvalidInitializer) {
    return grammarErrorOnNode(node.initializer!, Diagnostics.Initializers_are_not_allowed_in_ambient_contexts);
}
```

However, this PR does not attempt to mimic the `isInvalidInitializer` part, which checks if the initializer is a string/number literal or an enum reference. Doing so "correctly" would likely require type information. Quoting https://github.com/evanw/esbuild/commit/147163e2bb80c4b25a4a6cce04b2cd07ab6604c3,

> To future-proof this in case TypeScript allows more expressions as initializers in the future (such as `null`), esbuild will allow any expression as an initializer and will leave the specifics of TypeScript's special-casing here to the TypeScript type checker.

Instead, we avoid all errors with `declare readonly` that don't have a type annotation.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14817"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

