### PR TITLE
fix: Emit correct sourcemap ranges for `JSXText`

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/sourcemaps/JSXText/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/sourcemaps/JSXText/input.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function App() {
+  return (
+    <div className="App">
+      <h1>Welcome to my application!</h1>
+      This is my app!
+      <strong>MINE.</strong>
+    </div>
+  )
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/sourcemaps/JSXText/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/sourcemaps/JSXText/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": [["transform-react-jsx", { "runtime": "classic" }]],
+  "sourceMap": true
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/sourcemaps/JSXText/output.mjs
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/sourcemaps/JSXText/output.mjs
@@ -1,0 +1,6 @@
+import React from 'react';
+export default function App() {
+  return /*#__PURE__*/React.createElement("div", {
+    className: "App"
+  }, /*#__PURE__*/React.createElement("h1", null, "Welcome to my application!"), "This is my app!", /*#__PURE__*/React.createElement("strong", null, "MINE."));
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/sourcemaps/JSXText/source-map.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/sourcemaps/JSXText/source-map.json
@@ -1,0 +1,14 @@
+{
+  "version": 3,
+  "names": [
+    "React",
+    "App"
+  ],
+  "sources": [
+    "sourcemaps/JSXText/input.js"
+  ],
+  "sourcesContent": [
+    "import React from 'react';\n\nexport default function App() {\n  return (\n    <div className=\"App\">\n      <h1>Welcome to my application!</h1>\n      This is my app!\n      <strong>MINE.</strong>\n    </div>\n  )\n}"
+  ],
+  "mappings": "AAAA,OAAOA,KAAK,MAAM,OAAO;AAEzB,eAAe,SAASC,GAAG,GAAG;EAC5B,oBACE;IAAK,SAAS,EAAC;EAAK,gBAClB,gCAAI,4BAA0B,CAAK,mBAEnC,mDAAQ,OAAK,CAAS,CAClB;AAEV"
+}

--- a/packages/babel-types/src/utils/react/cleanJSXElementLiteralChild.ts
+++ b/packages/babel-types/src/utils/react/cleanJSXElementLiteralChild.ts
@@ -1,10 +1,9 @@
 import { stringLiteral } from "../../builders/generated";
 import type * as t from "../..";
+import { inherits } from "../..";
 
 export default function cleanJSXElementLiteralChild(
-  child: {
-    value: string;
-  },
+  child: t.JSXText,
   args: Array<t.Node>,
 ) {
   const lines = child.value.split(/\r\n|\n|\r/);
@@ -48,5 +47,5 @@ export default function cleanJSXElementLiteralChild(
     }
   }
 
-  if (str) args.push(stringLiteral(str));
+  if (str) args.push(inherits(stringLiteral(str), child));
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10869 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15233"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

https://evanw.github.io/source-map-visualization/#MjkzAGltcG9ydCBSZWFjdCBmcm9tICdyZWFjdCc7CmV4cG9ydCBkZWZhdWx0IGZ1bmN0aW9uIEFwcCgpIHsKICByZXR1cm4gLyojX19QVVJFX18qL1JlYWN0LmNyZWF0ZUVsZW1lbnQoImRpdiIsIHsKICAgIGNsYXNzTmFtZTogIkFwcCIKICB9LCAvKiNfX1BVUkVfXyovUmVhY3QuY3JlYXRlRWxlbWVudCgiaDEiLCBudWxsLCAiV2VsY29tZSB0byBteSBhcHBsaWNhdGlvbiEiKSwgIlRoaXMgaXMgbXkgYXBwISIsIC8qI19fUFVSRV9fKi9SZWFjdC5jcmVhdGVFbGVtZW50KCJzdHJvbmciLCBudWxsLCAiTUlORS4iKSk7Cn0KNTI2AHsKICAidmVyc2lvbiI6IDMsCiAgIm5hbWVzIjogWwogICAgIlJlYWN0IiwKICAgICJBcHAiCiAgXSwKICAic291cmNlcyI6IFsKICAgICJzb3VyY2VtYXBzL0pTWFRleHQvaW5wdXQuanMiCiAgXSwKICAic291cmNlc0NvbnRlbnQiOiBbCiAgICAiaW1wb3J0IFJlYWN0IGZyb20gJ3JlYWN0JztcblxuZXhwb3J0IGRlZmF1bHQgZnVuY3Rpb24gQXBwKCkge1xuICByZXR1cm4gKFxuICAgIDxkaXYgY2xhc3NOYW1lPVwiQXBwXCI+XG4gICAgICA8aDE+V2VsY29tZSB0byBteSBhcHBsaWNhdGlvbiE8L2gxPlxuICAgICAgVGhpcyBpcyBteSBhcHAhXG4gICAgICA8c3Ryb25nPk1JTkUuPC9zdHJvbmc+XG4gICAgPC9kaXY+XG4gIClcbn0iCiAgXSwKICAibWFwcGluZ3MiOiAiQUFBQSxPQUFPQSxLQUFLLE1BQU0sT0FBTztBQUV6QixlQUFlLFNBQVNDLEdBQUcsR0FBRztFQUM1QixvQkFDRTtJQUFLLFNBQVMsRUFBQztFQUFLLGdCQUNsQixnQ0FBSSw0QkFBMEIsQ0FBSyxtQkFFbkMsbURBQVEsT0FBSyxDQUFTLENBQ2xCO0FBRVYiCn0=

