### PR TITLE
Implement support for evaluating computed properties.

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -172,11 +172,11 @@ function _evaluate(path: NodePath, state: State): any {
       const type = typeof value;
 
       let key = null;
-      if (property.isIdentifier()) {
-        key = property.node.name;
-      } else if (path.node.computed) {
+      if (path.node.computed) {
         key = evaluateCached(property, state);
         if (!state.confident) return;
+      } else if (property.isIdentifier()) {
+        key = property.node.name;
       }
       if (
         (type === "number" || type === "string") &&

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -119,6 +119,11 @@ describe("evaluation", function () {
         .get("body.0.declarations.0.init")
         .evaluate().value,
     ).toBe("w");
+    expect(
+      getPath("var length = 1; var x = 'abc'[length];")
+        .get("body.1.declarations.0.init")
+        .evaluate().value,
+    ).toBe("b");
     const member_expr = getPath(
       "var x = Math.min(2,Math.max(3,4));var y = Math.random();",
     );

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -114,6 +114,11 @@ describe("evaluation", function () {
         .get("body.0.declarations.0.init")
         .evaluate().value,
     ).toBe(3);
+    expect(
+      getPath("var x = 'hello world'[6]")
+        .get("body.0.declarations.0.init")
+        .evaluate().value,
+    ).toBe("w");
     const member_expr = getPath(
       "var x = Math.min(2,Math.max(3,4));var y = Math.random();",
     );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The `evaluate()` function already supports handling properties using the dot operator, e.g. `"foo".length`. This adds support for computed properties with brackets, as long as the parameter's value is known (e.g. `"foo"["length"]` or `foo[0]`).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15313"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

