### PR TITLE
Decorators updates for 7.19.0

### DIFF
--- a/packages/babel-parser/src/typings.ts
+++ b/packages/babel-parser/src/typings.ts
@@ -53,6 +53,9 @@ export type ParserPluginWithOptions =
   | ["flow", FlowPluginOptions]
   | ["typescript", TypeScriptPluginOptions];
 
+export type PluginOptions<PluginName extends ParserPluginWithOptions[0]> =
+  Extract<ParserPluginWithOptions, [PluginName, any]>[1];
+
 export interface DecoratorsPluginOptions {
   decoratorsBeforeExport?: boolean;
 }

--- a/packages/babel-parser/test/fixtures/es2022/class-properties/arguments-in-nested-class-decorator-call-expression/options.json
+++ b/packages/babel-parser/test/fixtures/es2022/class-properties/arguments-in-nested-class-decorator-call-expression/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/class-property/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/class-property/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/compued-property/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/compued-property/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/decoratorsBeforeExport-required/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/decoratorsBeforeExport-required/options.json
@@ -1,4 +1,0 @@
-{
-  "plugins": ["decorators"],
-  "throws": "The 'decorators' plugin requires a 'decoratorsBeforeExport' option, whose value must be a boolean. If you are migrating from Babylon/Babel 6 or want to use the old decorators proposal, you should use the 'decorators-legacy' plugin instead of 'decorators'."
-}

--- a/packages/babel-parser/test/fixtures/experimental/decorators/no-object-methods/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/no-object-methods/options.json
@@ -1,10 +1,3 @@
 {
-  "plugins": [
-    [
-      "decorators",
-      {
-        "decoratorsBeforeExport": false
-      }
-    ]
-  ]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/no-semi/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/no-semi/options.json
@@ -1,11 +1,4 @@
 {
-  "plugins": [
-    [
-      "decorators",
-      {
-        "decoratorsBeforeExport": false
-      }
-    ]
-  ],
+  "plugins": ["decorators"],
   "throws": "Decorators must not be followed by a semicolon. (2:5)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/parenthesized-createParenthesizedExpressions/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/parenthesized-createParenthesizedExpressions/options.json
@@ -1,4 +1,4 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]],
+  "plugins": ["decorators"],
   "createParenthesizedExpressions": true
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/private-property/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/private-property/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["decorators"]
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/restricted-1/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/restricted-1/options.json
@@ -1,11 +1,4 @@
 {
-  "plugins": [
-    [
-      "decorators",
-      {
-        "decoratorsBeforeExport": false
-      }
-    ]
-  ],
+  "plugins": ["decorators"],
   "throws": "Leading decorators must be attached to a class declaration. (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/restricted-2/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/restricted-2/options.json
@@ -1,11 +1,4 @@
 {
-  "plugins": [
-    [
-      "decorators",
-      {
-        "decoratorsBeforeExport": false
-      }
-    ]
-  ],
+  "plugins": ["decorators"],
   "throws": "Leading decorators must be attached to a class declaration. (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-bare-identifier/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-bare-identifier/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "@@" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-parenthesized-identifier/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-parenthesized-identifier/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "@@" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-parenthesized-topic/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-at-proposal-class-decorator-with-parenthesized-topic/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "@@" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-bare-identifier/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-bare-identifier/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "^^" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-parenthesized-identifier/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-parenthesized-identifier/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "^^" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-parenthesized-topic/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/hack-double-caret-proposal-class-decorator-with-parenthesized-topic/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     ["pipelineOperator", { "proposal": "hack", "topicToken": "^^" }],
-    ["decorators", { "decoratorsBeforeExport": false }]
+    "decorators"
   ]
 }

--- a/packages/babel-parser/test/fixtures/flow/class-properties/declare-after-decorators/options.json
+++ b/packages/babel-parser/test/fixtures/flow/class-properties/declare-after-decorators/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "plugins": ["flow", ["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": ["flow", "decorators"]
 }

--- a/packages/babel-parser/test/fixtures/flow/class-properties/declare-before-decorators/options.json
+++ b/packages/babel-parser/test/fixtures/flow/class-properties/declare-before-decorators/options.json
@@ -1,5 +1,5 @@
 {
   "sourceType": "module",
-  "plugins": ["flow", ["decorators", { "decoratorsBeforeExport": false }]],
+  "plugins": ["flow", "decorators"],
   "throws": "Unexpected token (2:10)"
 }


### PR DESCRIPTION
- [x] [parser] Make `decoratorsBeforeExport` default to `false` (#14695)

## :warning: Use the "Rebase and merge" button!