### PR TITLE
Add support for static evaluation of ?? operator

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -309,6 +309,11 @@ function _evaluate(path: NodePath, state: State): any {
         if (!state.confident) return;
 
         return left && right;
+      case "??":
+        state.confident = leftConfident && (left != null || rightConfident);
+        if (!state.confident) return;
+
+        return left ?? right;
     }
   }
 

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -68,6 +68,14 @@ describe("evaluation", function () {
     expect(getPath("0 && x === 'y'").get("body")[0].evaluate().value).toBe(0);
   });
 
+  it("should handle ??", function () {
+    expect(getPath("null ?? 42").get("body")[0].evaluate().value).toBe(42);
+    expect(getPath("void 0 ?? 42").get("body")[0].evaluate().value).toBe(42);
+    expect(getPath("0 ?? 42").get("body")[0].evaluate().value).toBe(0);
+    expect(getPath("x ?? 42").get("body")[0].evaluate().confident).toBe(false);
+    expect(getPath("42 ?? x === 'y'").get("body")[0].evaluate().value).toBe(42);
+  });
+
   it("should work with repeated, indeterminate identifiers", function () {
     expect(
       getPath("var num = foo(); (num > 0 && num < 100);")


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | 🎉 
| Tests Added + Pass?      | 💯 
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This patch adds support for the nullish coalescing operator (`a ?? b`) in the static evaluation logic of babel-traverse.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14837"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

