### PR TITLE
tests: Support execution tests with output

### DIFF
--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -10,14 +10,14 @@ const require = createRequire(import.meta.url);
 
 const nodeVersion = semver.clean(process.version.slice(1));
 
-function humanize(val: string, noext?: boolean) {
-  if (noext) val = path.basename(val, path.extname(val));
+function humanize(val: string, noExt?: boolean) {
+  if (noExt) val = path.basename(val, path.extname(val));
   return val.replace(/-/g, " ");
 }
 
 interface TestIO {
   loc: string;
-  code: string;
+  code: string | null;
 }
 
 export interface TestFile extends TestIO {
@@ -241,7 +241,7 @@ function pushTask(
 
   // traceur checks
 
-  if (test.exec.code.indexOf("// Async.") >= 0) {
+  if (test.exec.code?.indexOf("// Async.") >= 0) {
     return;
   }
 
@@ -352,14 +352,11 @@ function wrapPackagesArray(
  * Resolve plugins/presets defined in options.json
  *
  * @export
- * @param {{}} options the imported options.json
- * @param {string} optionsDir the direcotry where options.json is placed
- * @returns {{}} options whose plugins/presets are resolved
+ * @param options the imported options.json
+ * @param optionsDir the dictionary where options.json is placed
+ * @returns options whose plugins/presets are resolved
  */
-export function resolveOptionPluginOrPreset(
-  options: any,
-  optionsDir: string,
-): {} {
+export function resolveOptionPluginOrPreset(options: any, optionsDir: string) {
   if (options.plugins) {
     options.plugins = wrapPackagesArray("plugin", options.plugins, optionsDir);
   }
@@ -435,11 +432,6 @@ export function multiple(entryLoc: string, ignore?: Array<string>) {
 }
 
 export function readFile(filename: string) {
-  if (fs.existsSync(filename)) {
-    let file = fs.readFileSync(filename, "utf8").trimRight();
-    file = file.replace(/\r\n/g, "\n");
-    return file;
-  } else {
-    return "";
-  }
+  if (!fs.existsSync(filename)) return null;
+  return fs.readFileSync(filename, "utf8").replace(/\r\n/g, "\n").trimRight();
 }

--- a/packages/babel-helper-transform-fixture-test-runner/test/fixtures/exec-with-output/work/exec.js
+++ b/packages/babel-helper-transform-fixture-test-runner/test/fixtures/exec-with-output/work/exec.js
@@ -1,0 +1,3 @@
+// @babel-test-output
+
+expect(1+1).toBe(2);

--- a/packages/babel-helper-transform-fixture-test-runner/test/fixtures/exec-with-output/work/output.js
+++ b/packages/babel-helper-transform-fixture-test-runner/test/fixtures/exec-with-output/work/output.js
@@ -1,0 +1,3 @@
+// @babel-test-output
+
+expect(1 + 1).toBe(2);

--- a/packages/babel-helper-transform-fixture-test-runner/test/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/test/index.js
@@ -1,5 +1,7 @@
-import { runCodeInTestContext } from "../lib/index.js";
 import { fileURLToPath } from "url";
+
+import runner from "@babel/helper-plugin-test-runner";
+import { runCodeInTestContext } from "../lib/index.js";
 
 const filename = fileURLToPath(import.meta.url);
 
@@ -52,3 +54,5 @@ describe("helper-transform-fixture-test-runner", function () {
     expect(opts.stack).toContain(opts.filename + ":1:13");
   });
 });
+
+runner(import.meta.url);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

1. `TestIO.code` becomes `string|null`,
2. Now we allow `output.js` to be generated for `exec.js`
3. Also made some simple refactorings.

Since `exec.js` is similar to `input.js` in most cases, this will allow us to write tests more conveniently, avoiding repeated copy-pasting and synchronous modification

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15227"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

