### PR TITLE
Fix(estree): Reset export's start after decorator

### DIFF
--- a/eslint/babel-eslint-tests/test/integration/eslint/verify.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/verify.js
@@ -2,6 +2,32 @@ import verifyAndAssertMessages from "../../helpers/verifyAndAssertMessages.js";
 import path from "path";
 import { fileURLToPath } from "url";
 
+function verifyDecoratorsLegacyAndAssertMessages(
+  code,
+  rules,
+  expectedMessages,
+  sourceType,
+) {
+  const overrideConfig = {
+    parserOptions: {
+      sourceType,
+      babelOptions: {
+        configFile: path.resolve(
+          path.dirname(fileURLToPath(import.meta.url)),
+          "../../../../babel-eslint-shared-fixtures/config/babel.config.decorators-legacy.js",
+        ),
+      },
+    },
+  };
+  return verifyAndAssertMessages(
+    code,
+    rules,
+    expectedMessages,
+    sourceType,
+    overrideConfig,
+  );
+}
+
 describe("verify", () => {
   it("arrow function support (issue #1)", () => {
     verifyAndAssertMessages("describe('stuff', () => {});");
@@ -1073,32 +1099,6 @@ describe("verify", () => {
   });
 
   describe("decorators #72 (legacy)", () => {
-    function verifyDecoratorsLegacyAndAssertMessages(
-      code,
-      rules,
-      expectedMessages,
-      sourceType,
-    ) {
-      const overrideConfig = {
-        parserOptions: {
-          sourceType,
-          babelOptions: {
-            configFile: path.resolve(
-              path.dirname(fileURLToPath(import.meta.url)),
-              "../../../../babel-eslint-shared-fixtures/config/babel.config.decorators-legacy.js",
-            ),
-          },
-        },
-      };
-      return verifyAndAssertMessages(
-        code,
-        rules,
-        expectedMessages,
-        sourceType,
-        overrideConfig,
-      );
-    }
-
     it("class declaration", () => {
       verifyDecoratorsLegacyAndAssertMessages(
         `
@@ -1243,6 +1243,16 @@ describe("verify", () => {
           }
         `,
         { "no-unused-vars": 1 },
+      );
+    });
+  });
+
+  describe("decorators #15085 (legacy)", () => {
+    it("works with keyword-spacing rule", () => {
+      verifyDecoratorsLegacyAndAssertMessages(
+        "@dec export class C {}; @dec export default class {}",
+        { "keyword-spacing": 1 },
+        [],
       );
     });
   });

--- a/packages/babel-parser/test/fixtures/estree/export/decorator-before-export/input.js
+++ b/packages/babel-parser/test/fixtures/estree/export/decorator-before-export/input.js
@@ -1,0 +1,2 @@
+@dec export class C {}
+@dec export default class {}

--- a/packages/babel-parser/test/fixtures/estree/export/decorator-before-export/options.json
+++ b/packages/babel-parser/test/fixtures/estree/export/decorator-before-export/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["estree", "decorators-legacy"]
+}

--- a/packages/babel-parser/test/fixtures/estree/export/decorator-before-export/output.json
+++ b/packages/babel-parser/test/fixtures/estree/export/decorator-before-export/output.json
@@ -1,0 +1,70 @@
+{
+  "type": "File",
+  "start":0,"end":51,"loc":{"start":{"line":1,"column":0},"end":{"line":2,"column":28}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":51,"loc":{"start":{"line":1,"column":0},"end":{"line":2,"column":28}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start":5,"end":22,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":22}},
+        "specifiers": [],
+        "source": null,
+        "declaration": {
+          "type": "ClassDeclaration",
+          "start":0,"end":22,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":22}},
+          "id": {
+            "type": "Identifier",
+            "start":18,"end":19,"loc":{"start":{"line":1,"column":18},"end":{"line":1,"column":19},"identifierName":"C"},
+            "name": "C"
+          },
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "start":20,"end":22,"loc":{"start":{"line":1,"column":20},"end":{"line":1,"column":22}},
+            "body": []
+          },
+          "decorators": [
+            {
+              "type": "Decorator",
+              "start":0,"end":4,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":4}},
+              "expression": {
+                "type": "Identifier",
+                "start":1,"end":4,"loc":{"start":{"line":1,"column":1},"end":{"line":1,"column":4},"identifierName":"dec"},
+                "name": "dec"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "ExportDefaultDeclaration",
+        "start":28,"end":51,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":28}},
+        "declaration": {
+          "type": "ClassDeclaration",
+          "start":23,"end":51,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":28}},
+          "id": null,
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "start":49,"end":51,"loc":{"start":{"line":2,"column":26},"end":{"line":2,"column":28}},
+            "body": []
+          },
+          "decorators": [
+            {
+              "type": "Decorator",
+              "start":23,"end":27,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":4}},
+              "expression": {
+                "type": "Identifier",
+                "start":24,"end":27,"loc":{"start":{"line":2,"column":1},"end":{"line":2,"column":4},"identifierName":"dec"},
+                "name": "dec"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15085 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we partially reverts https://github.com/babel/babel/pull/15032 when `estree` plugin is enabled, so that the legacy syntax `@dec export default class {}` still work with the `keyword-spacing` rule.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15107"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

