### PR TITLE
Let `path.remove()` remove `IfStatement.alternate`

### DIFF
--- a/packages/babel-traverse/src/path/lib/removal-hooks.ts
+++ b/packages/babel-traverse/src/path/lib/removal-hooks.ts
@@ -62,8 +62,7 @@ export const hooks = [
 
   function (self: NodePath, parent: NodePath) {
     if (
-      (parent.isIfStatement() &&
-        (self.key === "consequent" || self.key === "alternate")) ||
+      (parent.isIfStatement() && self.key === "consequent") ||
       (self.key === "body" &&
         (parent.isLoop() || parent.isArrowFunctionExpression()))
     ) {

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -52,7 +52,7 @@ describe("removal", function () {
       const ifPath = rootPath.get("body.0");
       ifPath.get("consequent").remove();
 
-      expect(ifPath.get("consequent").node).not.toBeNull();
+      expect(ifPath.get("consequent").type).toBe("BlockStatement");
     });
 
     it("completely removes alternate", function () {

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -45,4 +45,22 @@ describe("removal", function () {
 
     expect(generate(ast).code).toBe("");
   });
+
+  describe("within an IfStatement", function () {
+    it("does not make consequent null", function () {
+      const rootPath = getPath("if (x) foo(); else bar();");
+      const ifPath = rootPath.get("body.0");
+      ifPath.get("consequent").remove();
+
+      expect(ifPath.get("consequent").node).not.toBeNull();
+    });
+
+    it("completely removes alternate", function () {
+      const rootPath = getPath("if (x) foo(); else bar();");
+      const ifPath = rootPath.get("body.0");
+      ifPath.get("alternate").remove();
+
+      expect(ifPath.get("alternate").node).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 🤔
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | ❓
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

While writing a transformation plugin, I would expect calling `remove()` on an `else` clause to remove the `else`, not replace it with an empty block.  Special-casing "consequent" makes sense, because it is not permitted to be null, but there is no need to deviate from the normal `remove()` behavior for "alternate".

Let me know if tests are needed for this since it's a small change.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14833"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

