### PR TITLE
fix: Don't throw in `getTypeAnnotation` when using TS+inference

### DIFF
--- a/packages/babel-traverse/src/path/inference/inferer-reference.ts
+++ b/packages/babel-traverse/src/path/inference/inferer-reference.ts
@@ -155,7 +155,6 @@ function inferAnnotationFromBinaryExpression(
 
   if (operator !== "===" && operator !== "==") return;
 
-  //
   let typeofPath: NodePath<t.UnaryExpression>;
   let typePath: NodePath<t.Expression>;
   if (left.isUnaryExpression({ operator: "typeof" })) {

--- a/packages/babel-traverse/src/path/inference/util.ts
+++ b/packages/babel-traverse/src/path/inference/util.ts
@@ -8,8 +8,8 @@ import {
 import type * as t from "@babel/types";
 
 export function createUnionType(
-  types: Array<t.FlowType | t.TSType>,
-): t.FlowType | t.TSType {
+  types: (t.FlowType | t.TSType)[],
+): t.FlowType | t.TSType | undefined {
   if (process.env.BABEL_8_BREAKING) {
     if (types.every(v => isFlowType(v))) {
       return createFlowUnionType(types as t.FlowType[]);

--- a/packages/babel-traverse/src/path/inference/util.ts
+++ b/packages/babel-traverse/src/path/inference/util.ts
@@ -11,20 +11,20 @@ export function createUnionType(
   types: Array<t.FlowType | t.TSType>,
 ): t.FlowType | t.TSType {
   if (process.env.BABEL_8_BREAKING) {
-    if (isFlowType(types[0])) {
+    if (types.every(v => isFlowType(v))) {
       return createFlowUnionType(types as t.FlowType[]);
     }
-    if (isTSType(types[0])) {
+    if (types.every(v => isTSType(v))) {
       return createTSUnionType(types as t.TSType[]);
     }
   } else {
-    if (isFlowType(types[0])) {
+    if (types.every(v => isFlowType(v))) {
       if (createFlowUnionType) {
         return createFlowUnionType(types as t.FlowType[]);
       }
 
       return createUnionTypeAnnotation(types as t.FlowType[]);
-    } else {
+    } else if (types.every(v => isTSType(v))) {
       if (createTSUnionType) {
         return createTSUnionType(types as t.TSType[]);
       }

--- a/packages/babel-traverse/test/inference.js
+++ b/packages/babel-traverse/test/inference.js
@@ -701,5 +701,12 @@ describe("inference with TypeScript", function () {
       const path = tsGetPath(input).get("body.0.expression");
       expect(path.isGenericType("Array")).toBe(true);
     });
+    it("should not throw both flow and ts types", () => {
+      const path = tsGetPath(
+        `const bar = 0 ? mkList() : [];function mkList(): any[] {return [];}`,
+      ).get("body.0.declarations.0");
+      // TODO: This should be true
+      expect(path.isGenericType("Array")).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15380 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15383"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

