### PR TITLE
fix: Print build logs correctly

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -6,7 +6,6 @@ import { fileURLToPath } from "url";
 import plumber from "gulp-plumber";
 import through from "through2";
 import chalk from "chalk";
-import fancyLog from "fancy-log";
 import filter from "gulp-filter";
 import gulp from "gulp";
 import { rollup } from "rollup";
@@ -21,6 +20,7 @@ import rollupDts from "rollup-plugin-dts";
 import { Worker as JestWorker } from "jest-worker";
 import glob from "glob";
 import { resolve as importMetaResolve } from "import-meta-resolve";
+import { log } from "./utils.js";
 
 import rollupBabelSource from "./scripts/rollup-plugin-babel-source.js";
 import formatCode from "./scripts/utils/formatCode.js";
@@ -86,7 +86,7 @@ function getIndexFromPackage(name) {
 function errorsLogger() {
   return plumber({
     errorHandler(err) {
-      fancyLog(err.stack);
+      log(err.stack);
     },
   });
 }
@@ -116,7 +116,7 @@ function generateHelpers(generator, dest, filename, message) {
         file.contents = Buffer.from(
           formatCode(await generateCode(filename), dest + file.path)
         );
-        fancyLog(`${chalk.green("✔")} Generated ${message}`);
+        log(`${chalk.green("✔")} Generated ${message}`);
         callback(null, file);
       })
     )
