### PR TITLE
feat: Support `.cts` as configuration file

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -77,14 +77,6 @@
     "rimraf": "^3.0.0",
     "ts-node": "^10.9.1"
   },
-  "peerDependencies": {
-    "@babel/preset-typescript": "^7.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@babel/preset-typescript": {
-      "optional": true
-    }
-  },
   "conditions": {
     "BABEL_8_BREAKING": [
       null,

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -74,7 +74,8 @@
     "@types/gensync": "^1.0.0",
     "@types/resolve": "^1.3.2",
     "@types/semver": "^5.4.0",
-    "rimraf": "^3.0.0"
+    "rimraf": "^3.0.0",
+    "ts-node": "^10.9.1"
   },
   "conditions": {
     "BABEL_8_BREAKING": [

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -77,6 +77,14 @@
     "rimraf": "^3.0.0",
     "ts-node": "^10.9.1"
   },
+  "peerDependencies": {
+    "@babel/preset-typescript": "^7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@babel/preset-typescript": {
+      "optional": true
+    }
+  },
   "conditions": {
     "BABEL_8_BREAKING": [
       null,

--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -74,6 +74,7 @@ function loadCtsDefault(filepath: string) {
           {
             allowDeclareFields: true,
             disallowAmbiguousJSXLike: true,
+            allExtensions: true,
             onlyRemoveTypeImports: true,
             optimizeConstEnums: true,
           },

--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -71,13 +71,20 @@ function loadCtsDefault(filepath: string) {
       presets: [
         [
           "@babel/preset-typescript",
-          {
-            allowDeclareFields: true,
-            disallowAmbiguousJSXLike: true,
-            allExtensions: true,
-            onlyRemoveTypeImports: true,
-            optimizeConstEnums: true,
-          },
+          process.env.BABEL_8_BREAKING
+            ? {
+                disallowAmbiguousJSXLike: true,
+                allExtensions: true,
+                onlyRemoveTypeImports: true,
+                optimizeConstEnums: true,
+              }
+            : {
+                allowDeclareFields: true,
+                disallowAmbiguousJSXLike: true,
+                allExtensions: true,
+                onlyRemoveTypeImports: true,
+                optimizeConstEnums: true,
+              },
         ],
       ],
     };

--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -85,7 +85,7 @@ function loadCtsDefault(filepath: string) {
             allExtensions: true,
             onlyRemoveTypeImports: true,
             optimizeConstEnums: true,
-            ...(process.env.BABEL_8_BREAKING && {
+            ...(!process.env.BABEL_8_BREAKING && {
               allowDeclareFields: true,
             }),
           },

--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -68,7 +68,17 @@ function loadCtsDefault(filepath: string) {
       filename: path.basename(filepath),
       sourceType: "script",
       sourceMaps: "inline",
-      presets: ["@babel/preset-typescript"],
+      presets: [
+        [
+          "@babel/preset-typescript",
+          {
+            allowDeclareFields: true,
+            disallowAmbiguousJSXLike: true,
+            onlyRemoveTypeImports: true,
+            optimizeConstEnums: true,
+          },
+        ],
+      ],
     };
     const result = transformSync(code, opts);
     require.extensions[ext] = function (m, filename) {

--- a/packages/babel-core/src/config/files/plugins.ts
+++ b/packages/babel-core/src/config/files/plugins.ts
@@ -6,7 +6,7 @@ import buildDebug from "debug";
 import path from "path";
 import gensync, { type Handler } from "gensync";
 import { isAsync } from "../../gensync-utils/async";
-import loadCjsOrMjsDefault, { supportsESM } from "./module-types";
+import loadCodeDefault, { supportsESM } from "./module-types";
 import { fileURLToPath, pathToFileURL } from "url";
 
 import importMetaResolve from "./import-meta-resolve";
@@ -217,7 +217,7 @@ function* requireModule(type: string, name: string): Handler<unknown> {
     if (!process.env.BABEL_8_BREAKING) {
       LOADING_MODULES.add(name);
     }
-    return yield* loadCjsOrMjsDefault(
+    return yield* loadCodeDefault(
       name,
       `You appear to be using a native ECMAScript module ${type}, ` +
         "which is only supported when running Babel asynchronously.",

--- a/packages/babel-core/src/errors/config-error.ts
+++ b/packages/babel-core/src/errors/config-error.ts
@@ -1,9 +1,9 @@
-import { injcectVirtualStackFrame, expectedError } from "./rewrite-stack-trace";
+import { injectVirtualStackFrame, expectedError } from "./rewrite-stack-trace";
 
 export default class ConfigError extends Error {
   constructor(message: string, filename?: string) {
     super(message);
     expectedError(this);
-    if (filename) injcectVirtualStackFrame(this, filename);
+    if (filename) injectVirtualStackFrame(this, filename);
   }
 }

--- a/packages/babel-core/src/errors/rewrite-stack-trace.ts
+++ b/packages/babel-core/src/errors/rewrite-stack-trace.ts
@@ -1,5 +1,5 @@
 /**
- * This file uses the iternal V8 Stack Trace API (https://v8.dev/docs/stack-trace-api)
+ * This file uses the internal V8 Stack Trace API (https://v8.dev/docs/stack-trace-api)
  * to provide utilities to rewrite the stack trace.
  * When this API is not present, all the functions in this file become noops.
  *
@@ -33,10 +33,10 @@
  * - If e() throws an error, then its shown call stack will be "e, f"
  *
  * Additionally, an error can inject additional "virtual" stack frames using the
- * injcectVirtualStackFrame(error, filename) function: those are injected as a
+ * injectVirtualStackFrame(error, filename) function: those are injected as a
  * replacement of the hidden frames.
- * In the example above, if we called injcectVirtualStackFrame(err, "h") and
- * injcectVirtualStackFrame(err, "i") on the expected error thrown by c(), its
+ * In the example above, if we called injectVirtualStackFrame(err, "h") and
+ * injectVirtualStackFrame(err, "i") on the expected error thrown by c(), its
  * shown call stack would have been "h, i, e, f".
  * This can be useful, for example, to report config validation errors as if they
  * were directly thrown in the config file.
@@ -46,8 +46,8 @@ const ErrorToString = Function.call.bind(Error.prototype.toString);
 
 const SUPPORTED = !!Error.captureStackTrace;
 
-const START_HIDNG = "startHiding - secret - don't use this - v1";
-const STOP_HIDNG = "stopHiding - secret - don't use this - v1";
+const START_HIDING = "startHiding - secret - don't use this - v1";
+const STOP_HIDING = "stopHiding - secret - don't use this - v1";
 
 type CallSite = Parameters<typeof Error.prepareStackTrace>[1][number];
 
@@ -70,7 +70,7 @@ function CallSite(filename: string): CallSite {
   } as CallSite);
 }
 
-export function injcectVirtualStackFrame(error: Error, filename: string) {
+export function injectVirtualStackFrame(error: Error, filename: string) {
   if (!SUPPORTED) return;
 
   let frames = virtualFrames.get(error);
@@ -97,7 +97,7 @@ export function beginHiddenCallStack<A extends unknown[], R>(
       return fn(...args);
     },
     "name",
-    { value: STOP_HIDNG },
+    { value: STOP_HIDING },
   );
 }
 
@@ -111,7 +111,7 @@ export function endHiddenCallStack<A extends unknown[], R>(
       return fn(...args);
     },
     "name",
-    { value: START_HIDNG },
+    { value: START_HIDING },
   );
 }
 
@@ -144,9 +144,9 @@ function setupPrepareStackTrace() {
       : "unknown";
     for (let i = 0; i < trace.length; i++) {
       const name = trace[i].getFunctionName();
-      if (name === START_HIDNG) {
+      if (name === START_HIDING) {
         status = "hiding";
-      } else if (name === STOP_HIDNG) {
+      } else if (name === STOP_HIDING) {
         if (status === "hiding") {
           status = "showing";
           if (virtualFrames.has(err)) {

--- a/packages/babel-core/test/config-ts.js
+++ b/packages/babel-core/test/config-ts.js
@@ -1,0 +1,70 @@
+import { loadPartialConfigSync } from "../lib/index.js";
+import path from "path";
+import { fileURLToPath } from "url";
+import { createRequire } from "module";
+import { register } from "ts-node";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+describe("@babel/core config with ts", () => {
+  it("should work with simple .cts", () => {
+    const config = loadPartialConfigSync({
+      configFile: path.join(
+        __dirname,
+        "fixtures/config-ts/simple-cts/babel.config.cts",
+      ),
+    });
+
+    expect(config.options.targets).toMatchInlineSnapshot(`
+      Object {
+        "node": "12.0.0",
+      }
+    `);
+  });
+
+  it("should throw with invalid .ts register", () => {
+    require.extensions[".ts"] = () => {
+      throw new Error("Not support .ts.");
+    };
+    expect(() => {
+      loadPartialConfigSync({
+        configFile: path.join(
+          __dirname,
+          "fixtures/config-ts/invalid-cts-register/babel.config.cts",
+        ),
+      });
+    }).toThrowErrorMatchingInlineSnapshot(`"Unexpected identifier 'config'"`);
+    delete require.extensions[".ts"];
+  });
+
+  it("should work with ts-node", () => {
+    const service = register({
+      experimentalResolver: true,
+      compilerOptions: {
+        module: "CommonJS",
+      },
+    });
+    service.enabled(true);
+
+    require(path.join(
+      __dirname,
+      "fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts",
+    ));
+
+    const config = loadPartialConfigSync({
+      configFile: path.join(
+        __dirname,
+        "fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts",
+      ),
+    });
+
+    service.enabled(false);
+
+    expect(config.options.targets).toMatchInlineSnapshot(`
+      Object {
+        "node": "12.0.0",
+      }
+    `);
+  });
+});

--- a/packages/babel-core/test/config-ts.js
+++ b/packages/babel-core/test/config-ts.js
@@ -2,7 +2,7 @@ import { loadPartialConfigSync } from "../lib/index.js";
 import path from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
-import { register } from "ts-node";
+import semver from "semver";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -38,33 +38,35 @@ describe("@babel/core config with ts", () => {
     delete require.extensions[".ts"];
   });
 
-  it("should work with ts-node", () => {
-    const service = register({
-      experimentalResolver: true,
-      compilerOptions: {
-        module: "CommonJS",
-      },
-    });
-    service.enabled(true);
+  semver.gte(process.version, "12.0.0")
+    ? it
+    : it.skip("should work with ts-node", async () => {
+        const service = import("ts-node").register({
+          experimentalResolver: true,
+          compilerOptions: {
+            module: "CommonJS",
+          },
+        });
+        service.enabled(true);
 
-    require(path.join(
-      __dirname,
-      "fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts",
-    ));
+        require(path.join(
+          __dirname,
+          "fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts",
+        ));
 
-    const config = loadPartialConfigSync({
-      configFile: path.join(
-        __dirname,
-        "fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts",
-      ),
-    });
+        const config = loadPartialConfigSync({
+          configFile: path.join(
+            __dirname,
+            "fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts",
+          ),
+        });
 
-    service.enabled(false);
+        service.enabled(false);
 
-    expect(config.options.targets).toMatchInlineSnapshot(`
+        expect(config.options.targets).toMatchInlineSnapshot(`
       Object {
         "node": "12.0.0",
       }
     `);
-  });
+      });
 });

--- a/packages/babel-core/test/config-ts.js
+++ b/packages/babel-core/test/config-ts.js
@@ -7,41 +7,51 @@ import semver from "semver";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
-describe("@babel/core config with ts", () => {
-  it("should work with simple .cts", () => {
-    const config = loadPartialConfigSync({
-      configFile: path.join(
-        __dirname,
-        "fixtures/config-ts/simple-cts/babel.config.cts",
-      ),
-    });
+// We skip older versions of node testing for two reasons.
+// 1. ts-node does not support the old version of node.
+// 2. In the old version of node, jest has been registered in `require.extensions`, which will cause babel to disable the transforming as expected.
 
-    expect(config.options.targets).toMatchInlineSnapshot(`
+describe("@babel/core config with ts [dummy]", () => {
+  it("dummy", () => {
+    expect(1).toBe(1);
+  });
+});
+
+semver.gte(process.version, "12.0.0")
+  ? describe
+  : describe.skip("@babel/core config with ts", () => {
+      it("should work with simple .cts", () => {
+        const config = loadPartialConfigSync({
+          configFile: path.join(
+            __dirname,
+            "fixtures/config-ts/simple-cts/babel.config.cts",
+          ),
+        });
+
+        expect(config.options.targets).toMatchInlineSnapshot(`
       Object {
         "node": "12.0.0",
       }
     `);
-  });
-
-  it("should throw with invalid .ts register", () => {
-    require.extensions[".ts"] = () => {
-      throw new Error("Not support .ts.");
-    };
-    expect(() => {
-      loadPartialConfigSync({
-        configFile: path.join(
-          __dirname,
-          "fixtures/config-ts/invalid-cts-register/babel.config.cts",
-        ),
       });
-    }).toThrow(/Unexpected identifier.*/);
-    delete require.extensions[".ts"];
-  });
 
-  semver.gte(process.version, "12.0.0")
-    ? it
-    : it.skip("should work with ts-node", async () => {
-        const service = import("ts-node").register({
+      it("should throw with invalid .ts register", () => {
+        require.extensions[".ts"] = () => {
+          throw new Error("Not support .ts.");
+        };
+        expect(() => {
+          loadPartialConfigSync({
+            configFile: path.join(
+              __dirname,
+              "fixtures/config-ts/invalid-cts-register/babel.config.cts",
+            ),
+          });
+        }).toThrow(/Unexpected identifier.*/);
+        delete require.extensions[".ts"];
+      });
+
+      it("should work with ts-node", async () => {
+        const service = eval("import('ts-node')").register({
           experimentalResolver: true,
           compilerOptions: {
             module: "CommonJS",
@@ -69,4 +79,4 @@ describe("@babel/core config with ts", () => {
       }
     `);
       });
-});
+    });

--- a/packages/babel-core/test/config-ts.js
+++ b/packages/babel-core/test/config-ts.js
@@ -34,7 +34,7 @@ describe("@babel/core config with ts", () => {
           "fixtures/config-ts/invalid-cts-register/babel.config.cts",
         ),
       });
-    }).toThrowErrorMatchingInlineSnapshot(`"Unexpected identifier 'config'"`);
+    }).toThrow(/Unexpected identifier.*/);
     delete require.extensions[".ts"];
   });
 

--- a/packages/babel-core/test/fixtures/config-ts/invalid-cts-register/babel.config.cts
+++ b/packages/babel-core/test/fixtures/config-ts/invalid-cts-register/babel.config.cts
@@ -1,0 +1,2 @@
+type config = any;
+module.exports = { targets: "node 12.0.0" } as config;

--- a/packages/babel-core/test/fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts
+++ b/packages/babel-core/test/fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts
@@ -1,0 +1,2 @@
+type config = any;
+module.exports = { targets: "node 12.0.0" } as config;

--- a/packages/babel-core/test/fixtures/config-ts/simple-cts/babel.config.cts
+++ b/packages/babel-core/test/fixtures/config-ts/simple-cts/babel.config.cts
@@ -1,0 +1,2 @@
+type config = any;
+module.exports = { targets: "node 12.0.0" } as config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,6 +370,11 @@ __metadata:
     rimraf: ^3.0.0
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
     ts-node: ^10.9.1
+  peerDependencies:
+    "@babel/preset-typescript": ^7.0.0
+  peerDependenciesMeta:
+    "@babel/preset-typescript":
+      optional: true
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,11 +370,6 @@ __metadata:
     rimraf: ^3.0.0
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
     ts-node: ^10.9.1
-  peerDependencies:
-    "@babel/preset-typescript": ^7.0.0
-  peerDependenciesMeta:
-    "@babel/preset-typescript":
-      optional: true
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5316,21 +5316,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.4.1":
+"acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.7.0, acorn@npm:^8.7.1, acorn@npm:^8.8.0":
   version: 8.8.1
   resolution: "acorn@npm:8.8.1"
   bin:
     acorn: bin/acorn
   checksum: 4079b67283b94935157698831967642f24a075c52ce3feaaaafe095776dfbe15d86a1b33b1e53860fc0d062ed6c83f4284a5c87c85b9ad51853a01173da6097f
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.5.0, acorn@npm:^8.7.0, acorn@npm:^8.7.1, acorn@npm:^8.8.0":
-  version: 8.8.0
-  resolution: "acorn@npm:8.8.0"
-  bin:
-    acorn: bin/acorn
-  checksum: 7270ca82b242eafe5687a11fea6e088c960af712683756abf0791b68855ea9cace3057bd5e998ffcef50c944810c1e0ca1da526d02b32110e13c722aa959afdc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -369,6 +369,7 @@ __metadata:
     json5: ^2.2.2
     rimraf: ^3.0.0
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    ts-node: ^10.9.1
   languageName: unknown
   linkType: soft
 
@@ -3851,6 +3852,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cspotcode/source-map-support@npm:^0.8.0":
+  version: 0.8.1
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
+  dependencies:
+    "@jridgewell/trace-mapping": 0.3.9
+  checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
+  languageName: node
+  linkType: hard
+
 "@discoveryjs/json-ext@npm:^0.5.0":
   version: 0.5.2
   resolution: "@discoveryjs/json-ext@npm:0.5.2"
@@ -4162,7 +4172,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:3.1.0":
+"@jridgewell/resolve-uri@npm:3.1.0, @jridgewell/resolve-uri@npm:^3.0.3":
   version: 3.1.0
   resolution: "@jridgewell/resolve-uri@npm:3.1.0"
   checksum: b5ceaaf9a110fcb2780d1d8f8d4a0bfd216702f31c988d8042e5f8fbe353c55d9b0f55a1733afdc64806f8e79c485d2464680ac48a0d9fcadb9548ee6b81d267
@@ -4190,6 +4200,16 @@ __metadata:
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
   checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.0.3
+    "@jridgewell/sourcemap-codec": ^1.4.10
+  checksum: d89597752fd88d3f3480845691a05a44bd21faac18e2185b6f436c3b0fd0c5a859fbbd9aaa92050c4052caf325ad3e10e2e1d1b64327517471b7d51babc0ddef
   languageName: node
   linkType: hard
 
@@ -4392,6 +4412,34 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^1.7.0
   checksum: 7d3aef54e17c1073101cb64d953157c19d62a40e261a30923fa1ee337b049c5f29cc47b1f0c477880f42b5659848ba9ab897607ac8ea4acd5c30ddcfac57fca6
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node10@npm:^1.0.7":
+  version: 1.0.9
+  resolution: "@tsconfig/node10@npm:1.0.9"
+  checksum: a33ae4dc2a621c0678ac8ac4bceb8e512ae75dac65417a2ad9b022d9b5411e863c4c198b6ba9ef659e14b9fb609bbec680841a2e84c1172df7a5ffcf076539df
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node12@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node12@npm:1.0.11"
+  checksum: 5ce29a41b13e7897a58b8e2df11269c5395999e588b9a467386f99d1d26f6c77d1af2719e407621412520ea30517d718d5192a32403b8dfcc163bf33e40a338a
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node14@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@tsconfig/node14@npm:1.0.3"
+  checksum: 19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "@tsconfig/node16@npm:1.0.3"
+  checksum: 3a8b657dd047495b7ad23437d6afd20297ce90380ff0bdee93fc7d39a900dbd8d9e26e53ff6b465e7967ce2adf0b218782590ce9013285121e6a5928fbd6819f
   languageName: node
   linkType: hard
 
@@ -5225,6 +5273,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.1.1":
+  version: 8.2.0
+  resolution: "acorn-walk@npm:8.2.0"
+  checksum: 1715e76c01dd7b2d4ca472f9c58968516a4899378a63ad5b6c2d668bba8da21a71976c14ec5f5b75f887b6317c4ae0b897ab141c831d741dc76024d8745f1ad1
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^4.0.3":
   version: 4.0.13
   resolution: "acorn@npm:4.0.13"
@@ -5258,6 +5313,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 1860f23c2107c910c6177b7b7be71be350db9e1080d814493fae143ae37605189504152d1ba8743ba3178d0b37269ce1ffc42b101547fdc1827078f82671e407
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.4.1":
+  version: 8.8.1
+  resolution: "acorn@npm:8.8.1"
+  bin:
+    acorn: bin/acorn
+  checksum: 4079b67283b94935157698831967642f24a075c52ce3feaaaafe095776dfbe15d86a1b33b1e53860fc0d062ed6c83f4284a5c87c85b9ad51853a01173da6097f
   languageName: node
   linkType: hard
 
@@ -5491,6 +5555,13 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^2.0.6
   checksum: 9a746b1dbce4122f44002b0c39fbba5b2c6f52c00e88b6ccba6fc68652323f8a1355a20e8ab94846995626d8de3bf67669a3b4a037dff0885db14607168f2b15
+  languageName: node
+  linkType: hard
+
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 544af8dd3f60546d3e4aff084d451b96961d2267d668670199692f8d054f0415d86fc5497d0e641e91546f0aa920e7c29e5250e99fc89f5552a34b5d93b77f43
   languageName: node
   linkType: hard
 
@@ -7133,6 +7204,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^5.0.1":
   version: 5.1.0
   resolution: "cross-spawn@npm:5.1.0"
@@ -7409,6 +7487,13 @@ __metadata:
   version: 29.0.0
   resolution: "diff-sequences@npm:29.0.0"
   checksum: 2c084a3db03ecde26f649f6f2559974e01e174451debeb301a7e17199e73423a8e8ddeb9a35ae38638c084b4fa51296a4a20fa7f44f3db0c0ba566bdc704ed3d
+  languageName: node
+  linkType: hard
+
+"diff@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "diff@npm:4.0.2"
+  checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
   languageName: node
   linkType: hard
 
@@ -11270,6 +11355,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"make-error@npm:^1.1.1":
+  version: 1.3.6
+  resolution: "make-error@npm:1.3.6"
+  checksum: b86e5e0e25f7f777b77fabd8e2cbf15737972869d852a22b7e73c17623928fccb826d8e46b9951501d3f20e51ad74ba8c59ed584f610526a48f8ccf88aaec402
+  languageName: node
+  linkType: hard
+
 "make-iterator@npm:^1.0.0":
   version: 1.0.1
   resolution: "make-iterator@npm:1.0.1"
@@ -14619,6 +14711,44 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.9.1":
+  version: 10.9.1
+  resolution: "ts-node@npm:10.9.1"
+  dependencies:
+    "@cspotcode/source-map-support": ^0.8.0
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.2
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    v8-compile-cache-lib: ^3.0.1
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 090adff1302ab20bd3486e6b4799e90f97726ed39e02b39e566f8ab674fd5bd5f727f43615debbfc580d33c6d9d1c6b1b3ce7d8e3cca3e20530a145ffa232c35
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.14.1":
   version: 3.14.1
   resolution: "tsconfig-paths@npm:3.14.1"
@@ -15052,6 +15182,13 @@ fsevents@^1.2.7:
   bin:
     uuid: ./bin/uuid
   checksum: 21133d0e8a85e607f59a66913bf4f1dd79bdc4a80979a872b913f7ec75f530255edfe8bc6b69ce32017b8367f0d60a8b24ccd2af99156dc1ef2b8b9fe0ec8065
+  languageName: node
+  linkType: hard
+
+"v8-compile-cache-lib@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "v8-compile-cache-lib@npm:3.0.1"
+  checksum: 78089ad549e21bcdbfca10c08850022b22024cdcc2da9b168bcf5a73a6ed7bf01a9cebb9eac28e03cd23a684d81e0502797e88f3ccd27a32aeab1cfc44c39da0
   languageName: node
   linkType: hard
 
@@ -15697,6 +15834,13 @@ fsevents@^1.2.7:
     decamelize: ^1.0.0
     window-size: 0.1.0
   checksum: 73fd1978a311c853ae4c2c2da12642878912a33e4a8e9e8fec00900dc3b5db31a334c337cff04a542ebba7a32f64a9330419ba45249002f45f349a5d41010cab
+  languageName: node
+  linkType: hard
+
+"yn@npm:3.1.1":
+  version: 3.1.1
+  resolution: "yn@npm:3.1.1"
+  checksum: 2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Part of #8529  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | √
| Tests Added + Pass?      | √
| Documentation PR Link    | https://github.com/babel/website/pull/2722 <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Since the esm loader is not yet stable, and the command line parameters have to be set manually, I currently only choose to allow `.cts` as a configuration file.
This will be stable and there should be no risk of breaking changes in the future.
As an implementation detail, we do not transform when any of `.ts, .cts, .mts` exists in `require.extensions`.

This PR also contains some simplifications.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15283"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

