### PR TITLE
Optinal filename when preset uses fn test/include/exclude

### DIFF
--- a/packages/babel-core/src/config/full.ts
+++ b/packages/babel-core/src/config/full.ts
@@ -406,11 +406,17 @@ const instantiatePlugin = makeWeakCache(function* (
   return new Plugin(plugin, options, alias, externalDependencies);
 });
 
+const needsFilename = (val: unknown) => val && typeof val !== "function";
+
 const validateIfOptionNeedsFilename = (
   options: ValidatedOptions,
   descriptor: UnloadedDescriptor,
 ): void => {
-  if (options.test || options.include || options.exclude) {
+  if (
+    needsFilename(options.test) ||
+    needsFilename(options.include) ||
+    needsFilename(options.exclude)
+  ) {
     const formattedPresetName = descriptor.name
       ? `"${descriptor.name}"`
       : "/* your preset */";

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -236,6 +236,96 @@ describe("buildConfigChain", function () {
         expect(opts.comments).toBeUndefined();
       });
     });
+
+    describe("filename requirement", () => {
+      const BASE_OPTS = {
+        cwd: fixture("nonexistant-fake"),
+        babelrc: false,
+        configFile: false,
+      };
+
+      describe("in config", () => {
+        it("requires filename if string", () => {
+          expect(() =>
+            loadOptions({
+              ...BASE_OPTS,
+              test: fixture("nonexistant-fake"),
+            }),
+          ).toThrow(/no filename was passed/);
+        });
+
+        it("requires filename if RegExp", () => {
+          expect(() =>
+            loadOptions({
+              ...BASE_OPTS,
+              test: /file/,
+            }),
+          ).toThrow(/no filename was passed/);
+        });
+
+        it("does not require filename if function", () => {
+          const mock = jest.fn().mockReturnValue(true);
+
+          expect(() =>
+            loadOptions({
+              ...BASE_OPTS,
+              test: mock,
+            }),
+          ).not.toThrow();
+          expect(mock).toHaveBeenCalledWith(undefined, expect.anything());
+
+          expect(() =>
+            loadOptions({
+              ...BASE_OPTS,
+              filename: "some-filename",
+              test: mock,
+            }),
+          ).not.toThrow();
+          expect(mock.mock.calls[1][0].endsWith("some-filename")).toBe(true);
+        });
+      });
+
+      describe("in preset", () => {
+        it("requires filename if string", () => {
+          expect(() =>
+            loadOptions({
+              ...BASE_OPTS,
+              presets: [() => ({ test: fixture("nonexistant-fake") })],
+            }),
+          ).toThrow(/requires a filename/);
+        });
+
+        it("requires filename if RegExp", () => {
+          expect(() =>
+            loadOptions({
+              ...BASE_OPTS,
+              presets: [() => ({ test: /file/ })],
+            }),
+          ).toThrow(/requires a filename/);
+        });
+
+        it("does not require filename if function", () => {
+          const mock = jest.fn().mockReturnValue(true);
+
+          expect(() =>
+            loadOptions({
+              ...BASE_OPTS,
+              presets: [() => ({ test: mock })],
+            }),
+          ).not.toThrow();
+          expect(mock).toHaveBeenCalledWith(undefined, expect.anything());
+
+          expect(() =>
+            loadOptions({
+              ...BASE_OPTS,
+              filename: "some-filename",
+              presets: [() => ({ test: mock })],
+            }),
+          ).not.toThrow();
+          expect(mock.mock.calls[1][0].endsWith("some-filename")).toBe(true);
+        });
+      });
+    });
   });
 
   describe("include", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Include/exclude/test in config files usually require a filename, except if they are a function. This PR relaxes the requirement in presets, so that the filename is optional even when a preset uses include/exclude/test with a function value.

This was originally the first commit of https://github.com/babel/babel/pull/11316