### PR TITLE
Fix compilation of parameters in async generators

### DIFF
--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/15145/exec.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/15145/exec.js
@@ -1,0 +1,10 @@
+async function * foo (p = 1) {
+  yield "hello";
+  yield p;
+}
+
+return (async () => {
+  const res = [];
+  for await (const x of foo()) res.push(x);
+  expect(res).toEqual(["hello", 1]);
+})();

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/15145/options.json
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/15145/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["transform-parameters"],
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  }
+}

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/15145/options.json
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/15145/options.json
@@ -2,5 +2,6 @@
   "plugins": ["transform-parameters"],
   "parserOpts": {
     "allowReturnOutsideFunction": true
-  }
+  },
+  "minNodeVersion": "10.0.0"
 }

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/scope-gen-async/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/scope-gen-async/output.js
@@ -5,17 +5,25 @@ function f() {
     return a;
   }(a);
 }
-async function g() {
-  let a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 1;
-  return async function (a) {
-    var a = await a;
-    return a;
-  }(a);
+function g() {
+  try {
+    let a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 1;
+    return async function (a) {
+      var a = await a;
+      return a;
+    }(a);
+  } catch (e) {
+    return Promise.reject(e);
+  }
 }
-async function h() {
-  let a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 1;
-  return async function* (a) {
-    var a = await (yield a);
-    return a;
-  }(a);
+function h() {
+  try {
+    let a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 1;
+    return async function* (a) {
+      var a = await (yield a);
+      return a;
+    }(a);
+  } catch (e) {
+    return Promise.reject(e);
+  }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15145
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We cannot compile async generators to async functions, because async generators don't return promises.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15146"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

