### PR TITLE
Parser option to allow `new.target` outside functions

### DIFF
--- a/packages/babel-parser/data/schema.json
+++ b/packages/babel-parser/data/schema.json
@@ -49,6 +49,10 @@
       "description": "By default, a return statement at the top level raises an error.\nSet this to true to accept such code.",
       "type": "boolean"
     },
+    "allowNewTargetOutsideFunction": {
+      "description": "By default, new.target use is not allowed outside of a function or class.\nSet this to true to accept such code.",
+      "type": "boolean"
+    },
     "allowSuperOutsideMethod": {
       "type": "boolean"
     },

--- a/packages/babel-parser/src/options.ts
+++ b/packages/babel-parser/src/options.ts
@@ -43,8 +43,8 @@ export const defaultOptions: Options = {
   // When enabled, a return at the top level is not considered an
   // error.
   allowReturnOutsideFunction: false,
-  // When enabled, new.target at the top level is not considered an
-  // error.
+  // When enabled, new.target outside a function or class is not
+  // considered an error.
   allowNewTargetOutsideFunction: false,
   // When enabled, import/export statements are not constrained to
   // appearing at the top of the program.

--- a/packages/babel-parser/src/options.ts
+++ b/packages/babel-parser/src/options.ts
@@ -12,6 +12,7 @@ export type Options = {
   startLine: number;
   allowAwaitOutsideFunction: boolean;
   allowReturnOutsideFunction: boolean;
+  allowNewTargetOutsideFunction: boolean;
   allowImportExportEverywhere: boolean;
   allowSuperOutsideMethod: boolean;
   allowUndeclaredExports: boolean;
@@ -42,6 +43,9 @@ export const defaultOptions: Options = {
   // When enabled, a return at the top level is not considered an
   // error.
   allowReturnOutsideFunction: false,
+  // When enabled, new.target at the top level is not considered an
+  // error.
+  allowNewTargetOutsideFunction: false,
   // When enabled, import/export statements are not constrained to
   // appearing at the top of the program.
   allowImportExportEverywhere: false,

--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -1880,7 +1880,11 @@ export default abstract class ExpressionParser extends LValParser {
         "target",
       );
 
-      if (!this.scope.inNonArrowFunction && !this.scope.inClass) {
+      if (
+        !this.scope.inNonArrowFunction &&
+        !this.scope.inClass &&
+        !this.options.allowNewTargetOutsideFunction
+      ) {
         this.raise(Errors.UnexpectedNewTarget, { at: metaProp });
       }
 

--- a/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false-2/input.js
+++ b/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false-2/input.js
@@ -1,2 +1,1 @@
-const x = new.target;
 const y = () => new.target;

--- a/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false-2/options.json
+++ b/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false-2/options.json
@@ -1,0 +1,4 @@
+{
+  "errorRecovery": false,
+  "throws": "`new.target` can only be used in functions or class properties. (1:16)"
+}

--- a/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false/input.js
+++ b/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false/input.js
@@ -1,0 +1,1 @@
+new.target

--- a/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false/input.js
+++ b/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false/input.js
@@ -1,1 +1,1 @@
-new.target
+const x = new.target;

--- a/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false/options.json
+++ b/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false/options.json
@@ -1,0 +1,4 @@
+{
+  "errorRecovery": false,
+  "throws": "`new.target` can only be used in functions or class properties. (1:0)"
+}

--- a/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false/options.json
+++ b/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-false/options.json
@@ -1,4 +1,4 @@
 {
   "errorRecovery": false,
-  "throws": "`new.target` can only be used in functions or class properties. (1:0)"
+  "throws": "`new.target` can only be used in functions or class properties. (1:10)"
 }

--- a/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/input.js
+++ b/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/input.js
@@ -1,0 +1,1 @@
+new.target

--- a/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/options.json
+++ b/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/options.json
@@ -1,0 +1,4 @@
+{
+  "allowNewTargetOutsideFunction": true,
+  "errorRecovery": false
+}

--- a/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/output.json
+++ b/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/output.json
@@ -1,29 +1,79 @@
 {
   "type": "File",
-  "start":0,"end":10,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":10,"index":10}},
+  "start":0,"end":49,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":27,"index":49}},
   "program": {
     "type": "Program",
-    "start":0,"end":10,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":10,"index":10}},
+    "start":0,"end":49,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":27,"index":49}},
     "sourceType": "script",
     "interpreter": null,
     "body": [
       {
-        "type": "ExpressionStatement",
-        "start":0,"end":10,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":10,"index":10}},
-        "expression": {
-          "type": "MetaProperty",
-          "start":0,"end":10,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":10,"index":10}},
-          "meta": {
-            "type": "Identifier",
-            "start":0,"end":3,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":3,"index":3},"identifierName":"new"},
-            "name": "new"
-          },
-          "property": {
-            "type": "Identifier",
-            "start":4,"end":10,"loc":{"start":{"line":1,"column":4,"index":4},"end":{"line":1,"column":10,"index":10},"identifierName":"target"},
-            "name": "target"
+        "type": "VariableDeclaration",
+        "start":0,"end":21,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":21,"index":21}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":6,"end":20,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":20,"index":20}},
+            "id": {
+              "type": "Identifier",
+              "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"x"},
+              "name": "x"
+            },
+            "init": {
+              "type": "MetaProperty",
+              "start":10,"end":20,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":20,"index":20}},
+              "meta": {
+                "type": "Identifier",
+                "start":10,"end":13,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":13,"index":13},"identifierName":"new"},
+                "name": "new"
+              },
+              "property": {
+                "type": "Identifier",
+                "start":14,"end":20,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":20,"index":20},"identifierName":"target"},
+                "name": "target"
+              }
+            }
           }
-        }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start":22,"end":49,"loc":{"start":{"line":2,"column":0,"index":22},"end":{"line":2,"column":27,"index":49}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":28,"end":48,"loc":{"start":{"line":2,"column":6,"index":28},"end":{"line":2,"column":26,"index":48}},
+            "id": {
+              "type": "Identifier",
+              "start":28,"end":29,"loc":{"start":{"line":2,"column":6,"index":28},"end":{"line":2,"column":7,"index":29},"identifierName":"y"},
+              "name": "y"
+            },
+            "init": {
+              "type": "ArrowFunctionExpression",
+              "start":32,"end":48,"loc":{"start":{"line":2,"column":10,"index":32},"end":{"line":2,"column":26,"index":48}},
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "MetaProperty",
+                "start":38,"end":48,"loc":{"start":{"line":2,"column":16,"index":38},"end":{"line":2,"column":26,"index":48}},
+                "meta": {
+                  "type": "Identifier",
+                  "start":38,"end":41,"loc":{"start":{"line":2,"column":16,"index":38},"end":{"line":2,"column":19,"index":41},"identifierName":"new"},
+                  "name": "new"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "start":42,"end":48,"loc":{"start":{"line":2,"column":20,"index":42},"end":{"line":2,"column":26,"index":48},"identifierName":"target"},
+                  "name": "target"
+                }
+              }
+            }
+          }
+        ],
+        "kind": "const"
       }
     ],
     "directives": []

--- a/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/output.json
+++ b/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/output.json
@@ -1,0 +1,31 @@
+{
+  "type": "File",
+  "start":0,"end":10,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":10,"index":10}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":10,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":10,"index":10}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":10,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":10,"index":10}},
+        "expression": {
+          "type": "MetaProperty",
+          "start":0,"end":10,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":10,"index":10}},
+          "meta": {
+            "type": "Identifier",
+            "start":0,"end":3,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":3,"index":3},"identifierName":"new"},
+            "name": "new"
+          },
+          "property": {
+            "type": "Identifier",
+            "start":4,"end":10,"loc":{"start":{"line":1,"column":4,"index":4},"end":{"line":1,"column":10,"index":10},"identifierName":"target"},
+            "name": "target"
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -122,6 +122,12 @@ interface ParserOptions {
    */
   allowReturnOutsideFunction?: boolean;
 
+  /**
+   * By default, new.target use is not allowed outside of a function or class.
+   * Set this to true to accept such code.
+   */
+  allowNewTargetOutsideFunction?: boolean;
+
   allowSuperOutsideMethod?: boolean;
 
   /**


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | n/a
| Any Dependency Changes?  | No
| License                  | MIT

This PR adds an option for `parse` to allow `new.target` outside of functions.

There are 2 places this can be useful:

1. In CommonJS code, `new.target` at top level is legal (if fairly pointless) as CommonJS code is compiled in a function wrapper.
2. When parsing code which will be wrapped in a function or execute in `eval()` where it inherits `new.target` from the outer scope.

I've called the option `allowNewTargetOutsideFunction` to match `allowAwaitOutsideFunction` and `allowReturnOutsideFunction`.

If accepted, I'll make a 2nd PR on the website repo to document this new option.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15114"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

