### PR TITLE
Inline dynamic import transform

### DIFF
--- a/packages/babel-helper-module-transforms/src/dynamic-import.ts
+++ b/packages/babel-helper-module-transforms/src/dynamic-import.ts
@@ -1,0 +1,15 @@
+// Heavily inspired by
+// https://github.com/airbnb/babel-plugin-dynamic-import-node/blob/master/src/utils.js
+
+import * as t from "@babel/types";
+import template from "@babel/template";
+
+export function getDynamicImportSource(
+  node: t.CallExpression,
+): t.StringLiteral | t.TemplateLiteral {
+  const [source] = node.arguments;
+
+  return t.isStringLiteral(source) || t.isTemplateLiteral(source)
+    ? source
+    : (template.expression.ast`\`\${${source}}\`` as t.TemplateLiteral);
+}

--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -35,6 +35,8 @@ import type {
 } from "./normalize-and-load-metadata";
 import type { NodePath } from "@babel/traverse";
 
+export { getDynamicImportSource } from "./dynamic-import";
+
 export { default as getModuleName } from "./get-module-name";
 export type { PluginOptions } from "./get-module-name";
 

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -15,8 +15,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/helper-module-transforms": "workspace:^",
-    "@babel/helper-plugin-utils": "workspace:^",
-    "babel-plugin-dynamic-import-node": "^2.3.3"
+    "@babel/helper-plugin-utils": "workspace:^"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-modules-amd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-amd/src/index.ts
@@ -9,9 +9,9 @@ import {
   ensureStatementsHoisted,
   wrapInterop,
   getModuleName,
+  getDynamicImportSource,
 } from "@babel/helper-module-transforms";
 import { template, types as t } from "@babel/core";
-import { getImportSource } from "babel-plugin-dynamic-import-node/utils";
 import type { PluginOptions } from "@babel/helper-module-transforms";
 import type { NodePath } from "@babel/traverse";
 
@@ -102,7 +102,7 @@ export default declare<State>((api, options: Options) => {
           template.expression.ast`
             new Promise((${resolveId}, ${rejectId}) =>
               ${requireId}(
-                [${getImportSource(t, path.node)}],
+                [${getDynamicImportSource(path.node)}],
                 imported => ${t.cloneNode(resolveId)}(${result}),
                 ${t.cloneNode(rejectId)}
               )

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -15,8 +15,7 @@
   "dependencies": {
     "@babel/helper-module-transforms": "workspace:^",
     "@babel/helper-plugin-utils": "workspace:^",
-    "@babel/helper-simple-access": "workspace:^",
-    "babel-plugin-dynamic-import-node": "^2.3.3"
+    "@babel/helper-simple-access": "workspace:^"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-modules-commonjs/src/dynamic-import.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/dynamic-import.ts
@@ -1,0 +1,38 @@
+// Heavily inspired by
+// https://github.com/airbnb/babel-plugin-dynamic-import-node/blob/master/src/utils.js
+
+import type { NodePath } from "@babel/traverse";
+import { types as t, template, type File } from "@babel/core";
+import { getDynamicImportSource } from "@babel/helper-module-transforms";
+
+const requireNoInterop = (source: t.Expression) =>
+  template.expression.ast`require(${source})`;
+
+const requireInterop = (source: t.Expression, file: File) =>
+  t.callExpression(file.addHelper("interopRequireWildcard"), [
+    requireNoInterop(source),
+  ]);
+
+export function transformDynamicImport(
+  path: NodePath<t.CallExpression>,
+  noInterop: boolean,
+  file: File,
+) {
+  const buildRequire = noInterop ? requireNoInterop : requireInterop;
+
+  const source = getDynamicImportSource(path.node);
+
+  const replacement =
+    t.isStringLiteral(source) ||
+    (t.isTemplateLiteral(source) && source.quasis.length === 0)
+      ? template.expression.ast`
+        Promise.resolve().then(() => ${buildRequire(source, file)})
+      `
+      : template.expression.ast`
+        Promise.resolve(${source}).then(
+          s => ${buildRequire(t.identifier("s"), file)}
+        )
+      `;
+
+  path.replaceWith(replacement);
+}

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -16,8 +16,7 @@
     "@babel/helper-hoist-variables": "workspace:^",
     "@babel/helper-module-transforms": "workspace:^",
     "@babel/helper-plugin-utils": "workspace:^",
-    "@babel/helper-validator-identifier": "workspace:^",
-    "babel-plugin-dynamic-import-node": "^2.3.3"
+    "@babel/helper-validator-identifier": "workspace:^"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-modules-systemjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.ts
@@ -1,8 +1,11 @@
 import { declare } from "@babel/helper-plugin-utils";
 import hoistVariables from "@babel/helper-hoist-variables";
 import { template, types as t } from "@babel/core";
-import { getImportSource } from "babel-plugin-dynamic-import-node/utils";
-import { rewriteThis, getModuleName } from "@babel/helper-module-transforms";
+import {
+  rewriteThis,
+  getModuleName,
+  getDynamicImportSource,
+} from "@babel/helper-module-transforms";
 import type { PluginOptions } from "@babel/helper-module-transforms";
 import { isIdentifierName } from "@babel/helper-validator-identifier";
 import type { NodePath, Scope, Visitor } from "@babel/traverse";
@@ -276,7 +279,7 @@ export default declare<PluginState>((api, options: Options) => {
                 t.identifier(state.contextIdent),
                 t.identifier("import"),
               ),
-              [getImportSource(t, path.node)],
+              [getDynamicImportSource(path.node)],
             ),
           );
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2634,7 +2634,6 @@ __metadata:
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
     "@babel/plugin-external-helpers": "workspace:^"
-    babel-plugin-dynamic-import-node: ^2.3.3
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown
@@ -2666,7 +2665,6 @@ __metadata:
     "@babel/plugin-external-helpers": "workspace:^"
     "@babel/plugin-syntax-class-static-block": ^7.14.5
     "@babel/plugin-syntax-object-rest-spread": ^7.8.3
-    babel-plugin-dynamic-import-node: ^2.3.3
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown
@@ -2698,7 +2696,6 @@ __metadata:
     "@babel/helper-plugin-utils": "workspace:^"
     "@babel/helper-validator-identifier": "workspace:^"
     "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    babel-plugin-dynamic-import-node: ^2.3.3
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We should start working on babel/rfcs#4 (cc @JLHwung), but having the dynamic import transform in a separate repository makes it very hard to do so (aka impossible) because:
- well, we don't publish breaking changes on npm yet
- even if we did, the breaking change in the parser would make the transform tests fail until the separate repository is updated

This PR "inlines" https://github.com/airbnb/babel-plugin-dynamic-import-node/blob/master/src/utils.js (actually, I rewrote most of the code to adapt it to our style and to remove some parts only needed for compatibility with older Babel major versions).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15026"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

