### PR TITLE
Fix Jest end-to-end tests.

### DIFF
--- a/scripts/integration-tests/e2e-jest.sh
+++ b/scripts/integration-tests/e2e-jest.sh
@@ -48,7 +48,6 @@ if [ "$BABEL_8_BREAKING" = true ] ; then
 
   # Jest depends on @types/babel__traverse for Babel 7, and they contain the removed Noop node
   sed -i 's/t.Noop/any/g' node_modules/@types/babel__traverse/index.d.ts
-  sed -i 's/t.Noop/any/g' node_modules/@types/babel__traverse/ts4.1/index.d.ts
 
   node -e "
     var pkg = require('./package.json');


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`@types/babel__traverse` [removed](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/c2faae0ed6c0f50c65e8cd877cd79d8a19e8e078#diff-7c63e10f052a8af435ff6517d96d87268961520cc2f4a12e2f5533c93d907dbc) the `ts4.1` directory for version 7.18.3, which just got propagated to Jest when they [bumped their lockfile](https://github.com/facebook/jest/commit/5da283dc3a95d127eb30437c86c1d51dacc63197#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deL4381) yesterday. That broke the Jest integration tests; this fixes that test by removing the reference to the deleted directory.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15319"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

