### PR TITLE
[estree] attach comments after directives at the end of file

### DIFF
--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -97,18 +97,23 @@ export default (superClass: typeof Parser) =>
 
     // Cast a Directive to an ExpressionStatement. Mutates the input Directive.
     directiveToStmt(directive: N.Directive): N.ExpressionStatement {
-      const stmt = directive as any;
+      const expression = directive.value as any as N.EstreeLiteral;
+      delete directive.value;
+
+      expression.type = "Literal";
+      // @ts-expect-error N.EstreeLiteral.raw is not defined.
+      expression.raw = expression.extra.raw;
+      expression.value = expression.extra.expressionValue;
+
+      const stmt = directive as any as N.ExpressionStatement;
       stmt.type = "ExpressionStatement";
-      stmt.directive = stmt.value.extra.rawValue;
-      stmt.expression = stmt.value;
-      delete stmt.value;
+      stmt.expression = expression;
+      // @ts-expect-error N.ExpressionStatement.directive is not defined
+      stmt.directive = expression.extra.rawValue;
 
-      stmt.expression.type = "Literal";
-      stmt.expression.raw = stmt.expression.extra.raw;
-      stmt.expression.value = stmt.expression.extra.expressionValue;
-      delete stmt.expression.extra;
+      delete expression.extra;
 
-      return stmt as N.ExpressionStatement;
+      return stmt;
     }
 
     // ==================================

--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -111,6 +111,9 @@ export default (superClass: typeof Parser) =>
       // @ts-expect-error TS2339: Property 'raw' does not exist on type 'Undone '.
       expression.raw = directiveLiteral.extra.raw;
 
+      stmt.leadingComments = directive.leadingComments?.slice();
+      stmt.trailingComments = directive.trailingComments?.slice();
+
       stmt.expression = this.finishNodeAt(
         expression,
         "Literal",
@@ -175,6 +178,9 @@ export default (superClass: typeof Parser) =>
         end,
         afterBlockParse,
       );
+      if (node.directives.length) {
+        this.processComment(node);
+      }
 
       const directiveStatements = node.directives.map(d =>
         this.directiveToStmt(d),

--- a/packages/babel-parser/test/fixtures/estree/directives/interleaved-comments/input.js
+++ b/packages/babel-parser/test/fixtures/estree/directives/interleaved-comments/input.js
@@ -1,0 +1,4 @@
+// 1;
+"use strict";
+// 2;
+"use strict";

--- a/packages/babel-parser/test/fixtures/estree/directives/interleaved-comments/output.json
+++ b/packages/babel-parser/test/fixtures/estree/directives/interleaved-comments/output.json
@@ -1,0 +1,67 @@
+{
+  "type": "File",
+  "start":0,"end":39,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":13}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":39,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":13}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":6,"end":19,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":13}},
+        "trailingComments": [
+          {
+            "type": "CommentLine",
+            "value": " 2;",
+            "start":20,"end":25,"loc":{"start":{"line":3,"column":0,"index":20},"end":{"line":3,"column":5,"index":25}}
+          }
+        ],
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " 1;",
+            "start":0,"end":5,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":5,"index":5}}
+          }
+        ],
+        "directive": "use strict",
+        "expression": {
+          "type": "Literal",
+          "start":6,"end":18,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":12}},
+          "value": "use strict",
+          "raw": "\"use strict\""
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start":26,"end":39,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":13}},
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " 2;",
+            "start":20,"end":25,"loc":{"start":{"line":3,"column":0,"index":20},"end":{"line":3,"column":5,"index":25}}
+          }
+        ],
+        "directive": "use strict",
+        "expression": {
+          "type": "Literal",
+          "start":26,"end":38,"loc":{"start":{"line":4,"column":0},"end":{"line":4,"column":12}},
+          "value": "use strict",
+          "raw": "\"use strict\""
+        }
+      }
+    ]
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " 1;",
+      "start":0,"end":5,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":5,"index":5}}
+    },
+    {
+      "type": "CommentLine",
+      "value": " 2;",
+      "start":20,"end":25,"loc":{"start":{"line":3,"column":0,"index":20},"end":{"line":3,"column":5,"index":25}}
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/estree/directives/trailing-comment-eof/input.js
+++ b/packages/babel-parser/test/fixtures/estree/directives/trailing-comment-eof/input.js
@@ -1,0 +1,3 @@
+"use strict";
+
+/** @external foo */

--- a/packages/babel-parser/test/fixtures/estree/directives/trailing-comment-eof/output.json
+++ b/packages/babel-parser/test/fixtures/estree/directives/trailing-comment-eof/output.json
@@ -1,0 +1,37 @@
+{
+  "type": "File",
+  "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":20}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":35,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":20}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":13,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":13}},
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "* @external foo ",
+            "start":15,"end":35,"loc":{"start":{"line":3,"column":0,"index":15},"end":{"line":3,"column":20,"index":35}}
+          }
+        ],
+        "expression": {
+          "type": "Literal",
+          "start":0,"end":12,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":12}},
+          "value": "use strict",
+          "raw": "\"use strict\""
+        },
+        "directive": "use strict"
+      }
+    ]
+  },
+  "comments": [
+    {
+      "type": "CommentBlock",
+      "value": "* @external foo ",
+      "start":15,"end":35,"loc":{"start":{"line":3,"column":0,"index":15},"end":{"line":3,"column":20,"index":35}}
+    }
+  ]
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14919 
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR Link    | n/a
| Any Dependency Changes?  | no
| License                  | MIT

If a source file contains 1) a directive, followed by 2) a comment, and nothing else, then `@babel/parser` attaches the comment to the `Directive` node as a trailing comment.

The ESTree plugin handles `Directive` nodes by creating an `ExpressionStatement` node, then transferring information from the `Directive` node to the `ExpressionStatement` node. Previously, at the time it transfers information, comments hadn't yet been attached to the `Directive` node. And even if they had been, the ESTree plugin didn't do anything with comments attached to the `Directive` node. As a result, the source file's comment wasn't attached to any node in the resulting AST.

With this change, the ESTree plugin generates an AST in which the comment is attached to the `ExpressionStatement` node as a trailing comment.

Fixes #14919.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14920"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

