### PR TITLE
fix: OOM issue for `@babel/register` cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,9 @@ package-lock.json
 /packages/babel-runtime-corejs3/core-js-stable/**/*.js
 
 /packages/babel-register/test/.cache.babel
+/packages/babel-register/test/.babel-register-cache
 /packages/babel-register/test/.index.babel
+/packages/babel-register/test/tmp
 /packages/babel-cli/test/tmp
 /packages/babel-node/test/tmp
 /packages/*/lib

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "clone-deep": "^4.0.1",
     "find-cache-dir": "condition:BABEL_8_BREAKING ? ^3.3.1 : ^2.0.0",
+    "lru-cache": "condition:BABEL_8_BREAKING ? ^7.14.0 : ^5.1.1",
     "make-dir": "condition:BABEL_8_BREAKING ? : ^2.1.0",
     "pirates": "^4.0.5",
     "source-map-support": "^0.5.16"
@@ -31,7 +32,8 @@
     "@babel/core": "workspace:^",
     "@babel/plugin-transform-arrow-functions": "workspace:^",
     "@babel/plugin-transform-modules-commonjs": "workspace:^",
-    "browserify": "^16.5.2"
+    "browserify": "^16.5.2",
+    "rimraf": "^3.0.0"
   },
   "homepage": "https://babel.dev/docs/en/next/babel-register",
   "bugs": "https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A%20register%22+is%3Aopen",

--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -1,3 +1,9 @@
 // File moved to ./worker/cache.js
 // TODO: Remove this backward-compat "proxy file" in Babel 8
-module.exports = require("./worker/cache");
+if (process.env.BABEL_8_BREAKING) {
+  module.exports = require("./worker/cache");
+} else if (global.TEST_USE_NEW_CACHE ?? !process.env.BABEL_CACHE_PATH) {
+  module.exports = require("./worker/cache");
+} else {
+  module.exports = require("./worker/cache-legacy");
+}

--- a/packages/babel-register/src/worker/babel-core.js
+++ b/packages/babel-register/src/worker/babel-core.js
@@ -1,4 +1,11 @@
-const cache = require("./cache");
+let cache;
+if (process.env.BABEL_8_BREAKING) {
+  cache = require("./cache");
+} else if (global.TEST_USE_NEW_CACHE ?? !process.env.BABEL_CACHE_PATH) {
+  cache = require("./cache");
+} else {
+  cache = require("./cache-legacy");
+}
 
 function initialize(babel) {
   exports.init = null;

--- a/packages/babel-register/src/worker/cache-legacy.js
+++ b/packages/babel-register/src/worker/cache-legacy.js
@@ -1,0 +1,144 @@
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const findCacheDir = require("find-cache-dir");
+
+let FILENAME = process.env.BABEL_CACHE_PATH;
+
+// This function needs to be exported before requiring ./babel-core, because
+// there is a circular dependency between these two files.
+exports.initializeCacheFilename = function () {
+  FILENAME ||= path.join(
+    findCacheDir({ name: "@babel/register" }) || os.homedir() || os.tmpdir(),
+    `.babel.${babel.version}.${babel.getEnv()}.json`,
+  );
+};
+
+const babel = require("./babel-core");
+
+let data = {};
+
+let cacheDirty = false;
+
+let cacheDisabled = false;
+
+function isCacheDisabled() {
+  return process.env.BABEL_DISABLE_CACHE ?? cacheDisabled;
+}
+
+exports.save = save;
+/**
+ * Write stringified cache to disk.
+ */
+function save() {
+  if (isCacheDisabled() || !cacheDirty) return;
+  cacheDirty = false;
+
+  let serialised = "{}";
+
+  try {
+    serialised = JSON.stringify(data);
+  } catch (err) {
+    if (err.message === "Invalid string length") {
+      err.message = "Cache too large so it's been cleared.";
+      console.error(err.stack);
+    } else {
+      throw err;
+    }
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(FILENAME), { recursive: true });
+    fs.writeFileSync(FILENAME, serialised);
+  } catch (e) {
+    switch (e.code) {
+      // workaround https://github.com/nodejs/node/issues/31481
+      // todo: remove the ENOENT error check when we drop node.js 13 support
+      case "ENOENT":
+      case "EACCES":
+      case "EPERM":
+        console.warn(
+          `Babel could not write cache to file: ${FILENAME}
+due to a permission issue. Cache is disabled.`,
+        );
+        cacheDisabled = true;
+        break;
+      case "EROFS":
+        console.warn(
+          `Babel could not write cache to file: ${FILENAME}
+because it resides in a readonly filesystem. Cache is disabled.`,
+        );
+        cacheDisabled = true;
+        break;
+      default:
+        throw e;
+    }
+  }
+}
+
+/**
+ * Load cache from disk and parse.
+ */
+
+exports.load = function load() {
+  if (isCacheDisabled()) {
+    data = {};
+    return;
+  }
+
+  process.on("exit", save);
+  process.nextTick(save);
+
+  let cacheContent;
+
+  try {
+    // 128MB
+    if (fs.statSync(FILENAME).size >= 1024 * 1024 * 128) {
+      fs.rmSync(FILENAME);
+      return;
+    }
+
+    cacheContent = fs.readFileSync(FILENAME);
+  } catch (e) {
+    switch (e.code) {
+      // check EACCES only as fs.readFileSync will never throw EPERM on Windows
+      // https://github.com/libuv/libuv/blob/076df64dbbda4320f93375913a728efc40e12d37/src/win/fs.c#L735
+      case "EACCES":
+        console.warn(
+          `Babel could not read cache file: ${FILENAME}
+due to a permission issue. Cache is disabled.`,
+        );
+        cacheDisabled = true;
+      /* fall through */
+      default:
+        return;
+    }
+  }
+
+  try {
+    data = JSON.parse(cacheContent);
+  } catch {}
+};
+
+/**
+ * Retrieve data from cache.
+ */
+exports.get = function get() {
+  return data;
+};
+
+/**
+ * Set the cache dirty bit.
+ */
+exports.setDirty = function setDirty() {
+  cacheDirty = true;
+};
+
+/**
+ * Clear the cache object.
+ */
+exports.clear = function clear() {
+  data = {};
+};

