### PR TITLE
[babel 8] Remove `block` argument from `Scope#rename`

### DIFF
--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -619,11 +619,20 @@ export default class Scope {
     }
   }
 
-  rename(oldName: string, newName?: string, block?: t.Pattern | t.Scopable) {
+  rename(
+    oldName: string,
+    newName?: string,
+    // prettier-ignore
+    /* Babel 7 - block?: t.Pattern | t.Scopable */
+  ) {
     const binding = this.getBinding(oldName);
     if (binding) {
-      newName = newName || this.generateUidIdentifier(oldName).name;
-      return new Renamer(binding, oldName, newName).rename(block);
+      newName ||= this.generateUidIdentifier(oldName).name;
+      const renamer = new Renamer(binding, oldName, newName);
+      return process.env.BABEL_8_BREAKING
+        ? renamer.rename()
+        : // @ts-expect-error: babel 7->8
+          renamer.rename(arguments[2]);
     }
   }
 

--- a/packages/babel-traverse/src/scope/lib/renamer.ts
+++ b/packages/babel-traverse/src/scope/lib/renamer.ts
@@ -113,8 +113,7 @@ export default class Renamer {
     // );
   }
 
-  // TODO(Babel 8): Remove this `block` parameter. It's not needed anywhere.
-  rename(block?: t.Pattern | t.Scopable) {
+  rename(/* Babel 7 - block?: t.Pattern | t.Scopable */) {
     const { binding, oldName, newName } = this;
     const { scope, path } = binding;
 
@@ -133,8 +132,11 @@ export default class Renamer {
       }
     }
 
+    const blockToTraverse = process.env.BABEL_8_BREAKING
+      ? scope.block
+      : (arguments[0] as t.Pattern | t.Scopable) || scope.block;
     traverseNode(
-      block || scope.block,
+      blockToTraverse,
       explode(renameVisitor),
       scope,
       this,
@@ -144,7 +146,11 @@ export default class Renamer {
       { discriminant: true },
     );
 
-    if (!block) {
+    if (process.env.BABEL_8_BREAKING) {
+      scope.removeOwnBinding(oldName);
+      scope.bindings[newName] = binding;
+      this.binding.identifier.name = newName;
+    } else if (!arguments[0]) {
       scope.removeOwnBinding(oldName);
       scope.bindings[newName] = binding;
       this.binding.identifier.name = newName;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I noticed in https://github.com/babel/babel/pull/15287 that this param isn't actually used.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15288"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

