### PR TITLE
Bump TypeScript to 4.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "shelljs": "^0.8.5",
     "test262-stream": "^1.4.0",
     "through2": "^4.0.0",
-    "typescript": "~4.8.2"
+    "typescript": "~4.8.3"
   },
   "workspaces": [
     "codemods/*",

--- a/packages/babel-helper-replace-supers/src/index.ts
+++ b/packages/babel-helper-replace-supers/src/index.ts
@@ -383,20 +383,13 @@ export default class ReplaceSupers {
   declare opts: ReplaceSupersOptions;
 
   getObjectRef() {
-    return cloneNode(
-      this.opts.objectRef ||
-        // @ts-expect-error https://github.com/microsoft/TypeScript/issues/49643
-        this.opts.getObjectRef(),
-    );
+    return cloneNode(this.opts.objectRef || this.opts.getObjectRef());
   }
 
   getSuperRef() {
     if (this.opts.superRef) return cloneNode(this.opts.superRef);
     if (this.opts.getSuperRef) {
-      return cloneNode(
-        // @ts-expect-error https://github.com/microsoft/TypeScript/issues/49643
-        this.opts.getSuperRef(),
-      );
+      return cloneNode(this.opts.getSuperRef());
     }
   }
 

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -109,13 +109,7 @@ class NodePath<T extends t.Node = t.Node> {
   }
 
   getScope(scope: Scope): Scope {
-    // TODO: Remove this when TS is fixed.
-    // A regression was introduced in ts4.8 that would cause OOM.
-    // Avoid it by manually casting the types.
-    // https://github.com/babel/babel/pull/14880
-    return this.isScope()
-      ? new Scope(this as NodePath<t.Pattern | t.Scopable>)
-      : scope;
+    return this.isScope() ? new Scope(this) : scope;
   }
 
   setData(key: string | symbol, val: any): any {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5979,7 +5979,7 @@ __metadata:
     shelljs: ^0.8.5
     test262-stream: ^1.4.0
     through2: ^4.0.0
-    typescript: ~4.8.2
+    typescript: ~4.8.3
   dependenciesMeta:
     core-js:
       built: false
@@ -14777,23 +14777,23 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.8.2":
-  version: 4.8.2
-  resolution: "typescript@npm:4.8.2"
+"typescript@npm:~4.8.3":
+  version: 4.8.3
+  resolution: "typescript@npm:4.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7f5b81d0d558c9067f952c7af52ab7f19c2e70a916817929e4a5b256c93990bf3178eccb1ac8a850bc75df35f6781b6f4cb3370ce20d8b1ded92ed462348f628
+  checksum: 8286a5edcaf3d68e65c451aa1e7150ad1cf53ee0813c07ec35b7abdfdb10f355ecaa13c6a226a694ae7a67785fd7eeebf89f845da0b4f7e4a35561ddc459aba0
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.8.2#~builtin<compat/typescript>":
-  version: 4.8.2
-  resolution: "typescript@patch:typescript@npm%3A4.8.2#~builtin<compat/typescript>::version=4.8.2&hash=493e53"
+"typescript@patch:typescript@~4.8.3#~builtin<compat/typescript>":
+  version: 4.8.3
+  resolution: "typescript@patch:typescript@npm%3A4.8.3#~builtin<compat/typescript>::version=4.8.3&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6f49363af8af2fe480da1d5fa68712644438785208b06690a3cbe5e7365fd652c3a0f1e587bc8684d78fb69de3dde4de185c0bad7bb4f3664ddfc813ce8caad6
+  checksum: 0404a09c625df01934ef774b45ce1ca57ccae41cd625fcdbb82056715320d9329e70d9d75c2c732ec6ef947444ca978c189a332b71fa21f5c1437d5a83e24906
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Bump TypeScript to 4.8.3
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Also removed unused `@ts-expect-error` directives.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14914"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

