### PR TITLE
Fix missing `transformSync` function name

### DIFF
--- a/packages/babel-standalone/examples/example.htm
+++ b/packages/babel-standalone/examples/example.htm
@@ -25,7 +25,7 @@ const someDiv = <div>{getMessage()}</div>;
 
     function transform() {
       try {
-        outputEl.innerHTML = Babel.transformSync(inputEl.value, {
+        outputEl.innerHTML = Babel.transform(inputEl.value, {
           presets: [
             "es2015",
             "react",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

When opening the `/packages/babel-standalone/examples/example.htm`, it will throw an error message: 
```
ERROR: Babel.transformSync is not a function
```
I checked the `src/index.ts` of babel-standalone and found it does not export a function named `transformedSync`, but there is another synchronous function named just `transfrom`. So it seems that the `example.htm` used an outdated function name without  tests,  thus causing this error. In this PR, I just renamed the function to fix the problem, and it works fine now.