### PR TITLE
chore(traverse): fix some internal typescript types

### DIFF
--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -498,17 +498,26 @@ function getOuterBindingIdentifiers(
 
 export { getOuterBindingIdentifiers };
 
+function getBindingIdentifierPaths(
+  duplicates: true,
+  outerOnly?: boolean,
+): Record<string, NodePath<t.Identifier>[]>;
+function getBindingIdentifierPaths(
+  duplicates: false,
+  outerOnly?: boolean,
+): Record<string, NodePath<t.Identifier>>;
+function getBindingIdentifierPaths(
+  duplicates?: boolean,
+  outerOnly?: boolean,
+): Record<string, NodePath<t.Identifier> | NodePath<t.Identifier>[]>;
+
 // original source - https://github.com/babel/babel/blob/main/packages/babel-types/src/retrievers/getBindingIdentifiers.js
-// path.getBindingIdentifiers returns nodes where the following re-implementation
-// returns paths
-export function getBindingIdentifierPaths(
+// path.getBindingIdentifiers returns nodes where the following re-implementation returns paths
+function getBindingIdentifierPaths(
   this: NodePath,
   duplicates: boolean = false,
   outerOnly: boolean = false,
-): {
-  // todo: returns NodePath<t.Identifier>[] when duplicates is true
-  [x: string]: NodePath<t.Identifier>;
-} {
+): Record<string, NodePath<t.Identifier> | NodePath<t.Identifier>[]> {
   const path = this;
   const search = [path];
   const ids = Object.create(null);
@@ -563,13 +572,26 @@ export function getBindingIdentifierPaths(
     }
   }
 
-  // $FlowIssue Object.create() is object type
   return ids;
 }
 
-export function getOuterBindingIdentifierPaths(
-  this: NodePath,
+export { getBindingIdentifierPaths };
+
+function getOuterBindingIdentifierPaths(
+  duplicates: true,
+): Record<string, NodePath<t.Identifier>[]>;
+function getOuterBindingIdentifierPaths(
+  duplicates?: false,
+): Record<string, NodePath<t.Identifier>>;
+function getOuterBindingIdentifierPaths(
   duplicates?: boolean,
+): Record<string, NodePath<t.Identifier> | NodePath<t.Identifier>[]>;
+
+function getOuterBindingIdentifierPaths(
+  this: NodePath,
+  duplicates: boolean = false,
 ) {
   return this.getBindingIdentifierPaths(duplicates, true);
 }
+
+export { getOuterBindingIdentifierPaths };

--- a/packages/babel-traverse/src/scope/binding.ts
+++ b/packages/babel-traverse/src/scope/binding.ts
@@ -79,7 +79,7 @@ export default class Binding {
    * Register a constant violation with the provided `path`.
    */
 
-  reassign(path: any) {
+  reassign(path: NodePath) {
     this.constant = false;
     if (this.constantViolations.indexOf(path) !== -1) {
       return;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | 
| Documentation PR Link    | 
| Any Dependency Changes?  | no
| License                  | MIT

I recently fixed the types in [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61532) and found that some of the babel internal types are also not optimal. So here is a PR to fix them.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14821"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

