### PR TITLE
fix: react-cons-elem should not hoist router comp

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-14363-2/input.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-14363-2/input.mjs
@@ -1,0 +1,21 @@
+import { Routes, Route } from "react-router";
+import { router } from "common/router";
+
+function RoutesComponent() {
+  return <Routes>
+      {Object.keys(router).map(routerKey => {
+      const route = router[routerKey];
+
+      if (route && route.element) {
+        const {
+          path,
+          element: Component
+        } = route;
+        // Component should not be hoisted
+        return <Route key={routerKey} path={path} element={<Component />} />;
+      } else {
+        return null;
+      }
+    }).filter(Boolean)}
+    </Routes>;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-14363-2/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-14363-2/output.mjs
@@ -1,0 +1,21 @@
+import { Routes, Route } from "react-router";
+import { router } from "common/router";
+
+function RoutesComponent() {
+  return <Routes>
+      {Object.keys(router).map(routerKey => {
+      const route = router[routerKey];
+
+      if (route && route.element) {
+        const {
+          path,
+          element: Component
+        } = route; // Component should not be hoisted
+
+        return <Route key={routerKey} path={path} element={<Component />} />;
+      } else {
+        return null;
+      }
+    }).filter(Boolean)}
+    </Routes>;
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14363 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Thanks @budarin for the reproduction repo. It helps a lot. This PR is a follow-up to #14536. In this PR we set the initial value of the map `HOISTED` to be the `jsxScope`, which is the ancestry hoisting scope (if hoisted) or `path.scope`. Then we update `HOISTED` when it it actually hoisted. In this way, the `Component` in the test case won't be hoisted because its parent `Route`'s hoisting scope is the BlockStatement, instead of the ArrowFunction to which we never hoisted due to no advantages.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14828"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

