### PR TITLE
handling circular/shared structures in deep-clone

### DIFF
--- a/packages/babel-core/src/transformation/util/clone-deep.ts
+++ b/packages/babel-core/src/transformation/util/clone-deep.ts
@@ -5,12 +5,14 @@ function deepClone(value: any, cache: Map<any, any>): any {
     let cloned: any;
     if (Array.isArray(value)) {
       cloned = new Array(value.length);
+      cache.set(value, cloned);
       for (let i = 0; i < value.length; i++) {
         cloned[i] =
           typeof value[i] !== "object" ? value[i] : deepClone(value[i], cache);
       }
     } else {
       cloned = {};
+      cache.set(value, cloned);
       const keys = Object.keys(value);
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
@@ -20,7 +22,6 @@ function deepClone(value: any, cache: Map<any, any>): any {
             : deepClone(value[key], cache);
       }
     }
-    cache.set(value, cloned);
     return cloned;
   }
   return value;

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -300,6 +300,16 @@ describe("api", function () {
     expect(code).toBe(code2);
   });
 
+  it("transformFromAstSync should not cause infinite recursion with circular objects", () => {
+    const program = "const identifier = 1";
+    const node = parseSync(program);
+    node.program.body[0].extra = { parent: node.program };
+
+    expect(transformFromAstSync(node, program, {}).code).toBe(
+      "const identifier = 1;",
+    );
+  });
+
   it("transformFromAst should not mutate the AST", function () {
     const program = "const identifier = 1";
     const node = parseSync(program);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | unreported issue
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | no
| Documentation PR Link    |  no
| Any Dependency Changes?  | no
| License                  | MIT



Compiling our project gets into deep recursion and eventually stack overflow inside `deepClone`.  Setting the cache early (as in the patch) cuts on the recursion in many cases and actually made our project compile.  

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15366"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

