### PR TITLE
Expose `dts` option in `@babel/plugin-syntax-typescript`

### DIFF
--- a/packages/babel-plugin-syntax-typescript/src/index.ts
+++ b/packages/babel-plugin-syntax-typescript/src/index.ts
@@ -18,38 +18,41 @@ function removePlugin(plugins: ParserPlugin[], name: string) {
 
 export interface Options {
   disallowAmbiguousJSXLike?: boolean;
+  dts?: boolean;
   isTSX?: boolean;
 }
 
-export default declare((api, { isTSX, disallowAmbiguousJSXLike }: Options) => {
-  api.assertVersion(7);
+export default declare(
+  (api, { disallowAmbiguousJSXLike, dts, isTSX }: Options) => {
+    api.assertVersion(7);
 
-  return {
-    name: "syntax-typescript",
+    return {
+      name: "syntax-typescript",
 
-    manipulateOptions(opts, parserOpts) {
-      const { plugins } = parserOpts;
-      // If the Flow syntax plugin already ran, remove it since Typescript
-      // takes priority.
-      removePlugin(plugins, "flow");
+      manipulateOptions(opts, parserOpts) {
+        const { plugins } = parserOpts;
+        // If the Flow syntax plugin already ran, remove it since Typescript
+        // takes priority.
+        removePlugin(plugins, "flow");
 
-      // If the JSX syntax plugin already ran, remove it because JSX handling
-      // in TS depends on the extensions, and is purely dependent on 'isTSX'.
-      removePlugin(plugins, "jsx");
+        // If the JSX syntax plugin already ran, remove it because JSX handling
+        // in TS depends on the extensions, and is purely dependent on 'isTSX'.
+        removePlugin(plugins, "jsx");
 
-      plugins.push(
-        ["typescript", { disallowAmbiguousJSXLike }],
-        "classProperties",
-      );
+        plugins.push(
+          ["typescript", { disallowAmbiguousJSXLike, dts }],
+          "classProperties",
+        );
 
-      if (!process.env.BABEL_8_BREAKING) {
-        // This is enabled by default since @babel/parser 7.1.5
-        plugins.push("objectRestSpread");
-      }
+        if (!process.env.BABEL_8_BREAKING) {
+          // This is enabled by default since @babel/parser 7.1.5
+          plugins.push("objectRestSpread");
+        }
 
-      if (isTSX) {
-        plugins.push("jsx");
-      }
-    },
-  };
-});
+        if (isTSX) {
+          plugins.push("jsx");
+        }
+      },
+    };
+  },
+);

--- a/packages/babel-plugin-syntax-typescript/test/fixtures/dts/enabled/input.ts
+++ b/packages/babel-plugin-syntax-typescript/test/fixtures/dts/enabled/input.ts
@@ -1,0 +1,1 @@
+const foo: string;

--- a/packages/babel-plugin-syntax-typescript/test/fixtures/dts/enabled/options.json
+++ b/packages/babel-plugin-syntax-typescript/test/fixtures/dts/enabled/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["syntax-typescript", { "dts": true }]]
+}

--- a/packages/babel-plugin-syntax-typescript/test/fixtures/dts/enabled/output.js
+++ b/packages/babel-plugin-syntax-typescript/test/fixtures/dts/enabled/output.js
@@ -1,0 +1,1 @@
+const foo: string;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14871 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2676
| Any Dependency Changes?  |
| License                  | MIT

`dts` option of the `typescript` plugin of `@babel/parser` now forwarding from `@babel/plugin-syntax-typescript`

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14923"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

