### PR TITLE
Fix helper-builder-react-jsx compat with Babel 7.9

### DIFF
--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -18,6 +18,7 @@
     "@babel/types": "workspace:^"
   },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^"
   },
   "engines": {

--- a/packages/babel-helper-builder-react-jsx/test/index.js
+++ b/packages/babel-helper-builder-react-jsx/test/index.js
@@ -1,0 +1,72 @@
+import _helper from "../lib/index.js";
+import { transformSync } from "@babel/core";
+import * as t from "@babel/types";
+
+const helper = _helper.default || _helper;
+
+describe("@babel/helper-builder-react-jsx", () => {
+  // The builder-react-jsx usage in transform-react-jsx 7.9.0
+  // https://github.com/babel/babel/blob/v7.9.0/packages/babel-plugin-transform-react-jsx/src/transform-classic.js#L43
+  it("shuold pass post with plugin pass", () => {
+    const fn = jest.fn().mockReturnValue(t.identifier("foo"));
+    const visitor = helper({
+      post(state, pass) {
+        state.callee = pass.get("jsxIdentifier")();
+      },
+    });
+    visitor.Program = function enter(_, state) {
+      state.set("jsxIdentifier", fn);
+    };
+    const plugin = () => ({ visitor });
+    const input = `<element></element>`;
+    transformSync(input, {
+      filename: "builder-react-jsx-test.jsx",
+      configFile: false,
+      plugins: [plugin],
+      parserOpts: { plugins: ["jsx"] },
+    });
+    expect(fn).toBeCalledTimes(1);
+  });
+
+  it("shuold pass pre with plugin pass", () => {
+    const fn = jest.fn().mockReturnValue(t.identifier("foo"));
+    const visitor = helper({
+      pre(state, pass) {
+        state.callee = pass.get("jsxIdentifier")();
+      },
+    });
+    visitor.Program = function enter(_, state) {
+      state.set("jsxIdentifier", fn);
+    };
+    const plugin = () => ({ visitor });
+    const input = `<element></element>`;
+    transformSync(input, {
+      filename: "builder-react-jsx-test.jsx",
+      configFile: false,
+      plugins: [plugin],
+      parserOpts: { plugins: ["jsx"] },
+    });
+    expect(fn).toBeCalledTimes(1);
+  });
+
+  it("shuold pass filter with plugin pass", () => {
+    const fn = jest.fn().mockReturnValue(false);
+    const visitor = helper({
+      filter(_, pass) {
+        return pass.get("filterAll")();
+      },
+    });
+    visitor.Program = function enter(_, state) {
+      state.set("filterAll", fn);
+    };
+    const plugin = () => ({ visitor });
+    const input = `<element></element>`;
+    transformSync(input, {
+      filename: "builder-react-jsx-test.jsx",
+      configFile: false,
+      plugins: [plugin],
+      parserOpts: { plugins: ["jsx"] },
+    });
+    expect(fn).toBeCalledTimes(1);
+  });
+});

--- a/packages/babel-helper-builder-react-jsx/test/package.json
+++ b/packages/babel-helper-builder-react-jsx/test/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -511,6 +511,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-builder-react-jsx@workspace:packages/babel-helper-builder-react-jsx"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-annotate-as-pure": "workspace:^"
     "@babel/traverse": "workspace:^"
     "@babel/types": "workspace:^"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14884 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Fix a compatibility issue between `helper-builder-react-jsx` 7.18 and `transform-react-jsx` 7.9, introduced in #14601. Added behaviour tests to ensure the options interfaces are correct.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14886"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

