### PR TITLE
fix: do not remove type import used in TS import=

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -13,10 +13,15 @@ import transpileNamespace from "./namespace";
 function isInType(path: NodePath) {
   switch (path.parent.type) {
     case "TSTypeReference":
-    case "TSQualifiedName":
     case "TSExpressionWithTypeArguments":
     case "TSTypeQuery":
       return true;
+    case "TSQualifiedName":
+      return (
+        // `import foo = ns.bar` is transformed to `var foo = ns.bar` and should not be removed
+        path.parentPath.findParent(path => path.type !== "TSQualifiedName")
+          .type !== "TSImportEqualsDeclaration"
+      );
     case "ExportSpecifier":
       return (
         (path.parentPath.parent as t.ExportNamedDeclaration).exportKind ===

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -24,7 +24,8 @@ function isInType(path: NodePath) {
       );
     case "ExportSpecifier":
       return (
-        (path.parentPath.parent as t.ExportNamedDeclaration).exportKind ===
+        // @ts-expect-error: DeclareExportDeclaration does not have `exportKind`
+        (path.parentPath as NodePath<t.ExportSpecifier>).parent.exportKind ===
         "type"
       );
     default:

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-type-referenced-in-imports-equal-no/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-type-referenced-in-imports-equal-no/input.ts
@@ -1,0 +1,5 @@
+import nsa from "./module-a";
+import foo = nsa.bar;
+
+import nsb from "./module-b";
+import bar = nsb.foo.bar;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-type-referenced-in-imports-equal-no/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-type-referenced-in-imports-equal-no/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-typescript"]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-type-referenced-in-imports-equal-no/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-type-referenced-in-imports-equal-no/output.mjs
@@ -1,0 +1,4 @@
+import nsa from "./module-a";
+var foo = nsa.bar;
+import nsb from "./module-b";
+var bar = nsb.foo.bar;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14912 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The `import foo = ns.bar` is specially handled in the `isInType` check so that if `ns` here is an import binding, `ns` will not be removed by the TypeScript transform.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14913"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