@@ -176,7 +176,7 @@ function generateStandalone() {
     .src(babelStandalonePluginConfigGlob, { base: monorepoRoot })
     .pipe(
       through.obj((file, enc, callback) => {
-        fancyLog("Generating @babel/standalone files");
+        log("Generating @babel/standalone files");
         const pluginConfig = JSON.parse(file.contents);
         let imports = "";
         let list = "";
@@ -307,7 +307,7 @@ function buildRollup(packages, targetBrowsers) {
         );
 
         const input = getIndexFromPackage(src);
-        fancyLog(`Compiling '${chalk.cyan(input)}' with rollup ...`);
+        log(`Compiling '${chalk.cyan(input)}' with rollup ...`);
         const bundle = await rollup({
           input,
           external,
@@ -413,7 +413,7 @@ function buildRollup(packages, targetBrowsers) {
         });
 
         if (!process.env.IS_PUBLISH) {
-          fancyLog(
+          log(
             chalk.yellow(
               `Skipped minification of '${chalk.cyan(
                 outputFile
@@ -422,7 +422,7 @@ function buildRollup(packages, targetBrowsers) {
           );
           return undefined;
         }
-        fancyLog(`Minifying '${chalk.cyan(outputFile)}'...`);
+        log(`Minifying '${chalk.cyan(outputFile)}'...`);
 
         await bundle.write({
           file: outputFile.replace(/\.js$/, ".min.js"),
@@ -451,7 +451,7 @@ function buildRollupDts(packages) {
     packages.map(async packageName => {
       const input = `${mapToDts(packageName)}/src/index.d.ts`;
       const output = `${packageName}/lib/index.d.ts`;
-      fancyLog(`Bundling '${chalk.cyan(output)}' with rollup ...`);
+      log(`Bundling '${chalk.cyan(output)}' with rollup ...`);
 
       const bundle = await rollup({
         input,
@@ -514,7 +514,7 @@ const standaloneBundle = [
 ];
 
 gulp.task("generate-type-helpers", () => {
-  fancyLog("Generating @babel/types and @babel/traverse dynamic functions");
+  log("Generating @babel/types and @babel/traverse dynamic functions");
 
   return Promise.all([
     generateTypeHelpers("asserts"),
@@ -529,7 +529,7 @@ gulp.task("generate-type-helpers", () => {
 });
 
 gulp.task("generate-runtime-helpers", () => {
-  fancyLog("Generating @babel/helpers runtime helpers");
+  log("Generating @babel/helpers runtime helpers");
 
   return generateRuntimeHelpers();
 });
@@ -597,7 +597,7 @@ ${fs.readFileSync(path.join(path.dirname(input), "license"), "utf8")}*/
 
 gulp.task("build-cjs-bundles", () => {
   if (!USE_ESM) {
-    fancyLog(
+    log(
       chalk.yellow(
         "Skipping CJS-compat bundles for ESM-based builds, because not compiling to ESM"
       )

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -20,10 +20,10 @@ import rollupDts from "rollup-plugin-dts";
 import { Worker as JestWorker } from "jest-worker";
 import glob from "glob";
 import { resolve as importMetaResolve } from "import-meta-resolve";
-import { log } from "./utils.js";
 
 import rollupBabelSource from "./scripts/rollup-plugin-babel-source.js";
 import formatCode from "./scripts/utils/formatCode.js";
+import { log } from "./scripts/utils/logger.cjs";
 
 let USE_ESM = false;
 try {

--- a/babel-worker.cjs
+++ b/babel-worker.cjs
@@ -1,7 +1,7 @@
 const { transformSync } = require("@babel/core");
 const { mkdirSync, statSync, readFileSync, writeFileSync } = require("fs");
 const { dirname } = require("path");
-const fancyLog = require("fancy-log");
+const { log } = require("./utils.js");
 
 let chalk;
 const chalkP = import("chalk").then(ns => {
@@ -30,7 +30,7 @@ exports.transform = async function transform(src, dest) {
   if (!needCompile(src, dest)) {
     return;
   }
-  fancyLog(`Compiling '${chalk.cyan(src)}'...`);
+  log(`Compiling '${chalk.cyan(src)}'...`);
   const content = readFileSync(src, { encoding: "utf8" });
   const { code } = transformSync(content, {
     filename: src,

--- a/babel-worker.cjs
+++ b/babel-worker.cjs
@@ -1,7 +1,7 @@
 const { transformSync } = require("@babel/core");
 const { mkdirSync, statSync, readFileSync, writeFileSync } = require("fs");
 const { dirname } = require("path");
-const { log } = require("./utils.js");
+const { log } = require("./scripts/utils/logger.cjs");
 
 let chalk;
 const chalkP = import("chalk").then(ns => {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "eslint-plugin-jest": "^26.6.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "fancy-log": "^2.0.0",
     "glob": "^7.2.0",
     "gulp": "^4.0.2",
     "gulp-filter": "^7.0.0",

--- a/scripts/utils/logger.cjs
+++ b/scripts/utils/logger.cjs
@@ -1,4 +1,4 @@
-exports.log = function log(msg, ...args) {
+exports.log = function (msg, ...args) {
   const time = new Date().toLocaleTimeString("en-US", { hour12: false });
   console.log(`[${time}] ${msg}`, ...args);
 };

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,4 @@
+exports.log = function log(msg, ...args) {
+  const time = new Date().toLocaleTimeString("en-US", { hour12: false });
+  console.log(`[${time}] ${msg}`, ...args);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5926,7 +5926,6 @@ __metadata:
     eslint-plugin-jest: ^26.6.0
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
-    fancy-log: ^2.0.0
     glob: ^7.2.0
     gulp: ^4.0.2
     gulp-filter: ^7.0.0
@@ -8391,15 +8390,6 @@ __metadata:
     parse-node-version: ^1.0.0
     time-stamp: ^1.0.0
   checksum: 9482336fb7e2fb852bc7ee5a91bab03c0b16e9bc4c9901e06dbca8d3441a55608cffa652ca716171a9e2646a050785df2dbded22f16792a02858e3c91e93b216
-  languageName: node
-  linkType: hard
-
-"fancy-log@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "fancy-log@npm:2.0.0"
-  dependencies:
-    color-support: ^1.1.3
-  checksum: 5652bf35e6a0be68bc011cf38706c78c7724808311e88905a3e4623d0e86168f084a9f38109dce2b2f78078ae704e4b55095effda743b4795c37f30ddb70497e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | √
| Any Dependency Changes?  | removed `fancy-log`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

https://github.com/gulpjs/fancy-log/blob/6686d1784d11db4ccc4d91ad854e580a14ebe330/index.js#L46-L51
Since `fancy-log` splits a log into two prints, this can lead to confusion when multiple workers merge logs.

While this can technically be solved using `readline`, it is simpler and allows for more custom development in the future.

````
[18:58:50] Compiling './packages/babel-helpers/src/helpers-generated.ts'...
[18:58:50] Compiling './packages/babel-helpers/src/helpers/applyDecs.js'...
[18:58:50] [18:58:50] Compiling './packages/babel-helpers/src/helpers/jsx.js'...
Compiling './packages/babel-helpers/src/helpers/asyncIterator.js'...
[18:58:50] Compiling './packages/babel-helpers/src/helpers/objectSpread2.js'...
[18:58:50] Compiling './packages/babel-helpers/src/helpers/regeneratorRuntime.js'...
[18:58:50] Compiling './packages/babel-helpers/src/helpers/typeof.js'...
[18:58:50] Compiling './packages/babel-helpers/src/index.ts'...
[18:58:50] Compiling './packages/babel-node/src/_babel-node.ts'...
[18:58:50] [18:58:50] Compiling './packages/babel-highlight/src/index.ts'...
Compiling './packages/babel-helpers/src/helpers/wrapRegExp.js'...
[18:58:50] Compiling './packages/babel-node/src/babel-node.ts'...
[18:58:50] Compiling './packages/babel-parser/src/index.ts'...
````

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14846"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

