### PR TITLE
Fix a race condition in `@babel/core`

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -265,7 +265,7 @@ async function buildBabel(useWorker, ignore = []) {
     const dest = "./" + mapSrcToLib(file.slice(2));
     promises.push(worker.transform(file, dest));
   }
-  return Promise.all(promises).finally(() => {
+  return Promise.allSettled(promises).finally(() => {
     if (worker.end !== undefined) {
       worker.end();
     }

--- a/babel-worker.cjs
+++ b/babel-worker.cjs
@@ -1,4 +1,4 @@
-const { transformSync } = require("@babel/core");
+const { transformAsync } = require("@babel/core");
 const { mkdirSync, statSync, readFileSync, writeFileSync } = require("fs");
 const { dirname } = require("path");
 const fancyLog = require("fancy-log");
@@ -32,7 +32,7 @@ exports.transform = async function transform(src, dest) {
   }
   fancyLog(`Compiling '${chalk.cyan(src)}'...`);
   const content = readFileSync(src, { encoding: "utf8" });
-  const { code } = transformSync(content, {
+  const { code } = await transformAsync(content, {
     filename: src,
     caller: {
       // We have wrapped packages/babel-core/src/config/files/configuration.js with feature detection

--- a/packages/babel-core/src/config/config-descriptors.ts
+++ b/packages/babel-core/src/config/config-descriptors.ts
@@ -133,22 +133,26 @@ export function createUncachedDescriptors(
     options: optionsWithResolvedBrowserslistConfigFile(options, dirname),
     *plugins() {
       if (!plugins) {
-        plugins = yield* createPluginDescriptors(
+        const _plugins = yield* createPluginDescriptors(
           options.plugins || [],
           dirname,
           alias,
         );
+        // check plugins again to avoid race conditions
+        plugins ??= _plugins;
       }
       return plugins;
     },
     *presets() {
       if (!presets) {
-        presets = yield* createPresetDescriptors(
+        const _presets = yield* createPresetDescriptors(
           options.presets || [],
           dirname,
           alias,
           !!options.passPerPreset,
         );
+        // check presets again to avoid race conditions
+        presets ??= _presets;
       }
       return presets;
     },

--- a/packages/babel-core/src/gensync-utils/functional.ts
+++ b/packages/babel-core/src/gensync-utils/functional.ts
@@ -1,0 +1,31 @@
+import type { Handler } from "gensync";
+
+import { isAsync, waitFor } from "./async";
+
+export function once<R>(fn: () => Handler<R>): () => Handler<R> {
+  let result: R;
+  let resultP: Promise<R>;
+  return function* () {
+    if (result) return result;
+    if (!(yield* isAsync())) return (result = yield* fn());
+    if (resultP) return yield* waitFor(resultP);
+
+    let resolve: (result: R) => void, reject: (error: unknown) => void;
+    resultP = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    try {
+      result = yield* fn();
+      // Avoid keeping the promise around
+      // now that we have the result.
+      resultP = null;
+      resolve(result);
+      return result;
+    } catch (error) {
+      reject(error);
+      throw error;
+    }
+  };
+}

--- a/packages/babel-core/test/config-loading.js
+++ b/packages/babel-core/test/config-loading.js
@@ -1,14 +1,13 @@
-import _loadConfigRunner, {
-  loadPartialConfig,
-  createConfigItem,
-} from "../lib/config/index.js";
+import {
+  loadOptionsSync,
+  loadPartialConfigSync,
+  createConfigItemSync,
+} from "../lib/index.js";
 import path from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
-
-const loadConfig = (_loadConfigRunner.default || _loadConfigRunner).sync;
 
 describe("@babel/core config loading", () => {
   const FILEPATH = path.join(
@@ -45,7 +44,7 @@ describe("@babel/core config loading", () => {
     };
   }
 
-  describe("createConfigItem", () => {
+  describe("createConfigItemSync", () => {
     // Windows uses different file paths
     const noWin = process.platform === "win32" ? it.skip : it;
 
@@ -54,7 +53,7 @@ describe("@babel/core config loading", () => {
         return {};
       }
 
-      expect(createConfigItem(myPlugin)).toEqual({
+      expect(createConfigItemSync(myPlugin)).toEqual({
         dirname: process.cwd(),
         file: undefined,
         name: undefined,
@@ -69,7 +68,7 @@ describe("@babel/core config loading", () => {
       }
 
       expect(
-        createConfigItem(myPlugin, { dirname: "/foo", type: "plugin" }),
+        createConfigItemSync(myPlugin, { dirname: "/foo", type: "plugin" }),
       ).toEqual({
         dirname: "/foo",
         file: undefined,
@@ -80,13 +79,13 @@ describe("@babel/core config loading", () => {
     });
   });
 
-  describe("loadPartialConfig", () => {
+  describe("loadPartialConfigSync", () => {
     it("should preserve disabled plugins in the partial config", () => {
       const plugin = function () {
         return {};
       };
 
-      const opts = loadPartialConfig({
+      const opts = loadPartialConfigSync({
         ...makeOpts(true),
         babelrc: false,
         configFile: false,
@@ -105,7 +104,7 @@ describe("@babel/core config loading", () => {
         return {};
       };
 
-      const opts = loadPartialConfig({
+      const opts = loadPartialConfigSync({
         ...makeOpts(true),
         babelrc: false,
         configFile: false,
@@ -128,7 +127,7 @@ describe("@babel/core config loading", () => {
         "nested",
       );
 
-      const { options } = await loadPartialConfig({
+      const { options } = await loadPartialConfigSync({
         cwd,
         filename: path.join(cwd, "file.js"),
         rootMode: "upward",
@@ -139,11 +138,11 @@ describe("@babel/core config loading", () => {
     });
   });
 
-  describe("config file", () => {
+  describe("loadOptionsSync", () => {
     it("should load and cache the config with plugins and presets", () => {
       const opts = makeOpts();
 
-      const options1 = loadConfig(opts).options;
+      const options1 = loadOptionsSync(opts);
       expect(options1.plugins.map(p => p.key)).toEqual([
         "plugin1",
         "plugin2",
@@ -153,7 +152,7 @@ describe("@babel/core config loading", () => {
         "plugin3",
       ]);
 
-      const options2 = loadConfig(opts).options;
+      const options2 = loadOptionsSync(opts);
       expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options2.plugins.length; i++) {
@@ -162,7 +161,7 @@ describe("@babel/core config loading", () => {
     });
 
     it("should load and cache the config for unique opts objects", () => {
-      const options1 = loadConfig(makeOpts(true)).options;
+      const options1 = loadOptionsSync(makeOpts(true));
       expect(options1.plugins.map(p => p.key)).toEqual([
         "plugin1",
         "plugin2",
@@ -170,7 +169,7 @@ describe("@babel/core config loading", () => {
         "plugin3",
       ]);
 
-      const options2 = loadConfig(makeOpts(true)).options;
+      const options2 = loadOptionsSync(makeOpts(true));
       expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options2.plugins.length; i++) {
@@ -181,11 +180,11 @@ describe("@babel/core config loading", () => {
     it("should invalidate config file plugins", () => {
       const opts = makeOpts();
 
-      const options1 = loadConfig(opts).options;
+      const options1 = loadOptionsSync(opts);
 
       process.env.INVALIDATE_PLUGIN1 = true;
 
-      const options2 = loadConfig(opts).options;
+      const options2 = loadOptionsSync(opts);
       expect(options2.plugins.length).toBe(options1.plugins.length);
 
       expect(options2.plugins[0]).not.toBe(options1.plugins[0]);
@@ -195,7 +194,7 @@ describe("@babel/core config loading", () => {
 
       process.env.INVALIDATE_PLUGIN3 = true;
 
-      const options3 = loadConfig(opts).options;
+      const options3 = loadOptionsSync(opts);
       expect(options3.plugins.length).toBe(options1.plugins.length);
       expect(options3.plugins.length).toBe(6);
       expect(options3.plugins[0]).not.toBe(options1.plugins[0]);
@@ -208,11 +207,11 @@ describe("@babel/core config loading", () => {
     it("should invalidate config file presets and their children", () => {
       const opts = makeOpts();
 
-      const options1 = loadConfig(opts).options;
+      const options1 = loadOptionsSync(opts);
 
       process.env.INVALIDATE_PRESET1 = true;
 
-      const options2 = loadConfig(opts).options;
+      const options2 = loadOptionsSync(opts);
       expect(options2.plugins.length).toBe(options1.plugins.length);
       expect(options2.plugins.length).toBe(6);
       expect(options2.plugins[5]).not.toBe(options1.plugins[5]);
@@ -222,7 +221,7 @@ describe("@babel/core config loading", () => {
 
       process.env.INVALIDATE_PRESET2 = true;
 
-      const options3 = loadConfig(opts).options;
+      const options3 = loadOptionsSync(opts);
       expect(options3.plugins.length).toBe(options1.plugins.length);
       expect(options3.plugins.length).toBe(6);
       expect(options3.plugins[4]).not.toBe(options1.plugins[4]);
@@ -235,11 +234,11 @@ describe("@babel/core config loading", () => {
     it("should invalidate the config file and its plugins/presets", () => {
       const opts = makeOpts();
 
-      const options1 = loadConfig(opts).options;
+      const options1 = loadOptionsSync(opts);
 
       process.env.INVALIDATE_BABELRC = true;
 
-      const options2 = loadConfig(opts).options;
+      const options2 = loadOptionsSync(opts);
       expect(options2.plugins.length).toBe(options1.plugins.length);
       expect(options2.plugins.length).toBe(6);
       expect(options2.plugins[0]).not.toBe(options1.plugins[0]);
@@ -256,9 +255,9 @@ describe("@babel/core config loading", () => {
     it("should not invalidate the plugins when given a fresh object", () => {
       const opts = makeOpts();
 
-      const options1 = loadConfig(opts).options;
+      const options1 = loadOptionsSync(opts);
 
-      const options2 = loadConfig(Object.assign({}, opts)).options;
+      const options2 = loadOptionsSync(Object.assign({}, opts));
       expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options2.plugins.length; i++) {
@@ -269,12 +268,12 @@ describe("@babel/core config loading", () => {
     it("should not invalidate the plugins when given a fresh arrays", () => {
       const opts = makeOpts();
 
-      const options1 = loadConfig(opts).options;
+      const options1 = loadOptionsSync(opts);
 
-      const options2 = loadConfig({
+      const options2 = loadOptionsSync({
         ...opts,
         plugins: opts.plugins.slice(),
-      }).options;
+      });
       expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options2.plugins.length; i++) {
@@ -285,12 +284,12 @@ describe("@babel/core config loading", () => {
     it("should not invalidate the presets when given a fresh arrays", () => {
       const opts = makeOpts();
 
-      const options1 = loadConfig(opts).options;
+      const options1 = loadOptionsSync(opts);
 
-      const options2 = loadConfig({
+      const options2 = loadOptionsSync({
         ...opts,
         presets: opts.presets.slice(),
-      }).options;
+      });
       expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options2.plugins.length; i++) {
@@ -301,12 +300,12 @@ describe("@babel/core config loading", () => {
     it("should invalidate the plugins when given a fresh options", () => {
       const opts = makeOpts();
 
-      const options1 = loadConfig(opts).options;
+      const options1 = loadOptionsSync(opts);
 
-      const options2 = loadConfig({
+      const options2 = loadOptionsSync({
         ...opts,
         plugins: opts.plugins.map(([plg, opt]) => [plg, { ...opt }]),
-      }).options;
+      });
       expect(options2.plugins.length).toBe(options1.plugins.length);
       expect(options2.plugins.length).toBe(6);
 
@@ -322,12 +321,12 @@ describe("@babel/core config loading", () => {
     it("should invalidate the presets when given a fresh options", () => {
       const opts = makeOpts();
 
-      const options1 = loadConfig(opts).options;
+      const options1 = loadOptionsSync(opts);
 
-      const options2 = loadConfig({
+      const options2 = loadOptionsSync({
         ...opts,
         presets: opts.presets.map(([plg, opt]) => [plg, { ...opt }]),
-      }).options;
+      });
       expect(options2.plugins.length).toBe(options1.plugins.length);
       expect(options2.plugins.length).toBe(6);
 
@@ -343,11 +342,11 @@ describe("@babel/core config loading", () => {
     it("should invalidate the programmatic plugins", () => {
       const opts = makeOpts();
 
-      const options1 = loadConfig(opts).options;
+      const options1 = loadOptionsSync(opts);
 
       process.env.INVALIDATE_PLUGIN6 = true;
 
-      const options2 = loadConfig(opts).options;
+      const options2 = loadOptionsSync(opts);
       expect(options2.plugins.length).toBe(options1.plugins.length);
       expect(options2.plugins.length).toBe(6);
 
@@ -363,11 +362,11 @@ describe("@babel/core config loading", () => {
     it("should invalidate the programmatic presets and their children", () => {
       const opts = makeOpts();
 
-      const options1 = loadConfig(opts).options;
+      const options1 = loadOptionsSync(opts);
 
       process.env.INVALIDATE_PRESET3 = true;
 
-      const options2 = loadConfig(opts).options;
+      const options2 = loadOptionsSync(opts);
       expect(options2.plugins.length).toBe(options1.plugins.length);
       expect(options2.plugins.length).toBe(6);
 
@@ -390,7 +389,7 @@ describe("@babel/core config loading", () => {
         plugins: [fooPlugin],
       };
 
-      expect(() => loadConfig(opts)).toThrow(
+      expect(() => loadOptionsSync(opts)).toThrow(
         /\.inherits must be a function, or undefined/,
       );
     });
@@ -407,7 +406,7 @@ describe("@babel/core config loading", () => {
         plugins: [fooPlugin],
       };
 
-      expect(() => loadConfig(opts)).toThrow(
+      expect(() => loadOptionsSync(opts)).toThrow(
         /\.visitor cannot contain catch-all "enter" or "exit" handlers\. Please target individual nodes\./,
       );
     });
@@ -415,29 +414,29 @@ describe("@babel/core config loading", () => {
 
   describe("caller metadata", () => {
     it("should pass caller data through", () => {
-      const options1 = loadConfig({
+      const options1 = loadOptionsSync({
         ...makeOpts(),
         caller: {
           name: "babel-test",
           someFlag: true,
         },
-      }).options;
+      });
 
       expect(options1.caller.name).toBe("babel-test");
       expect(options1.caller.someFlag).toBe(true);
     });
 
     it("should pass unknown caller data through", () => {
-      const options1 = loadConfig({
+      const options1 = loadOptionsSync({
         ...makeOpts(),
         caller: undefined,
-      }).options;
+      });
 
       expect(options1.caller).toBeUndefined();
     });
 
     it("should pass caller data to test functions", () => {
-      const options1 = loadConfig({
+      const options1 = loadOptionsSync({
         ...makeOpts(),
         caller: {
           name: "babel-test",
@@ -453,7 +452,7 @@ describe("@babel/core config loading", () => {
             ast: false,
           },
         ],
-      }).options;
+      });
 
       expect(options1.comments).toBe(false);
       expect(options1.ast).not.toBe(false);

--- a/packages/babel-core/test/config-loading.js
+++ b/packages/babel-core/test/config-loading.js
@@ -1,5 +1,6 @@
 import {
   loadOptionsSync,
+  loadOptionsAsync,
   loadPartialConfigSync,
   createConfigItemSync,
 } from "../lib/index.js";
@@ -248,6 +249,31 @@ describe("@babel/core config loading", () => {
 
       expect(options2.plugins[2]).toBe(options1.plugins[2]);
       expect(options2.plugins[3]).toBe(options1.plugins[3]);
+    });
+  });
+
+  describe("loadOptionsAsync", () => {
+    it("should load and cache the config with plugins and presets when executed in parallel", async () => {
+      const opts = makeOpts();
+
+      const [options1, options2] = await Promise.all([
+        loadOptionsAsync(opts),
+        loadOptionsAsync(opts),
+      ]);
+      expect(options1.plugins.map(p => p.key)).toEqual([
+        "plugin1",
+        "plugin2",
+        "plugin6",
+        "plugin5",
+        "plugin4",
+        "plugin3",
+      ]);
+
+      expect(options2.plugins.length).toBe(options1.plugins.length);
+
+      for (let i = 0; i < options2.plugins.length; i++) {
+        expect(options2.plugins[i]).toBe(options1.plugins[i]);
+      }
     });
   });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/pull/14806#issuecomment-1209451143
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes a race condition in `createUncachedDescriptors`: After we asynchronously initialize plugins/presets descriptors, we don't check again whether it has been initialized in another task. So we assign different descriptors to config item and the plugins/presets are loaded more than once.

I recommend to review this PR by commits.

This PR also reverts #14806 per Nicolò's comment on that PR.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14843"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

