### PR TITLE
Fix tdz analysis for reassigned captured for bindings

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/validation.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/validation.ts
@@ -131,9 +131,9 @@ function getTDZReplacement(
   if (skipTDZChecks.has(id)) return;
   skipTDZChecks.add(id);
 
-  const bindingPath = path.scope.getBinding(id.name).path;
+  const bindingPath = path.scope.getBinding(id.name)?.path;
 
-  if (bindingPath.isFunctionDeclaration()) return;
+  if (!bindingPath || bindingPath.isFunctionDeclaration()) return;
 
   const status = getTDZStatus(path, bindingPath);
   if (status === "outside") return;

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/updated-for-binding-with-tdz-enabled/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/updated-for-binding-with-tdz-enabled/input.js
@@ -1,0 +1,4 @@
+for (let index = 0; index < 10; index++) {
+  index++;
+  () => index;
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/updated-for-binding-with-tdz-enabled/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/updated-for-binding-with-tdz-enabled/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-block-scoping", { "tdz": true }]]
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/updated-for-binding-with-tdz-enabled/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/updated-for-binding-with-tdz-enabled/output.js
@@ -1,0 +1,8 @@
+var _loop = function (_index) {
+  _index++;
+  () => _index;
+  index = _index;
+};
+for (var index = 0; index < 10; index++) {
+  _loop(index);
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | A bug introduced in #15200
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When extracting the loop body in the test case to its own function, the scope info is temporarily not correct and the `index`/`_index` bindings are partially mixed, causing problems for TDZ analysis.

Specifically, we have `_index` usages in `index`'s reference paths, but then `scope.getBinding(_index)` returns `undefined`. Since the closure param is never in TDZ, it's safe to just return early when it happens.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15278"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

