### PR TITLE
fix: `this` in arrow function in class constructor parameter

### DIFF
--- a/packages/babel-plugin-transform-classes/src/transformClass.ts
+++ b/packages/babel-plugin-transform-classes/src/transformClass.ts
@@ -380,7 +380,7 @@ export default function transformClass(
     const path = classState.userConstructorPath;
     const body = path.get("body");
 
-    path.traverse(findThisesVisitor);
+    body.traverse(findThisesVisitor);
 
     let thisRef = function () {
       const ref = path.scope.generateDeclaredUidIdentifier("this");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/arrow-func-in-params-of-constructor/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/arrow-func-in-params-of-constructor/exec.js
@@ -1,0 +1,14 @@
+class Root {}
+
+class Foo extends Root {
+  constructor(
+    cb = () => {
+      return this;
+    }
+  ) {
+    super();
+    this.cb = cb;
+  }
+}
+
+expect(new Foo().cb().constructor.name).toBe("Foo");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/arrow-func-in-params-of-constructor/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/arrow-func-in-params-of-constructor/input.js
@@ -1,0 +1,12 @@
+class Root {}
+
+class Foo extends Root {
+  constructor(
+    cb = () => {
+      console.log("this is", this);
+    }
+  ) {
+    super();
+    this.cb = cb;
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/arrow-func-in-params-of-constructor/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/arrow-func-in-params-of-constructor/output.js
@@ -1,0 +1,21 @@
+var Root = /*#__PURE__*/babelHelpers.createClass(function Root() {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, Root);
+});
+var Foo = /*#__PURE__*/function (_Root) {
+  "use strict";
+
+  babelHelpers.inherits(Foo, _Root);
+  var _super = babelHelpers.createSuper(Foo);
+  function Foo(cb = () => {
+    console.log("this is", this);
+  }) {
+    var _this;
+    babelHelpers.classCallCheck(this, Foo);
+    _this = _super.call(this);
+    _this.cb = cb;
+    return _this;
+  }
+  return babelHelpers.createClass(Foo);
+}(Root);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15251 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
