### PR TITLE
refactor: remove ModuleDeclaration usage

### DIFF
--- a/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
+++ b/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
@@ -142,7 +142,7 @@ export default function normalizeModuleAndLoadMetadata(
     stringSpecifiers,
   );
 
-  removeModuleDeclarations(programPath);
+  removeImportExportDeclarations(programPath);
 
   // Reuse the imported namespace name if there is one.
   for (const [, metadata] of source) {
@@ -558,7 +558,7 @@ function nameAnonymousExports(programPath: NodePath<t.Program>) {
   });
 }
 
-function removeModuleDeclarations(programPath: NodePath<t.Program>) {
+function removeImportExportDeclarations(programPath: NodePath<t.Program>) {
   programPath.get("body").forEach(child => {
     if (child.isImportDeclaration()) {
       child.remove();

--- a/packages/babel-helpers/src/index.ts
+++ b/packages/babel-helpers/src/index.ts
@@ -89,7 +89,7 @@ function getHelperMetadata(file: File): HelperMetadata {
       throw child.buildCodeFrameError("Helpers can only export default");
     },
     Statement(child) {
-      if (child.isModuleDeclaration()) return;
+      if (child.isImportDeclaration() || child.isExportDeclaration()) return;
 
       child.skip();
     },

--- a/packages/babel-node/src/_babel-node.ts
+++ b/packages/babel-node/src/_babel-node.ts
@@ -115,9 +115,10 @@ const replPlugin = ({ types: t }: PluginAPI): PluginObject => ({
     },
 
     Program(path) {
+      let hasExpressionStatement: boolean;
       for (const bodyPath of path.get("body")) {
         if (bodyPath.isExpressionStatement()) {
-          return;
+          hasExpressionStatement = true;
         } else if (
           bodyPath.isExportDeclaration() ||
           bodyPath.isImportDeclaration()
@@ -127,6 +128,7 @@ const replPlugin = ({ types: t }: PluginAPI): PluginObject => ({
           );
         }
       }
+      if (hasExpressionStatement) return;
 
       // If the executed code doesn't evaluate to a value,
       // prevent implicit strict mode from printing 'use strict'.

--- a/packages/babel-node/src/_babel-node.ts
+++ b/packages/babel-node/src/_babel-node.ts
@@ -106,10 +106,6 @@ register(babelOptions);
 
 const replPlugin = ({ types: t }: PluginAPI): PluginObject => ({
   visitor: {
-    ModuleDeclaration(path) {
-      throw path.buildCodeFrameError("Modules aren't supported in the REPL");
-    },
-
     VariableDeclaration(path) {
       if (path.node.kind !== "var") {
         throw path.buildCodeFrameError(
@@ -119,7 +115,18 @@ const replPlugin = ({ types: t }: PluginAPI): PluginObject => ({
     },
 
     Program(path) {
-      if (path.get("body").some(child => child.isExpressionStatement())) return;
+      for (const bodyPath of path.get("body")) {
+        if (bodyPath.isExpressionStatement()) {
+          return;
+        } else if (
+          bodyPath.isExportDeclaration() ||
+          bodyPath.isImportDeclaration()
+        ) {
+          throw bodyPath.buildCodeFrameError(
+            "Modules aren't supported in the REPL",
+          );
+        }
+      }
 
       // If the executed code doesn't evaluate to a value,
       // prevent implicit strict mode from printing 'use strict'.

--- a/packages/babel-parser/ast/spec.md
+++ b/packages/babel-parser/ast/spec.md
@@ -108,7 +108,6 @@ These are the core @babel/parser (babylon) AST node types.
   - [ClassExpression](#classexpression)
   - [MetaProperty](#metaproperty)
 - [Modules](#modules)
-  - [ModuleDeclaration](#moduledeclaration)
   - [ModuleSpecifier](#modulespecifier)
   - [Imports](#imports)
     - [ImportDeclaration](#importdeclaration)
@@ -117,6 +116,7 @@ These are the core @babel/parser (babylon) AST node types.
     - [ImportNamespaceSpecifier](#importnamespacespecifier)
     - [ImportAttribute](#importattribute)
   - [Exports](#exports)
+    - [ExportDeclaration](#exportdeclaration)
     - [ExportNamedDeclaration](#exportnameddeclaration)
     - [ExportSpecifier](#exportspecifier)
     - [ExportNamespaceSpecifier](#exportnamespacespecifier)
@@ -275,7 +275,7 @@ interface Program <: Node {
   type: "Program";
   interpreter: InterpreterDirective | null;
   sourceType: "script" | "module";
-  body: [ Statement | ModuleDeclaration ];
+  body: [ Statement | ImportDeclaration | ExportDeclaration ];
   directives: [ Directive ];
 }
 ```
@@ -1265,14 +1265,6 @@ interface MetaProperty <: Expression {
 
 # Modules
 
-## ModuleDeclaration
-
-```js
-interface ModuleDeclaration <: Node { }
-```
-
-A module `import` or `export` declaration.
-
 ## ModuleSpecifier
 
 ```js
@@ -1288,7 +1280,7 @@ A specifier in an import or export declaration.
 ### ImportDeclaration
 
 ```js
-interface ImportDeclaration <: ModuleDeclaration {
+interface ImportDeclaration <: Node {
   type: "ImportDeclaration";
   importKind: null | "type" | "typeof" | "value";
   specifiers: [ ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier ];
@@ -1346,10 +1338,18 @@ An attribute specified on the ImportDeclaration.
 
 ## Exports
 
+### ExportDeclaration
+
+```js
+interface ExportDeclaration <: Node {}
+```
+
+An `export` declaration.
+
 ### ExportNamedDeclaration
 
 ```js
-interface ExportNamedDeclaration <: ModuleDeclaration {
+interface ExportNamedDeclaration <: ExportDeclaration {
   type: "ExportNamedDeclaration";
   declaration: Declaration | null;
   specifiers: [ ExportSpecifier | ExportNamespaceSpecifier ];
@@ -1400,7 +1400,7 @@ interface OptClassDeclaration <: ClassDeclaration {
   id: Identifier | null;
 }
 
-interface ExportDefaultDeclaration <: ModuleDeclaration {
+interface ExportDefaultDeclaration <: ExportDeclaration {
   type: "ExportDefaultDeclaration";
   declaration: OptFunctionDeclaration | OptClassDeclaration | Expression;
 }
@@ -1411,7 +1411,7 @@ An export default declaration, e.g., `export default function () {};` or `export
 ### ExportAllDeclaration
 
 ```js
-interface ExportAllDeclaration <: ModuleDeclaration {
+interface ExportAllDeclaration <: ExportDeclaration {
   type: "ExportAllDeclaration";
   source: StringLiteral;
   assertions?: [ ImportAttribute ];

--- a/packages/babel-plugin-transform-typescript/src/enum.ts
+++ b/packages/babel-plugin-transform-typescript/src/enum.ts
@@ -27,7 +27,9 @@ export default function transpileEnum(
       if (seen(path.parentPath)) {
         path.remove();
       } else {
-        const isGlobal = t.isProgram(path.parent); // && !path.parent.body.some(t.isModuleDeclaration);
+        // todo: Consider exclude program with import/export
+        // && !path.parent.body.some(n => t.isImportDeclaration(n) || t.isExportDeclaration(n));
+        const isGlobal = t.isProgram(path.parent);
         path.scope.registerDeclaration(
           path.replaceWith(makeVar(node.id, t, isGlobal ? "var" : "let"))[0],
         );

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -24,7 +24,6 @@ import {
   isImportDeclaration,
   isLiteral,
   isMethod,
-  isModuleDeclaration,
   isModuleSpecifier,
   isNullLiteral,
   isObjectExpression,
@@ -50,6 +49,7 @@ import {
   isTopicReference,
   isMetaProperty,
   isPrivateName,
+  isExportDeclaration,
 } from "@babel/types";
 import type * as t from "@babel/types";
 import { scope as scopeCache } from "../cache";
@@ -60,7 +60,7 @@ type NodePart = string | number | boolean;
 function gatherNodeParts(node: t.Node, parts: NodePart[]) {
   switch (node?.type) {
     default:
-      if (isModuleDeclaration(node)) {
+      if (isImportDeclaration(node) || isExportDeclaration(node)) {
         if (
           (isExportAllDeclaration(node) ||
             isExportNamedDeclaration(node) ||


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is the first step of deprecating the `ModuleDeclaration` alias in light of the AST type `ModuleDeclaration` proposed in the [Stage 1 proposal](https://github.com/tc39/proposal-module-declarations). It replaces current alias usage to a union of ImportDeclaration and ExportDeclaration.

The AST spec changes are editorial.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15236"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

