### PR TITLE
fix: helper-wrap-function compat with old traverse

### DIFF
--- a/packages/babel-helper-wrap-function/src/index.ts
+++ b/packages/babel-helper-wrap-function/src/index.ts
@@ -97,7 +97,12 @@ function plainFunction(
   let functionId = null;
   let node;
   if (path.isArrowFunctionExpression()) {
-    path = path.arrowFunctionToExpression({ noNewArrows });
+    if (process.env.BABEL_8_BREAKING) {
+      path = path.arrowFunctionToExpression({ noNewArrows });
+    } else {
+      // arrowFunctionToExpression returns undefined in @babel/traverse < 7.18.10
+      path = path.arrowFunctionToExpression({ noNewArrows }) ?? path;
+    }
     node = path.node as t.FunctionDeclaration | t.FunctionExpression;
   } else {
     node = path.node as t.FunctionDeclaration | t.FunctionExpression;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14822, fixes #14824 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
A follow-up to #14752. In this PR we fix compatibility issue with `@babel/traverse` < 7.18.10.

For those affected by this issue, you don't have to wait for this fix. Instead you can upgrade `@babel/traverse` to the latest version.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14825"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