--- a/packages/babel-register/src/worker/cache.js
+++ b/packages/babel-register/src/worker/cache.js
@@ -1,138 +1,225 @@
 "use strict";
 
+// This function needs to be exported before requiring ./babel-core, because
+// there is a circular dependency between these two files.
+exports.initializeCacheFilename = () => {};
+
+const babel = require("./babel-core");
+const findCacheDir = require("find-cache-dir");
+const LRU = require("lru-cache");
+
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const findCacheDir = require("find-cache-dir");
+const crypto = require("crypto");
+const zlib = require("zlib");
 
-let FILENAME = process.env.BABEL_CACHE_PATH;
+const CACHE_FILE_SUFFIX = process.env.BABEL_8_BREAKING ? ".v2.gz" : ".v1.gz";
+const MAX_PACKED_CACHE_SIZE = 1024 * 1024 * 128; // 128MB
+const SMALL_FILE_SIZE = 1024 * 32; // 32KB
 
-// This function needs to be exported before requiring ./babel-core, because
-// there is a circular dependency between these two files.
-exports.initializeCacheFilename = function () {
-  FILENAME ||= path.join(
-    findCacheDir({ name: "@babel/register" }) || os.homedir() || os.tmpdir(),
-    `.babel.${babel.version}.${babel.getEnv()}.json`,
-  );
-};
+class Cache {
+  constructor() {
+    this.BABEL_DISABLE_CACHE = process.env.BABEL_DISABLE_CACHE;
+    this.cacheDisabled = false;
+    this.cacheDir = process.env.BABEL_CACHE_PATH;
+    this.packedCachePath = undefined;
+    this.hasListener = false;
+    this.cacheDirty = false;
 
-const babel = require("./babel-core");
+    this.cacheDir ||= path.join(
+      findCacheDir({ name: "@babel/register" }) || os.tmpdir() || os.homedir(),
+      `.babel-register-cache`,
+    );
 
-let data = {};
+    this.packedCachePath = path.join(
+      this.cacheDir,
+      "packed-cache" + CACHE_FILE_SUFFIX,
+    );
 
-let cacheDirty = false;
+    try {
+      fs.mkdirSync(this.cacheDir, { recursive: true });
+    } catch (error) {
+      console.warn(error);
+      this.cacheDisabled = true;
+    }
 
-let cacheDisabled = false;
+    const sizeCalculation = data => data._cacheSize;
+    this.lruCache = process.env.BABEL_8_BREAKING
+      ? new LRU({
+          maxSize: MAX_PACKED_CACHE_SIZE,
+          sizeCalculation: sizeCalculation,
+        })
+      : new LRU({
+          max: MAX_PACKED_CACHE_SIZE,
+          length: sizeCalculation,
+        });
+  }
 
-function isCacheDisabled() {
-  return process.env.BABEL_DISABLE_CACHE ?? cacheDisabled;
-}
+  isCacheDisabled() {
+    return this.BABEL_DISABLE_CACHE || this.cacheDisabled;
+  }
 
-exports.save = save;
-/**
- * Write stringified cache to disk.
- */
-function save() {
-  if (isCacheDisabled() || !cacheDirty) return;
-  cacheDirty = false;
+  /**
+   *
+   * @returns return null when error
+   */
+  readCache(p) {
+    let value;
+    try {
+      value = fs.readFileSync(p);
+    } catch (e) {
+      switch (e.code) {
+        // check EACCES only as fs.readFileSync will never throw EPERM on Windows
+        // https://github.com/libuv/libuv/blob/076df64dbbda4320f93375913a728efc40e12d37/src/win/fs.c#L735
+        case "EACCES":
+          console.warn(
+            `Babel could not read cache file: ${p}
+due to a permission issue. Cache is disabled.`,
+          );
+          this.cacheDisabled = true;
+      }
+      return;
+    }
+    try {
+      value = JSON.parse(zlib.unzipSync(value));
+      return value;
+    } catch (error) {
+      return null;
+    }
+  }
 
-  let serialised = "{}";
+  writeCache(p, value) {
+    value = zlib.gzipSync(JSON.stringify(value));
+    try {
+      fs.writeFileSync(p, value);
+    } catch (e) {
+      switch (e.code) {
+        case "EACCES":
+        case "EPERM":
+          console.warn(
+            `Babel could not write cache to file: ${p}
+  due to a permission issue. Cache is disabled.`,
+          );
+          this.BABEL_DISABLE_CACHE = true;
+          break;
+        case "EROFS":
+          console.warn(
+            `Babel could not write cache to file: ${p}
+  because it resides in a readonly filesystem. Cache is disabled.`,
+          );
+          this.BABEL_DISABLE_CACHE = true;
+          break;
+        default:
+          console.error(e);
+      }
+    }
+  }
 
-  try {
-    serialised = JSON.stringify(data);
-  } catch (err) {
-    if (err.message === "Invalid string length") {
-      err.message = "Cache too large so it's been cleared.";
-      console.error(err.stack);
+  save = () => {
+    if (this.isCacheDisabled() || !this.cacheDirty) return;
+
+    this.writeCache(this.packedCachePath, { data: this.lruCache.dump() });
+    this.cacheDirty = false;
+  };
+
+  enable() {
+    if (this.BABEL_DISABLE_CACHE) {
+      return;
+    }
+
+    if (!this.hasListener) {
+      process.on("exit", this.save);
+      this.hasListener = true;
+    }
+    process.nextTick(this.save);
+
+    const packedCache = this.readCache(this.packedCachePath);
+
+    if (packedCache === null) {
+      try {
+        fs.rmSync(this.packedCachePath);
+      } catch (error) {}
+    }
+
+    if (packedCache) {
+      this.lruCache.load(packedCache.data);
+    } else if (process.env.BABEL_8_BREAKING) {
+      this.lruCache.clear();
     } else {
-      throw err;
+      this.lruCache.reset();
     }
+
+    this.cacheDirty = false;
   }
 
-  try {
-    fs.mkdirSync(path.dirname(FILENAME), { recursive: true });
-    fs.writeFileSync(FILENAME, serialised);
-  } catch (e) {
-    switch (e.code) {
-      // workaround https://github.com/nodejs/node/issues/31481
-      // todo: remove the ENOENT error check when we drop node.js 13 support
-      case "ENOENT":
-      case "EACCES":
-      case "EPERM":
-        console.warn(
-          `Babel could not write cache to file: ${FILENAME}
-due to a permission issue. Cache is disabled.`,
-        );
-        cacheDisabled = true;
-        break;
-      case "EROFS":
-        console.warn(
-          `Babel could not write cache to file: ${FILENAME}
-because it resides in a readonly filesystem. Cache is disabled.`,
-        );
-        cacheDisabled = true;
-        break;
-      default:
-        throw e;
+  disable() {
+    this.cacheDisabled = true;
+  }
+
+  get(opts, filePath) {
+    const id = v => v;
+
+    if (this.isCacheDisabled()) return { cached: null, store: id };
+
+    let cacheKey = `${JSON.stringify(opts)}:${babel.version}`;
+    const env = babel.getEnv();
+    if (env) cacheKey += `:${env}`;
+    cacheKey = crypto.createHash("sha1").update(cacheKey).digest("hex");
+
+    let cachePath;
+    let cached = this.lruCache.get(cacheKey);
+    if (!cached) {
+      cachePath = path.join(this.cacheDir, cacheKey + CACHE_FILE_SUFFIX);
+      cached = this.readCache(cachePath);
     }
+
+    const fileMtime = +fs.statSync(filePath).mtime;
+
+    if (cached && cached.mtime === fileMtime) {
+      return { cached: cached.value, store: id };
+    }
+
+    if (process.env.BABEL_8_BREAKING) {
+      this.lruCache.delete(cacheKey);
+    } else {
+      this.lruCache.del(cacheKey);
+    }
+
+    return {
+      cached: null,
+      store: value => {
+        const data = {
+          _cacheSize: JSON.stringify(value).length,
+          value,
+          mtime: fileMtime,
+        };
+
+        if (data._cacheSize > SMALL_FILE_SIZE) {
+          this.writeCache(cachePath, data);
+        } else {
+          this.lruCache.set(cacheKey, data);
+          this.cacheDirty = true;
+        }
+
+        return value;
+      },
+    };
   }
 }
 
-/**
- * Load cache from disk and parse.
- */
+exports.Cache = Cache;
 
-exports.load = function load() {
-  if (isCacheDisabled()) {
-    data = {};
-    return;
-  }
+const defaultCache = new Cache();
 
-  process.on("exit", save);
-  process.nextTick(save);
-
-  let cacheContent;
-
-  try {
-    cacheContent = fs.readFileSync(FILENAME);
-  } catch (e) {
-    switch (e.code) {
-      // check EACCES only as fs.readFileSync will never throw EPERM on Windows
-      // https://github.com/libuv/libuv/blob/076df64dbbda4320f93375913a728efc40e12d37/src/win/fs.c#L735
-      case "EACCES":
-        console.warn(
-          `Babel could not read cache file: ${FILENAME}
-due to a permission issue. Cache is disabled.`,
-        );
-        cacheDisabled = true;
-      /* fall through */
-      default:
-        return;
-    }
-  }
-
-  try {
-    data = JSON.parse(cacheContent);
-  } catch {}
+exports.enable = () => {
+  defaultCache.enable();
 };
 
-/**
- * Retrieve data from cache.
- */
-exports.get = function get() {
-  return data;
+exports.disable = function () {
+  defaultCache.disable();
 };
 
-/**
- * Set the cache dirty bit.
- */
-exports.setDirty = function setDirty() {
-  cacheDirty = true;
-};
-
-/**
- * Clear the cache object.
- */
-exports.clear = function clear() {
-  data = {};
+exports.get = function (opts, filePath) {
+  return defaultCache.get(opts, filePath);
 };

--- a/packages/babel-register/src/worker/transform.js
+++ b/packages/babel-register/src/worker/transform.js
@@ -16,12 +16,22 @@ function escapeRegExp(string) {
 let cache;
 let transformOpts;
 exports.setOptions = function (opts) {
-  if (opts.cache === false && cache) {
-    registerCache.clear();
-    cache = null;
-  } else if (opts.cache !== false && !cache) {
-    registerCache.load();
-    cache = registerCache.get();
+  if (registerCache.enable) {
+    if (opts.cache === false) {
+      registerCache.disable();
+    } else if (opts.cache !== false) {
+      registerCache.enable();
+    }
+    // eslint-disable-next-line no-func-assign
+    cacheLookup = registerCache.get;
+  } else {
+    if (opts.cache === false && cache) {
+      registerCache.clear();
+      cache = null;
+    } else if (opts.cache !== false && !cache) {
+      registerCache.load();
+      cache = registerCache.get();
+    }
   }
 
   delete opts.cache;

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -2,158 +2,283 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { createRequire, Module } from "module";
+import rimraf from "rimraf";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
-
-const testCacheFilename = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  ".cache.babel",
-);
-const oldBabelDisableCacheValue = process.env.BABEL_DISABLE_CACHE;
-
-process.env.BABEL_CACHE_PATH = testCacheFilename;
-delete process.env.BABEL_DISABLE_CACHE;
-
-function writeCache(data, mode = 0o666) {
-  if (typeof data === "object") {
-    data = JSON.stringify(data);
-  }
-
-  fs.writeFileSync(testCacheFilename, data, { mode });
-}
-
-function cleanCache() {
-  try {
-    fs.unlinkSync(testCacheFilename);
-  } catch (e) {
-    // It is convenient to always try to clear
-  }
-}
-
-function resetCache() {
-  process.env.BABEL_CACHE_PATH = null;
-  process.env.BABEL_DISABLE_CACHE = oldBabelDisableCacheValue;
-}
-
 const OLD_JEST_MOCKS = !!jest.doMock;
 
 describe("@babel/register - caching", () => {
   describe("cache", () => {
-    let load, get, setDirty, save;
-    let consoleWarnSpy;
+    beforeAll(() => {
+      global.TEST_USE_NEW_CACHE = true;
+    });
 
-    if (!OLD_JEST_MOCKS) {
-      let oldModuleCache;
-      beforeAll(() => {
-        oldModuleCache = Module._cache;
-      });
-      afterAll(() => {
-        Module._cache = oldModuleCache;
-      });
-    }
+    afterAll(() => {
+      delete global.TEST_USE_NEW_CACHE;
+      delete process.env.BABEL_CACHE_PATH;
+    });
+
+    const tmpPath = path.join(__dirname, "tmp");
+    let cache;
 
     beforeEach(() => {
-      // Since lib/cache is a singleton we need to fully reload it
-      if (OLD_JEST_MOCKS) {
-        jest.resetModules();
-      } else {
-        Module._cache = {};
-      }
-      const cache = require("../lib/cache.js");
-
-      load = cache.load;
-      get = cache.get;
-      setDirty = cache.setDirty;
-      save = cache.save;
-
-      consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      rimraf.sync(tmpPath);
+      fs.mkdirSync(tmpPath, { recursive: true });
     });
 
     afterEach(() => {
-      cleanCache();
-      consoleWarnSpy.mockRestore();
-    });
-    afterAll(resetCache);
-
-    it("should load and get cached data", () => {
-      writeCache({ foo: "bar" });
-
-      load();
-
-      expect(get()).toEqual({ foo: "bar" });
+      cache && cache.disable();
+      rimraf.sync(tmpPath);
     });
 
-    it("should load and get an object with no cached data", () => {
-      load();
+    it("should cache data", () => {
+      const Cache = require("../lib/cache.js").Cache;
+      cache = new Cache();
+      cache.enable();
 
-      expect(get()).toEqual({});
+      const file1 = path.join(tmpPath, "1.txt");
+      fs.writeFileSync(file1, "");
+      const file2 = path.join(tmpPath, "2.txt");
+      fs.writeFileSync(file2, "");
+
+      const result1 = cache.get({ id: 1 }, file1);
+      result1.store("1");
+      const result2 = cache.get({ id: 2 }, file1);
+      result2.store("2");
+      const result3 = cache.get({ id: 3 }, file2);
+      result3.store("3");
+
+      expect(cache.get({ id: 1 }, file1).cached).toBe("1");
+      expect(cache.get({ id: 2 }, file1).cached).toBe("2");
+      expect(cache.get({ id: 3 }, file2).cached).toBe("3");
+      expect(cache.get({ id: 4 }, file2).cached).toBeNull();
+
+      cache.save();
+      cache.disable();
+
+      cache = new Cache();
+
+      expect(cache.get({ id: 1 }, file1).cached).toBeNull();
+      expect(cache.get({ id: 2 }, file1).cached).toBeNull();
+      expect(cache.get({ id: 3 }, file2).cached).toBeNull();
+      expect(cache.get({ id: 4 }, file2).cached).toBeNull();
+
+      cache.enable();
+
+      expect(cache.get({ id: 1 }, file1).cached).toBe("1");
+      expect(cache.get({ id: 2 }, file1).cached).toBe("2");
+      expect(cache.get({ id: 3 }, file2).cached).toBe("3");
+      expect(cache.get({ id: 4 }, file2).cached).toBeNull();
+
+      fs.writeFileSync(file1, "");
+
+      expect(cache.get({ id: 1 }, file1).cached).toBeNull();
+      expect(cache.get({ id: 2 }, file1).cached).toBeNull();
+      expect(cache.get({ id: 3 }, file2).cached).toBe("3");
+      expect(cache.get({ id: 4 }, file2).cached).toBeNull();
     });
 
-    it("should load and get an object with invalid cached data", () => {
-      writeCache("foobar");
+    it("should work with broken data", () => {
+      const Cache = require("../lib/cache.js").Cache;
 
-      load();
+      process.env.BABEL_CACHE_PATH = path.join(
+        __dirname,
+        ".babel-register-cache",
+      );
 
-      expect(get()).toEqual({});
+      cache = new Cache();
+      cache.enable();
+
+      const file1 = path.join(tmpPath, "1.txt");
+      fs.writeFileSync(file1, "");
+
+      let result1 = cache.get({ id: 1 }, file1);
+      result1.store("1");
+
+      expect(cache.get({ id: 1 }, file1).cached).toBe("1");
+
+      cache.save();
+      cache.disable();
+
+      fs.writeFileSync(
+        path.join(
+          process.env.BABEL_CACHE_PATH,
+          "packed-cache" + (process.env.BABEL_8_BREAKING ? ".v2.gz" : ".v1.gz"),
+        ),
+        "123",
+      );
+
+      cache = new Cache();
+      cache.enable();
+
+      result1 = cache.get({ id: 1 }, file1);
+
+      expect(result1.cached).toBeNull();
+
+      result1.store("1");
+
+      cache.save();
+      cache.disable();
+
+      cache = new Cache();
+      cache.enable();
+
+      expect(cache.get({ id: 1 }, file1).cached).toBe("1");
+
+      rimraf.sync(process.env.BABEL_CACHE_PATH);
     });
+  });
 
-    it("should not create the cache if not dirty", () => {
-      save();
+  !process.env.BABEL_8_BREAKING &&
+    describe("cache-legacy", () => {
+      let load, get, setDirty, save;
+      let consoleWarnSpy;
 
-      expect(fs.existsSync(testCacheFilename)).toBe(false);
-      expect(get()).toEqual({});
-    });
-
-    it("should create the cache on save if dirty", () => {
-      setDirty();
-      save();
-
-      expect(fs.existsSync(testCacheFilename)).toBe(true);
-      expect(get()).toEqual({});
-    });
-
-    it("should create the cache after dirty", () => {
-      load();
-      setDirty();
-      return new Promise(resolve => {
-        process.nextTick(() => {
-          expect(fs.existsSync(testCacheFilename)).toBe(true);
-          expect(get()).toEqual({});
-          resolve();
+      if (!OLD_JEST_MOCKS) {
+        let oldModuleCache;
+        beforeAll(() => {
+          oldModuleCache = Module._cache;
         });
-      });
-    });
+        afterAll(() => {
+          Module._cache = oldModuleCache;
+        });
+      }
 
-    // Only write mode is effective on Windows
-    if (process.platform !== "win32") {
-      it("should be disabled when CACHE_PATH is not allowed to read", () => {
-        writeCache({ foo: "bar" }, 0o266);
+      const testCacheFilename = path.join(__dirname, ".cache.babel");
+      const oldBabelDisableCacheValue = process.env.BABEL_DISABLE_CACHE;
+
+      function writeCache(data, mode = 0o666) {
+        if (typeof data === "object") {
+          data = JSON.stringify(data);
+        }
+
+        fs.writeFileSync(testCacheFilename, data, { mode });
+      }
+
+      function cleanCache() {
+        try {
+          fs.unlinkSync(testCacheFilename);
+        } catch (e) {
+          // It is convenient to always try to clear
+        }
+      }
+
+      beforeAll(() => {
+        global.TEST_USE_NEW_CACHE = false;
+        process.env.BABEL_CACHE_PATH = testCacheFilename;
+        delete process.env.BABEL_DISABLE_CACHE;
+      });
+
+      afterAll(() => {
+        delete global.TEST_USE_NEW_CACHE;
+        delete process.env.BABEL_CACHE_PATH;
+        process.env.BABEL_DISABLE_CACHE = oldBabelDisableCacheValue;
+      });
+
+      beforeEach(() => {
+        // Since lib/cache is a singleton we need to fully reload it
+        if (OLD_JEST_MOCKS) {
+          jest.resetModules();
+        } else {
+          Module._cache = {};
+        }
+        const cache = require("../lib/cache.js");
+
+        load = cache.load;
+        get = cache.get;
+        setDirty = cache.setDirty;
+        save = cache.save;
+
+        consoleWarnSpy = jest
+          .spyOn(console, "warn")
+          .mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        cleanCache();
+        consoleWarnSpy.mockRestore();
+      });
+
+      it("should load and get cached data", () => {
+        writeCache({ foo: "bar" });
+
+        load();
+
+        expect(get()).toEqual({ foo: "bar" });
+      });
+
+      it("should load and get an object with no cached data", () => {
         load();
 
         expect(get()).toEqual({});
-        expect(consoleWarnSpy.mock.calls[0][0]).toContain(
-          "Babel could not read cache file",
-        );
       });
-    }
 
-    it("should be disabled when CACHE_PATH is not allowed to write", () => {
-      writeCache({ foo: "bar" }, 0o466);
+      it("should load and get an object with invalid cached data", () => {
+        writeCache("foobar");
 
-      load();
-      setDirty();
+        load();
 
-      expect(get()).toEqual({ foo: "bar" });
-      return new Promise(resolve => {
-        process.nextTick(() => {
+        expect(get()).toEqual({});
+      });
+
+      it("should not create the cache if not dirty", () => {
+        save();
+
+        expect(fs.existsSync(testCacheFilename)).toBe(false);
+        expect(get()).toEqual({});
+      });
+
+      it("should create the cache on save if dirty", () => {
+        setDirty();
+        save();
+
+        expect(fs.existsSync(testCacheFilename)).toBe(true);
+        expect(get()).toEqual({});
+      });
+
+      it("should create the cache after dirty", () => {
+        load();
+        setDirty();
+        return new Promise(resolve => {
+          process.nextTick(() => {
+            expect(fs.existsSync(testCacheFilename)).toBe(true);
+            expect(get()).toEqual({});
+            resolve();
+          });
+        });
+      });
+
+      // Only write mode is effective on Windows
+      if (process.platform !== "win32") {
+        it("should be disabled when CACHE_PATH is not allowed to read", () => {
+          writeCache({ foo: "bar" }, 0o266);
           load();
+
           expect(get()).toEqual({});
           expect(consoleWarnSpy.mock.calls[0][0]).toContain(
-            "Babel could not write cache to file",
+            "Babel could not read cache file",
           );
-          resolve();
+        });
+      }
+
+      it("should be disabled when CACHE_PATH is not allowed to write", () => {
+        writeCache({ foo: "bar" }, 0o466);
+
+        load();
+        setDirty();
+
+        expect(get()).toEqual({ foo: "bar" });
+        return new Promise(resolve => {
+          process.nextTick(() => {
+            load();
+            expect(get()).toEqual({});
+            expect(consoleWarnSpy.mock.calls[0][0]).toContain(
+              "Babel could not write cache to file",
+            );
+            resolve();
+          });
         });
       });
     });
-  });
 });

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -32,8 +32,17 @@ describe("@babel/register - caching", () => {
       rimraf.sync(tmpPath);
     });
 
-    it("should cache data", () => {
+    it("should cache data", async () => {
       const Cache = require("../lib/cache.js").Cache;
+
+      if (process.env.USE_ESM) {
+        // We must wait for the @babel/core used by @babel/register to be loaded
+        // eslint-disable-next-line no-unused-vars
+        await new Promise(resolve =>
+          eval("import('@babel/core').then(resolve)"),
+        );
+      }
+
       cache = new Cache();
       cache.enable();
 
@@ -79,8 +88,16 @@ describe("@babel/register - caching", () => {
       expect(cache.get({ id: 4 }, file2).cached).toBeNull();
     });
 
-    it("should work with broken data", () => {
+    it("should work with broken data", async () => {
       const Cache = require("../lib/cache.js").Cache;
+
+      if (process.env.USE_ESM) {
+        // We must wait for the @babel/core used by @babel/register to be loaded
+        // eslint-disable-next-line no-unused-vars
+        await new Promise(resolve =>
+          eval("import('@babel/core').then(resolve)"),
+        );
+      }
 
       process.env.BABEL_CACHE_PATH = path.join(
         __dirname,

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -408,8 +408,11 @@ describe("@babel/register", function () {
   }
 });
 
-function spawnNodeAsync(args, cwd = dirname, env) {
-  const spawn = child.spawn(process.execPath, args, { cwd, env });
+function spawnNodeAsync(args, cwd = dirname, env = {}) {
+  const spawn = child.spawn(process.execPath, args, {
+    cwd,
+    env: { ...env, BABEL_8_BREAKING: process.env.BABEL_8_BREAKING },
+  });
 
   let output = "";
   let callback;

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -3,6 +3,7 @@ import path from "path";
 import fs from "fs";
 import child from "child_process";
 import { fileURLToPath } from "url";
+import rimraf from "rimraf";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -24,7 +25,7 @@ const defaultOptions = {
 
 function cleanCache() {
   try {
-    fs.unlinkSync(testCacheFilename);
+    rimraf.sync(testCacheFilename);
   } catch (e) {
     // It is convenient to always try to clear
   }
@@ -409,9 +410,14 @@ describe("@babel/register", function () {
 });
 
 function spawnNodeAsync(args, cwd = dirname, env = {}) {
+  const newEnv = { ...env };
+  if (process.env.BABEL_8_BREAKING) {
+    newEnv.BABEL_8_BREAKING = process.env.BABEL_8_BREAKING;
+  }
+
   const spawn = child.spawn(process.execPath, args, {
     cwd,
-    env: { ...env, BABEL_8_BREAKING: process.env.BABEL_8_BREAKING },
+    env: newEnv,
   });
 
   let output = "";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,8 +3590,10 @@ __metadata:
     browserify: ^16.5.2
     clone-deep: ^4.0.1
     find-cache-dir: "condition:BABEL_8_BREAKING ? ^3.3.1 : ^2.0.0"
+    lru-cache: "condition:BABEL_8_BREAKING ? ^7.14.0 : ^5.1.1"
     make-dir: "condition:BABEL_8_BREAKING ? : ^2.1.0"
     pirates: ^4.0.5
+    rimraf: ^3.0.0
     source-map-support: ^0.5.16
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -11158,6 +11160,32 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"lru-cache-BABEL_8_BREAKING-false@npm:lru-cache@^5.1.1, lru-cache@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "lru-cache@npm:5.1.1"
+  dependencies:
+    yallist: ^3.0.2
+  checksum: c154ae1cbb0c2206d1501a0e94df349653c92c8cbb25236d7e85190bcaf4567a03ac6eb43166fabfa36fd35623694da7233e88d9601fbf411a9a481d85dbd2cb
+  languageName: node
+  linkType: hard
+
+"lru-cache-BABEL_8_BREAKING-true@npm:lru-cache@^7.14.0":
+  version: 7.14.0
+  resolution: "lru-cache@npm:7.14.0"
+  checksum: efdd329f2c1bb790b71d497c6c59272e6bc2d7dd060ba55fc136becd3dd31fc8346edb446275504d94cb60d3c8385dbf5267b79b23789e409b2bdf302d13f0d7
+  languageName: node
+  linkType: hard
+
+"lru-cache@condition:BABEL_8_BREAKING ? ^7.14.0 : ^5.1.1":
+  version: 0.0.0-condition-3beea6
+  resolution: "lru-cache@condition:BABEL_8_BREAKING?^7.14.0:^5.1.1#3beea6"
+  dependencies:
+    lru-cache-BABEL_8_BREAKING-false: "npm:lru-cache@^5.1.1"
+    lru-cache-BABEL_8_BREAKING-true: "npm:lru-cache@^7.14.0"
+  checksum: 98731c35aeb5d215f8936d30c8c14879d84ed1c4415a232dc9a0093c3b936a585a9219a772a073d333b92cd496622f6bca813a28b8b9849fc16117d2c6aabdeb
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^4.0.1":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
@@ -11165,15 +11193,6 @@ fsevents@^1.2.7:
     pseudomap: ^1.0.2
     yallist: ^2.1.2
   checksum: 4bb4b58a36cd7dc4dcec74cbe6a8f766a38b7426f1ff59d4cf7d82a2aa9b9565cd1cb98f6ff60ce5cd174524868d7bc9b7b1c294371851356066ca9ac4cf135a
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "lru-cache@npm:5.1.1"
-  dependencies:
-    yallist: ^3.0.2
-  checksum: c154ae1cbb0c2206d1501a0e94df349653c92c8cbb25236d7e85190bcaf4567a03ac6eb43166fabfa36fd35623694da7233e88d9601fbf411a9a481d85dbd2cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #5667 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |?
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | add `lru-cache`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is a refactoring of the `@babel/register` cache, still using `JSON.xxx` as this is not too slow and v8 mirrors do not allow cross node version compatibility
I marked it as discussion hoping to get more suggestions.
In this PR, the cache path is expected to be a directory instead of a file, which creates compatibility issues (in older versions, it would crash directly if the cache path was a directory), so I'm currently keeping the old logic, I'm not sure Is this a good practice.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15097"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

