### PR TITLE
Avoid fancy stack traces size computation

### DIFF
--- a/packages/babel-core/src/errors/rewrite-stack-trace.ts
+++ b/packages/babel-core/src/errors/rewrite-stack-trace.ts
@@ -46,15 +46,6 @@ const ErrorToString = Function.call.bind(Error.prototype.toString);
 
 const SUPPORTED = !!Error.captureStackTrace;
 
-// We add some extra frames to Error.stackTraceLimit, so that we can respect
-// the original Error.stackTraceLimit even after removing all our internal
-// frames.
-// STACK_TRACE_LIMIT_DELTA should be bigger than the expected number of internal
-// frames, but not too big because capturing the stack trace is slow (this is
-// why Error.stackTraceLimit does not default to Infinity!).
-// Increase it if needed.
-const STACK_TRACE_LIMIT_DELTA = 100;
-
 const START_HIDNG = "startHiding - secret - don't use this - v1";
 const STOP_HIDNG = "stopHiding - secret - don't use this - v1";
 
@@ -131,7 +122,17 @@ function setupPrepareStackTrace() {
 
   const { prepareStackTrace = defaultPrepareStackTrace } = Error;
 
-  Error.stackTraceLimit += STACK_TRACE_LIMIT_DELTA;
+  // We add some extra frames to Error.stackTraceLimit, so that we can
+  // always show some useful frames even after deleting ours.
+  // STACK_TRACE_LIMIT_DELTA should be around the maximum expected number
+  // of internal frames, and not too big because capturing the stack trace
+  // is slow (this is why Error.stackTraceLimit does not default to Infinity!).
+  // Increase it if needed.
+  const MIN_STACK_TRACE_LIMIT = 50;
+  Error.stackTraceLimit = Math.max(
+    Error.stackTraceLimit,
+    MIN_STACK_TRACE_LIMIT,
+  );
 
   Error.prepareStackTrace = function stackTraceRewriter(err, trace) {
     let newTrace = [];
@@ -160,10 +161,7 @@ function setupPrepareStackTrace() {
       }
     }
 
-    return prepareStackTrace(
-      err,
-      newTrace.slice(0, Error.stackTraceLimit - STACK_TRACE_LIMIT_DELTA),
-    );
+    return prepareStackTrace(err, newTrace);
   };
 }
 

--- a/packages/babel-core/src/errors/rewrite-stack-trace.ts
+++ b/packages/babel-core/src/errors/rewrite-stack-trace.ts
@@ -128,8 +128,9 @@ function setupPrepareStackTrace() {
   // of internal frames, and not too big because capturing the stack trace
   // is slow (this is why Error.stackTraceLimit does not default to Infinity!).
   // Increase it if needed.
+  // However, we only do it if the user did not explicitly set it to 0.
   const MIN_STACK_TRACE_LIMIT = 50;
-  Error.stackTraceLimit = Math.max(
+  Error.stackTraceLimit &&= Math.max(
     Error.stackTraceLimit,
     MIN_STACK_TRACE_LIMIT,
   );

--- a/packages/babel-core/test/errors-stacks.js
+++ b/packages/babel-core/test/errors-stacks.js
@@ -76,13 +76,6 @@ const fixture = name =>
   );
 
 describe("@babel/core errors", function () {
-  beforeAll(() => {
-    Error.stackTraceLimit += 100;
-  });
-  afterAll(() => {
-    Error.stackTraceLimit -= 100;
-  });
-
   it("error inside config function", function () {
     expectError(() => {
       babel.parseSync("foo;", {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14927
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This will end up with the actual number of frames not exactly matching the user-set Error.stackTraceLimit. However, Error.stackTraceLimit is usually set to generic numbers (10, 100, 1000, Infinity), and it does not matter if it's not _really_ X but a bit less or more.

(How long before we get a bug report "Hey, I use Error.stackTraceLimit=1562 but it's only giving me 1543 frames!"?)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14930"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

