### PR TITLE
Properly transpile exported classes that shadowed builtins

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/class-shadow-builtins/input.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/class-shadow-builtins/input.mjs
@@ -1,0 +1,3 @@
+export class TypeError {
+  #message
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/class-shadow-builtins/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/class-shadow-builtins/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["proposal-class-properties"],
+  "externalHelpers": false
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/class-shadow-builtins/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/class-shadow-builtins/output.mjs
@@ -1,0 +1,12 @@
+function _classPrivateFieldInitSpec(obj, privateMap, value) { _checkPrivateRedeclaration(obj, privateMap); privateMap.set(obj, value); }
+function _checkPrivateRedeclaration(obj, privateCollection) { if (privateCollection.has(obj)) { throw new TypeError("Cannot initialize the same private elements twice on an object"); } }
+var _message = /*#__PURE__*/new WeakMap();
+class _TypeError {
+  constructor() {
+    _classPrivateFieldInitSpec(this, _message, {
+      writable: true,
+      value: void 0
+    });
+  }
+}
+export { _TypeError as TypeError };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/class-shadow-builtins/input.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/class-shadow-builtins/input.mjs
@@ -1,0 +1,3 @@
+export class TypeError {
+  #message
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/class-shadow-builtins/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/class-shadow-builtins/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["proposal-class-properties"],
+  "externalHelpers": false
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/class-shadow-builtins/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/class-shadow-builtins/output.mjs
@@ -1,0 +1,12 @@
+function _classPrivateFieldInitSpec(obj, privateMap, value) { _checkPrivateRedeclaration(obj, privateMap); privateMap.set(obj, value); }
+function _checkPrivateRedeclaration(obj, privateCollection) { if (privateCollection.has(obj)) { throw new TypeError("Cannot initialize the same private elements twice on an object"); } }
+var _message = /*#__PURE__*/new WeakMap();
+class _TypeError {
+  constructor() {
+    _classPrivateFieldInitSpec(this, _message, {
+      writable: true,
+      value: void 0
+    });
+  }
+}
+export { _TypeError as TypeError };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/class-shadow-builtins/input.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/class-shadow-builtins/input.mjs
@@ -1,0 +1,3 @@
+export class TypeError {
+  message
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/class-shadow-builtins/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/class-shadow-builtins/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["proposal-class-properties"],
+  "externalHelpers": false
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/class-shadow-builtins/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/class-shadow-builtins/output.mjs
@@ -1,0 +1,9 @@
+function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
+function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+class _TypeError {
+  constructor() {
+    _defineProperty(this, "message", void 0);
+  }
+}
+export { _TypeError as TypeError };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/class-shadow-builtins/input.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/class-shadow-builtins/input.mjs
@@ -1,0 +1,3 @@
+export class TypeError {
+  message
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/class-shadow-builtins/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/class-shadow-builtins/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["proposal-class-properties"],
+  "externalHelpers": false
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/class-shadow-builtins/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/class-shadow-builtins/output.mjs
@@ -1,0 +1,9 @@
+function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
+function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+class _TypeError {
+  constructor() {
+    _defineProperty(this, "message", void 0);
+  }
+}
+export { _TypeError as TypeError };


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15293
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This is a hotfix for #15293. See below for the root cause analysis.

In the future we should revisit how and when the helpers are injected.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15294"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

