### PR TITLE
fix: wrap anonymous class expression within statement

### DIFF
--- a/packages/babel-plugin-proposal-decorators/src/transformer-2022-03.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-2022-03.ts
@@ -937,7 +937,12 @@ function transformClass(
         class extends ${state.addHelper("identity")} {}
       ` as t.ClassExpression;
       staticsClass.body.body = [
-        t.staticBlock([t.toStatement(path.node, false)]),
+        t.staticBlock([
+          t.toStatement(originalClass, true) ||
+            // If toStatement returns false, originalClass must be an anonymous ClassExpression,
+            // because `export default @dec ...` has been handled in the export visitor before.
+            t.expressionStatement(originalClass as t.ClassExpression),
+        ]),
         ...statics,
       ];
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions-static-blocks/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions-static-blocks/input.js
@@ -1,0 +1,12 @@
+const dec = () => {};
+const A = @dec class A { static {} }
+const B = @dec class C { static {} }
+const D = @dec class { static {} }
+const E = (@dec class { static {} }, 123);
+const F = [@dec class G { static {} }, @dec class { static {} }];
+const H = @dec class extends I { static {} };
+const J = @dec class K extends L { static {} };
+
+function classFactory() {
+  return @dec class { static {} }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions-static-blocks/output.js
@@ -1,0 +1,67 @@
+var _initClass, _A, _temp, _initClass2, _C, _temp2, _initClass3, _D, _temp3, _initClass4, _decorated_class, _temp4, _class2, _initClass5, _G, _temp5, _initClass6, _decorated_class2, _temp6, _class3, _initClass7, _H, _temp7, _initClass8, _K, _temp8;
+const dec = () => {};
+const A = (new (_temp = class extends babelHelpers.identity {
+  constructor() {
+    super(_A), (() => {})(), _initClass();
+  }
+}, (() => {
+  class A {}
+  [_A, _initClass] = babelHelpers.applyDecs(A, [], [dec]);
+})(), _temp)(), _A);
+const B = (new (_temp2 = class extends babelHelpers.identity {
+  constructor() {
+    super(_C), (() => {})(), _initClass2();
+  }
+}, (() => {
+  class C {}
+  [_C, _initClass2] = babelHelpers.applyDecs(C, [], [dec]);
+})(), _temp2)(), _C);
+const D = (new (_temp3 = class extends babelHelpers.identity {
+  constructor() {
+    super(_D), (() => {})(), _initClass3();
+  }
+}, (() => {
+  class D {}
+  [_D, _initClass3] = babelHelpers.applyDecs(D, [], [dec]);
+})(), _temp3)(), _D);
+const E = ((new (_temp4 = class extends babelHelpers.identity {
+  constructor() {
+    super(_decorated_class), (() => {})(), _initClass4();
+  }
+}, (_class2 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs(_class2, [], [dec])), _temp4)(), _decorated_class), 123);
+const F = [(new (_temp5 = class extends babelHelpers.identity {
+  constructor() {
+    super(_G), (() => {})(), _initClass5();
+  }
+}, (() => {
+  class G {}
+  [_G, _initClass5] = babelHelpers.applyDecs(G, [], [dec]);
+})(), _temp5)(), _G), (new (_temp6 = class extends babelHelpers.identity {
+  constructor() {
+    super(_decorated_class2), (() => {})(), _initClass6();
+  }
+}, (_class3 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs(_class3, [], [dec])), _temp6)(), _decorated_class2)];
+const H = (new (_temp7 = class extends babelHelpers.identity {
+  constructor() {
+    super(_H), (() => {})(), _initClass7();
+  }
+}, (() => {
+  class H extends I {}
+  [_H, _initClass7] = babelHelpers.applyDecs(H, [], [dec]);
+})(), _temp7)(), _H);
+const J = (new (_temp8 = class extends babelHelpers.identity {
+  constructor() {
+    super(_K), (() => {})(), _initClass8();
+  }
+}, (() => {
+  class K extends L {}
+  [_K, _initClass8] = babelHelpers.applyDecs(K, [], [dec]);
+})(), _temp8)(), _K);
+function classFactory() {
+  var _initClass9, _decorated_class3, _temp9, _class5;
+  return new (_temp9 = class extends babelHelpers.identity {
+    constructor() {
+      super(_decorated_class3), (() => {})(), _initClass9();
+    }
+  }, (_class5 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs(_class5, [], [dec])), _temp9)(), _decorated_class3;
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/expressions-static-blocks/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/expressions-static-blocks/input.js
@@ -1,0 +1,12 @@
+const dec = () => {};
+const A = @dec class A { static {} }
+const B = @dec class C { static {} }
+const D = @dec class { static {} }
+const E = (@dec class { static {} }, 123);
+const F = [@dec class G { static {} }, @dec class { static {} }];
+const H = @dec class extends I { static {} };
+const J = @dec class K extends L { static {} };
+
+function classFactory() {
+  return @dec class { static {} }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/expressions-static-blocks/output.js
@@ -1,0 +1,112 @@
+var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
+const dec = () => {};
+const A = (new class extends babelHelpers.identity {
+  static {
+    class A {
+      static {
+        [_A, _initClass] = babelHelpers.applyDecs(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_A), (() => {})(), _initClass();
+  }
+}(), _A);
+const B = (new class extends babelHelpers.identity {
+  static {
+    class C {
+      static {
+        [_C, _initClass2] = babelHelpers.applyDecs(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_C), (() => {})(), _initClass2();
+  }
+}(), _C);
+const D = (new class extends babelHelpers.identity {
+  static {
+    class D {
+      static {
+        [_D, _initClass3] = babelHelpers.applyDecs(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_D), (() => {})(), _initClass3();
+  }
+}(), _D);
+const E = ((new class extends babelHelpers.identity {
+  static {
+    (class {
+      static {
+        [_decorated_class, _initClass4] = babelHelpers.applyDecs(this, [], [dec]);
+      }
+    });
+  }
+  constructor() {
+    super(_decorated_class), (() => {})(), _initClass4();
+  }
+}(), _decorated_class), 123);
+const F = [(new class extends babelHelpers.identity {
+  static {
+    class G {
+      static {
+        [_G, _initClass5] = babelHelpers.applyDecs(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_G), (() => {})(), _initClass5();
+  }
+}(), _G), (new class extends babelHelpers.identity {
+  static {
+    (class {
+      static {
+        [_decorated_class2, _initClass6] = babelHelpers.applyDecs(this, [], [dec]);
+      }
+    });
+  }
+  constructor() {
+    super(_decorated_class2), (() => {})(), _initClass6();
+  }
+}(), _decorated_class2)];
+const H = (new class extends babelHelpers.identity {
+  static {
+    class H extends I {
+      static {
+        [_H, _initClass7] = babelHelpers.applyDecs(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_H), (() => {})(), _initClass7();
+  }
+}(), _H);
+const J = (new class extends babelHelpers.identity {
+  static {
+    class K extends L {
+      static {
+        [_K, _initClass8] = babelHelpers.applyDecs(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_K), (() => {})(), _initClass8();
+  }
+}(), _K);
+function classFactory() {
+  var _initClass9, _decorated_class3;
+  return new class extends babelHelpers.identity {
+    static {
+      (class {
+        static {
+          [_decorated_class3, _initClass9] = babelHelpers.applyDecs(this, [], [dec]);
+        }
+      });
+    }
+    constructor() {
+      super(_decorated_class3), (() => {})(), _initClass9();
+    }
+  }(), _decorated_class3;
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions-static-blocks/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions-static-blocks/input.js
@@ -1,0 +1,12 @@
+const dec = () => {};
+const A = @dec class A { static {} }
+const B = @dec class C { static {} }
+const D = @dec class { static {} }
+const E = (@dec class { static {} }, 123);
+const F = [@dec class G { static {} }, @dec class { static {} }];
+const H = @dec class extends I { static {} };
+const J = @dec class K extends L { static {} };
+
+function classFactory() {
+  return @dec class { static {} }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions-static-blocks/output.js
@@ -1,0 +1,67 @@
+var _initClass, _A, _temp, _initClass2, _C, _temp2, _initClass3, _D, _temp3, _initClass4, _decorated_class, _temp4, _class2, _initClass5, _G, _temp5, _initClass6, _decorated_class2, _temp6, _class3, _initClass7, _H, _temp7, _initClass8, _K, _temp8;
+const dec = () => {};
+const A = (new (_temp = class extends babelHelpers.identity {
+  constructor() {
+    super(_A), (() => {})(), _initClass();
+  }
+}, (() => {
+  class A {}
+  [_A, _initClass] = babelHelpers.applyDecs2203(A, [], [dec]);
+})(), _temp)(), _A);
+const B = (new (_temp2 = class extends babelHelpers.identity {
+  constructor() {
+    super(_C), (() => {})(), _initClass2();
+  }
+}, (() => {
+  class C {}
+  [_C, _initClass2] = babelHelpers.applyDecs2203(C, [], [dec]);
+})(), _temp2)(), _C);
+const D = (new (_temp3 = class extends babelHelpers.identity {
+  constructor() {
+    super(_D), (() => {})(), _initClass3();
+  }
+}, (() => {
+  class D {}
+  [_D, _initClass3] = babelHelpers.applyDecs2203(D, [], [dec]);
+})(), _temp3)(), _D);
+const E = ((new (_temp4 = class extends babelHelpers.identity {
+  constructor() {
+    super(_decorated_class), (() => {})(), _initClass4();
+  }
+}, (_class2 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2203(_class2, [], [dec])), _temp4)(), _decorated_class), 123);
+const F = [(new (_temp5 = class extends babelHelpers.identity {
+  constructor() {
+    super(_G), (() => {})(), _initClass5();
+  }
+}, (() => {
+  class G {}
+  [_G, _initClass5] = babelHelpers.applyDecs2203(G, [], [dec]);
+})(), _temp5)(), _G), (new (_temp6 = class extends babelHelpers.identity {
+  constructor() {
+    super(_decorated_class2), (() => {})(), _initClass6();
+  }
+}, (_class3 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2203(_class3, [], [dec])), _temp6)(), _decorated_class2)];
+const H = (new (_temp7 = class extends babelHelpers.identity {
+  constructor() {
+    super(_H), (() => {})(), _initClass7();
+  }
+}, (() => {
+  class H extends I {}
+  [_H, _initClass7] = babelHelpers.applyDecs2203(H, [], [dec]);
+})(), _temp7)(), _H);
+const J = (new (_temp8 = class extends babelHelpers.identity {
+  constructor() {
+    super(_K), (() => {})(), _initClass8();
+  }
+}, (() => {
+  class K extends L {}
+  [_K, _initClass8] = babelHelpers.applyDecs2203(K, [], [dec]);
+})(), _temp8)(), _K);
+function classFactory() {
+  var _initClass9, _decorated_class3, _temp9, _class5;
+  return new (_temp9 = class extends babelHelpers.identity {
+    constructor() {
+      super(_decorated_class3), (() => {})(), _initClass9();
+    }
+  }, (_class5 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2203(_class5, [], [dec])), _temp9)(), _decorated_class3;
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/expressions-static-blocks/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/expressions-static-blocks/input.js
@@ -1,0 +1,12 @@
+const dec = () => {};
+const A = @dec class A { static {} }
+const B = @dec class C { static {} }
+const D = @dec class { static {} }
+const E = (@dec class { static {} }, 123);
+const F = [@dec class G { static {} }, @dec class { static {} }];
+const H = @dec class extends I { static {} };
+const J = @dec class K extends L { static {} };
+
+function classFactory() {
+  return @dec class { static {} }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/expressions-static-blocks/output.js
@@ -1,0 +1,112 @@
+var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
+const dec = () => {};
+const A = (new class extends babelHelpers.identity {
+  static {
+    class A {
+      static {
+        [_A, _initClass] = babelHelpers.applyDecs2203(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_A), (() => {})(), _initClass();
+  }
+}(), _A);
+const B = (new class extends babelHelpers.identity {
+  static {
+    class C {
+      static {
+        [_C, _initClass2] = babelHelpers.applyDecs2203(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_C), (() => {})(), _initClass2();
+  }
+}(), _C);
+const D = (new class extends babelHelpers.identity {
+  static {
+    class D {
+      static {
+        [_D, _initClass3] = babelHelpers.applyDecs2203(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_D), (() => {})(), _initClass3();
+  }
+}(), _D);
+const E = ((new class extends babelHelpers.identity {
+  static {
+    (class {
+      static {
+        [_decorated_class, _initClass4] = babelHelpers.applyDecs2203(this, [], [dec]);
+      }
+    });
+  }
+  constructor() {
+    super(_decorated_class), (() => {})(), _initClass4();
+  }
+}(), _decorated_class), 123);
+const F = [(new class extends babelHelpers.identity {
+  static {
+    class G {
+      static {
+        [_G, _initClass5] = babelHelpers.applyDecs2203(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_G), (() => {})(), _initClass5();
+  }
+}(), _G), (new class extends babelHelpers.identity {
+  static {
+    (class {
+      static {
+        [_decorated_class2, _initClass6] = babelHelpers.applyDecs2203(this, [], [dec]);
+      }
+    });
+  }
+  constructor() {
+    super(_decorated_class2), (() => {})(), _initClass6();
+  }
+}(), _decorated_class2)];
+const H = (new class extends babelHelpers.identity {
+  static {
+    class H extends I {
+      static {
+        [_H, _initClass7] = babelHelpers.applyDecs2203(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_H), (() => {})(), _initClass7();
+  }
+}(), _H);
+const J = (new class extends babelHelpers.identity {
+  static {
+    class K extends L {
+      static {
+        [_K, _initClass8] = babelHelpers.applyDecs2203(this, [], [dec]);
+      }
+    }
+  }
+  constructor() {
+    super(_K), (() => {})(), _initClass8();
+  }
+}(), _K);
+function classFactory() {
+  var _initClass9, _decorated_class3;
+  return new class extends babelHelpers.identity {
+    static {
+      (class {
+        static {
+          [_decorated_class3, _initClass9] = babelHelpers.applyDecs2203(this, [], [dec]);
+        }
+      });
+    }
+    constructor() {
+      super(_decorated_class3), (() => {})(), _initClass9();
+    }
+  }(), _decorated_class3;
+}

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.ts
@@ -531,7 +531,7 @@ export default declare((api, opts: Options) => {
           nodeWithoutSpread.right = t.identifier(refName);
           nodes.push(t.expressionStatement(nodeWithoutSpread));
           nodes.push(
-            t.toStatement(
+            t.expressionStatement(
               t.assignmentExpression("=", argument, callExpression),
             ),
           );

--- a/packages/babel-plugin-transform-jscript/src/index.ts
+++ b/packages/babel-plugin-transform-jscript/src/index.ts
@@ -19,7 +19,7 @@ export default declare(api => {
                 null,
                 [],
                 t.blockStatement([
-                  // @ts-expect-error fixme: t.toStatement may return false
+                  // @ts-expect-error t.toStatement must return a FunctionDeclaration if node.id is defined
                   t.toStatement(node),
                   t.returnStatement(t.cloneNode(node.id)),
                 ]),


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15112 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Babel currently throws at decorated anonymous class expression, e.g. `@dec class { static {} }` because we invoked `t.toStatement`. Here we wrap the class expression within an expression statement so that it can be fit in the static block that we used for class decorators.

Before develop this issue I realize that Babel doesn't support the named evaluation for decorated class expression, for example

```js
const dec = (value, context) => {
  context.name; // <-- should be "A", currently "_class"
  return value;
};

let A;
A = @dec class {}
```

TypeScript injects `__setFunctionName` helper call before applying the decorator transform to ensure that `context.name` is always correct (https://github.com/microsoft/TypeScript/pull/50820#discussion_r1009828932). I will address this issue in a separate PR.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15113"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

