### PR TITLE
fix: `transform-block-scoping` accesses properties of `null`

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/validation.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/validation.ts
@@ -10,6 +10,8 @@ export function validateUsage(
 
   for (const name of Object.keys(path.getBindingIdentifiers())) {
     const binding = path.scope.getBinding(name);
+    // binding may be null. ref: https://github.com/babel/babel/issues/15300
+    if (!binding) continue;
     if (tdzEnabled) {
       if (injectTDZChecks(binding, state)) dynamicTDZNames.push(name);
     }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15300 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |√
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | ×
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I haven't actually reproduced this issue yet, due to the plethora of bug reports, this is a guesswork fix.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15301"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

