### PR TITLE
Fix tdz analysis for reassigned captured for bindings

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/default/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/default/input.js
@@ -1,0 +1,8 @@
+let a;
+a;
+
+b;
+let b;
+
+maybe(() => c);
+let c;

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/default/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/default/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-block-scoping"]
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/default/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/default/output.js
@@ -1,0 +1,6 @@
+var a;
+a;
+babelHelpers.tdz("b");
+var b;
+maybe(() => c);
+var c;

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/false/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/false/input.js
@@ -1,0 +1,8 @@
+let a;
+a;
+
+b;
+let b;
+
+maybe(() => c);
+let c;

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/false/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/false/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-block-scoping", { "tdz": false }]]
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/false/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/false/output.js
@@ -1,0 +1,6 @@
+var a;
+a;
+b;
+var b;
+maybe(() => c);
+var c;

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/true/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/true/input.js
@@ -1,0 +1,8 @@
+let a;
+a;
+
+b;
+let b;
+
+maybe(() => c);
+let c;

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/true/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/true/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-block-scoping", { "tdz": true }]]
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/true/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/tdz-option/true/output.js
@@ -1,0 +1,7 @@
+var c = babelHelpers.temporalUndefined;
+var a;
+a;
+babelHelpers.tdz("b");
+var b;
+maybe(() => babelHelpers.temporalRef(c, "c"));
+var c = void 0;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Now that the TDZ transform is more stable, this PR enables TDZ checks for statically analyzable TDZ errors by default. In a future minor I would like to add a `noDynamicTDZ` assumption (that defaults to *true*) that, when not enabled, makes the block scoping plugin inject the dynamic TDZ checks.

The `tdz` option will then become unnecessary, and can be removed in Babel 8. It's currently one of the few options that require users to explicitly list the plugin in their config.

As a "spec compliancy" PR, I don't think that this one needs to wait for a minor.