### PR TITLE
fix: Ts import type and func with duplicate name

### DIFF
--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/import-type-func-with-duplicate-name/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/import-type-func-with-duplicate-name/input.ts
@@ -1,0 +1,4 @@
+import type {Foo} from 'foo';
+import {type Foo2} from 'foo';
+function Foo(){}
+function Foo2(){}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/import-type-func-with-duplicate-name/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/import-type-func-with-duplicate-name/output.mjs
@@ -1,0 +1,3 @@
+function Foo() {}
+function Foo2() {}
+export {};

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -733,9 +733,17 @@ export default class Scope {
       if (path.node.declare) return;
       this.registerBinding("let", path);
     } else if (path.isImportDeclaration()) {
+      const isTypeDeclaration =
+        path.node.importKind === "type" || path.node.importKind === "typeof";
       const specifiers = path.get("specifiers");
       for (const specifier of specifiers) {
-        this.registerBinding("module", specifier);
+        const isTypeSpecifier =
+          isTypeDeclaration ||
+          (specifier.isImportSpecifier() &&
+            (specifier.node.importKind === "type" ||
+              specifier.node.importKind === "typeof"));
+
+        this.registerBinding(isTypeSpecifier ? "unknown" : "module", specifier);
       }
     } else if (path.isExportDeclaration()) {
       // todo: improve babel-types

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -386,6 +386,23 @@ describe("scope", () => {
       ).toBe("ImportSpecifier");
     });
 
+    it("import type and func with duplicate name", function () {
+      expect(() => {
+        getPath(
+          `
+            import type {Foo} from 'foo';
+            import {type Foo2} from 'foo';
+            function Foo(){}
+            function Foo2(){}
+          `,
+          {
+            plugins: ["typescript"],
+            sourceType: "module",
+          },
+        );
+      }).not.toThrow();
+    });
+
     it("variable constantness", function () {
       expect(getPath("var a = 1;").scope.getBinding("a").constant).toBe(true);
       expect(getPath("var a = 1; a = 2;").scope.getBinding("a").constant).toBe(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/issues/15262 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is just an incomplete solution, I haven't figured out what to do with `import value` and `function value(){}`.
But since that is too difficult, I'll deal with this separately first.
I registered it as `unknown` instead of skipping the registration to avoid regressions because there is a `getBinding` for `import type` test for flow.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15284"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

