### PR TITLE
Simplify deps graph relying on `@babel/core` peerDependency

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -109,3 +109,17 @@ gen_enforced_dependency(WorkspaceCwd, 'core-js', '^2.6.12', DependencyType) :-
   (DependencyType = 'dependencies'),
   % The rule works for @babel/runtime-corejs2 only
   (WorkspaceIdent = '@babel/runtime-corejs2').
+
+% Plugins and helper packages should have a peerDependency on @babel/core,
+% rather than depending directly on @babel/types, @babel/traverse and @babel/template.
+gen_enforced_dependency(WorkspaceCwd, DependencyName, null, 'dependencies') :-
+  workspace_ident(WorkspaceCwd, WorkspaceIdent),
+  (atom_concat('@babel/helper-', _, WorkspaceIdent); atom_concat('@babel/plugin-', _, WorkspaceIdent)),
+  (DependencyName = '@babel/types'; DependencyName = '@babel/traverse'; DependencyName = '@babel/template').
+
+% Every package that has a peerDependency on @babel/core should also list it as a devDependency,
+% so that it's guaranteed to be available during development.
+gen_enforced_dependency(WorkspaceCwd, '@babel/core', 'workspace:^', 'devDependencies') :-
+  workspace_has_dependency(WorkspaceCwd, '@babel/core', _, 'peerDependencies').
+
+

--- a/packages/babel-helper-annotate-as-pure/package.json
+++ b/packages/babel-helper-annotate-as-pure/package.json
@@ -13,8 +13,8 @@
     "access": "public"
   },
   "main": "./lib/index.js",
-  "dependencies": {
-    "@babel/types": "workspace:^"
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"
@@ -38,5 +38,8 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  }
 }

--- a/packages/babel-helper-annotate-as-pure/src/index.ts
+++ b/packages/babel-helper-annotate-as-pure/src/index.ts
@@ -1,18 +1,18 @@
-import { addComment, type Node } from "@babel/types";
+import { types as t } from "@babel/core";
 import type { NodePath } from "@babel/traverse";
 
 const PURE_ANNOTATION = "#__PURE__";
 
