### PR TITLE
fix: `tsSatisfiesExpression` does not exist in the bundled old version `@babel/types`

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -1,6 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxTypeScript from "@babel/plugin-syntax-typescript";
-import { types as t, template } from "@babel/core";
+import type { types as t } from "@babel/core";
 import { injectInitialization } from "@babel/helper-create-class-features-plugin";
 import type { Binding, NodePath, Scope } from "@babel/traverse";
 import type { Options as SyntaxOptions } from "@babel/plugin-syntax-typescript";
@@ -96,6 +96,10 @@ type ExtraNodeProps = {
 };
 
 export default declare((api, opts: Options) => {
+  // Some downstream bundled `@babel/core` and `@babel/types`.
+  // Ref: https://github.com/babel/babel/issues/15089
+  const { types: t, template } = api;
+
   api.assertVersion(7);
 
   const JSX_PRAGMA_REGEX = /\*?\s*@jsx((?:Frag)?)\s+([^\s]+)/;
@@ -595,9 +599,7 @@ export default declare((api, opts: Options) => {
 
       [`TSAsExpression${
         // Added in Babel 7.20.0
-        // Some downstream bundled `@babel/core` and `@babel/types`.
-        // Ref: https://github.com/babel/babel/issues/15089
-        api.types.tsSatisfiesExpression ? "|TSSatisfiesExpression" : ""
+        t.tsSatisfiesExpression ? "|TSSatisfiesExpression" : ""
       }`](path: NodePath<t.TSAsExpression | t.TSSatisfiesExpression>) {
         let { node }: { node: t.Expression } = path;
         do {

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -96,7 +96,7 @@ type ExtraNodeProps = {
 };
 
 export default declare((api, opts: Options) => {
-  // Some downstream bundled `@babel/core` and `@babel/types`.
+  // `@babel/core` and `@babel/types` are bundled in some downstream libraries.
   // Ref: https://github.com/babel/babel/issues/15089
   const { types: t, template } = api;
 

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -595,7 +595,9 @@ export default declare((api, opts: Options) => {
 
       [`TSAsExpression${
         // Added in Babel 7.20.0
-        t.tsSatisfiesExpression ? "|TSSatisfiesExpression" : ""
+        // Some downstream bundled `@babel/core` and `@babel/types`.
+        // Ref: https://github.com/babel/babel/issues/15089
+        api.types.tsSatisfiesExpression ? "|TSSatisfiesExpression" : ""
       }`](path: NodePath<t.TSAsExpression | t.TSSatisfiesExpression>) {
         let { node }: { node: t.Expression } = path;
         do {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15089 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | ×
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15121"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

