### PR TITLE
fix: `delete this` in static class properties initialization

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -24,6 +24,7 @@
     "@babel/helper-member-expression-to-functions": "workspace:^",
     "@babel/helper-optimise-call-expression": "workspace:^",
     "@babel/helper-replace-supers": "workspace:^",
+    "@babel/helper-skip-transparent-expression-wrappers": "workspace:^",
     "@babel/helper-split-export-declaration": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -890,6 +890,9 @@ type ReplaceThisState = {
 const thisContextVisitor = traverse.visitors.merge<ReplaceThisState>([
   {
     ThisExpression(path, state) {
+      if (t.isUnaryExpression(path.parent, { operator: "delete" })) {
+        return;
+      }
       state.needsClassRef = true;
       path.replaceWith(t.cloneNode(state.classRef));
     },

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -891,6 +891,7 @@ const thisContextVisitor = traverse.visitors.merge<ReplaceThisState>([
   {
     ThisExpression(path, state) {
       if (t.isUnaryExpression(path.parent, { operator: "delete" })) {
+        path.parentPath.replaceWith(t.booleanLiteral(true));
         return;
       }
       state.needsClassRef = true;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/delete-this/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/delete-this/exec.js
@@ -1,0 +1,7 @@
+class Foo {
+  x = delete this;
+  static x = delete this;
+}
+
+expect(new Foo().x).toBe(true);
+expect(Foo.x).toBe(true);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/delete-this/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/delete-this/input.js
@@ -1,0 +1,4 @@
+class Foo {
+  x = delete this;
+  static x = delete this;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/delete-this/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/delete-this/output.js
@@ -1,0 +1,7 @@
+var Foo = /*#__PURE__*/babelHelpers.createClass(function Foo() {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, Foo);
+  babelHelpers.defineProperty(this, "x", delete this);
+});
+babelHelpers.defineProperty(Foo, "x", delete this);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/delete-this/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/delete-this/output.js
@@ -4,4 +4,4 @@ var Foo = /*#__PURE__*/babelHelpers.createClass(function Foo() {
   babelHelpers.classCallCheck(this, Foo);
   babelHelpers.defineProperty(this, "x", delete this);
 });
-babelHelpers.defineProperty(Foo, "x", delete this);
+babelHelpers.defineProperty(Foo, "x", true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,6 +591,7 @@ __metadata:
     "@babel/helper-optimise-call-expression": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-replace-supers": "workspace:^"
+    "@babel/helper-skip-transparent-expression-wrappers": "workspace:^"
     "@babel/helper-split-export-declaration": "workspace:^"
     "@babel/plugin-syntax-class-static-block": ^7.14.5
     "@babel/preset-env": "workspace:^"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15128
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | :+1:
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`delete this` in static class properties initialization:

```js
class Foo {
  static x = delete this;
}
```

Previously transformed into:

```js
class Foo {}
_defineProperty(Foo, "x", delete Foo);
```

`delete this` should be evaluated to `true`, but `delete Foo` will get `false` in non-strict mode and  throw `SyntaxError` in strict mode. In this PR, the `this` in `delete this` will be replaced with `true` so it can get the correct result:

```js
class Foo {}
_defineProperty(Foo, "x", true);
```

(If we keep the `delete this`, it would be transformed into `delete void 0` by `transform-modules-commonjs`, which is evaluated to `false`.)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15312"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

