### PR TITLE
fix: runtime-corejs 2 should depend on core-js@2

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -92,7 +92,7 @@ gen_enforced_field(WorkspaceCwd, 'exports', '{ ".": "./lib/index.js", "./package
 gen_enforced_field(WorkspaceCwd, 'type', 'commonjs') :-
   \+ workspace_field(WorkspaceCwd, 'type', 'module').
 
-% Enforce a default 'conditions', unless it's already specified
+% Enforces a default 'conditions', unless it's already specified
 gen_enforced_field(WorkspaceCwd, 'conditions', '{ "USE_ESM": [{ "type": "module" }, null] }') :-
   \+ workspace_field(WorkspaceCwd, 'private', true),
   \+ workspace_field(WorkspaceCwd, 'conditions', _),
@@ -100,3 +100,12 @@ gen_enforced_field(WorkspaceCwd, 'conditions', '{ "USE_ESM": [{ "type": "module"
   % Exclude some packages
   workspace_ident(WorkspaceCwd, WorkspaceIdent),
   WorkspaceIdent \= '@babel/compat-data'.
+
+% Enforces that @babel/runtime-corejs2 must depend on core-js 2
+gen_enforced_dependency(WorkspaceCwd, 'core-js', '^2.6.12', DependencyType) :-
+  % Get the workspace name
+  workspace_ident(WorkspaceCwd, WorkspaceIdent),
+  % Only consider 'dependencies'
+  (DependencyType = 'dependencies'),
+  % The rule works for @babel/runtime-corejs2 only
+  (WorkspaceIdent = '@babel/runtime-corejs2').

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://babel.dev/docs/en/next/babel-runtime-corejs2",
   "author": "The Babel Team (https://babel.dev/team)",
   "dependencies": {
-    "core-js": "^3.25.1",
+    "core-js": "^2.6.12",
     "regenerator-runtime": "^0.13.4"
   },
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3582,7 +3582,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/runtime-corejs2@workspace:packages/babel-runtime-corejs2"
   dependencies:
-    core-js: ^3.25.1
+    core-js: ^2.6.12
     regenerator-runtime: ^0.13.4
   languageName: unknown
   linkType: soft
@@ -7020,6 +7020,13 @@ __metadata:
   version: 3.25.1
   resolution: "core-js-pure@npm:3.25.1"
   checksum: 0123131ec7ab3a1e56f0b4df4ae659de03d9c245ce281637d4d0f18f9839d8e0cfbfa989bd577ce1b67826f889a7dcc734421f697cf1bbe59f605f29c537a678
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^2.6.12":
+  version: 2.6.12
+  resolution: "core-js@npm:2.6.12"
+  checksum: 44fa9934a85f8c78d61e0c8b7b22436330471ffe59ec5076fe7f324d6e8cf7f824b14b1c81ca73608b13bdb0fef035bd820989bf059767ad6fa13123bb8bd016
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14936 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes a regression introduced in #14924: We run `yarn up core-js` without checking that `@babel/runtime-corejs2` must depend on `core-js@2`. This issue had happened once before but then we fixed it before we published. Anyway I draft a new yarn constraint and hopefully it won't bother us any more.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14937"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