-const isPureAnnotated = ({ leadingComments }: Node): boolean =>
+const isPureAnnotated = ({ leadingComments }: t.Node): boolean =>
   !!leadingComments &&
   leadingComments.some(comment => /[@#]__PURE__/.test(comment.value));
 
-export default function annotateAsPure(pathOrNode: Node | NodePath): void {
+export default function annotateAsPure(pathOrNode: t.Node | NodePath): void {
   const node =
     // @ts-expect-error Node will not have `node` property
-    (pathOrNode["node"] || pathOrNode) as Node;
+    (pathOrNode["node"] || pathOrNode) as t.Node;
   if (isPureAnnotated(node)) {
     return;
   }
-  addComment(node, "leading", PURE_ANNOTATION);
+  t.addComment(node, "leading", PURE_ANNOTATION);
 }

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -14,8 +14,10 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "@babel/helper-explode-assignable-expression": "workspace:^",
-    "@babel/types": "workspace:^"
+    "@babel/helper-explode-assignable-expression": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"
@@ -39,5 +41,8 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  }
 }

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.ts
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.ts
@@ -1,7 +1,6 @@
+import { types as t } from "@babel/core";
 import explode from "@babel/helper-explode-assignable-expression";
-import { assignmentExpression, sequenceExpression } from "@babel/types";
 import type { Visitor } from "@babel/traverse";
-import type * as t from "@babel/types";
 
 export default function (opts: {
   build: (
@@ -21,13 +20,13 @@ export default function (opts: {
       // @ts-expect-error Fixme: node.left can be a TSAsExpression
       const exploded = explode(node.left, nodes, this, scope);
       nodes.push(
-        assignmentExpression(
+        t.assignmentExpression(
           "=",
           exploded.ref,
           build(exploded.uid, node.right),
         ),
       );
-      path.replaceWith(sequenceExpression(nodes));
+      path.replaceWith(t.sequenceExpression(nodes));
     },
 
     BinaryExpression(path) {

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -14,12 +14,14 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "@babel/helper-annotate-as-pure": "workspace:^",
-    "@babel/types": "workspace:^"
+    "@babel/helper-annotate-as-pure": "workspace:^"
   },
   "devDependencies": {
     "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-builder-react-jsx/src/index.ts
+++ b/packages/babel-helper-builder-react-jsx/src/index.ts
@@ -1,4 +1,8 @@
-import {
+import { types as t, type PluginPass } from "@babel/core";
+import annotateAsPure from "@babel/helper-annotate-as-pure";
+import type { NodePath, Visitor } from "@babel/traverse";
+
+const {
   booleanLiteral,
   callExpression,
   identifier,
@@ -21,11 +25,7 @@ import {
   spreadElement,
   stringLiteral,
   thisExpression,
-} from "@babel/types";
-import annotateAsPure from "@babel/helper-annotate-as-pure";
-import type { NodePath, Visitor } from "@babel/traverse";
-import type { PluginPass } from "@babel/core";
-import type * as t from "@babel/types";
+} = t;
 
 type ElementState = {
   tagExpr: t.Expression; // tag node,

--- a/packages/babel-helper-check-duplicate-nodes/package.json
+++ b/packages/babel-helper-check-duplicate-nodes/package.json
@@ -27,11 +27,11 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "dependencies": {
-    "@babel/types": "workspace:^"
-  },
   "devDependencies": {
     "@babel/core": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "type": "commonjs",
   "conditions": {

--- a/packages/babel-helper-check-duplicate-nodes/src/index.ts
+++ b/packages/babel-helper-check-duplicate-nodes/src/index.ts
@@ -1,5 +1,4 @@
-import { VISITOR_KEYS } from "@babel/types";
-import type * as t from "@babel/types";
+import { types as t } from "@babel/core";
 
 type StackItem = {
   node: t.Node;
@@ -26,7 +25,7 @@ export default function checkDuplicateNodes(ast: t.Node) {
     const { node, parent } = item;
     if (!node) continue;
 
-    const keys = VISITOR_KEYS[node.type];
+    const keys = t.VISITOR_KEYS[node.type];
     if (!keys) continue;
 
     if (parentsMap.has(node)) {

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -14,8 +14,10 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "@babel/helper-function-name": "workspace:^",
-    "@babel/types": "workspace:^"
+    "@babel/helper-function-name": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"
@@ -39,5 +41,8 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  }
 }

--- a/packages/babel-helper-define-map/src/index.ts
+++ b/packages/babel-helper-define-map/src/index.ts
@@ -1,5 +1,8 @@
 import nameFunction from "@babel/helper-function-name";
-import {
+import { types as t, type File } from "@babel/core";
+import type { Scope } from "@babel/traverse";
+
+const {
   arrayExpression,
   booleanLiteral,
   functionExpression,
@@ -16,10 +19,7 @@ import {
   removeComments,
   toComputedKey,
   toKeyAlias,
-} from "@babel/types";
-import type { File } from "@babel/core";
-import type * as t from "@babel/types";
-import type { Scope } from "@babel/traverse";
+} = t;
 
 function toKind(node: t.Property | t.Method) {
   if (isClassMethod(node) || isObjectMethod(node)) {

--- a/packages/babel-helper-environment-visitor/package.json
+++ b/packages/babel-helper-environment-visitor/package.json
@@ -18,8 +18,12 @@
     "./package.json": "./package.json"
   },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -13,11 +13,12 @@
     "access": "public"
   },
   "main": "./lib/index.js",
-  "dependencies": {
-    "@babel/types": "workspace:^"
-  },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-explode-assignable-expression/src/index.ts
+++ b/packages/babel-helper-explode-assignable-expression/src/index.ts
@@ -1,5 +1,7 @@
 import type { Scope } from "@babel/traverse";
-import {
+import { types as t } from "@babel/core";
+
+const {
   assignmentExpression,
   cloneNode,
   isIdentifier,
@@ -10,8 +12,7 @@ import {
   isSuper,
   memberExpression,
   toComputedKey,
-} from "@babel/types";
-import type * as t from "@babel/types";
+} = t;
 
 function getObjRef(
   node: t.Identifier | t.MemberExpression,

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -13,9 +13,8 @@
     "access": "public"
   },
   "main": "./lib/index.js",
-  "dependencies": {
-    "@babel/template": "workspace:^",
-    "@babel/types": "workspace:^"
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"
@@ -39,5 +38,8 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  }
 }

--- a/packages/babel-helper-function-name/src/index.ts
+++ b/packages/babel-helper-function-name/src/index.ts
@@ -1,5 +1,7 @@
-import template from "@babel/template";
-import {
+import { types as t, template } from "@babel/core";
+import type { NodePath, Scope, Visitor } from "@babel/traverse";
+
+const {
   NOT_LOCAL_BINDING,
   cloneNode,
   identifier,
@@ -16,9 +18,7 @@ import {
   isTemplateLiteral,
   isVariableDeclarator,
   toBindingIdentifierName,
-} from "@babel/types";
-import type * as t from "@babel/types";
-import type { NodePath, Scope, Visitor } from "@babel/traverse";
+} = t;
 
 function getFunctionArity(node: t.Function): number {
   const count = node.params.findIndex(

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -13,12 +13,13 @@
     "access": "public"
   },
   "main": "./lib/index.js",
-  "dependencies": {
-    "@babel/types": "workspace:^"
-  },
   "TODO": "The @babel/traverse dependency is only needed for the NodePath TS type. We can consider exporting it from @babel/core.",
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-hoist-variables/src/index.ts
+++ b/packages/babel-helper-hoist-variables/src/index.ts
@@ -1,10 +1,7 @@
-import {
-  assignmentExpression,
-  expressionStatement,
-  identifier,
-} from "@babel/types";
-import type * as t from "@babel/types";
+import { types as t } from "@babel/core";
 import type { NodePath, Visitor } from "@babel/traverse";
+
+const { assignmentExpression, expressionStatement, identifier } = t;
 
 export type EmitFunction = (
   id: t.Identifier,

--- a/packages/babel-helper-member-expression-to-functions/package.json
+++ b/packages/babel-helper-member-expression-to-functions/package.json
@@ -14,11 +14,12 @@
   },
   "main": "./lib/index.js",
   "author": "The Babel Team (https://babel.dev/team)",
-  "dependencies": {
-    "@babel/types": "workspace:^"
-  },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-member-expression-to-functions/src/index.ts
+++ b/packages/babel-helper-member-expression-to-functions/src/index.ts
@@ -1,5 +1,8 @@
+import { types as t } from "@babel/core";
 import type { NodePath, Visitor } from "@babel/traverse";
-import {
+import { willPathCastToBoolean } from "./util";
+
+const {
   LOGICAL_OPERATORS,
   arrowFunctionExpression,
   assignmentExpression,
@@ -20,10 +23,7 @@ import {
   optionalMemberExpression,
   sequenceExpression,
   updateExpression,
-} from "@babel/types";
-import type * as t from "@babel/types";
-import { willPathCastToBoolean } from "./util";
-
+} = t;
 class AssignmentMemoiser {
   private _map: WeakMap<t.Expression, { count: number; value: t.Identifier }>;
   constructor() {

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -14,12 +14,12 @@
     "directory": "packages/babel-helper-module-imports"
   },
   "main": "./lib/index.js",
-  "dependencies": {
-    "@babel/types": "workspace:^"
-  },
   "devDependencies": {
     "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-module-imports/src/import-builder.ts
+++ b/packages/babel-helper-module-imports/src/import-builder.ts
@@ -1,5 +1,8 @@
 import assert from "assert";
-import {
+import { types as t, type File } from "@babel/core";
+import type { Scope } from "@babel/traverse";
+
+const {
   callExpression,
   cloneNode,
   expressionStatement,
@@ -12,10 +15,7 @@ import {
   stringLiteral,
   variableDeclaration,
   variableDeclarator,
-} from "@babel/types";
-import type * as t from "@babel/types";
-import type { Scope } from "@babel/traverse";
-import type { File } from "@babel/core";
+} = t;
 
 /**
  * A class to track and accumulate mutations to the AST that will eventually

--- a/packages/babel-helper-module-imports/src/import-injector.ts
+++ b/packages/babel-helper-module-imports/src/import-injector.ts
@@ -1,11 +1,11 @@
 import assert from "assert";
-import { numericLiteral, sequenceExpression } from "@babel/types";
-import type * as t from "@babel/types";
+import { types as t, type File } from "@babel/core";
 import type { NodePath, Scope } from "@babel/traverse";
-import type { File } from "@babel/core";
 
 import ImportBuilder from "./import-builder";
 import isModule from "./is-module";
+
+const { numericLiteral, sequenceExpression } = t;
 
 export type ImportOptions = {
   /**

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -19,10 +19,10 @@
     "@babel/helper-module-imports": "workspace:^",
     "@babel/helper-simple-access": "workspace:^",
     "@babel/helper-split-export-declaration": "workspace:^",
-    "@babel/helper-validator-identifier": "workspace:^",
-    "@babel/template": "workspace:^",
-    "@babel/traverse": "workspace:^",
-    "@babel/types": "workspace:^"
+    "@babel/helper-validator-identifier": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"
@@ -45,5 +45,8 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  }
 }

--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -1,5 +1,7 @@
 import assert from "assert";
-import {
+import { types as t, template } from "@babel/core";
+
+const {
   booleanLiteral,
   callExpression,
   cloneNode,
@@ -13,9 +15,7 @@ import {
   valueToNode,
   variableDeclaration,
   variableDeclarator,
-} from "@babel/types";
-import type * as t from "@babel/types";
-import template from "@babel/template";
+} = t;
 
 import { isModule } from "@babel/helper-module-imports";
 

--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
@@ -1,5 +1,11 @@
 import assert from "assert";
-import {
+import { types as t, template } from "@babel/core";
+import type { NodePath, Visitor, Scope } from "@babel/traverse";
+import simplifyAccess from "@babel/helper-simple-access";
+
+import type { ModuleMetadata } from "./normalize-and-load-metadata";
+
+const {
   assignmentExpression,
   callExpression,
   cloneNode,
@@ -16,13 +22,7 @@ import {
   stringLiteral,
   variableDeclaration,
   variableDeclarator,
-} from "@babel/types";
-import type * as t from "@babel/types";
-import template from "@babel/template";
-import type { NodePath, Visitor, Scope } from "@babel/traverse";
-import simplifyAccess from "@babel/helper-simple-access";
-
-import type { ModuleMetadata } from "./normalize-and-load-metadata";
+} = t;
 
 interface RewriteReferencesVisitorState {
   exported: Map<any, any>;

--- a/packages/babel-helper-module-transforms/src/rewrite-this.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-this.ts
@@ -1,6 +1,7 @@
+import { types as t, traverse } from "@babel/core";
 import environmentVisitor from "@babel/helper-environment-visitor";
-import traverse from "@babel/traverse";
-import { numericLiteral, unaryExpression } from "@babel/types";
+
+const { numericLiteral, unaryExpression } = t;
 
 import type { NodePath, Visitor } from "@babel/traverse";
 export default function rewriteThis(programPath: NodePath) {

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -13,12 +13,13 @@
     "access": "public"
   },
   "main": "./lib/index.js",
-  "dependencies": {
-    "@babel/types": "workspace:^"
-  },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/generator": "workspace:^",
     "@babel/parser": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-optimise-call-expression/src/index.ts
+++ b/packages/babel-helper-optimise-call-expression/src/index.ts
@@ -1,4 +1,5 @@
-import {
+import { types as t } from "@babel/core";
+const {
   callExpression,
   identifier,
   isIdentifier,
@@ -6,12 +7,7 @@ import {
   memberExpression,
   optionalCallExpression,
   optionalMemberExpression,
-} from "@babel/types";
-import type {
-  CallExpression,
-  Expression,
-  OptionalCallExpression,
-} from "@babel/types";
+} = t;
 
 /**
  * A helper function that generates a new call expression with given thisNode.
@@ -25,11 +21,11 @@ import type {
  * @returns {CallExpression | OptionalCallExpression} The generated new call expression
  */
 export default function optimiseCallExpression(
-  callee: Expression,
-  thisNode: Expression,
-  args: Readonly<CallExpression["arguments"]>,
+  callee: t.Expression,
+  thisNode: t.Expression,
+  args: Readonly<t.CallExpression["arguments"]>,
   optional: boolean,
-): CallExpression | OptionalCallExpression {
+): t.CallExpression | t.OptionalCallExpression {
   if (
     args.length === 1 &&
     isSpreadElement(args[0]) &&

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "@babel/helper-annotate-as-pure": "workspace:^",
     "@babel/helper-environment-visitor": "workspace:^",
-    "@babel/helper-wrap-function": "workspace:^",
-    "@babel/types": "workspace:^"
+    "@babel/helper-wrap-function": "workspace:^"
   },
   "devDependencies": {
     "@babel/core": "workspace:^",

--- a/packages/babel-helper-remap-async-to-generator/src/index.ts
+++ b/packages/babel-helper-remap-async-to-generator/src/index.ts
@@ -1,18 +1,16 @@
-/* @noflow */
-
 import type { NodePath } from "@babel/traverse";
 import wrapFunction from "@babel/helper-wrap-function";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 import environmentVisitor from "@babel/helper-environment-visitor";
-import { traverse } from "@babel/core";
-import {
+import { traverse, types as t } from "@babel/core";
+
+const {
   callExpression,
   cloneNode,
   isIdentifier,
   isThisExpression,
   yieldExpression,
-} from "@babel/types";
-import type * as t from "@babel/types";
+} = t;
 
 const awaitVisitor = traverse.visitors.merge<{ wrapAwait: t.Expression }>([
   {

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -16,9 +16,10 @@
   "dependencies": {
     "@babel/helper-environment-visitor": "workspace:^",
     "@babel/helper-member-expression-to-functions": "workspace:^",
-    "@babel/helper-optimise-call-expression": "workspace:^",
-    "@babel/traverse": "workspace:^",
-    "@babel/types": "workspace:^"
+    "@babel/helper-optimise-call-expression": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"
@@ -42,5 +43,8 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  }
 }

--- a/packages/babel-helper-replace-supers/src/index.ts
+++ b/packages/babel-helper-replace-supers/src/index.ts
@@ -1,10 +1,11 @@
+import { types as t, traverse, type File } from "@babel/core";
 import type { NodePath, Scope } from "@babel/traverse";
-import traverse from "@babel/traverse";
 import memberExpressionToFunctions from "@babel/helper-member-expression-to-functions";
 import type { HandlerState } from "@babel/helper-member-expression-to-functions";
 import optimiseCall from "@babel/helper-optimise-call-expression";
 import environmentVisitor from "@babel/helper-environment-visitor";
-import {
+
+const {
   assignmentExpression,
   booleanLiteral,
   callExpression,
@@ -14,9 +15,7 @@ import {
   sequenceExpression,
   stringLiteral,
   thisExpression,
-} from "@babel/types";
-import type * as t from "@babel/types";
-import type { File } from "@babel/core";
+} = t;
 
 // TODO (Babel 8): Don't export this.
 export {

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -14,12 +14,12 @@
     "directory": "packages/babel-helper-simple-access"
   },
   "main": "./lib/index.js",
-  "dependencies": {
-    "@babel/types": "workspace:^"
-  },
   "devDependencies": {
     "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-simple-access/src/index.ts
+++ b/packages/babel-helper-simple-access/src/index.ts
@@ -1,4 +1,7 @@
-import {
+import { types as t } from "@babel/core";
+import type { NodePath, Scope, Visitor } from "@babel/traverse";
+
+const {
   LOGICAL_OPERATORS,
   assignmentExpression,
   binaryExpression,
@@ -8,9 +11,7 @@ import {
   numericLiteral,
   sequenceExpression,
   unaryExpression,
-} from "@babel/types";
-import type * as t from "@babel/types";
-import type { NodePath, Scope, Visitor } from "@babel/traverse";
+} = t;
 
 type State = {
   scope: Scope;

--- a/packages/babel-helper-skip-transparent-expression-wrappers/package.json
+++ b/packages/babel-helper-skip-transparent-expression-wrappers/package.json
@@ -16,11 +16,12 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "dependencies": {
-    "@babel/types": "workspace:^"
-  },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-skip-transparent-expression-wrappers/src/index.ts
+++ b/packages/babel-helper-skip-transparent-expression-wrappers/src/index.ts
@@ -1,13 +1,13 @@
-import {
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/traverse";
+
+const {
   isParenthesizedExpression,
   isTSAsExpression,
   isTSNonNullExpression,
   isTSTypeAssertion,
   isTypeCastExpression,
-} from "@babel/types";
-
-import type * as t from "@babel/types";
-import type { NodePath } from "@babel/traverse";
+} = t;
 
 export type TransparentExprWrapper =
   | t.TSAsExpression

--- a/packages/babel-helper-split-export-declaration/package.json
+++ b/packages/babel-helper-split-export-declaration/package.json
@@ -13,8 +13,8 @@
     "access": "public"
   },
   "main": "./lib/index.js",
-  "dependencies": {
-    "@babel/types": "workspace:^"
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"
@@ -38,5 +38,8 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  }
 }

--- a/packages/babel-helper-split-export-declaration/src/index.ts
+++ b/packages/babel-helper-split-export-declaration/src/index.ts
@@ -1,13 +1,14 @@
-import {
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/traverse";
+
+const {
   cloneNode,
   exportNamedDeclaration,
   exportSpecifier,
   identifier,
   variableDeclaration,
   variableDeclarator,
-} from "@babel/types";
-import type * as t from "@babel/types";
-import type { NodePath } from "@babel/traverse";
+} = t;
 
 export default function splitExportDeclaration(
   exportDeclaration: NodePath<

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -14,10 +14,10 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "@babel/helper-function-name": "workspace:^",
-    "@babel/template": "workspace:^",
-    "@babel/traverse": "workspace:^",
-    "@babel/types": "workspace:^"
+    "@babel/helper-function-name": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"
@@ -41,5 +41,8 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  }
 }

--- a/packages/babel-helper-wrap-function/src/index.ts
+++ b/packages/babel-helper-wrap-function/src/index.ts
@@ -1,7 +1,8 @@
 import type { NodePath } from "@babel/traverse";
 import nameFunction from "@babel/helper-function-name";
-import template from "@babel/template";
-import {
+import { types as t, template } from "@babel/core";
+
+const {
   blockStatement,
   callExpression,
   functionExpression,
@@ -9,8 +10,7 @@ import {
   isFunctionDeclaration,
   isRestElement,
   returnStatement,
-} from "@babel/types";
-import type * as t from "@babel/types";
+} = t;
 
 type ExpressionWrapperBuilder<ExtraBody extends t.Node[]> = (
   replacements?: Parameters<ReturnType<typeof template.expression>>[0],

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -20,11 +20,15 @@
     "@babel/types": "workspace:^"
   },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/generator": "workspace:^",
     "@babel/helper-plugin-test-runner": "workspace:^",
     "@babel/parser": "workspace:^",
     "regenerator-runtime": "^0.13.9",
     "terser": "^5.9.0"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-plugin-syntax-decimal/package.json
+++ b/packages/babel-plugin-syntax-decimal/package.json
@@ -37,5 +37,8 @@
       },
       null
     ]
+  },
+  "devDependencies": {
+    "@babel/core": "workspace:^"
   }
 }

--- a/packages/babel-plugin-syntax-destructuring-private/package.json
+++ b/packages/babel-plugin-syntax-destructuring-private/package.json
@@ -44,5 +44,8 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  }
 }

--- a/packages/babel-plugin-syntax-module-blocks/package.json
+++ b/packages/babel-plugin-syntax-module-blocks/package.json
@@ -37,5 +37,8 @@
       },
       null
     ]
+  },
+  "devDependencies": {
+    "@babel/core": "workspace:^"
   }
 }

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -20,8 +20,7 @@
     "@babel/helper-annotate-as-pure": "workspace:^",
     "@babel/helper-module-imports": "workspace:^",
     "@babel/helper-plugin-utils": "workspace:^",
-    "@babel/plugin-syntax-jsx": "workspace:^",
-    "@babel/types": "workspace:^"
+    "@babel/plugin-syntax-jsx": "workspace:^"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -28,7 +28,11 @@
     "globals": "condition:BABEL_8_BREAKING ? ^13.5.0 : ^11.1.0"
   },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/helper-plugin-test-runner": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,7 +485,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-annotate-as-pure@workspace:packages/babel-helper-annotate-as-pure"
   dependencies:
-    "@babel/types": "workspace:^"
+    "@babel/core": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -503,8 +505,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-builder-binary-assignment-operator-visitor@workspace:packages/babel-helper-builder-binary-assignment-operator-visitor"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-explode-assignable-expression": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -515,7 +519,8 @@ __metadata:
     "@babel/core": "workspace:^"
     "@babel/helper-annotate-as-pure": "workspace:^"
     "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -524,7 +529,8 @@ __metadata:
   resolution: "@babel/helper-check-duplicate-nodes@workspace:packages/babel-helper-check-duplicate-nodes"
   dependencies:
     "@babel/core": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -624,8 +630,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-define-map@workspace:packages/babel-helper-define-map"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-function-name": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -656,8 +664,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-environment-visitor@workspace:packages/babel-helper-environment-visitor"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/traverse": "workspace:^"
     "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -674,8 +685,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-explode-assignable-expression@workspace:packages/babel-helper-explode-assignable-expression"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -702,8 +715,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-function-name@workspace:packages/babel-helper-function-name"
   dependencies:
-    "@babel/template": "workspace:^"
-    "@babel/types": "workspace:^"
+    "@babel/core": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -720,8 +734,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-hoist-variables@workspace:packages/babel-helper-hoist-variables"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -738,8 +754,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-member-expression-to-functions@workspace:packages/babel-helper-member-expression-to-functions"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -758,7 +776,8 @@ __metadata:
   dependencies:
     "@babel/core": "workspace:^"
     "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -782,14 +801,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-module-transforms@workspace:packages/babel-helper-module-transforms"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-module-imports": "workspace:^"
     "@babel/helper-simple-access": "workspace:^"
     "@babel/helper-split-export-declaration": "workspace:^"
     "@babel/helper-validator-identifier": "workspace:^"
-    "@babel/template": "workspace:^"
-    "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -806,9 +825,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-optimise-call-expression@workspace:packages/babel-helper-optimise-call-expression"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/generator": "workspace:^"
     "@babel/parser": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -856,7 +877,6 @@ __metadata:
     "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-wrap-function": "workspace:^"
     "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0
   languageName: unknown
@@ -879,11 +899,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-replace-supers@workspace:packages/babel-helper-replace-supers"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-member-expression-to-functions": "workspace:^"
     "@babel/helper-optimise-call-expression": "workspace:^"
-    "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -902,7 +923,8 @@ __metadata:
   dependencies:
     "@babel/core": "workspace:^"
     "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -919,8 +941,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-skip-transparent-expression-wrappers@workspace:packages/babel-helper-skip-transparent-expression-wrappers"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -937,7 +961,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-split-export-declaration@workspace:packages/babel-helper-split-export-declaration"
   dependencies:
-    "@babel/types": "workspace:^"
+    "@babel/core": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -1014,10 +1040,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-wrap-function@workspace:packages/babel-helper-wrap-function"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-function-name": "workspace:^"
-    "@babel/template": "workspace:^"
-    "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -1036,6 +1062,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helpers@workspace:packages/babel-helpers"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/generator": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/parser": "workspace:^"
@@ -1044,6 +1071,8 @@ __metadata:
     "@babel/types": "workspace:^"
     regenerator-runtime: ^0.13.9
     terser: ^5.9.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -1859,6 +1888,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/plugin-syntax-decimal@workspace:packages/babel-plugin-syntax-decimal"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -1880,6 +1910,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/plugin-syntax-destructuring-private@workspace:packages/babel-plugin-syntax-destructuring-private"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -2044,6 +2075,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/plugin-syntax-module-blocks@workspace:packages/babel-plugin-syntax-module-blocks"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -2999,7 +3031,6 @@ __metadata:
     "@babel/helper-plugin-utils": "workspace:^"
     "@babel/plugin-syntax-jsx": "workspace:^"
     "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown
@@ -3780,6 +3811,7 @@ __metadata:
   resolution: "@babel/traverse@workspace:packages/babel-traverse"
   dependencies:
     "@babel/code-frame": "workspace:^"
+    "@babel/core": "workspace:^"
     "@babel/generator": "workspace:^"
     "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-function-name": "workspace:^"
@@ -3790,6 +3822,8 @@ __metadata:
     "@babel/types": "workspace:^"
     debug: ^4.1.0
     globals: "condition:BABEL_8_BREAKING ? ^13.5.0 : ^11.1.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #13977
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR simplifies the dependencies graph of a common `@babel/core`+`@babel/preset-env` install, by sharing types/traverse/template using the `@babel/core` peer dependency rather than explicitly depending on those packages. This avoids us relying on the package manager hoisting strategy to prevent duplicate copies of those packages.

In https://github.com/babel/babel/issues/13977#issuecomment-973216347 I said that we needed to wait for Babel 8 because adding a peer dependency is, in general, a breaking change. However, I realized that it's not true in this specific case: all those packages are already dependencies of packages that have a peer dependency on `@babel/core`, so `@babel/core` is already available.