### PR TITLE
[babel 8] Bump eslint parser deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,18 +197,15 @@ jobs:
       - name: Downgrade Jest for node <= 10
         if: matrix.node-version == '6' || matrix.node-version == '8' || matrix.node-version == '10'
         run: |
-          yarn remove jest
-          yarn add --dev jest@24
+          yarn up jest@24
           # Deduplicate dependencies, because duplicate copies of graceful-fs cause
           # problems with the "path" module: https://github.com/facebook/jest/issues/9656
           yarn dedupe
-      - name: Downgrade Jest for node == 12
+      - name: Downgrade Jest and jest-light-runner for node == 12
         if: matrix.node-version == '12'
         run: |
-          yarn remove jest
-          yarn remove jest-light-runner
-          yarn add --dev jest@28
-          yarn add --dev jest-light-runner@0.3.0
+          yarn up jest@28
+          yarn up jest-light-runner@0.3.0
           # Deduplicate dependencies, because duplicate copies of graceful-fs cause
           # problems with the "path" module: https://github.com/facebook/jest/issues/9656
           yarn dedupe
@@ -430,3 +427,25 @@ jobs:
           node-version: 16.6
       - name: Test Node.js 16.6
         run: yarn test:runtime:node
+
+  eslint7-test:
+    name: Test @babel/eslint-* with ESLint 7.5.0
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Use Node.js latest
+        uses: actions/setup-node@v3
+        with:
+          node-version: "*"
+          cache: "yarn"
+      - name: Install
+        run: yarn install
+      - uses: actions/download-artifact@v3
+        with:
+          name: babel-artifact
+      - name: Downgrade ESLint to 7.5.0
+        run: yarn up eslint@7.5.0
+      - name: Run babel/eslint tests
+        run: node ./node_modules/.bin/jest eslint

--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@babel/core": "workspace:^",
     "dedent": "^0.7.0",
-    "eslint": "^7.27.0",
-    "eslint-8": "npm:eslint@^8.0.0"
+    "eslint": "^8.22.0",
+    "eslint-7": "npm:eslint@^7.27.0"
   }
 }

--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -31,8 +31,8 @@
     "eslint": "^7.5.0 || ^8.0.0"
   },
   "dependencies": {
-    "eslint-scope": "^5.1.1",
-    "eslint-visitor-keys": "^2.1.0",
+    "eslint-scope": "condition:BABEL_8_BREAKING ? ^7.1.1 : ^5.1.1",
+    "eslint-visitor-keys": "condition:BABEL_8_BREAKING ? ^3.3.0 : ^2.1.0",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   },
   "devDependencies": {

--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@babel/core": "workspace:^",
     "dedent": "^0.7.0",
-    "eslint": "^8.22.0",
-    "eslint-7": "npm:eslint@^7.27.0"
+    "eslint": "^8.22.0"
   }
 }

--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -31,7 +31,8 @@
     "eslint": "^7.5.0 || ^8.0.0"
   },
   "dependencies": {
-    "eslint-scope": "condition:BABEL_8_BREAKING ? ^7.1.1 : ^5.1.1",
+    "@nicolo-ribaudo/eslint-scope-5-internals": "condition:BABEL_8_BREAKING ? : 5.1.1-v1",
+    "eslint-scope": "condition:BABEL_8_BREAKING ? ^7.1.1 : ",
     "eslint-visitor-keys": "condition:BABEL_8_BREAKING ? ^3.3.0 : ^2.1.0",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   },

--- a/eslint/babel-eslint-parser/src/analyze-scope.cjs
+++ b/eslint/babel-eslint-parser/src/analyze-scope.cjs
@@ -1,7 +1,13 @@
 const escope = require("eslint-scope");
-const { Definition } = require("eslint-scope/lib/definition");
-const OriginalPatternVisitor = require("eslint-scope/lib/pattern-visitor");
-const OriginalReferencer = require("eslint-scope/lib/referencer");
+const { Definition } = process.env.BABEL_8_BREAKING
+  ? escope
+  : require("eslint-scope/lib/definition");
+const OriginalPatternVisitor = process.env.BABEL_8_BREAKING
+  ? escope.PatternVisitor
+  : require("eslint-scope/lib/pattern-visitor");
+const OriginalReferencer = process.env.BABEL_8_BREAKING
+  ? escope.Referencer
+  : require("eslint-scope/lib/referencer");
 const { getKeys: fallback } = require("eslint-visitor-keys");
 
 let visitorKeysMap;

--- a/eslint/babel-eslint-parser/src/analyze-scope.cjs
+++ b/eslint/babel-eslint-parser/src/analyze-scope.cjs
@@ -1,13 +1,12 @@
-const escope = require("eslint-scope");
-const { Definition } = process.env.BABEL_8_BREAKING
-  ? escope
-  : require("eslint-scope/lib/definition");
-const OriginalPatternVisitor = process.env.BABEL_8_BREAKING
-  ? escope.PatternVisitor
-  : require("eslint-scope/lib/pattern-visitor");
-const OriginalReferencer = process.env.BABEL_8_BREAKING
-  ? escope.Referencer
-  : require("eslint-scope/lib/referencer");
+const {
+  Definition,
+  PatternVisitor: OriginalPatternVisitor,
+  Referencer: OriginalReferencer,
+  Scope,
+  ScopeManager,
+} = process.env.BABEL_8_BREAKING
+  ? require("eslint-scope")
+  : require("@nicolo-ribaudo/eslint-scope-5-internals");
 const { getKeys: fallback } = require("eslint-visitor-keys");
 
 let visitorKeysMap;
@@ -242,7 +241,7 @@ class Referencer extends OriginalReferencer {
     }
 
     const parentScope = this.scopeManager.__currentScope;
