### PR TITLE
chore: refine visitor typings

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -107,7 +107,6 @@ interface PrivateNameVisitorState {
 function privateNameVisitorFactory<S>(
   visitor: Visitor<PrivateNameVisitorState & S>,
 ) {
-  // @ts-expect-error Fixme: TS complains _exploded: boolean does not satisfy visitor functions
   const privateNameVisitor: Visitor<PrivateNameVisitorState & S> = {
     ...visitor,
 

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -20,18 +20,11 @@ export type { HubInterface } from "./hub";
 
 export { visitors };
 
-// fixme: The TraverseOptions should have been { scope ... } & Visitor<S>
-// however TS does not support excluding certain string literals from general string
-// type. If we change here to { scope ... } & Visitor<S>, TS will throw
-// noScope: boolean because it matched `noScope` to the [k in string]: VisitNode<> catch-all
-// in Visitor
-export type TraverseOptions<S = t.Node> =
-  | {
-      scope?: Scope;
-      noScope?: boolean;
-      denylist?: string[];
-    }
-  | Visitor<S>;
+export type TraverseOptions<S = t.Node> = {
+  scope?: Scope;
+  noScope?: boolean;
+  denylist?: string[];
+} & Visitor<S>;
 
 function traverse<S>(
   parent: t.Node,

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -62,7 +62,7 @@ class NodePath<T extends t.Node = t.Node> {
   listKey: string | null = null;
   key: string | number | null = null;
   node: T = null;
-  type: string | null = null;
+  type: T["type"] | null = null;
 
   static get({
     hub,

--- a/packages/babel-traverse/src/path/lib/virtual-types.ts
+++ b/packages/babel-traverse/src/path/lib/virtual-types.ts
@@ -21,9 +21,7 @@ export interface VirtualTypeAliases {
   Var: t.VariableDeclaration;
 }
 
-type NodeTypes = t.Node["type"] | t.Comment["type"] | keyof t.Aliases;
-
-type VirtualTypeMapping = readonly NodeTypes[] | null;
+type VirtualTypeMapping = readonly (t.Node["type"] | keyof t.Aliases)[] | null;
 
 export const ReferencedIdentifier: VirtualTypeMapping = [
   "Identifier",

--- a/packages/babel-traverse/src/types.ts
+++ b/packages/babel-traverse/src/types.ts
@@ -11,7 +11,10 @@ export type Visitor<S = {}> = VisitNodeObject<S, t.Node> & {
 } & {
   [K in keyof InternalVisitorFlags]?: InternalVisitorFlags[K];
 } & {
-  [k: string]: VisitNode<S, t.Node>;
+  // Babel supports `NodeTypesWithoutComment | NodeTypesWithoutComment | ... ` but it is
+  // too complex for TS. So we type it as a general visitor only if the key contains `|`
+  // this is good enough for non-visitor traverse options e.g. `noScope`
+  [k: `${string}|${string}`]: VisitNode<S, t.Node>;
 };
 
 /** @internal */

--- a/packages/babel-types/src/definitions/placeholders.ts
+++ b/packages/babel-types/src/definitions/placeholders.ts
@@ -9,7 +9,7 @@ export const PLACEHOLDERS = [
   "BlockStatement",
   "ClassBody",
   "Pattern",
-];
+] as const;
 
 export const PLACEHOLDERS_ALIAS: Record<string, string[]> = {
   Declaration: ["Statement"],

--- a/packages/babel-types/src/definitions/utils.ts
+++ b/packages/babel-types/src/definitions/utils.ts
@@ -3,11 +3,12 @@ import { validateField, validateChild } from "../validators/validate";
 import type * as t from "..";
 
 export const VISITOR_KEYS: Record<string, string[]> = {};
-export const ALIAS_KEYS: Record<string, string[]> = {};
-export const FLIPPED_ALIAS_KEYS: Record<string, string[]> = {};
+export const ALIAS_KEYS: Partial<Record<NodeTypesWithoutComment, string[]>> =
+  {};
+export const FLIPPED_ALIAS_KEYS: Record<string, NodeTypesWithoutComment[]> = {};
 export const NODE_FIELDS: Record<string, FieldDefinitions> = {};
 export const BUILDER_KEYS: Record<string, string[]> = {};
-export const DEPRECATED_KEYS: Record<string, string> = {};
+export const DEPRECATED_KEYS: Record<string, NodeTypesWithoutComment> = {};
 export const NODE_PARENT_VALIDATIONS: Record<string, Validator> = {};
 
 function getType(val: any) {
@@ -20,7 +21,9 @@ function getType(val: any) {
   }
 }
 
-type NodeTypes = t.Node["type"] | t.Comment["type"] | keyof t.Aliases;
+type NodeTypesWithoutComment = t.Node["type"] | keyof t.Aliases;
+
+type NodeTypes = NodeTypesWithoutComment | t.Comment["type"];
 
 type PrimitiveTypes = ReturnType<typeof getType>;
 
@@ -330,7 +333,7 @@ export default function defineType(type: string, opts: DefineTypeOpts = {}) {
   }
 
   if (opts.deprecatedAlias) {
-    DEPRECATED_KEYS[opts.deprecatedAlias] = type;
+    DEPRECATED_KEYS[opts.deprecatedAlias] = type as NodeTypesWithoutComment;
   }
 
   // ensure all field keys are represented in `fields`
@@ -360,10 +363,10 @@ export default function defineType(type: string, opts: DefineTypeOpts = {}) {
   VISITOR_KEYS[type] = opts.visitor = visitor;
   BUILDER_KEYS[type] = opts.builder = builder;
   NODE_FIELDS[type] = opts.fields = fields;
-  ALIAS_KEYS[type] = opts.aliases = aliases;
+  ALIAS_KEYS[type as NodeTypesWithoutComment] = opts.aliases = aliases;
   aliases.forEach(alias => {
     FLIPPED_ALIAS_KEYS[alias] = FLIPPED_ALIAS_KEYS[alias] || [];
-    FLIPPED_ALIAS_KEYS[alias].push(type);
+    FLIPPED_ALIAS_KEYS[alias].push(type as NodeTypesWithoutComment);
   });
 
   if (opts.validate) {

--- a/packages/babel-types/src/validators/isType.ts
+++ b/packages/babel-types/src/validators/isType.ts
@@ -19,6 +19,7 @@ export default function isType(nodeType: string, targetType: string): boolean {
 
   // This is a fast-path. If the test above failed, but an alias key is found, then the
   // targetType was a primary node type, so there's no need to check the aliases.
+  // @ts-expect-error targetType may not index ALIAS_KEYS
   if (ALIAS_KEYS[targetType]) return false;
 
   const aliases: Array<string> | undefined = FLIPPED_ALIAS_KEYS[targetType];


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Refine visitor typings so that
```ts
travese({
  noScope: true,
  BinaryExpression(path) { }
})
```
is now properly typed. In this PR we mark any key who contains `|` as a visitor function, so that we can allow non-visitor traverse options like `noScope` and `denylist`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14862"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

