### PR TITLE
Update typescript to 4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "shelljs": "^0.8.5",
     "test262-stream": "^1.4.0",
     "through2": "^4.0.0",
-    "typescript": "~4.7.4"
+    "typescript": "~4.8.2"
   },
   "workspaces": [
     "codemods/*",

--- a/packages/babel-core/src/config/caching.ts
+++ b/packages/babel-core/src/config/caching.ts
@@ -395,6 +395,8 @@ export function assertSimpleType(value: unknown): SimpleType {
       "Cache keys must be either string, boolean, number, null, or undefined.",
     );
   }
+  // @ts-expect-error Type 'unknown' is not assignable to type 'SimpleType'. This can be removed
+  // when strictNullCheck is enabled
   return value;
 }
 

--- a/packages/babel-core/src/config/helpers/deep-array.ts
+++ b/packages/babel-core/src/config/helpers/deep-array.ts
@@ -10,7 +10,9 @@ export function finalize<T>(deepArr: DeepArray<T>): ReadonlyDeepArray<T> {
   return Object.freeze(deepArr) as ReadonlyDeepArray<T>;
 }
 
-export function flattenToSet<T>(arr: ReadonlyDeepArray<T>): Set<T> {
+export function flattenToSet<T extends string>(
+  arr: ReadonlyDeepArray<T>,
+): Set<T> {
   const result = new Set<T>();
   const stack = [arr];
   while (stack.length > 0) {

--- a/packages/babel-parser/tsconfig.json
+++ b/packages/babel-parser/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "./typings/**/*.ts",
-    "./src/**/*.ts"
-  ]
-}

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -109,7 +109,13 @@ class NodePath<T extends t.Node = t.Node> {
   }
 
   getScope(scope: Scope): Scope {
-    return this.isScope() ? new Scope(this as any) : scope;
+    // TODO: Remove this when TS is fixed.
+    // A regression was introduced in ts4.8 that would cause OOM.
+    // Avoid it by manually casting the types.
+    // https://github.com/babel/babel/pull/14880
+    return this.isScope()
+      ? new Scope(this as NodePath<t.Pattern | t.Scopable>)
+      : scope;
   }
 
   setData(key: string | symbol, val: any): any {

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -109,7 +109,7 @@ class NodePath<T extends t.Node = t.Node> {
   }
 
   getScope(scope: Scope): Scope {
-    return this.isScope() ? new Scope(this) : scope;
+    return this.isScope() ? new Scope(this as any) : scope;
   }
 
   setData(key: string | symbol, val: any): any {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5947,7 +5947,7 @@ __metadata:
     shelljs: ^0.8.5
     test262-stream: ^1.4.0
     through2: ^4.0.0
-    typescript: ~4.7.4
+    typescript: ~4.8.2
   dependenciesMeta:
     core-js:
       built: false
@@ -14762,23 +14762,23 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.7.4":
-  version: 4.7.4
-  resolution: "typescript@npm:4.7.4"
+"typescript@npm:~4.8.2":
+  version: 4.8.2
+  resolution: "typescript@npm:4.8.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 5750181b1cd7e6482c4195825547e70f944114fb47e58e4aa7553e62f11b3f3173766aef9c281783edfd881f7b8299cf35e3ca8caebe73d8464528c907a164df
+  checksum: 7f5b81d0d558c9067f952c7af52ab7f19c2e70a916817929e4a5b256c93990bf3178eccb1ac8a850bc75df35f6781b6f4cb3370ce20d8b1ded92ed462348f628
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.7.4#~builtin<compat/typescript>":
-  version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=493e53"
+"typescript@patch:typescript@~4.8.2#~builtin<compat/typescript>":
+  version: 4.8.2
+  resolution: "typescript@patch:typescript@npm%3A4.8.2#~builtin<compat/typescript>::version=4.8.2&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 96d3030cb01143570567cb4f3a616b10df65f658f0e74e853e77a089a6a954e35c800be7db8b9bfe9a1ae05d9c2897e281359f65e4caa1caf266368e1c4febd3
+  checksum: 6f49363af8af2fe480da1d5fa68712644438785208b06690a3cbe5e7365fd652c3a0f1e587bc8684d78fb69de3dde4de185c0bad7bb4f3664ddfc813ce8caad6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Bump TS to 4.8 and fix new typing errors
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Also removed `babel-parser`'s tsconfig now that we have converted the parser to TS.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14880"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

