### PR TITLE
Use `startLoc.index` instead of carrying around `start`

### DIFF
--- a/packages/babel-parser/src/parser/node.ts
+++ b/packages/babel-parser/src/parser/node.ts
@@ -102,14 +102,14 @@ export abstract class NodeUtils extends UtilParser {
     return new Node(this, this.state.start, this.state.startLoc);
   }
 
-  startNodeAt<T extends NodeType>(pos: number, loc: Position): Undone<T> {
+  startNodeAt<T extends NodeType>(loc: Position): Undone<T> {
     // @ts-expect-error cast Node as Undone<T>
-    return new Node(this, pos, loc);
+    return new Node(this, loc.index, loc);
   }
 
   /** Start a new node with a previous node's location. */
   startNodeAtNode<T extends NodeType>(type: Undone<NodeType>): Undone<T> {
-    return this.startNodeAt(type.start, type.loc.start);
+    return this.startNodeAt(type.loc.start);
   }
 
   // Finish an AST node, adding `type` and `end` properties.
@@ -141,10 +141,10 @@ export abstract class NodeUtils extends UtilParser {
     return node as T;
   }
 
-  resetStartLocation(node: NodeBase, start: number, startLoc: Position): void {
-    node.start = start;
+  resetStartLocation(node: NodeBase, startLoc: Position): void {
+    node.start = startLoc.index;
     node.loc.start = startLoc;
-    if (this.options.ranges) node.range[0] = start;
+    if (this.options.ranges) node.range[0] = startLoc.index;
   }
 
   resetEndLocation(
@@ -160,6 +160,6 @@ export abstract class NodeUtils extends UtilParser {
    * Reset the start location of node to the start location of locationNode
    */
   resetStartLocationFromNode(node: NodeBase, locationNode: NodeBase): void {
-    this.resetStartLocation(node, locationNode.start, locationNode.loc.start);
+    this.resetStartLocation(node, locationNode.loc.start);
   }
 }

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -573,17 +573,15 @@ export default abstract class StatementParser extends ExpressionParser {
       // So that the decorators of any nested class expressions will be dealt with separately
       this.state.decoratorStack.push([]);
 
-      const startPos = this.state.start;
       const startLoc = this.state.startLoc;
       let expr: N.Expression;
 
       if (this.match(tt.parenL)) {
-        const startPos = this.state.start;
         const startLoc = this.state.startLoc;
         this.next(); // eat '('
         expr = this.parseExpression();
         this.expect(tt.parenR);
-        expr = this.wrapParenthesis(startPos, startLoc, expr);
+        expr = this.wrapParenthesis(startLoc, expr);
 
         const paramsStartLoc = this.state.startLoc;
         node.expression = this.parseMaybeDecoratorArguments(expr);
@@ -600,7 +598,7 @@ export default abstract class StatementParser extends ExpressionParser {
         expr = this.parseIdentifier(false);
 
         while (this.eat(tt.dot)) {
-          const node = this.startNodeAt(startPos, startLoc);
+          const node = this.startNodeAt(startLoc);
           node.object = expr;
           if (this.match(tt.privateName)) {
             this.classScope.usePrivateName(
@@ -2200,10 +2198,7 @@ export default abstract class StatementParser extends ExpressionParser {
     if (this.isContextual(tt._as)) {
       if (!node.specifiers) node.specifiers = [];
 
-      const specifier = this.startNodeAt(
-        this.state.lastTokStart,
-        this.state.lastTokStartLoc,
-      );
+      const specifier = this.startNodeAt(this.state.lastTokStartLoc);
 
       this.next();
 

--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -349,14 +349,12 @@ export default (superClass: typeof Parser) =>
 
     parseObjectProperty(
       prop: N.ObjectProperty,
-      startPos: number | undefined | null,
       startLoc: Position | undefined | null,
       isPattern: boolean,
       refExpressionErrors?: ExpressionErrors | null,
     ): N.ObjectProperty | undefined | null {
       const node: N.EstreeProperty = super.parseObjectProperty(
         prop,
-        startPos,
         startLoc,
         isPattern,
         refExpressionErrors,
@@ -483,18 +481,11 @@ export default (superClass: typeof Parser) =>
 
     parseSubscript(
       base: N.Expression,
-      startPos: number,
       startLoc: Position,
       noCalls: boolean | undefined | null,
       state: N.ParseSubscriptState,
     ) {
-      const node = super.parseSubscript(
-        base,
-        startPos,
-        startLoc,
-        noCalls,
-        state,
-      );
+      const node = super.parseSubscript(base, startLoc, noCalls, state);
 
       if (state.optionalChainMember) {
         // https://github.com/estree/estree/blob/master/es2020.md#chainexpression
@@ -547,8 +538,8 @@ export default (superClass: typeof Parser) =>
       return toESTreeLocation(super.finishNodeAt(node, type, endLoc));
     }
 
-    resetStartLocation(node: N.Node, start: number, startLoc: Position) {
-      super.resetStartLocation(node, start, startLoc);
+    resetStartLocation(node: N.Node, startLoc: Position) {
+      super.resetStartLocation(node, startLoc);
       toESTreeLocation(node);
     }
 

--- a/packages/babel-parser/src/plugins/v8intrinsic.ts
+++ b/packages/babel-parser/src/plugins/v8intrinsic.ts
@@ -12,7 +12,7 @@ export default (superClass: typeof Parser) =>
         const node = this.startNode<N.Identifier>();
         this.next(); // eat '%'
         if (tokenIsIdentifier(this.state.type)) {
-          const name = this.parseIdentifierName(this.state.start);
+          const name = this.parseIdentifierName();
           const identifier = this.createIdentifier(node, name);
           // @ts-expect-error: avoid mutating AST types
           identifier.type = "V8IntrinsicIdentifier";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Now that `Position` objects have an `.index` property, we can use `startLoc` and `startLoc.index` in most places, instead of carrying around two parameters (`startLoc` and `startPos`).