-    const scope = new escope.Scope(
+    const scope = new Scope(
       this.scopeManager,
       "type-parameters",
       parentScope,
@@ -355,7 +354,7 @@ module.exports = function analyzeScope(ast, parserOptions, client) {
 
   options.childVisitorKeys = client.getVisitorKeys();
 
-  const scopeManager = new escope.ScopeManager(options);
+  const scopeManager = new ScopeManager(options);
   const referencer = new Referencer(options, scopeManager, client);
 
   referencer.visit(ast);

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -130,20 +130,20 @@ describe("Babel and Espree", () => {
     // Use the version of Espree that is a dependency of
     // the version of ESLint we are testing against.
     const espree7Path = require.resolve("espree", {
-      paths: [path.dirname(require.resolve("eslint"))],
+      paths: [path.dirname(require.resolve("eslint-7"))],
     });
     const espree8Path = require.resolve("espree", {
-      paths: [path.dirname(require.resolve("eslint-8"))],
+      paths: [path.dirname(require.resolve("eslint"))],
     });
 
     espree7 = require(espree7Path);
     espree8 = require(espree8Path);
 
     const espree7pkg = require(require.resolve("espree/package.json", {
-      paths: [path.dirname(require.resolve("eslint"))],
+      paths: [path.dirname(require.resolve("eslint-7"))],
     }));
     const espree8pkg = require(require.resolve("espree/package.json", {
-      paths: [path.dirname(require.resolve("eslint-8"))],
+      paths: [path.dirname(require.resolve("eslint"))],
     }));
     if (!espree7pkg.version.startsWith("7.")) {
       throw new Error(`Expected espree 7, but found ${espree7pkg.version}`);

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -15,6 +15,16 @@ function parseForESLint8(code, options) {
   }
 }
 
+function parseForESLint7(code, options) {
+  const { ESLINT_VERSION_FOR_BABEL } = process.env;
+  process.env.ESLINT_VERSION_FOR_BABEL = "7";
+  try {
+    return parseForESLint(code, options);
+  } finally {
+    process.env.ESLINT_VERSION_FOR_BABEL = ESLINT_VERSION_FOR_BABEL;
+  }
+}
+
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const BABEL_OPTIONS = {
@@ -89,7 +99,7 @@ describe("Babel and Espree", () => {
         ...espreeOptions,
         ecmaVersion: 2021,
       });
-      const babelAST = parseForESLint(code, {
+      const babelAST = parseForESLint7(code, {
         eslintVisitorKeys: true,
         eslintScopeManager: true,
         babelOptions: BABEL_OPTIONS,

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -72,14 +72,7 @@ describe("Babel and Espree", () => {
     sourceType: "module",
   };
 
-  function parseAndAssertSame(
-    code,
-    eslintVersion = undefined,
-    babelEcmaFeatures = null,
-  ) {
-    if (eslintVersion !== undefined) {
-      throw new Error("eslintVersion is not undefined");
-    }
+  function parseAndAssertSame(code, babelEcmaFeatures = null) {
     code = unpad(code);
 
     if (isESLint7) {
@@ -888,7 +881,7 @@ describe("Babel and Espree", () => {
 
     if (process.env.BABEL_8_BREAKING) {
       it("return outside function with ecmaFeatures.globalReturn: true", () => {
-        parseAndAssertSame("return;", /* version */ undefined, {
+        parseAndAssertSame("return;", {
           globalReturn: true,
         });
       });

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -76,10 +76,6 @@ describe("Babel and Espree", () => {
     code = unpad(code);
 
     if (isESLint7) {
-      if (process.env.IS_PUBLISH) {
-        console.warn("Skipping ESLint 7 test because using a release build.");
-        return;
-      }
       // ESLint 7
       const espreeAST = espree.parse(code, {
         ...espreeOptions,

--- a/eslint/babel-eslint-plugin-development-internal/package.json
+++ b/eslint/babel-eslint-plugin-development-internal/package.json
@@ -20,7 +20,7 @@
     "eslint": ">=7.5.0"
   },
   "devDependencies": {
-    "eslint": "^7.27.0"
+    "eslint": "^8.22.0"
   },
   "type": "commonjs"
 }

--- a/eslint/babel-eslint-plugin-development/package.json
+++ b/eslint/babel-eslint-plugin-development/package.json
@@ -31,6 +31,6 @@
   },
   "homepage": "https://babel.dev/",
   "devDependencies": {
-    "eslint": "^7.27.0"
+    "eslint": "^8.22.0"
   }
 }

--- a/eslint/babel-eslint-plugin/package.json
+++ b/eslint/babel-eslint-plugin/package.json
@@ -41,6 +41,6 @@
   },
   "devDependencies": {
     "clone-deep": "^4.0.1",
-    "eslint": "^7.27.0"
+    "eslint": "^8.22.0"
   }
 }

--- a/eslint/babel-eslint-plugin/src/rules/no-invalid-this.cjs
+++ b/eslint/babel-eslint-plugin/src/rules/no-invalid-this.cjs
@@ -1,33 +1,40 @@
 const ruleComposer = require("eslint-rule-composer");
 const eslint = require("eslint");
+const eslintVersion = eslint.ESLint.version;
 
 const noInvalidThisRule = new eslint.Linter().getRules().get("no-invalid-this");
 
-module.exports = ruleComposer.filterReports(noInvalidThisRule, problem => {
-  let inClassMember = false;
-  let node = problem.node;
+if (parseInt(eslintVersion, 10) >= 8) {
+  // ESLint 8 supports class properties / private methods natively
+  // so we simply forward the original rule
+  module.exports = noInvalidThisRule;
+} else {
+  module.exports = ruleComposer.filterReports(noInvalidThisRule, problem => {
+    let inClassMember = false;
+    let node = problem.node;
 
-  while (node) {
-    if (
-      node.type === "ClassPrivateMethod" ||
-      node.type === "ClassPrivateProperty" ||
-      node.type === "ClassProperty" ||
-      node.type === "PropertyDefinition" ||
-      (node.type === "MethodDefinition" &&
-        node.key.type === "PrivateIdentifier")
-    ) {
-      inClassMember = true;
-      break;
-    } else if (
-      node.type === "FunctionDeclaration" ||
-      node.type === "FunctionExpression"
-    ) {
-      inClassMember = false;
-      break;
+    while (node) {
+      if (
+        node.type === "ClassPrivateMethod" ||
+        node.type === "ClassPrivateProperty" ||
+        node.type === "ClassProperty" ||
+        node.type === "PropertyDefinition" ||
+        (node.type === "MethodDefinition" &&
+          node.key.type === "PrivateIdentifier")
+      ) {
+        inClassMember = true;
+        break;
+      } else if (
+        node.type === "FunctionDeclaration" ||
+        node.type === "FunctionExpression"
+      ) {
+        inClassMember = false;
+        break;
+      }
+
+      node = node.parent;
     }
 
-    node = node.parent;
-  }
-
-  return !inClassMember;
-});
+    return !inClassMember;
+  });
+}

--- a/eslint/babel-eslint-shared-fixtures/package.json
+++ b/eslint/babel-eslint-shared-fixtures/package.json
@@ -15,7 +15,7 @@
     "@babel/preset-env": "workspace:^",
     "@babel/preset-flow": "workspace:^",
     "@babel/preset-react": "workspace:^",
-    "eslint": "^7.27.0"
+    "eslint": "^8.22.0"
   },
   "type": "commonjs"
 }

--- a/eslint/babel-eslint-shared-fixtures/utils/RuleTester.js
+++ b/eslint/babel-eslint-shared-fixtures/utils/RuleTester.js
@@ -4,7 +4,7 @@ RuleTester.setDefaultConfig({
   parser: require.resolve("@babel/eslint-parser"),
   parserOptions: {
     sourceType: "module",
-    ecmaVersion: 11,
+    ecmaVersion: "latest",
     babelOptions: {
       configFile: require.resolve("../config/babel.config.js"),
     },

--- a/eslint/babel-eslint-tests/package.json
+++ b/eslint/babel-eslint-tests/package.json
@@ -8,7 +8,7 @@
     "@babel/eslint-parser": "workspace:^",
     "@babel/preset-react": "workspace:^",
     "dedent": "^0.7.0",
-    "eslint": "^7.27.0",
+    "eslint": "^8.22.0",
     "eslint-plugin-import": "^2.25.4",
     "npm-babel-parser": "npm:@babel/parser@^7.14.0"
   },

--- a/eslint/babel-eslint-tests/test/integration/config-files.js
+++ b/eslint/babel-eslint-tests/test/integration/config-files.js
@@ -1,4 +1,4 @@
-import eslint from "eslint";
+import { ESLint } from "eslint";
 import path from "path";
 import { fileURLToPath } from "url";
 import fs from "fs";
@@ -16,27 +16,30 @@ describe("Babel config files", () => {
   const itNode12upNoESM =
     USE_ESM || parseInt(process.versions.node) < 12 ? it.skip : it;
 
-  itESM("works with babel.config.mjs", () => {
-    const engine = new eslint.CLIEngine({ ignore: false });
+  itESM("works with babel.config.mjs", async () => {
+    const engine = new ESLint({ ignore: false });
     expect(
-      engine.executeOnFiles([
+      await engine.lintFiles([
         path.resolve(
           path.dirname(fileURLToPath(import.meta.url)),
           `../fixtures/mjs-config-file/a.js`,
         ),
       ]),
-    ).toMatchObject({ errorCount: 0 });
+    ).toMatchObject([{ errorCount: 0 }]);
   });
 
-  itNode12upNoESM("experimental worker works with babel.config.mjs", () => {
-    const engine = new eslint.CLIEngine({ ignore: false });
-    expect(
-      engine.executeOnFiles([
-        path.resolve(
-          path.dirname(fileURLToPath(import.meta.url)),
-          `../fixtures/mjs-config-file-babel-7/a.js`,
+  itNode12upNoESM(
+    "experimental worker works with babel.config.mjs",
+    async () => {
+      const engine = new ESLint({ ignore: false });
+      expect(
+        await engine.lintFiles(
+          path.resolve(
+            path.dirname(fileURLToPath(import.meta.url)),
+            `../fixtures/mjs-config-file-babel-7/a.js`,
+          ),
         ),
-      ]),
-    ).toMatchObject({ errorCount: 0 });
-  });
+      ).toMatchObject([{ errorCount: 0 }]);
+    },
+  );
 });

--- a/eslint/babel-eslint-tests/test/integration/duplicated-babel-parser.js
+++ b/eslint/babel-eslint-tests/test/integration/duplicated-babel-parser.js
@@ -1,17 +1,16 @@
-import eslint from "eslint";
+import { ESLint } from "eslint";
 import path from "path";
 import { fileURLToPath } from "url";
 
 describe("https://github.com/babel/babel/issues/12985", () => {
-  it("works with different copies of @babel/parser", () => {
-    const engine = new eslint.CLIEngine({ ignore: false });
-    expect(() =>
-      engine.executeOnFiles([
-        path.resolve(
-          path.dirname(fileURLToPath(import.meta.url)),
-          `../fixtures/duplicated-babel-parser/a.js`,
-        ),
-      ]),
-    ).not.toThrow();
+  it("works with different copies of @babel/parser", async () => {
+    const engine = new ESLint({ ignore: false });
+
+    await engine.lintFiles(
+      path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        `../fixtures/duplicated-babel-parser/a.js`,
+      ),
+    );
   });
 });

--- a/eslint/babel-eslint-tests/test/integration/eslint-plugin-import.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint-plugin-import.js
@@ -1,11 +1,12 @@
-import eslint from "eslint";
+import { ESLint } from "eslint";
 import path from "path";
 import { fileURLToPath } from "url";
 
 describe("https://github.com/babel/babel-eslint/issues/558", () => {
-  it("doesn't crash with eslint-plugin-import", () => {
-    const engine = new eslint.CLIEngine({ ignore: false });
-    engine.executeOnFiles(
+  it("doesn't crash with eslint-plugin-import", async () => {
+    const engine = new ESLint({ ignore: false });
+
+    await engine.lintFiles(
       ["a.js", "b.js", "c.js"].map(file =>
         path.resolve(
           path.dirname(fileURLToPath(import.meta.url)),

--- a/eslint/babel-eslint-tests/test/integration/eslint/rules/strict.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/rules/strict.js
@@ -1,10 +1,11 @@
-import eslint from "eslint";
+import { Linter } from "eslint";
 import fs from "fs";
 import path from "path";
 import * as parser from "../../../../../babel-eslint-parser/lib/index.cjs";
 import { fileURLToPath } from "url";
 
-eslint.linter.defineParser("@babel/eslint-parser", parser);
+const linter = new Linter();
+linter.defineParser("@babel/eslint-parser", parser);
 
 const paths = {
   fixtures: path.join(
@@ -28,7 +29,7 @@ const baseEslintOpts = {
 };
 
 /**
- * Load a fixture and run eslint.linter.verify() on it.
+ * Load a fixture and run linter.verify() on it.
  * Pass the return value to done().
  * @param object opts
  * @param function done
@@ -37,7 +38,7 @@ function lint(opts) {
   return new Promise((resolve, reject) => {
     readFixture(opts.fixture, (err, src) => {
       if (err) return reject(err);
-      resolve(eslint.linter.verify(src, opts.eslint));
+      resolve(linter.verify(src, opts.eslint));
     });
   });
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -36,10 +36,10 @@ module.exports = {
     "<rootDir>/packages/babel-core/src/vendor/.*",
   ],
 
-  // The eslint/* packages use ESLint v6, which has dropped support for Node v6.
+  // The eslint/* packages is tested against ESLint v8, which has dropped support for Node v10.
   // TODO: Remove this process.version check in Babel 8.
   testRegex: `./(packages|codemods${
-    semver.satisfies(nodeVersion, "<10") ? "" : "|eslint"
+    semver.satisfies(nodeVersion, "<12") ? "" : "|eslint"
   })/[^/]+/test/.+\\.m?js$`,
   testPathIgnorePatterns: [
     "/node_modules/",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chalk": "^5.0.0",
     "charcodes": "^0.2.0",
     "core-js": "^3.25.1",
-    "eslint": "^8.20.0",
+    "eslint": "^8.22.0",
     "eslint-formatter-codeframe": "^7.32.1",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,10 +368,11 @@ __metadata:
   resolution: "@babel/eslint-parser@workspace:eslint/babel-eslint-parser"
   dependencies:
     "@babel/core": "workspace:^"
+    "@nicolo-ribaudo/eslint-scope-5-internals": "condition:BABEL_8_BREAKING ? : 5.1.1-v1"
     dedent: ^0.7.0
     eslint: ^7.27.0
     eslint-8: "npm:eslint@^8.0.0"
-    eslint-scope: "condition:BABEL_8_BREAKING ? ^7.1.1 : ^5.1.1"
+    eslint-scope: "condition:BABEL_8_BREAKING ? ^7.1.1 : "
     eslint-visitor-keys: "condition:BABEL_8_BREAKING ? ^3.3.0 : ^2.1.0"
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   peerDependencies:
@@ -4217,6 +4218,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nicolo-ribaudo/eslint-scope-5-internals-BABEL_8_BREAKING-false@npm:@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
+  version: 5.1.1-v1
+  resolution: "@nicolo-ribaudo/eslint-scope-5-internals@npm:5.1.1-v1"
+  dependencies:
+    eslint-scope: 5.1.1
+  checksum: f2e3b2d6a6e2d9f163ca22105910c9f850dc4897af0aea3ef0a5886b63d8e1ba6505b71c99cb78a3bba24a09557d601eb21c8dede3f3213753fcfef364eb0e57
+  languageName: node
+  linkType: hard
+
+"@nicolo-ribaudo/eslint-scope-5-internals@condition:BABEL_8_BREAKING ? : 5.1.1-v1":
+  version: 0.0.0-condition-a67dfe
+  resolution: "@nicolo-ribaudo/eslint-scope-5-internals@condition:BABEL_8_BREAKING?:5.1.1-v1#a67dfe"
+  dependencies:
+    "@nicolo-ribaudo/eslint-scope-5-internals-BABEL_8_BREAKING-false": "npm:@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1"
+  checksum: 35c6c2d0fe2e6ff24708b60835fe4f53e8bcdc0dcda98f81ce04849d27e51f6039b213e08d8440d8ee14aa5b8d94654314b1a2ba4d64bb09bd16feb01db74631
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.3":
   version: 2.1.3
   resolution: "@nodelib/fs.scandir@npm:2.1.3"
@@ -7944,16 +7963,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope-BABEL_8_BREAKING-false@npm:eslint-scope@^5.1.1, eslint-scope@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "eslint-scope@npm:5.1.1"
-  dependencies:
-    esrecurse: ^4.3.0
-    estraverse: ^4.1.1
-  checksum: 47e4b6a3f0cc29c7feedee6c67b225a2da7e155802c6ea13bbef4ac6b9e10c66cd2dcb987867ef176292bf4e64eccc680a49e35e9e9c669f4a02bac17e86abdb
-  languageName: node
-  linkType: hard
-
 "eslint-scope-BABEL_8_BREAKING-true@npm:eslint-scope@^7.1.1, eslint-scope@npm:^7.1.1":
   version: 7.1.1
   resolution: "eslint-scope@npm:7.1.1"
@@ -7964,13 +7973,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@condition:BABEL_8_BREAKING ? ^7.1.1 : ^5.1.1":
-  version: 0.0.0-condition-8f021b
-  resolution: "eslint-scope@condition:BABEL_8_BREAKING?^7.1.1:^5.1.1#8f021b"
+"eslint-scope@condition:BABEL_8_BREAKING ? ^7.1.1 : ":
+  version: 0.0.0-condition-10b8c2
+  resolution: "eslint-scope@condition:BABEL_8_BREAKING?^7.1.1:#10b8c2"
   dependencies:
-    eslint-scope-BABEL_8_BREAKING-false: "npm:eslint-scope@^5.1.1"
     eslint-scope-BABEL_8_BREAKING-true: "npm:eslint-scope@^7.1.1"
-  checksum: 600efff5322843a5c87c44b7a2854799a0b451f9dc03d0b7f463d3d774e0a173c0d98e37d9f34086003707f2014f2f6fb70ef63bd2b97b87aeacef668dfff21e
+  checksum: a059b6e5cdef7c711e44a3ba007355c2282e4a7bb04e59c4b7e1f537f4a7911144beff36b7f52b53098b4bd57ddfb6756f3c09c059d76ca598554465fe07b375
+  languageName: node
+  linkType: hard
+
+"eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "eslint-scope@npm:5.1.1"
+  dependencies:
+    esrecurse: ^4.3.0
+    estraverse: ^4.1.1
+  checksum: 47e4b6a3f0cc29c7feedee6c67b225a2da7e155802c6ea13bbef4ac6b9e10c66cd2dcb987867ef176292bf4e64eccc680a49e35e9e9c669f4a02bac17e86abdb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,7 +384,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/eslint-plugin-development-internal@workspace:eslint/babel-eslint-plugin-development-internal"
   dependencies:
-    eslint: ^7.27.0
+    eslint: ^8.22.0
   peerDependencies:
     "@babel/eslint-parser": ">=7.11.0"
     eslint: ">=7.5.0"
@@ -395,7 +395,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/eslint-plugin-development@workspace:eslint/babel-eslint-plugin-development"
   dependencies:
-    eslint: ^7.27.0
+    eslint: ^8.22.0
   languageName: unknown
   linkType: soft
 
@@ -404,7 +404,7 @@ __metadata:
   resolution: "@babel/eslint-plugin@workspace:eslint/babel-eslint-plugin"
   dependencies:
     clone-deep: ^4.0.1
-    eslint: ^7.27.0
+    eslint: ^8.22.0
     eslint-rule-composer: ^0.3.0
   peerDependencies:
     "@babel/eslint-parser": ">=7.11.0"
@@ -427,7 +427,7 @@ __metadata:
     "@babel/preset-env": "workspace:^"
     "@babel/preset-flow": "workspace:^"
     "@babel/preset-react": "workspace:^"
-    eslint: ^7.27.0
+    eslint: ^8.22.0
   languageName: unknown
   linkType: soft
 
@@ -439,7 +439,7 @@ __metadata:
     "@babel/eslint-parser": "workspace:^"
     "@babel/preset-react": "workspace:^"
     dedent: ^0.7.0
-    eslint: ^7.27.0
+    eslint: ^8.22.0
     eslint-plugin-import: ^2.25.4
     npm-babel-parser: "npm:@babel/parser@^7.14.0"
   languageName: unknown
@@ -3848,7 +3848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^1.0.2, @eslint/eslintrc@npm:^1.3.0":
+"@eslint/eslintrc@npm:^1.3.0":
   version: 1.3.0
   resolution: "@eslint/eslintrc@npm:1.3.0"
   dependencies:
@@ -3865,6 +3865,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@humanwhocodes/config-array@npm:^0.10.4":
+  version: 0.10.4
+  resolution: "@humanwhocodes/config-array@npm:0.10.4"
+  dependencies:
+    "@humanwhocodes/object-schema": ^1.2.1
+    debug: ^4.1.1
+    minimatch: ^3.0.4
+  checksum: d480e5d57e6d787565b6cff78e27c3d1b380692d4ffb0ada7d7f5957a56c9032f034da05a3e443065dbd0671ebf4d859036ced34e96b325bbc1badbae3c05300
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.5.0":
   version: 0.5.0
   resolution: "@humanwhocodes/config-array@npm:0.5.0"
@@ -3876,25 +3887,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/config-array@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@humanwhocodes/config-array@npm:0.6.0"
-  dependencies:
-    "@humanwhocodes/object-schema": ^1.2.0
-    debug: ^4.1.1
-    minimatch: ^3.0.4
-  checksum: 1025b07514b7bfd10a05e8b6cb5e6520878e9c8836b3dd0569fc07df29a09e428c2df1e0760b1d461da8ed6f81ca83ecb02e24198f80b0a177a2acbf532e267c
-  languageName: node
-  linkType: hard
-
-"@humanwhocodes/config-array@npm:^0.9.2":
-  version: 0.9.3
-  resolution: "@humanwhocodes/config-array@npm:0.9.3"
-  dependencies:
-    "@humanwhocodes/object-schema": ^1.2.1
-    debug: ^4.1.1
-    minimatch: ^3.0.4
-  checksum: 6e5d7d274941c459bab0a14a87e372206d89fad3e4879d982edc942e8cc34da6510ea3644b8535a2a9edaa6527e91dccceabc6837ffa8ee506d66bca5d269ebc
+"@humanwhocodes/gitignore-to-minimatch@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@humanwhocodes/gitignore-to-minimatch@npm:1.0.2"
+  checksum: aba5c40c9e3770ed73a558b0bfb53323842abfc2ce58c91d7e8b1073995598e6374456d38767be24ab6176915f0a8d8b23eaae5c85e2b488c0dccca6d795e2ad
   languageName: node
   linkType: hard
 
@@ -5220,7 +5216,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.4, acorn@npm:^8.7.0, acorn@npm:^8.7.1":
+"acorn@npm:^8.0.4, acorn@npm:^8.7.0, acorn@npm:^8.8.0":
   version: 8.8.0
   resolution: "acorn@npm:8.8.0"
   bin:
@@ -5964,7 +5960,7 @@ __metadata:
     chalk: ^5.0.0
     charcodes: ^0.2.0
     core-js: ^3.25.1
-    eslint: ^8.20.0
+    eslint: ^8.22.0
     eslint-formatter-codeframe: ^7.32.1
     eslint-import-resolver-node: ^0.3.6
     eslint-plugin-import: ^2.26.0
@@ -7779,31 +7775,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-8@npm:eslint@^8.0.0":
-  version: 8.0.0
-  resolution: "eslint@npm:8.0.0"
+"eslint-8@npm:eslint@^8.0.0, eslint@npm:^8.22.0":
+  version: 8.22.0
+  resolution: "eslint@npm:8.22.0"
   dependencies:
-    "@eslint/eslintrc": ^1.0.2
-    "@humanwhocodes/config-array": ^0.6.0
+    "@eslint/eslintrc": ^1.3.0
+    "@humanwhocodes/config-array": ^0.10.4
+    "@humanwhocodes/gitignore-to-minimatch": ^1.0.2
     ajv: ^6.10.0
     chalk: ^4.0.0
     cross-spawn: ^7.0.2
     debug: ^4.3.2
     doctrine: ^3.0.0
-    enquirer: ^2.3.5
     escape-string-regexp: ^4.0.0
-    eslint-scope: ^6.0.0
+    eslint-scope: ^7.1.1
     eslint-utils: ^3.0.0
-    eslint-visitor-keys: ^3.0.0
-    espree: ^9.0.0
+    eslint-visitor-keys: ^3.3.0
+    espree: ^9.3.3
     esquery: ^1.4.0
     esutils: ^2.0.2
     fast-deep-equal: ^3.1.3
     file-entry-cache: ^6.0.1
+    find-up: ^5.0.0
     functional-red-black-tree: ^1.0.1
     glob-parent: ^6.0.1
-    globals: ^13.6.0
-    ignore: ^4.0.6
+    globals: ^13.15.0
+    globby: ^11.1.0
+    grapheme-splitter: ^1.0.4
+    ignore: ^5.2.0
     import-fresh: ^3.0.0
     imurmurhash: ^0.1.4
     is-glob: ^4.0.0
@@ -7811,19 +7810,17 @@ __metadata:
     json-stable-stringify-without-jsonify: ^1.0.1
     levn: ^0.4.1
     lodash.merge: ^4.6.2
-    minimatch: ^3.0.4
+    minimatch: ^3.1.2
     natural-compare: ^1.4.0
     optionator: ^0.9.1
-    progress: ^2.0.0
     regexpp: ^3.2.0
-    semver: ^7.2.1
-    strip-ansi: ^6.0.0
+    strip-ansi: ^6.0.1
     strip-json-comments: ^3.1.0
     text-table: ^0.2.0
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: 68ba2838862782d9cbf6100218cbf0d69873b6d5d1de5860627b5424f067e2145d334810168142452fb93692666aa1cbeb4d0a94eea089a7d54d3ae32e99942c
+  checksum: 2d84a7a2207138cdb250759b047fdb05a57fede7f87b7a039d9370edba7f26e23a873a208becfd4b2c9e4b5499029f3fc3b9318da3290e693d25c39084119c80
   languageName: node
   linkType: hard
 
@@ -7987,16 +7984,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "eslint-scope@npm:6.0.0"
-  dependencies:
-    esrecurse: ^4.3.0
-    estraverse: ^5.2.0
-  checksum: 3f1b3578f288c3820f68ad2aae102300e546be8a98a958f515405dc20cc2fe64fda583d364977628bb14fe3d4f96f37de5e9bc5d6eb26bc310da33ba2a677dc3
-  languageName: node
-  linkType: hard
-
 "eslint-utils@npm:^2.0.0, eslint-utils@npm:^2.1.0":
   version: 2.1.0
   resolution: "eslint-utils@npm:2.1.0"
@@ -8024,7 +8011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys-BABEL_8_BREAKING-true@npm:eslint-visitor-keys@^3.3.0, eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.3.0":
+"eslint-visitor-keys-BABEL_8_BREAKING-true@npm:eslint-visitor-keys@^3.3.0, eslint-visitor-keys@npm:^3.3.0":
   version: 3.3.0
   resolution: "eslint-visitor-keys@npm:3.3.0"
   checksum: d59e68a7c5a6d0146526b0eec16ce87fbf97fe46b8281e0d41384224375c4e52f5ffb9e16d48f4ea50785cde93f766b0c898e31ab89978d88b0e1720fbfb7808
@@ -8098,51 +8085,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.20.0":
-  version: 8.20.0
-  resolution: "eslint@npm:8.20.0"
-  dependencies:
-    "@eslint/eslintrc": ^1.3.0
-    "@humanwhocodes/config-array": ^0.9.2
-    ajv: ^6.10.0
-    chalk: ^4.0.0
-    cross-spawn: ^7.0.2
-    debug: ^4.3.2
-    doctrine: ^3.0.0
-    escape-string-regexp: ^4.0.0
-    eslint-scope: ^7.1.1
-    eslint-utils: ^3.0.0
-    eslint-visitor-keys: ^3.3.0
-    espree: ^9.3.2
-    esquery: ^1.4.0
-    esutils: ^2.0.2
-    fast-deep-equal: ^3.1.3
-    file-entry-cache: ^6.0.1
-    functional-red-black-tree: ^1.0.1
-    glob-parent: ^6.0.1
-    globals: ^13.15.0
-    ignore: ^5.2.0
-    import-fresh: ^3.0.0
-    imurmurhash: ^0.1.4
-    is-glob: ^4.0.0
-    js-yaml: ^4.1.0
-    json-stable-stringify-without-jsonify: ^1.0.1
-    levn: ^0.4.1
-    lodash.merge: ^4.6.2
-    minimatch: ^3.1.2
-    natural-compare: ^1.4.0
-    optionator: ^0.9.1
-    regexpp: ^3.2.0
-    strip-ansi: ^6.0.1
-    strip-json-comments: ^3.1.0
-    text-table: ^0.2.0
-    v8-compile-cache: ^2.0.3
-  bin:
-    eslint: bin/eslint.js
-  checksum: a31adf390d71d916925586bc8467b48f620e93dd0416bc1e897d99265af88b48d4eba3985b5ff4653ae5cc46311a360d373574002277e159bb38a4363abf9228
-  languageName: node
-  linkType: hard
-
 "espree@npm:^7.3.0, espree@npm:^7.3.1":
   version: 7.3.1
   resolution: "espree@npm:7.3.1"
@@ -8154,14 +8096,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"espree@npm:^9.0.0, espree@npm:^9.3.2":
-  version: 9.3.2
-  resolution: "espree@npm:9.3.2"
+"espree@npm:^9.3.2, espree@npm:^9.3.3":
+  version: 9.3.3
+  resolution: "espree@npm:9.3.3"
   dependencies:
-    acorn: ^8.7.1
+    acorn: ^8.8.0
     acorn-jsx: ^5.3.2
     eslint-visitor-keys: ^3.3.0
-  checksum: 9a790d6779847051e87f70d720a0f6981899a722419e80c92ab6dee01e1ab83b8ce52d11b4dc96c2c490182efb5a4c138b8b0d569205bfe1cd4629e658e58c30
+  checksum: 33e8a36fc15d082e68672e322e22a53856b564d60aad8f291a667bfc21b2c900c42412d37dd3c7a0f18b9d0d8f8858dabe8776dbd4b4c2f72c5cf4d6afeabf65
   languageName: node
   linkType: hard
 
@@ -8640,6 +8582,16 @@ __metadata:
     locate-path: ^5.0.0
     path-exists: ^4.0.0
   checksum: 4c172680e8f8c1f78839486e14a43ef82e9decd0e74145f40707cc42e7420506d5ec92d9a11c22bd2c48fb0c384ea05dd30e10dd152fefeec6f2f75282a8b844
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "find-up@npm:5.0.0"
+  dependencies:
+    locate-path: ^6.0.0
+    path-exists: ^4.0.0
+  checksum: 07955e357348f34660bde7920783204ff5a26ac2cafcaa28bace494027158a97b9f56faaf2d89a6106211a8174db650dd9f503f9c0d526b1202d5554a00b9095
   languageName: node
   linkType: hard
 
@@ -9155,6 +9107,13 @@ fsevents@^1.2.7:
   version: 4.2.9
   resolution: "graceful-fs@npm:4.2.9"
   checksum: 68ea4e07ff2c041ada184f9278b830375f8e0b75154e3f080af6b70f66172fabb4108d19b3863a96b53fc068a310b9b6493d86d1291acc5f3861eb4b79d26ad6
+  languageName: node
+  linkType: hard
+
+"grapheme-splitter@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "grapheme-splitter@npm:1.0.4"
+  checksum: 0c22ec54dee1b05cd480f78cf14f732cb5b108edc073572c4ec205df4cd63f30f8db8025afc5debc8835a8ddeacf648a1c7992fe3dcd6ad38f9a476d84906620
   languageName: node
   linkType: hard
 
@@ -11178,6 +11137,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"locate-path@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "locate-path@npm:6.0.0"
+  dependencies:
+    p-locate: ^5.0.0
+  checksum: 72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
+  languageName: node
+  linkType: hard
+
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -12187,7 +12155,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^3.1.0":
+"p-limit@npm:^3.0.2, p-limit@npm:^3.1.0":
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
   dependencies:
@@ -12220,6 +12188,15 @@ fsevents@^1.2.7:
   dependencies:
     p-limit: ^2.2.0
   checksum: 513bd14a455f5da4ebfcb819ef706c54adb09097703de6aeaa5d26fe5ea16df92b48d1ac45e01e3944ce1e6aa2a66f7f8894742b8c9d6e276e16cd2049a2b870
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "p-locate@npm:5.0.0"
+  dependencies:
+    p-limit: ^3.0.2
+  checksum: 1623088f36cf1cbca58e9b61c4e62bf0c60a07af5ae1ca99a720837356b5b6c5ba3eb1b2127e47a06865fee59dd0453cad7cc844cda9d5a62ac1a5a51b7c86d3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,7 +371,6 @@ __metadata:
     "@nicolo-ribaudo/eslint-scope-5-internals": "condition:BABEL_8_BREAKING ? : 5.1.1-v1"
     dedent: ^0.7.0
     eslint: ^8.22.0
-    eslint-7: "npm:eslint@^7.27.0"
     eslint-scope: "condition:BABEL_8_BREAKING ? ^7.1.1 : "
     eslint-visitor-keys: "condition:BABEL_8_BREAKING ? ^3.3.0 : ^2.1.0"
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
@@ -3832,23 +3831,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@eslint/eslintrc@npm:0.4.3"
-  dependencies:
-    ajv: ^6.12.4
-    debug: ^4.1.1
-    espree: ^7.3.0
-    globals: ^13.9.0
-    ignore: ^4.0.6
-    import-fresh: ^3.2.1
-    js-yaml: ^3.13.1
-    minimatch: ^3.0.4
-    strip-json-comments: ^3.1.1
-  checksum: 03a7704150b868c318aab6a94d87a33d30dc2ec579d27374575014f06237ba1370ae11178db772f985ef680d469dc237e7b16a1c5d8edaaeb8c3733e7a95a6d3
-  languageName: node
-  linkType: hard
-
 "@eslint/eslintrc@npm:^1.3.0":
   version: 1.3.0
   resolution: "@eslint/eslintrc@npm:1.3.0"
@@ -3877,17 +3859,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/config-array@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@humanwhocodes/config-array@npm:0.5.0"
-  dependencies:
-    "@humanwhocodes/object-schema": ^1.2.0
-    debug: ^4.1.1
-    minimatch: ^3.0.4
-  checksum: 44ee6a9f05d93dd9d5935a006b17572328ba9caff8002442f601736cbda79c580cc0f5a49ce9eb88fbacc5c3a6b62098357c2e95326cd17bb9f1a6c61d6e95e7
-  languageName: node
-  linkType: hard
-
 "@humanwhocodes/gitignore-to-minimatch@npm:^1.0.2":
   version: 1.0.2
   resolution: "@humanwhocodes/gitignore-to-minimatch@npm:1.0.2"
@@ -3895,7 +3866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/object-schema@npm:^1.2.0, @humanwhocodes/object-schema@npm:^1.2.1":
+"@humanwhocodes/object-schema@npm:^1.2.1":
   version: 1.2.1
   resolution: "@humanwhocodes/object-schema@npm:1.2.1"
   checksum: a824a1ec31591231e4bad5787641f59e9633827d0a2eaae131a288d33c9ef0290bd16fda8da6f7c0fcb014147865d12118df10db57f27f41e20da92369fcb3f1
@@ -5172,7 +5143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-jsx@npm:^5.3.1, acorn-jsx@npm:^5.3.2":
+"acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
   peerDependencies:
@@ -5226,7 +5197,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^7.0.0, acorn@npm:^7.4.0":
+"acorn@npm:^7.0.0":
   version: 7.4.1
   resolution: "acorn@npm:7.4.1"
   bin:
@@ -5281,18 +5252,6 @@ __metadata:
     json-schema-traverse: ^0.4.1
     uri-js: ^4.2.2
   checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.0.1":
-  version: 8.11.0
-  resolution: "ajv@npm:8.11.0"
-  dependencies:
-    fast-deep-equal: ^3.1.1
-    json-schema-traverse: ^1.0.0
-    require-from-string: ^2.0.2
-    uri-js: ^4.2.2
-  checksum: 5e0ff226806763be73e93dd7805b634f6f5921e3e90ca04acdf8db81eed9d8d3f0d4c5f1213047f45ebbf8047ffe0c840fa1ef2ec42c3a644899f69aa72b5bef
   languageName: node
   linkType: hard
 
@@ -7207,7 +7166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
+"debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -7579,7 +7538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enquirer@npm:^2.3.5, enquirer@npm:^2.3.6":
+"enquirer@npm:^2.3.6":
   version: 2.3.6
   resolution: "enquirer@npm:2.3.6"
   dependencies:
@@ -7794,56 +7753,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-7@npm:eslint@^7.27.0":
-  version: 7.32.0
-  resolution: "eslint@npm:7.32.0"
-  dependencies:
-    "@babel/code-frame": 7.12.11
-    "@eslint/eslintrc": ^0.4.3
-    "@humanwhocodes/config-array": ^0.5.0
-    ajv: ^6.10.0
-    chalk: ^4.0.0
-    cross-spawn: ^7.0.2
-    debug: ^4.0.1
-    doctrine: ^3.0.0
-    enquirer: ^2.3.5
-    escape-string-regexp: ^4.0.0
-    eslint-scope: ^5.1.1
-    eslint-utils: ^2.1.0
-    eslint-visitor-keys: ^2.0.0
-    espree: ^7.3.1
-    esquery: ^1.4.0
-    esutils: ^2.0.2
-    fast-deep-equal: ^3.1.3
-    file-entry-cache: ^6.0.1
-    functional-red-black-tree: ^1.0.1
-    glob-parent: ^5.1.2
-    globals: ^13.6.0
-    ignore: ^4.0.6
-    import-fresh: ^3.0.0
-    imurmurhash: ^0.1.4
-    is-glob: ^4.0.0
-    js-yaml: ^3.13.1
-    json-stable-stringify-without-jsonify: ^1.0.1
-    levn: ^0.4.1
-    lodash.merge: ^4.6.2
-    minimatch: ^3.0.4
-    natural-compare: ^1.4.0
-    optionator: ^0.9.1
-    progress: ^2.0.0
-    regexpp: ^3.1.0
-    semver: ^7.2.1
-    strip-ansi: ^6.0.0
-    strip-json-comments: ^3.1.0
-    table: ^6.0.9
-    text-table: ^0.2.0
-    v8-compile-cache: ^2.0.3
-  bin:
-    eslint: bin/eslint.js
-  checksum: cc85af9985a3a11085c011f3d27abe8111006d34cc274291b3c4d7bea51a4e2ff6135780249becd919ba7f6d6d1ecc38a6b73dacb6a7be08d38453b344dc8d37
-  languageName: node
-  linkType: hard
-
 "eslint-formatter-codeframe@npm:^7.32.1":
   version: 7.32.1
   resolution: "eslint-formatter-codeframe@npm:7.32.1"
@@ -8003,7 +7912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-utils@npm:^2.0.0, eslint-utils@npm:^2.1.0":
+"eslint-utils@npm:^2.0.0":
   version: 2.1.0
   resolution: "eslint-utils@npm:2.1.0"
   dependencies:
@@ -8047,7 +7956,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^1.1.0, eslint-visitor-keys@npm:^1.3.0":
+"eslint-visitor-keys@npm:^1.1.0":
   version: 1.3.0
   resolution: "eslint-visitor-keys@npm:1.3.0"
   checksum: 37a19b712f42f4c9027e8ba98c2b06031c17e0c0a4c696cd429bd9ee04eb43889c446f2cd545e1ff51bef9593fcec94ecd2c2ef89129fcbbf3adadbef520376a
@@ -8100,17 +8009,6 @@ __metadata:
   bin:
     eslint: bin/eslint.js
   checksum: 2d84a7a2207138cdb250759b047fdb05a57fede7f87b7a039d9370edba7f26e23a873a208becfd4b2c9e4b5499029f3fc3b9318da3290e693d25c39084119c80
-  languageName: node
-  linkType: hard
-
-"espree@npm:^7.3.0, espree@npm:^7.3.1":
-  version: 7.3.1
-  resolution: "espree@npm:7.3.1"
-  dependencies:
-    acorn: ^7.4.0
-    acorn-jsx: ^5.3.1
-    eslint-visitor-keys: ^1.3.0
-  checksum: aa9b50dcce883449af2e23bc2b8d9abb77118f96f4cb313935d6b220f77137eaef7724a83c3f6243b96bc0e4ab14766198e60818caad99f9519ae5a336a39b45
   languageName: node
   linkType: hard
 
@@ -9089,7 +8987,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"globals@npm:^13.15.0, globals@npm:^13.6.0, globals@npm:^13.9.0":
+"globals@npm:^13.15.0":
   version: 13.17.0
   resolution: "globals@npm:13.17.0"
   dependencies:
@@ -9480,13 +9378,6 @@ fsevents@^1.2.7:
   version: 0.1.5
   resolution: "iferr@npm:0.1.5"
   checksum: a18d19b6ad06a2d5412c0d37f6364869393ef6d1688d59d00082c1f35c92399094c031798340612458cd832f4f2e8b13bc9615934a7d8b0c53061307a3816aa1
-  languageName: node
-  linkType: hard
-
-"ignore@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "ignore@npm:4.0.6"
-  checksum: 248f82e50a430906f9ee7f35e1158e3ec4c3971451dd9f99c9bc1548261b4db2b99709f60ac6c6cac9333494384176cc4cc9b07acbe42d52ac6a09cad734d800
   languageName: node
   linkType: hard
 
@@ -10777,13 +10668,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"json-schema-traverse@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "json-schema-traverse@npm:1.0.0"
-  checksum: 02f2f466cdb0362558b2f1fd5e15cce82ef55d60cd7f8fa828cf35ba74330f8d767fcae5c5c2adb7851fa811766c694b9405810879bc4e1ddd78a7c0e03658ad
-  languageName: node
-  linkType: hard
-
 "json-schema@npm:0.2.3":
   version: 0.2.3
   resolution: "json-schema@npm:0.2.3"
@@ -11182,13 +11066,6 @@ fsevents@^1.2.7:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
-  languageName: node
-  linkType: hard
-
-"lodash.truncate@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "lodash.truncate@npm:4.4.2"
-  checksum: b463d8a382cfb5f0e71c504dcb6f807a7bd379ff1ea216669aa42c52fc28c54e404bfbd96791aa09e6df0de2c1d7b8f1b7f4b1a61f324d38fe98bc535aeee4f5
   languageName: node
   linkType: hard
 
@@ -12686,13 +12563,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"progress@npm:^2.0.0":
-  version: 2.0.3
-  resolution: "progress@npm:2.0.3"
-  checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7
-  languageName: node
-  linkType: hard
-
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -13026,7 +12896,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"regexpp@npm:^3.0.0, regexpp@npm:^3.1.0, regexpp@npm:^3.2.0":
+"regexpp@npm:^3.0.0, regexpp@npm:^3.2.0":
   version: 3.2.0
   resolution: "regexpp@npm:3.2.0"
   checksum: a78dc5c7158ad9ddcfe01aa9144f46e192ddbfa7b263895a70a5c6c73edd9ce85faf7c0430e59ac38839e1734e275b9c3de5c57ee3ab6edc0e0b1bdebefccef8
@@ -13157,13 +13027,6 @@ fsevents@^1.2.7:
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
   checksum: fb47e70bf0001fdeabdc0429d431863e9475e7e43ea5f94ad86503d918423c1543361cc5166d713eaa7029dd7a3d34775af04764bebff99ef413111a5af18c80
-  languageName: node
-  linkType: hard
-
-"require-from-string@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "require-from-string@npm:2.0.2"
-  checksum: a03ef6895445f33a4015300c426699bc66b2b044ba7b670aa238610381b56d3f07c686251740d575e22f4c87531ba662d06937508f0f3c0f1ddc04db3130560b
   languageName: node
   linkType: hard
 
@@ -13508,7 +13371,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.7":
+"semver@npm:^7.0.0, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.7":
   version: 7.3.7
   resolution: "semver@npm:7.3.7"
   dependencies:
@@ -14334,19 +14197,6 @@ fsevents@^1.2.7:
   dependencies:
     acorn-node: ^1.2.0
   checksum: c1c3f048fed1948865fda5e79e11b02addb32da323c9c9fb214d3a933f9fda668e55c848f7c4082514ea4f1cf3dcfab0c7b9c762bfad1306271753c0fcc4b14f
-  languageName: node
-  linkType: hard
-
-"table@npm:^6.0.9":
-  version: 6.8.0
-  resolution: "table@npm:6.8.0"
-  dependencies:
-    ajv: ^8.0.1
-    lodash.truncate: ^4.4.2
-    slice-ansi: ^4.0.0
-    string-width: ^4.2.3
-    strip-ansi: ^6.0.1
-  checksum: 5b07fe462ee03d2e1fac02cbb578efd2e0b55ac07e3d3db2e950aa9570ade5a4a2b8d3c15e9f25c89e4e50b646bc4269934601ee1eef4ca7968ad31960977690
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,8 +371,8 @@ __metadata:
     dedent: ^0.7.0
     eslint: ^7.27.0
     eslint-8: "npm:eslint@^8.0.0"
-    eslint-scope: ^5.1.1
-    eslint-visitor-keys: ^2.1.0
+    eslint-scope: "condition:BABEL_8_BREAKING ? ^7.1.1 : ^5.1.1"
+    eslint-visitor-keys: "condition:BABEL_8_BREAKING ? ^3.3.0 : ^2.1.0"
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   peerDependencies:
     "@babel/core": ">=7.11.0"
@@ -7947,6 +7947,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-scope-BABEL_8_BREAKING-false@npm:eslint-scope@^5.1.1, eslint-scope@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "eslint-scope@npm:5.1.1"
+  dependencies:
+    esrecurse: ^4.3.0
+    estraverse: ^4.1.1
+  checksum: 47e4b6a3f0cc29c7feedee6c67b225a2da7e155802c6ea13bbef4ac6b9e10c66cd2dcb987867ef176292bf4e64eccc680a49e35e9e9c669f4a02bac17e86abdb
+  languageName: node
+  linkType: hard
+
+"eslint-scope-BABEL_8_BREAKING-true@npm:eslint-scope@^7.1.1, eslint-scope@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "eslint-scope@npm:7.1.1"
+  dependencies:
+    esrecurse: ^4.3.0
+    estraverse: ^5.2.0
+  checksum: 9f6e974ab2db641ca8ab13508c405b7b859e72afe9f254e8131ff154d2f40c99ad4545ce326fd9fde3212ff29707102562a4834f1c48617b35d98c71a97fbf3e
+  languageName: node
+  linkType: hard
+
+"eslint-scope@condition:BABEL_8_BREAKING ? ^7.1.1 : ^5.1.1":
+  version: 0.0.0-condition-8f021b
+  resolution: "eslint-scope@condition:BABEL_8_BREAKING?^7.1.1:^5.1.1#8f021b"
+  dependencies:
+    eslint-scope-BABEL_8_BREAKING-false: "npm:eslint-scope@^5.1.1"
+    eslint-scope-BABEL_8_BREAKING-true: "npm:eslint-scope@^7.1.1"
+  checksum: 600efff5322843a5c87c44b7a2854799a0b451f9dc03d0b7f463d3d774e0a173c0d98e37d9f34086003707f2014f2f6fb70ef63bd2b97b87aeacef668dfff21e
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:^4.0.3":
   version: 4.0.3
   resolution: "eslint-scope@npm:4.0.3"
@@ -7957,16 +7987,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "eslint-scope@npm:5.1.1"
-  dependencies:
-    esrecurse: ^4.3.0
-    estraverse: ^4.1.1
-  checksum: 47e4b6a3f0cc29c7feedee6c67b225a2da7e155802c6ea13bbef4ac6b9e10c66cd2dcb987867ef176292bf4e64eccc680a49e35e9e9c669f4a02bac17e86abdb
-  languageName: node
-  linkType: hard
-
 "eslint-scope@npm:^6.0.0":
   version: 6.0.0
   resolution: "eslint-scope@npm:6.0.0"
@@ -7974,16 +7994,6 @@ __metadata:
     esrecurse: ^4.3.0
     estraverse: ^5.2.0
   checksum: 3f1b3578f288c3820f68ad2aae102300e546be8a98a958f515405dc20cc2fe64fda583d364977628bb14fe3d4f96f37de5e9bc5d6eb26bc310da33ba2a677dc3
-  languageName: node
-  linkType: hard
-
-"eslint-scope@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "eslint-scope@npm:7.1.1"
-  dependencies:
-    esrecurse: ^4.3.0
-    estraverse: ^5.2.0
-  checksum: 9f6e974ab2db641ca8ab13508c405b7b859e72afe9f254e8131ff154d2f40c99ad4545ce326fd9fde3212ff29707102562a4834f1c48617b35d98c71a97fbf3e
   languageName: node
   linkType: hard
 
@@ -8007,24 +8017,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^1.1.0, eslint-visitor-keys@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "eslint-visitor-keys@npm:1.3.0"
-  checksum: 37a19b712f42f4c9027e8ba98c2b06031c17e0c0a4c696cd429bd9ee04eb43889c446f2cd545e1ff51bef9593fcec94ecd2c2ef89129fcbbf3adadbef520376a
-  languageName: node
-  linkType: hard
-
-"eslint-visitor-keys@npm:^2.0.0, eslint-visitor-keys@npm:^2.1.0":
+"eslint-visitor-keys-BABEL_8_BREAKING-false@npm:eslint-visitor-keys@^2.1.0, eslint-visitor-keys@npm:^2.0.0":
   version: 2.1.0
   resolution: "eslint-visitor-keys@npm:2.1.0"
   checksum: e3081d7dd2611a35f0388bbdc2f5da60b3a3c5b8b6e928daffff7391146b434d691577aa95064c8b7faad0b8a680266bcda0a42439c18c717b80e6718d7e267d
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.3.0":
+"eslint-visitor-keys-BABEL_8_BREAKING-true@npm:eslint-visitor-keys@^3.3.0, eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.3.0":
   version: 3.3.0
   resolution: "eslint-visitor-keys@npm:3.3.0"
   checksum: d59e68a7c5a6d0146526b0eec16ce87fbf97fe46b8281e0d41384224375c4e52f5ffb9e16d48f4ea50785cde93f766b0c898e31ab89978d88b0e1720fbfb7808
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@condition:BABEL_8_BREAKING ? ^3.3.0 : ^2.1.0":
+  version: 0.0.0-condition-f0c342
+  resolution: "eslint-visitor-keys@condition:BABEL_8_BREAKING?^3.3.0:^2.1.0#f0c342"
+  dependencies:
+    eslint-visitor-keys-BABEL_8_BREAKING-false: "npm:eslint-visitor-keys@^2.1.0"
+    eslint-visitor-keys-BABEL_8_BREAKING-true: "npm:eslint-visitor-keys@^3.3.0"
+  checksum: a7191f76d5f69e2ff4b01c7cd319cd07432e0e1d29b9b3cdc63ae0d3f8619cfaf211c65cd0ed68a7a91b23eb80483a898a80a55661277b72d1c95c8de631e51a
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^1.1.0, eslint-visitor-keys@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "eslint-visitor-keys@npm:1.3.0"
+  checksum: 37a19b712f42f4c9027e8ba98c2b06031c17e0c0a4c696cd429bd9ee04eb43889c446f2cd545e1ff51bef9593fcec94ecd2c2ef89129fcbbf3adadbef520376a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,8 +370,8 @@ __metadata:
     "@babel/core": "workspace:^"
     "@nicolo-ribaudo/eslint-scope-5-internals": "condition:BABEL_8_BREAKING ? : 5.1.1-v1"
     dedent: ^0.7.0
-    eslint: ^7.27.0
-    eslint-8: "npm:eslint@^8.0.0"
+    eslint: ^8.22.0
+    eslint-7: "npm:eslint@^7.27.0"
     eslint-scope: "condition:BABEL_8_BREAKING ? ^7.1.1 : "
     eslint-visitor-keys: "condition:BABEL_8_BREAKING ? ^3.3.0 : ^2.1.0"
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
@@ -7794,52 +7794,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-8@npm:eslint@^8.0.0, eslint@npm:^8.22.0":
-  version: 8.22.0
-  resolution: "eslint@npm:8.22.0"
+"eslint-7@npm:eslint@^7.27.0":
+  version: 7.32.0
+  resolution: "eslint@npm:7.32.0"
   dependencies:
-    "@eslint/eslintrc": ^1.3.0
-    "@humanwhocodes/config-array": ^0.10.4
-    "@humanwhocodes/gitignore-to-minimatch": ^1.0.2
+    "@babel/code-frame": 7.12.11
+    "@eslint/eslintrc": ^0.4.3
+    "@humanwhocodes/config-array": ^0.5.0
     ajv: ^6.10.0
     chalk: ^4.0.0
     cross-spawn: ^7.0.2
-    debug: ^4.3.2
+    debug: ^4.0.1
     doctrine: ^3.0.0
+    enquirer: ^2.3.5
     escape-string-regexp: ^4.0.0
-    eslint-scope: ^7.1.1
-    eslint-utils: ^3.0.0
-    eslint-visitor-keys: ^3.3.0
-    espree: ^9.3.3
+    eslint-scope: ^5.1.1
+    eslint-utils: ^2.1.0
+    eslint-visitor-keys: ^2.0.0
+    espree: ^7.3.1
     esquery: ^1.4.0
     esutils: ^2.0.2
     fast-deep-equal: ^3.1.3
     file-entry-cache: ^6.0.1
-    find-up: ^5.0.0
     functional-red-black-tree: ^1.0.1
-    glob-parent: ^6.0.1
-    globals: ^13.15.0
-    globby: ^11.1.0
-    grapheme-splitter: ^1.0.4
-    ignore: ^5.2.0
+    glob-parent: ^5.1.2
+    globals: ^13.6.0
+    ignore: ^4.0.6
     import-fresh: ^3.0.0
     imurmurhash: ^0.1.4
     is-glob: ^4.0.0
-    js-yaml: ^4.1.0
+    js-yaml: ^3.13.1
     json-stable-stringify-without-jsonify: ^1.0.1
     levn: ^0.4.1
     lodash.merge: ^4.6.2
-    minimatch: ^3.1.2
+    minimatch: ^3.0.4
     natural-compare: ^1.4.0
     optionator: ^0.9.1
-    regexpp: ^3.2.0
-    strip-ansi: ^6.0.1
+    progress: ^2.0.0
+    regexpp: ^3.1.0
+    semver: ^7.2.1
+    strip-ansi: ^6.0.0
     strip-json-comments: ^3.1.0
+    table: ^6.0.9
     text-table: ^0.2.0
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: 2d84a7a2207138cdb250759b047fdb05a57fede7f87b7a039d9370edba7f26e23a873a208becfd4b2c9e4b5499029f3fc3b9318da3290e693d25c39084119c80
+  checksum: cc85af9985a3a11085c011f3d27abe8111006d34cc274291b3c4d7bea51a4e2ff6135780249becd919ba7f6d6d1ecc38a6b73dacb6a7be08d38453b344dc8d37
   languageName: node
   linkType: hard
 
@@ -8053,53 +8054,52 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^7.27.0":
-  version: 7.32.0
-  resolution: "eslint@npm:7.32.0"
+"eslint@npm:^8.22.0":
+  version: 8.22.0
+  resolution: "eslint@npm:8.22.0"
   dependencies:
-    "@babel/code-frame": 7.12.11
-    "@eslint/eslintrc": ^0.4.3
-    "@humanwhocodes/config-array": ^0.5.0
+    "@eslint/eslintrc": ^1.3.0
+    "@humanwhocodes/config-array": ^0.10.4
+    "@humanwhocodes/gitignore-to-minimatch": ^1.0.2
     ajv: ^6.10.0
     chalk: ^4.0.0
     cross-spawn: ^7.0.2
-    debug: ^4.0.1
+    debug: ^4.3.2
     doctrine: ^3.0.0
-    enquirer: ^2.3.5
     escape-string-regexp: ^4.0.0
-    eslint-scope: ^5.1.1
-    eslint-utils: ^2.1.0
-    eslint-visitor-keys: ^2.0.0
-    espree: ^7.3.1
+    eslint-scope: ^7.1.1
+    eslint-utils: ^3.0.0
+    eslint-visitor-keys: ^3.3.0
+    espree: ^9.3.3
     esquery: ^1.4.0
     esutils: ^2.0.2
     fast-deep-equal: ^3.1.3
     file-entry-cache: ^6.0.1
+    find-up: ^5.0.0
     functional-red-black-tree: ^1.0.1
-    glob-parent: ^5.1.2
-    globals: ^13.6.0
-    ignore: ^4.0.6
+    glob-parent: ^6.0.1
+    globals: ^13.15.0
+    globby: ^11.1.0
+    grapheme-splitter: ^1.0.4
+    ignore: ^5.2.0
     import-fresh: ^3.0.0
     imurmurhash: ^0.1.4
     is-glob: ^4.0.0
-    js-yaml: ^3.13.1
+    js-yaml: ^4.1.0
     json-stable-stringify-without-jsonify: ^1.0.1
     levn: ^0.4.1
     lodash.merge: ^4.6.2
-    minimatch: ^3.0.4
+    minimatch: ^3.1.2
     natural-compare: ^1.4.0
     optionator: ^0.9.1
-    progress: ^2.0.0
-    regexpp: ^3.1.0
-    semver: ^7.2.1
-    strip-ansi: ^6.0.0
+    regexpp: ^3.2.0
+    strip-ansi: ^6.0.1
     strip-json-comments: ^3.1.0
-    table: ^6.0.9
     text-table: ^0.2.0
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: cc85af9985a3a11085c011f3d27abe8111006d34cc274291b3c4d7bea51a4e2ff6135780249becd919ba7f6d6d1ecc38a6b73dacb6a7be08d38453b344dc8d37
+  checksum: 2d84a7a2207138cdb250759b047fdb05a57fede7f87b7a039d9370edba7f26e23a873a208becfd4b2c9e4b5499029f3fc3b9318da3290e693d25c39084119c80
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14496
| Patch: Bug Fix?          | ESLint rule `@babel/semi` conflicts with ESLint 8.0.0 when reporting class properties trailing commas
| Major: Breaking Change?  | Yes
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | `eslint-scope` is bumped to 7.1.1 and `eslint-visitor-keys` to 3.3.0
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Bumped `eslint-scope` and `eslint-visitor-keys`. Because they drop Node.js 10 support, the update is behind the `BABEL_8_BREAKING` flag.

This PR also bumps `eslint` dev dependencies to ESLint 8 and fixes compatibility issues of the following rules:

- `semi`
- `no-invalid-this`

Because ESLint 8 officially supported class properties / private methods. These rules become no-op when using with ESLint 8.

In this PR we also introduce a new test workflow `eslint7-test` where we downgrade `eslint` to 7 and run the `eslint` related tests. The test is refactored so that we can test eslint parser/plugins against either ESLint 7 or ESLint 8, but not both. Compared to the current approach, the new approach
1. avoid the [test interference](https://github.com/babel/babel/runs/8235693311?check_suite_focus=true#step:10:819) when one test worker is testing eslint plugins with ESLint 8 and another worker is testing `@babel/eslint-parser` with `ESLINT_VERSION_FOR_BABEL = 7`
2. test other `@babel/eslint-*` with both ESLint 7 and ESLint 8
3. simplify the build process by removing a customized Babel plugin

Hopefully we can remove this workflow when we decide to drop ESLint 7 support in the future.

I wish we could match the Node.js release frequency, otherwise when our deps drop unmaintained Node.js versions support, we have to either 1) pin older versions because we can't drop EOL node versions in minors, or 2) fork the legacy dep and offer runtime switch like we did for `chokidar@2`. 

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14872"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

