### PR TITLE
Fix `TaggedTemplateLiteral` evaluation

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -431,10 +431,8 @@ function evaluateQuasis(
 
   let i = 0;
   const exprs: Array<NodePath<t.Node>> = path.isTemplateLiteral()
-    ? path.get('expressions')
-    : (path as NodePath<t.TaggedTemplateExpression>)
-        .get('quasi')
-        .get('expressions');
+    ? path.get("expressions")
+    : path.get("quasi.expressions");
 
   for (const elem of quasis) {
     // not confident, evaluated an expression we don't like

--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -430,7 +430,11 @@ function evaluateQuasis(
   let str = "";
 
   let i = 0;
-  const exprs = path.get("expressions");
+  const exprs: Array<NodePath<t.Node>> = path.isTemplateLiteral()
+    ? path.get('expressions')
+    : (path as NodePath<t.TaggedTemplateExpression>)
+        .get('quasi')
+        .get('expressions');
 
   for (const elem of quasis) {
     // not confident, evaluated an expression we don't like

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -100,12 +100,27 @@ describe("evaluation", function () {
     ).toBe(false);
   });
 
-  it("should evaluate template literals", function () {
-    expect(
-      getPath("var x = 8; var y = 1; var z = `value is ${x >>> y}`")
-        .get("body.2.declarations.0.init")
-        .evaluate().value,
-    ).toBe("value is 4");
+  describe("template literals", function () {
+    it("should evaluate template literals", function () {
+      expect(
+        getPath("var x = 8; var y = 1; var z = `value is ${x >>> y}`")
+          .get("body.2.declarations.0.init")
+          .evaluate().value,
+      ).toBe("value is 4");
+    });
+
+    it("shold evaluate String.raw tags", function () {
+      expect(
+        getPath("String.raw`a\\n${1}\\u`;").get("body.0.expression").evaluate()
+          .value,
+      ).toBe("a\\n1\\u");
+    });
+
+    addDeoptTest(
+      "a`x${b}y`",
+      "TaggedTemplateExpression",
+      "TaggedTemplateExpression",
+    );
   });
 
   it("should evaluate member expressions", function () {


### PR DESCRIPTION
This line of code causes a type error since `TaggedTemplateLiteral`s do not have a property called "expressions".

This change does what is probably expected. However, to maintain the existing behaviour, the line should instead be:

```js
const exprs: Array<undefined | NodePath<t.Node>> = path.isTemplateLiteral()
    ? path.get('expressions')
    : []
```


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15224"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

