### PR TITLE
Allow negative number in ambient const initializer

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -2778,24 +2778,12 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         if (!init) continue;
 
         // var and let aren't ever allowed initializers.
-        //
-        // If a const declaration has no type annotation and is initiailized to
-        // a string literal, numeric literal, or enum reference, then it is
-        // allowed. In an ideal world, we'd check whether init was *actually* an
-        // enum reference, but we allow anything that "could be" a literal enum
-        // in `isPossiblyLiteralEnum` since we don't have all the information
-        // that the typescript compiler has.
         if (kind !== "const" || !!id.typeAnnotation) {
           this.raise(TSErrors.InitializerNotAllowedInAmbientContext, {
             at: init,
           });
         } else if (
-          init.type !== "StringLiteral" &&
-          init.type !== "BooleanLiteral" &&
-          init.type !== "NumericLiteral" &&
-          init.type !== "BigIntLiteral" &&
-          (init.type !== "TemplateLiteral" || init.expressions.length > 0) &&
-          !isPossiblyLiteralEnum(init)
+          !isValidAmbientConstInitializer(init, this.hasPlugin("estree"))
         ) {
           this.raise(
             TSErrors.ConstInitiailizerMustBeStringOrNumericLiteralOrLiteralEnumReference,
@@ -4110,6 +4098,65 @@ function isPossiblyLiteralEnum(expression: N.Expression): boolean {
   }
 
   return isUncomputedMemberExpressionChain(expression.object);
+}
+
+// If a const declaration has no type annotation and is initiailized to
+// a string literal, numeric literal, or enum reference, then it is
+// allowed. In an ideal world, we'd check whether init was *actually* an
+// enum reference, but we allow anything that "could be" a literal enum
+// in `isPossiblyLiteralEnum` since we don't have all the information
+// that the typescript compiler has.
+function isValidAmbientConstInitializer(
+  expression: N.Expression,
+  estree: boolean,
+): boolean {
+  const { type } = expression;
+  if (estree) {
+    if (type === "Literal") {
+      const { value } = expression;
+      if (typeof value === "string" || typeof value === "boolean") {
+        return true;
+      }
+    }
+  } else {
+    if (type === "StringLiteral" || type === "BooleanLiteral") {
+      return true;
+    }
+  }
+  if (isNumber(expression, estree) || isNegativeNumber(expression, estree)) {
+    return true;
+  }
+  if (type === "TemplateLiteral" && expression.expressions.length === 0) {
+    return true;
+  }
+  if (isPossiblyLiteralEnum(expression)) {
+    return true;
+  }
+  return false;
+}
+
+function isNumber(expression: N.Expression, estree: boolean): boolean {
+  if (estree) {
+    return (
+      expression.type === "Literal" &&
+      (typeof expression.value === "number" || "bigint" in expression)
+    );
+  } else {
+    return (
+      expression.type === "NumericLiteral" ||
+      expression.type === "BigIntLiteral"
+    );
+  }
+}
+
+function isNegativeNumber(expression: N.Expression, estree: boolean): boolean {
+  if (expression.type === "UnaryExpression") {
+    const { operator, argument } = expression as N.UnaryExpression;
+    if (operator === "-" && isNumber(argument, estree)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function isUncomputedMemberExpressionChain(expression: N.Expression): boolean {

--- a/packages/babel-parser/test/fixtures/typescript/const/initializer-ambient-context/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/const/initializer-ambient-context/input.ts
@@ -1,0 +1,15 @@
+declare module N {
+  enum E {
+    ok = 0
+  }
+
+  export const string = "2";
+  export const number = 1.;
+  export const bigint = 0n;
+  export const negative_bigint = -0n;
+  export const negative_number = -1;
+  export const template = `-2`;
+  export const False = false;
+  export const True = true;
+  export const E_ok = E.ok;
+}

--- a/packages/babel-parser/test/fixtures/typescript/const/initializer-ambient-context/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/const/initializer-ambient-context/output.json
@@ -1,0 +1,363 @@
+{
+  "type": "File",
+  "start":0,"end":325,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":15,"column":1,"index":325}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":325,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":15,"column":1,"index":325}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSModuleDeclaration",
+        "start":0,"end":325,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":15,"column":1,"index":325}},
+        "id": {
+          "type": "Identifier",
+          "start":15,"end":16,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":16,"index":16},"identifierName":"N"},
+          "name": "N"
+        },
+        "body": {
+          "type": "TSModuleBlock",
+          "start":17,"end":325,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":15,"column":1,"index":325}},
+          "body": [
+            {
+              "type": "TSEnumDeclaration",
+              "start":21,"end":44,"loc":{"start":{"line":2,"column":2,"index":21},"end":{"line":4,"column":3,"index":44}},
+              "id": {
+                "type": "Identifier",
+                "start":26,"end":27,"loc":{"start":{"line":2,"column":7,"index":26},"end":{"line":2,"column":8,"index":27},"identifierName":"E"},
+                "name": "E"
+              },
+              "members": [
+                {
+                  "type": "TSEnumMember",
+                  "start":34,"end":40,"loc":{"start":{"line":3,"column":4,"index":34},"end":{"line":3,"column":10,"index":40}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":34,"end":36,"loc":{"start":{"line":3,"column":4,"index":34},"end":{"line":3,"column":6,"index":36},"identifierName":"ok"},
+                    "name": "ok"
+                  },
+                  "initializer": {
+                    "type": "NumericLiteral",
+                    "start":39,"end":40,"loc":{"start":{"line":3,"column":9,"index":39},"end":{"line":3,"column":10,"index":40}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ]
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":48,"end":74,"loc":{"start":{"line":6,"column":2,"index":48},"end":{"line":6,"column":28,"index":74}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":55,"end":74,"loc":{"start":{"line":6,"column":9,"index":55},"end":{"line":6,"column":28,"index":74}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":61,"end":73,"loc":{"start":{"line":6,"column":15,"index":61},"end":{"line":6,"column":27,"index":73}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":61,"end":67,"loc":{"start":{"line":6,"column":15,"index":61},"end":{"line":6,"column":21,"index":67},"identifierName":"string"},
+                      "name": "string"
+                    },
+                    "init": {
+                      "type": "StringLiteral",
+                      "start":70,"end":73,"loc":{"start":{"line":6,"column":24,"index":70},"end":{"line":6,"column":27,"index":73}},
+                      "extra": {
+                        "rawValue": "2",
+                        "raw": "\"2\""
+                      },
+                      "value": "2"
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":77,"end":102,"loc":{"start":{"line":7,"column":2,"index":77},"end":{"line":7,"column":27,"index":102}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":84,"end":102,"loc":{"start":{"line":7,"column":9,"index":84},"end":{"line":7,"column":27,"index":102}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":90,"end":101,"loc":{"start":{"line":7,"column":15,"index":90},"end":{"line":7,"column":26,"index":101}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":90,"end":96,"loc":{"start":{"line":7,"column":15,"index":90},"end":{"line":7,"column":21,"index":96},"identifierName":"number"},
+                      "name": "number"
+                    },
+                    "init": {
+                      "type": "NumericLiteral",
+                      "start":99,"end":101,"loc":{"start":{"line":7,"column":24,"index":99},"end":{"line":7,"column":26,"index":101}},
+                      "extra": {
+                        "rawValue": 1,
+                        "raw": "1."
+                      },
+                      "value": 1
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":105,"end":130,"loc":{"start":{"line":8,"column":2,"index":105},"end":{"line":8,"column":27,"index":130}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":112,"end":130,"loc":{"start":{"line":8,"column":9,"index":112},"end":{"line":8,"column":27,"index":130}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":118,"end":129,"loc":{"start":{"line":8,"column":15,"index":118},"end":{"line":8,"column":26,"index":129}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":118,"end":124,"loc":{"start":{"line":8,"column":15,"index":118},"end":{"line":8,"column":21,"index":124},"identifierName":"bigint"},
+                      "name": "bigint"
+                    },
+                    "init": {
+                      "type": "BigIntLiteral",
+                      "start":127,"end":129,"loc":{"start":{"line":8,"column":24,"index":127},"end":{"line":8,"column":26,"index":129}},
+                      "extra": {
+                        "rawValue": "0",
+                        "raw": "0n"
+                      },
+                      "value": "0"
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":133,"end":168,"loc":{"start":{"line":9,"column":2,"index":133},"end":{"line":9,"column":37,"index":168}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":140,"end":168,"loc":{"start":{"line":9,"column":9,"index":140},"end":{"line":9,"column":37,"index":168}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":146,"end":167,"loc":{"start":{"line":9,"column":15,"index":146},"end":{"line":9,"column":36,"index":167}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":146,"end":161,"loc":{"start":{"line":9,"column":15,"index":146},"end":{"line":9,"column":30,"index":161},"identifierName":"negative_bigint"},
+                      "name": "negative_bigint"
+                    },
+                    "init": {
+                      "type": "UnaryExpression",
+                      "start":164,"end":167,"loc":{"start":{"line":9,"column":33,"index":164},"end":{"line":9,"column":36,"index":167}},
+                      "operator": "-",
+                      "prefix": true,
+                      "argument": {
+                        "type": "BigIntLiteral",
+                        "start":165,"end":167,"loc":{"start":{"line":9,"column":34,"index":165},"end":{"line":9,"column":36,"index":167}},
+                        "extra": {
+                          "rawValue": "0",
+                          "raw": "0n"
+                        },
+                        "value": "0"
+                      }
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":171,"end":205,"loc":{"start":{"line":10,"column":2,"index":171},"end":{"line":10,"column":36,"index":205}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":178,"end":205,"loc":{"start":{"line":10,"column":9,"index":178},"end":{"line":10,"column":36,"index":205}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":184,"end":204,"loc":{"start":{"line":10,"column":15,"index":184},"end":{"line":10,"column":35,"index":204}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":184,"end":199,"loc":{"start":{"line":10,"column":15,"index":184},"end":{"line":10,"column":30,"index":199},"identifierName":"negative_number"},
+                      "name": "negative_number"
+                    },
+                    "init": {
+                      "type": "UnaryExpression",
+                      "start":202,"end":204,"loc":{"start":{"line":10,"column":33,"index":202},"end":{"line":10,"column":35,"index":204}},
+                      "operator": "-",
+                      "prefix": true,
+                      "argument": {
+                        "type": "NumericLiteral",
+                        "start":203,"end":204,"loc":{"start":{"line":10,"column":34,"index":203},"end":{"line":10,"column":35,"index":204}},
+                        "extra": {
+                          "rawValue": 1,
+                          "raw": "1"
+                        },
+                        "value": 1
+                      }
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":208,"end":237,"loc":{"start":{"line":11,"column":2,"index":208},"end":{"line":11,"column":31,"index":237}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":215,"end":237,"loc":{"start":{"line":11,"column":9,"index":215},"end":{"line":11,"column":31,"index":237}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":221,"end":236,"loc":{"start":{"line":11,"column":15,"index":221},"end":{"line":11,"column":30,"index":236}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":221,"end":229,"loc":{"start":{"line":11,"column":15,"index":221},"end":{"line":11,"column":23,"index":229},"identifierName":"template"},
+                      "name": "template"
+                    },
+                    "init": {
+                      "type": "TemplateLiteral",
+                      "start":232,"end":236,"loc":{"start":{"line":11,"column":26,"index":232},"end":{"line":11,"column":30,"index":236}},
+                      "expressions": [],
+                      "quasis": [
+                        {
+                          "type": "TemplateElement",
+                          "start":233,"end":235,"loc":{"start":{"line":11,"column":27,"index":233},"end":{"line":11,"column":29,"index":235}},
+                          "value": {
+                            "raw": "-2",
+                            "cooked": "-2"
+                          },
+                          "tail": true
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":240,"end":267,"loc":{"start":{"line":12,"column":2,"index":240},"end":{"line":12,"column":29,"index":267}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":247,"end":267,"loc":{"start":{"line":12,"column":9,"index":247},"end":{"line":12,"column":29,"index":267}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":253,"end":266,"loc":{"start":{"line":12,"column":15,"index":253},"end":{"line":12,"column":28,"index":266}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":253,"end":258,"loc":{"start":{"line":12,"column":15,"index":253},"end":{"line":12,"column":20,"index":258},"identifierName":"False"},
+                      "name": "False"
+                    },
+                    "init": {
+                      "type": "BooleanLiteral",
+                      "start":261,"end":266,"loc":{"start":{"line":12,"column":23,"index":261},"end":{"line":12,"column":28,"index":266}},
+                      "value": false
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":270,"end":295,"loc":{"start":{"line":13,"column":2,"index":270},"end":{"line":13,"column":27,"index":295}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":277,"end":295,"loc":{"start":{"line":13,"column":9,"index":277},"end":{"line":13,"column":27,"index":295}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":283,"end":294,"loc":{"start":{"line":13,"column":15,"index":283},"end":{"line":13,"column":26,"index":294}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":283,"end":287,"loc":{"start":{"line":13,"column":15,"index":283},"end":{"line":13,"column":19,"index":287},"identifierName":"True"},
+                      "name": "True"
+                    },
+                    "init": {
+                      "type": "BooleanLiteral",
+                      "start":290,"end":294,"loc":{"start":{"line":13,"column":22,"index":290},"end":{"line":13,"column":26,"index":294}},
+                      "value": true
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":298,"end":323,"loc":{"start":{"line":14,"column":2,"index":298},"end":{"line":14,"column":27,"index":323}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":305,"end":323,"loc":{"start":{"line":14,"column":9,"index":305},"end":{"line":14,"column":27,"index":323}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":311,"end":322,"loc":{"start":{"line":14,"column":15,"index":311},"end":{"line":14,"column":26,"index":322}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":311,"end":315,"loc":{"start":{"line":14,"column":15,"index":311},"end":{"line":14,"column":19,"index":315},"identifierName":"E_ok"},
+                      "name": "E_ok"
+                    },
+                    "init": {
+                      "type": "MemberExpression",
+                      "start":318,"end":322,"loc":{"start":{"line":14,"column":22,"index":318},"end":{"line":14,"column":26,"index":322}},
+                      "object": {
+                        "type": "Identifier",
+                        "start":318,"end":319,"loc":{"start":{"line":14,"column":22,"index":318},"end":{"line":14,"column":23,"index":319},"identifierName":"E"},
+                        "name": "E"
+                      },
+                      "computed": false,
+                      "property": {
+                        "type": "Identifier",
+                        "start":320,"end":322,"loc":{"start":{"line":14,"column":24,"index":320},"end":{"line":14,"column":26,"index":322},"identifierName":"ok"},
+                        "name": "ok"
+                      }
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            }
+          ]
+        },
+        "declare": true
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/const/invalid-initializer-ambient-context/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/const/invalid-initializer-ambient-context/input.ts
@@ -1,0 +1,8 @@
+declare module N {
+  export const not_enum = N[not + enum];
+  export const binary_expression = 1 + 2;
+  export const regex = /1/;
+  export const Undefined = undefined;
+  export const Null = null;
+  export const identifier_reference = globalThis;
+}

--- a/packages/babel-parser/test/fixtures/typescript/const/invalid-initializer-ambient-context/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/const/invalid-initializer-ambient-context/output.json
@@ -1,0 +1,246 @@
+{
+  "type": "File",
+  "start":0,"end":247,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":8,"column":1,"index":247}},
+  "errors": [
+    "SyntaxError: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference. (2:26)",
+    "SyntaxError: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference. (3:35)",
+    "SyntaxError: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference. (4:23)",
+    "SyntaxError: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference. (5:27)",
+    "SyntaxError: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference. (6:22)",
+    "SyntaxError: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference. (7:38)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":247,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":8,"column":1,"index":247}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSModuleDeclaration",
+        "start":0,"end":247,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":8,"column":1,"index":247}},
+        "id": {
+          "type": "Identifier",
+          "start":15,"end":16,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":16,"index":16},"identifierName":"N"},
+          "name": "N"
+        },
+        "body": {
+          "type": "TSModuleBlock",
+          "start":17,"end":247,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":8,"column":1,"index":247}},
+          "body": [
+            {
+              "type": "ExportNamedDeclaration",
+              "start":21,"end":59,"loc":{"start":{"line":2,"column":2,"index":21},"end":{"line":2,"column":40,"index":59}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":28,"end":59,"loc":{"start":{"line":2,"column":9,"index":28},"end":{"line":2,"column":40,"index":59}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":34,"end":58,"loc":{"start":{"line":2,"column":15,"index":34},"end":{"line":2,"column":39,"index":58}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":34,"end":42,"loc":{"start":{"line":2,"column":15,"index":34},"end":{"line":2,"column":23,"index":42},"identifierName":"not_enum"},
+                      "name": "not_enum"
+                    },
+                    "init": {
+                      "type": "MemberExpression",
+                      "start":45,"end":58,"loc":{"start":{"line":2,"column":26,"index":45},"end":{"line":2,"column":39,"index":58}},
+                      "object": {
+                        "type": "Identifier",
+                        "start":45,"end":46,"loc":{"start":{"line":2,"column":26,"index":45},"end":{"line":2,"column":27,"index":46},"identifierName":"N"},
+                        "name": "N"
+                      },
+                      "computed": true,
+                      "property": {
+                        "type": "BinaryExpression",
+                        "start":47,"end":57,"loc":{"start":{"line":2,"column":28,"index":47},"end":{"line":2,"column":38,"index":57}},
+                        "left": {
+                          "type": "Identifier",
+                          "start":47,"end":50,"loc":{"start":{"line":2,"column":28,"index":47},"end":{"line":2,"column":31,"index":50},"identifierName":"not"},
+                          "name": "not"
+                        },
+                        "operator": "+",
+                        "right": {
+                          "type": "Identifier",
+                          "start":53,"end":57,"loc":{"start":{"line":2,"column":34,"index":53},"end":{"line":2,"column":38,"index":57},"identifierName":"enum"},
+                          "name": "enum"
+                        }
+                      }
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":62,"end":101,"loc":{"start":{"line":3,"column":2,"index":62},"end":{"line":3,"column":41,"index":101}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":69,"end":101,"loc":{"start":{"line":3,"column":9,"index":69},"end":{"line":3,"column":41,"index":101}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":75,"end":100,"loc":{"start":{"line":3,"column":15,"index":75},"end":{"line":3,"column":40,"index":100}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":75,"end":92,"loc":{"start":{"line":3,"column":15,"index":75},"end":{"line":3,"column":32,"index":92},"identifierName":"binary_expression"},
+                      "name": "binary_expression"
+                    },
+                    "init": {
+                      "type": "BinaryExpression",
+                      "start":95,"end":100,"loc":{"start":{"line":3,"column":35,"index":95},"end":{"line":3,"column":40,"index":100}},
+                      "left": {
+                        "type": "NumericLiteral",
+                        "start":95,"end":96,"loc":{"start":{"line":3,"column":35,"index":95},"end":{"line":3,"column":36,"index":96}},
+                        "extra": {
+                          "rawValue": 1,
+                          "raw": "1"
+                        },
+                        "value": 1
+                      },
+                      "operator": "+",
+                      "right": {
+                        "type": "NumericLiteral",
+                        "start":99,"end":100,"loc":{"start":{"line":3,"column":39,"index":99},"end":{"line":3,"column":40,"index":100}},
+                        "extra": {
+                          "rawValue": 2,
+                          "raw": "2"
+                        },
+                        "value": 2
+                      }
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":104,"end":129,"loc":{"start":{"line":4,"column":2,"index":104},"end":{"line":4,"column":27,"index":129}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":111,"end":129,"loc":{"start":{"line":4,"column":9,"index":111},"end":{"line":4,"column":27,"index":129}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":117,"end":128,"loc":{"start":{"line":4,"column":15,"index":117},"end":{"line":4,"column":26,"index":128}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":117,"end":122,"loc":{"start":{"line":4,"column":15,"index":117},"end":{"line":4,"column":20,"index":122},"identifierName":"regex"},
+                      "name": "regex"
+                    },
+                    "init": {
+                      "type": "RegExpLiteral",
+                      "start":125,"end":128,"loc":{"start":{"line":4,"column":23,"index":125},"end":{"line":4,"column":26,"index":128}},
+                      "extra": {
+                        "raw": "/1/"
+                      },
+                      "pattern": "1",
+                      "flags": ""
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":132,"end":167,"loc":{"start":{"line":5,"column":2,"index":132},"end":{"line":5,"column":37,"index":167}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":139,"end":167,"loc":{"start":{"line":5,"column":9,"index":139},"end":{"line":5,"column":37,"index":167}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":145,"end":166,"loc":{"start":{"line":5,"column":15,"index":145},"end":{"line":5,"column":36,"index":166}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":145,"end":154,"loc":{"start":{"line":5,"column":15,"index":145},"end":{"line":5,"column":24,"index":154},"identifierName":"Undefined"},
+                      "name": "Undefined"
+                    },
+                    "init": {
+                      "type": "Identifier",
+                      "start":157,"end":166,"loc":{"start":{"line":5,"column":27,"index":157},"end":{"line":5,"column":36,"index":166},"identifierName":"undefined"},
+                      "name": "undefined"
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":170,"end":195,"loc":{"start":{"line":6,"column":2,"index":170},"end":{"line":6,"column":27,"index":195}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":177,"end":195,"loc":{"start":{"line":6,"column":9,"index":177},"end":{"line":6,"column":27,"index":195}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":183,"end":194,"loc":{"start":{"line":6,"column":15,"index":183},"end":{"line":6,"column":26,"index":194}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":183,"end":187,"loc":{"start":{"line":6,"column":15,"index":183},"end":{"line":6,"column":19,"index":187},"identifierName":"Null"},
+                      "name": "Null"
+                    },
+                    "init": {
+                      "type": "NullLiteral",
+                      "start":190,"end":194,"loc":{"start":{"line":6,"column":22,"index":190},"end":{"line":6,"column":26,"index":194}}
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            },
+            {
+              "type": "ExportNamedDeclaration",
+              "start":198,"end":245,"loc":{"start":{"line":7,"column":2,"index":198},"end":{"line":7,"column":49,"index":245}},
+              "exportKind": "value",
+              "specifiers": [],
+              "source": null,
+              "declaration": {
+                "type": "VariableDeclaration",
+                "start":205,"end":245,"loc":{"start":{"line":7,"column":9,"index":205},"end":{"line":7,"column":49,"index":245}},
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start":211,"end":244,"loc":{"start":{"line":7,"column":15,"index":211},"end":{"line":7,"column":48,"index":244}},
+                    "id": {
+                      "type": "Identifier",
+                      "start":211,"end":231,"loc":{"start":{"line":7,"column":15,"index":211},"end":{"line":7,"column":35,"index":231},"identifierName":"identifier_reference"},
+                      "name": "identifier_reference"
+                    },
+                    "init": {
+                      "type": "Identifier",
+                      "start":234,"end":244,"loc":{"start":{"line":7,"column":38,"index":234},"end":{"line":7,"column":48,"index":244},"identifierName":"globalThis"},
+                      "name": "globalThis"
+                    }
+                  }
+                ],
+                "kind": "const"
+              }
+            }
+          ]
+        },
+        "declare": true
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15337 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
- Allow negative numbers in ambient const initializers. E.g.

```ts
declare module N {
  const negative_number = -1;
}
```

- Added new tests as it seems that the error is not covered by any other tests.

The literal AST difference between Babel and ESTree is somehow annoying, an `estree` boolean toggle is added so we don't have to take care of the inheritance ordering between the `estree` plugin and the `typescript` plugin. (We may want to enforce plugin orderings for `estree` and other language extensions.)