### PR TITLE
[parser] Improve `getPluginOptions` type

### DIFF
--- a/packages/babel-parser/src/parser/base.ts
+++ b/packages/babel-parser/src/parser/base.ts
@@ -5,7 +5,11 @@ import type ScopeHandler from "../util/scope";
 import type ExpressionScopeHandler from "../util/expression-scope";
 import type ClassScopeHandler from "../util/class-scope";
 import type ProductionParameterHandler from "../util/production-parameter";
-import type { PluginConfig } from "../typings";
+import type {
+  ParserPluginWithOptions,
+  PluginConfig,
+  PluginOptions,
+} from "../typings";
 
 export default class BaseParser {
   // Properties set by constructor in index.js
@@ -54,7 +58,12 @@ export default class BaseParser {
     }
   }
 
-  getPluginOption(plugin: string, name: string) {
-    return this.plugins.get(plugin)?.[name];
+  getPluginOption<
+    PluginName extends ParserPluginWithOptions[0],
+    OptionName extends keyof PluginOptions<PluginName>,
+  >(plugin: PluginName, name: OptionName) {
+    return (this.plugins.get(plugin) as null | PluginOptions<PluginName>)?.[
+      name
+    ];
   }
 }

--- a/packages/babel-parser/src/plugin-utils.ts
+++ b/packages/babel-parser/src/plugin-utils.ts
@@ -1,5 +1,9 @@
 import type Parser from "./parser";
-import type { PluginConfig } from "./typings";
+import type {
+  ParserPluginWithOptions,
+  PluginConfig,
+  PluginOptions,
+} from "./typings";
 
 export type Plugin = PluginConfig;
 
@@ -47,11 +51,10 @@ export function hasPlugin(
   });
 }
 
-export function getPluginOption(
-  plugins: PluginList,
-  name: string,
-  option: string,
-) {
+export function getPluginOption<
+  PluginName extends ParserPluginWithOptions[0],
+  OptionName extends keyof PluginOptions<PluginName>,
+>(plugins: PluginList, name: PluginName, option: OptionName) {
   const plugin = plugins.find(plugin => {
     if (Array.isArray(plugin)) {
       return plugin[0] === name;
@@ -60,9 +63,8 @@ export function getPluginOption(
     }
   });
 
-  if (plugin && Array.isArray(plugin)) {
-    // @ts-expect-error Fixme: should check whether option is defined
-    return plugin[1][option];
+  if (plugin && Array.isArray(plugin) && plugin.length > 1) {
+    return (plugin[1] as PluginOptions<PluginName>)[option];
   }
 
   return null;

--- a/packages/babel-parser/src/typings.ts
+++ b/packages/babel-parser/src/typings.ts
@@ -7,13 +7,11 @@ export type Plugin =
   | "classProperties"
   | "classStaticBlock" // Enabled by default
   | "decimal"
-  | "decorators"
   | "decorators-legacy"
   | "decoratorAutoAccessors"
   | "destructuringPrivate"
   | "doExpressions"
   | "dynamicImport"
-  | "estree"
   | "exportDefaultFrom"
   | "exportNamespaceFrom" // deprecated
   | "flow"
@@ -24,8 +22,6 @@ export type Plugin =
   | "jsx"
   | "logicalAssignment"
   | "importAssertions"
-  // @deprecated
-  | "moduleAttributes"
   | "moduleBlocks"
   | "moduleStringNames"
   | "nullishCoalescingOperator"
@@ -34,24 +30,28 @@ export type Plugin =
   | "optionalCatchBinding"
   | "optionalChaining"
   | "partialApplication"
-  | "pipelineOperator"
   | "placeholders"
   | "privateIn" // Enabled by default
-  | "recordAndTuple"
   | "regexpUnicodeSets"
   | "throwExpressions"
   | "topLevelAwait"
-  | "typescript"
-  | "v8intrinsic";
-
-export type PluginConfig = Plugin | ParserPluginWithOptions;
+  | "v8intrinsic"
+  | ParserPluginWithOptions[0];
 
 export type ParserPluginWithOptions =
   | ["decorators", DecoratorsPluginOptions]
+  | ["estree", { classFeatures?: boolean }]
+  // @deprecated
+  | ["moduleAttributes", { version: "may-2020" }]
   | ["pipelineOperator", PipelineOperatorPluginOptions]
   | ["recordAndTuple", RecordAndTuplePluginOptions]
   | ["flow", FlowPluginOptions]
   | ["typescript", TypeScriptPluginOptions];
+
+export type PluginConfig = Plugin | ParserPluginWithOptions;
+
+export type PluginOptions<PluginName extends ParserPluginWithOptions[0]> =
+  Extract<ParserPluginWithOptions, [PluginName, any]>[1];
 
 export interface DecoratorsPluginOptions {
   decoratorsBeforeExport?: boolean;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This caught two missing options definitions in `typings.ts`: for `"estree"` and for `"modulesAttributes"`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14861"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

