### PR TITLE
[security] do not match json5 2.2.1 or older (@babel/core)

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -59,7 +59,7 @@
     "convert-source-map": "^1.7.0",
     "debug": "^4.1.0",
     "gensync": "^1.0.0-beta.2",
-    "json5": "^2.2.2",
+    "json5": ">=2.2.2 ^2.2.2",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes a potential security vulnerability, even after the dependency change <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | N/A
| Major: Breaking Change?  | N/A
| Minor: New Feature?      | N/A
| Tests Added + Pass?      | (only modified file is `packages/babel-core/package.json`
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Guarantees `json5` to be version 2.2.2 or newer
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is for security reasons: Dependabot reminded my repo that it's version 2.2.1 of the json5 package that had the security vulnerability. The version pattern `">=2.2.2 ^2.2.2"` is guaranteed not to match version 2.2.1 or older.

This means that other packages depending on Babel and not directly on json5 don't need to have a maintainer manually rectify `package.json`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15336"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

