### PR TITLE
fix: `parser` typings for plugins

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -553,7 +553,7 @@ function buildRollupDts(packages) {
     build(
       "packages/babel-parser/typings/babel-parser.source.d.ts",
       "packages/babel-parser/typings/babel-parser.d.ts",
-      "/* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/consistent-type-imports, prettier/prettier */"
+      "// This file is auto-generated! Do not modify it directly.\n/* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/consistent-type-imports, prettier/prettier */"
     )
   );
 

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -527,7 +527,7 @@ function buildRollup(packages, buildStandalone) {
 }
 
 function buildRollupDts(packages) {
-  async function build(input, output) {
+  async function build(input, output, banner) {
     log(`Bundling '${chalk.cyan(output)}' with rollup ...`);
 
     const bundle = await rollup({
@@ -538,6 +538,7 @@ function buildRollupDts(packages) {
     await bundle.write({
       file: output,
       format: "es",
+      banner,
     });
   }
 
@@ -551,7 +552,8 @@ function buildRollupDts(packages) {
   tasks.push(
     build(
       "packages/babel-parser/typings/babel-parser.source.d.ts",
-      "packages/babel-parser/typings/babel-parser.d.ts"
+      "packages/babel-parser/typings/babel-parser.d.ts",
+      "/* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/consistent-type-imports, prettier/prettier */"
     )
   );
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "mergeiterator": "^1.4.4",
     "prettier": "^2.7.1",
     "rollup": "^2.78.0",
-    "rollup-plugin-dts": "^4.2.2",
+    "rollup-plugin-dts": "^5.0.0",
     "rollup-plugin-polyfill-node": "^0.10.2",
     "rollup-plugin-terser": "^7.0.2",
     "semver": "^6.3.0",

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/consistent-type-imports, prettier/prettier */
 import * as _babel_types from '@babel/types';
 
 type Plugin =

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -1,3 +1,4 @@
+// This file is auto-generated! Do not modify it directly.
 /* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/consistent-type-imports, prettier/prettier */
 import * as _babel_types from '@babel/types';
 

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -206,6 +206,8 @@ interface ParserOptions {
   createParenthesizedExpressions?: boolean;
 }
 
+type ParserPlugin = PluginConfig;
+
 
 declare const tokTypes: {
   // todo(flow->ts) real token type
@@ -221,4 +223,4 @@ type ParseResult<Result> = Result & {
   errors: ParseError[];
 };
 
-export { DecoratorsPluginOptions, FlowPluginOptions, ParseError, ParserOptions, PluginConfig as ParserPlugin, ParserPluginWithOptions, PipelineOperatorPluginOptions, RecordAndTuplePluginOptions, TypeScriptPluginOptions, parse, parseExpression, tokTypes };
+export { DecoratorsPluginOptions, FlowPluginOptions, ParseError, ParserOptions, ParserPlugin, ParserPluginWithOptions, PipelineOperatorPluginOptions, RecordAndTuplePluginOptions, TypeScriptPluginOptions, parse, parseExpression, tokTypes };

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -141,6 +141,7 @@ export type ParserPlugin =
   | "doExpressions"
   | "dynamicImport"
   | "estree"
+  | "explicitResourceManagement"
   | "exportDefaultFrom"
   | "exportNamespaceFrom" // deprecated
   | "flow"
@@ -151,6 +152,7 @@ export type ParserPlugin =
   | "jsx"
   | "logicalAssignment"
   | "importAssertions"
+  | "importReflection"
   | "moduleBlocks"
   | "moduleStringNames"
   | "nullishCoalescingOperator"

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -41,9 +41,9 @@ type Plugin =
   | "throwExpressions"
   | "topLevelAwait"
   | "v8intrinsic"
-  | ParserPluginWithOptions$1[0];
+  | ParserPluginWithOptions[0];
 
-type ParserPluginWithOptions$1 =
+type ParserPluginWithOptions =
   | ["decorators", DecoratorsPluginOptions]
   | ["estree", { classFeatures?: boolean }]
   // @deprecated
@@ -53,7 +53,7 @@ type ParserPluginWithOptions$1 =
   | ["flow", FlowPluginOptions]
   | ["typescript", TypeScriptPluginOptions];
 
-type PluginConfig = Plugin | ParserPluginWithOptions$1;
+type PluginConfig = Plugin | ParserPluginWithOptions;
 
 interface DecoratorsPluginOptions {
   decoratorsBeforeExport?: boolean;
@@ -206,11 +206,6 @@ interface ParserOptions {
   createParenthesizedExpressions?: boolean;
 }
 
-type ParserPluginWithOptions =
-  ParserPluginWithOptions$1;
-
-type ParserPlugin = PluginConfig;
-
 
 declare const tokTypes: {
   // todo(flow->ts) real token type
@@ -226,4 +221,4 @@ type ParseResult<Result> = Result & {
   errors: ParseError[];
 };
 
-export { DecoratorsPluginOptions, FlowPluginOptions, ParseError, ParserOptions, ParserPlugin, ParserPluginWithOptions, PipelineOperatorPluginOptions, RecordAndTuplePluginOptions, TypeScriptPluginOptions, parse, parseExpression, tokTypes };
+export { DecoratorsPluginOptions, FlowPluginOptions, ParseError, ParserOptions, PluginConfig as ParserPlugin, ParserPluginWithOptions, PipelineOperatorPluginOptions, RecordAndTuplePluginOptions, TypeScriptPluginOptions, parse, parseExpression, tokTypes };

--- a/packages/babel-parser/typings/babel-parser.source.d.ts
+++ b/packages/babel-parser/typings/babel-parser.source.d.ts
@@ -1,83 +1,3 @@
-import * as _babel_types from '@babel/types';
-
-type Plugin =
-  | "asyncDoExpressions"
-  | "asyncGenerators"
-  | "bigInt"
-  | "classPrivateMethods"
-  | "classPrivateProperties"
-  | "classProperties"
-  | "classStaticBlock" // Enabled by default
-  | "decimal"
-  | "decorators-legacy"
-  | "decoratorAutoAccessors"
-  | "destructuringPrivate"
-  | "doExpressions"
-  | "dynamicImport"
-  | "explicitResourceManagement"
-  | "exportDefaultFrom"
-  | "exportNamespaceFrom" // deprecated
-  | "flow"
-  | "flowComments"
-  | "functionBind"
-  | "functionSent"
-  | "importMeta"
-  | "jsx"
-  | "logicalAssignment"
-  | "importAssertions"
-  | "importReflection"
-  | "moduleBlocks"
-  | "moduleStringNames"
-  | "nullishCoalescingOperator"
-  | "numericSeparator"
-  | "objectRestSpread"
-  | "optionalCatchBinding"
-  | "optionalChaining"
-  | "partialApplication"
-  | "placeholders"
-  | "privateIn" // Enabled by default
-  | "regexpUnicodeSets"
-  | "throwExpressions"
-  | "topLevelAwait"
-  | "v8intrinsic"
-  | ParserPluginWithOptions$1[0];
-
-type ParserPluginWithOptions$1 =
-  | ["decorators", DecoratorsPluginOptions]
-  | ["estree", { classFeatures?: boolean }]
-  // @deprecated
-  | ["moduleAttributes", { version: "may-2020" }]
-  | ["pipelineOperator", PipelineOperatorPluginOptions]
-  | ["recordAndTuple", RecordAndTuplePluginOptions]
-  | ["flow", FlowPluginOptions]
-  | ["typescript", TypeScriptPluginOptions];
-
-type PluginConfig = Plugin | ParserPluginWithOptions$1;
-
-interface DecoratorsPluginOptions {
-  decoratorsBeforeExport?: boolean;
-  allowCallParenthesized?: boolean;
-}
-
-interface PipelineOperatorPluginOptions {
-  proposal: "minimal" | "fsharp" | "hack" | "smart";
-  topicToken?: "%" | "#" | "@@" | "^^" | "^";
-}
-
-interface RecordAndTuplePluginOptions {
-  syntaxType: "bar" | "hash";
-}
-
-interface FlowPluginOptions {
-  all?: boolean;
-  enums?: boolean;
-}
-
-interface TypeScriptPluginOptions {
-  dts?: boolean;
-  disallowAmbiguousJSXLike?: boolean;
-}
-
 // Type definitions for @babel/parser
 // Project: https://github.com/babel/babel/tree/main/packages/babel-parser
 // Definitions by: Troy Gerwien <https://github.com/yortus>
@@ -88,20 +8,20 @@ interface TypeScriptPluginOptions {
 /**
  * Parse the provided code as an entire ECMAScript program.
  */
-declare function parse(
+export function parse(
   input: string,
   options?: ParserOptions
-): ParseResult<_babel_types.File>;
+): ParseResult<import("@babel/types").File>;
 
 /**
  * Parse the provided code as a single expression.
  */
-declare function parseExpression(
+export function parseExpression(
   input: string,
   options?: ParserOptions
-): ParseResult<_babel_types.Expression>;
+): ParseResult<import("@babel/types").Expression>;
 
-interface ParserOptions {
+export interface ParserOptions {
   /**
    * By default, import and export declarations can only appear at a program's top level.
    * Setting this option to true allows them anywhere where a statement is allowed.
@@ -205,18 +125,25 @@ interface ParserOptions {
   createParenthesizedExpressions?: boolean;
 }
 
-type ParserPluginWithOptions =
-  ParserPluginWithOptions$1;
+export type ParserPluginWithOptions =
+  import("../src/typings").ParserPluginWithOptions;
 
-type ParserPlugin = PluginConfig;
+export type ParserPlugin = import("../src/typings").PluginConfig;
 
+export type {
+  DecoratorsPluginOptions,
+  PipelineOperatorPluginOptions,
+  RecordAndTuplePluginOptions,
+  FlowPluginOptions,
+  TypeScriptPluginOptions,
+} from "../src/typings";
 
-declare const tokTypes: {
+export const tokTypes: {
   // todo(flow->ts) real token type
   [name: string]: any;
 };
 
-interface ParseError {
+export interface ParseError {
   code: string;
   reasonCode: string;
 }
@@ -224,5 +151,3 @@ interface ParseError {
 type ParseResult<Result> = Result & {
   errors: ParseError[];
 };
-
-export { DecoratorsPluginOptions, FlowPluginOptions, ParseError, ParserOptions, ParserPlugin, ParserPluginWithOptions, PipelineOperatorPluginOptions, RecordAndTuplePluginOptions, TypeScriptPluginOptions, parse, parseExpression, tokTypes };

--- a/packages/babel-parser/typings/babel-parser.source.d.ts
+++ b/packages/babel-parser/typings/babel-parser.source.d.ts
@@ -125,12 +125,9 @@ export interface ParserOptions {
   createParenthesizedExpressions?: boolean;
 }
 
-export type ParserPluginWithOptions =
-  import("../src/typings").ParserPluginWithOptions;
-
-export type ParserPlugin = import("../src/typings").PluginConfig;
-
 export type {
+  PluginConfig as ParserPlugin,
+  ParserPluginWithOptions,
   DecoratorsPluginOptions,
   PipelineOperatorPluginOptions,
   RecordAndTuplePluginOptions,

--- a/packages/babel-parser/typings/babel-parser.source.d.ts
+++ b/packages/babel-parser/typings/babel-parser.source.d.ts
@@ -125,8 +125,9 @@ export interface ParserOptions {
   createParenthesizedExpressions?: boolean;
 }
 
+export type ParserPlugin = import("../src/typings").PluginConfig;
+
 export type {
-  PluginConfig as ParserPlugin,
   ParserPluginWithOptions,
   DecoratorsPluginOptions,
   PipelineOperatorPluginOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5964,7 +5964,7 @@ __metadata:
     mergeiterator: ^1.4.4
     prettier: ^2.7.1
     rollup: ^2.78.0
-    rollup-plugin-dts: ^4.2.2
+    rollup-plugin-dts: ^5.0.0
     rollup-plugin-polyfill-node: ^0.10.2
     rollup-plugin-terser: ^7.0.2
     semver: ^6.3.0
@@ -11172,12 +11172,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.26.1":
-  version: 0.26.1
-  resolution: "magic-string@npm:0.26.1"
+"magic-string@npm:^0.26.7":
+  version: 0.26.7
+  resolution: "magic-string@npm:0.26.7"
   dependencies:
     sourcemap-codec: ^1.4.8
-  checksum: 23f21f5734346ddfbabd7b9834e3ecda3521e3e1db81166c1513b45b729489bbed1eafa8cd052c7db7fdc7c68ebc5c03bc00dd5a23697edda15dbecaf8c98397
+  checksum: 89b0d60cbb32bbf3d1e23c46ea93db082d18a8230b972027aecb10a40bba51be519ecce0674f995571e3affe917b76b09f59d8dbc9a1b2c9c4102a2b6e8a2b01
   languageName: node
   linkType: hard
 
@@ -13231,19 +13231,19 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"rollup-plugin-dts@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "rollup-plugin-dts@npm:4.2.2"
+"rollup-plugin-dts@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "rollup-plugin-dts@npm:5.0.0"
   dependencies:
-    "@babel/code-frame": ^7.16.7
-    magic-string: ^0.26.1
+    "@babel/code-frame": ^7.18.6
+    magic-string: ^0.26.7
   peerDependencies:
-    rollup: ^2.55
+    rollup: ^3.0.0
     typescript: ^4.1
   dependenciesMeta:
     "@babel/code-frame":
       optional: true
-  checksum: cf4b45f6cca442a5f44af0f0fb567c8fc540ecb792c763571d1bcda9bf495803bcc8d4eaef451a2dd32f7f391eb822e2b96cc6b86b096db54a4d3935236fd8da
+  checksum: feb2d614528c255ee698120be0fd404b0a4fa312362a3d687d76551157464decc66be6dfecb624c42bc64a9e6298ed21e13e689dc9b144acab8294cd08a53455
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15093 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We currently need to maintain two parser type definitions, which is kind of annoying.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15094"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

