### PR TITLE
feat: add proposal-record-and-tuple to standalone

### DIFF
--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -31,6 +31,7 @@
     "@babel/plugin-proposal-pipeline-operator": "workspace:^",
     "@babel/plugin-proposal-private-methods": "workspace:^",
     "@babel/plugin-proposal-private-property-in-object": "workspace:^",
+    "@babel/plugin-proposal-record-and-tuple": "workspace:^",
     "@babel/plugin-proposal-throw-expressions": "workspace:^",
     "@babel/plugin-proposal-unicode-property-regex": "workspace:^",
     "@babel/plugin-proposal-unicode-sets-regex": "workspace:^",

--- a/packages/babel-standalone/scripts/pluginConfig.json
+++ b/packages/babel-standalone/scripts/pluginConfig.json
@@ -42,6 +42,7 @@
   "proposal-pipeline-operator",
   "proposal-private-methods",
   "proposal-private-property-in-object",
+  "proposal-record-and-tuple",
   "proposal-throw-expressions",
   "proposal-unicode-property-regex",
   "proposal-unicode-sets-regex",

--- a/packages/babel-standalone/src/generated/plugins.ts
+++ b/packages/babel-standalone/src/generated/plugins.ts
@@ -45,6 +45,7 @@ import proposalOptionalChaining from "@babel/plugin-proposal-optional-chaining";
 import proposalPipelineOperator from "@babel/plugin-proposal-pipeline-operator";
 import proposalPrivateMethods from "@babel/plugin-proposal-private-methods";
 import proposalPrivatePropertyInObject from "@babel/plugin-proposal-private-property-in-object";
+import proposalRecordAndTuple from "@babel/plugin-proposal-record-and-tuple";
 import proposalThrowExpressions from "@babel/plugin-proposal-throw-expressions";
 import proposalUnicodePropertyRegex from "@babel/plugin-proposal-unicode-property-regex";
 import proposalUnicodeSetsRegex from "@babel/plugin-proposal-unicode-sets-regex";
@@ -143,6 +144,7 @@ export {
   proposalPipelineOperator,
   proposalPrivateMethods,
   proposalPrivatePropertyInObject,
+  proposalRecordAndTuple,
   proposalThrowExpressions,
   proposalUnicodePropertyRegex,
   proposalUnicodeSetsRegex,
@@ -242,6 +244,7 @@ export const all: { [k: string]: any } = {
   "proposal-pipeline-operator": proposalPipelineOperator,
   "proposal-private-methods": proposalPrivateMethods,
   "proposal-private-property-in-object": proposalPrivatePropertyInObject,
+  "proposal-record-and-tuple": proposalRecordAndTuple,
   "proposal-throw-expressions": proposalThrowExpressions,
   "proposal-unicode-property-regex": proposalUnicodePropertyRegex,
   "proposal-unicode-sets-regex": proposalUnicodeSetsRegex,

--- a/packages/babel-standalone/src/preset-stage-2.ts
+++ b/packages/babel-standalone/src/preset-stage-2.ts
@@ -30,7 +30,10 @@ export default (_: any, opts: any = {}) => {
       ],
       babelPlugins.proposalFunctionSent,
       babelPlugins.proposalThrowExpressions,
-      [babelPlugins.syntaxRecordAndTuple, { syntaxType: recordAndTupleSyntax }],
+      [
+        babelPlugins.proposalRecordAndTuple,
+        { syntaxType: recordAndTupleSyntax },
+      ],
       babelPlugins.syntaxModuleBlocks,
     ],
   };

--- a/packages/babel-standalone/test/preset-stage-1.test.js
+++ b/packages/babel-standalone/test/preset-stage-1.test.js
@@ -72,4 +72,10 @@ describe("stage-1 preset", () => {
     }).code;
     expect(output).toMatchInlineSnapshot(`"/[d-p]/u;"`);
   });
+  it("should support record and tuple", () => {
+    const output = Babel.transform("#[#{}]", {
+      presets: [["stage-1", { decoratorsVersion: "2021-12" }]],
+    }).code;
+    expect(output).toMatchInlineSnapshot(`"Tuple(Record({}));"`);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,7 +1707,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/plugin-proposal-record-and-tuple@workspace:packages/babel-plugin-proposal-record-and-tuple":
+"@babel/plugin-proposal-record-and-tuple@workspace:^, @babel/plugin-proposal-record-and-tuple@workspace:packages/babel-plugin-proposal-record-and-tuple":
   version: 0.0.0-use.local
   resolution: "@babel/plugin-proposal-record-and-tuple@workspace:packages/babel-plugin-proposal-record-and-tuple"
   dependencies:
@@ -3602,6 +3602,7 @@ __metadata:
     "@babel/plugin-proposal-pipeline-operator": "workspace:^"
     "@babel/plugin-proposal-private-methods": "workspace:^"
     "@babel/plugin-proposal-private-property-in-object": "workspace:^"
+    "@babel/plugin-proposal-record-and-tuple": "workspace:^"
     "@babel/plugin-proposal-throw-expressions": "workspace:^"
     "@babel/plugin-proposal-unicode-property-regex": "workspace:^"
     "@babel/plugin-proposal-unicode-sets-regex": "workspace:^"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/discussions/14866
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Added the transform plugin to `babel-standalone`.

When developing this PR, I spot that `.matchInlineSnapshot` does not generate snapshot automatically on the `jest-light-runner`. I managed to output snapshot from `jest-runner`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14867"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

