### PR TITLE
fix: ts exported vars are shadowed by `declare`

### DIFF
--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/declare-shadowed/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/declare-shadowed/input.ts
@@ -1,0 +1,9 @@
+declare class Signal<T = any> {
+	value: T
+}
+
+function Signal(this: Signal, value?: unknown) {
+	this.value = value
+}
+
+export { Signal };

--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/declare-shadowed/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/declare-shadowed/input.ts
@@ -7,3 +7,13 @@ function Signal(this: Signal, value?: unknown) {
 }
 
 export { Signal };
+
+
+function Signal2(this: Signal2, value?: unknown) {
+	this.value = value
+}
+declare class Signal2<T = any> {
+	value: T
+}
+
+export { Signal2 };

--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/declare-shadowed/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/declare-shadowed/output.mjs
@@ -1,0 +1,5 @@
+function Signal(value) {
+  this.value = value;
+}
+
+export { Signal };

--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/declare-shadowed/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/declare-shadowed/output.mjs
@@ -3,3 +3,9 @@ function Signal(value) {
 }
 
 export { Signal };
+
+function Signal2(value) {
+  this.value = value;
+}
+
+export { Signal2 };


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #14945 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |√
| Tests Added + Pass?      | √
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

For performance I didn't do a full traversal, for ts this is enough.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/14946"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

