### PR TITLE
fix: Version lower than Eslint 7, no ESLint class

### DIFF
--- a/eslint/babel-eslint-plugin/src/rules/no-invalid-this.cjs
+++ b/eslint/babel-eslint-plugin/src/rules/no-invalid-this.cjs
@@ -1,6 +1,6 @@
 const ruleComposer = require("eslint-rule-composer");
 const eslint = require("eslint");
-const eslintVersion = eslint.ESLint.version;
+const eslintVersion = eslint?.ESLint.version;
 
 const noInvalidThisRule = new eslint.Linter().getRules().get("no-invalid-this");
 

--- a/eslint/babel-eslint-plugin/src/rules/no-invalid-this.cjs
+++ b/eslint/babel-eslint-plugin/src/rules/no-invalid-this.cjs
@@ -1,6 +1,6 @@
 const ruleComposer = require("eslint-rule-composer");
 const eslint = require("eslint");
-const eslintVersion = eslint?.ESLint.version;
+const eslintVersion = eslint?.ESLint.version ?? "7";
 
 const noInvalidThisRule = new eslint.Linter().getRules().get("no-invalid-this");
 

--- a/eslint/babel-eslint-plugin/src/rules/no-invalid-this.cjs
+++ b/eslint/babel-eslint-plugin/src/rules/no-invalid-this.cjs
@@ -1,6 +1,6 @@
 const ruleComposer = require("eslint-rule-composer");
 const eslint = require("eslint");
-const eslintVersion = eslint?.ESLint.version ?? "7";
+const eslintVersion = eslint.ESLint?.version ?? "7";
 
 const noInvalidThisRule = new eslint.Linter().getRules().get("no-invalid-this");
 

--- a/eslint/babel-eslint-plugin/src/rules/semi.cjs
+++ b/eslint/babel-eslint-plugin/src/rules/semi.cjs
@@ -1,6 +1,6 @@
 const ruleComposer = require("eslint-rule-composer");
 const eslint = require("eslint");
-const eslintVersion = eslint?.ESLint.version;
+const eslintVersion = eslint?.ESLint.version ?? "7";
 
 const OPT_OUT_PATTERN = /^[-[(/+`]/; // One of [(/+-`
 

--- a/eslint/babel-eslint-plugin/src/rules/semi.cjs
+++ b/eslint/babel-eslint-plugin/src/rules/semi.cjs
@@ -1,6 +1,6 @@
 const ruleComposer = require("eslint-rule-composer");
 const eslint = require("eslint");
-const eslintVersion = eslint?.ESLint.version ?? "7";
+const eslintVersion = eslint.ESLint?.version ?? "7";
 
 const OPT_OUT_PATTERN = /^[-[(/+`]/; // One of [(/+-`
 

--- a/eslint/babel-eslint-plugin/src/rules/semi.cjs
+++ b/eslint/babel-eslint-plugin/src/rules/semi.cjs
@@ -1,6 +1,6 @@
 const ruleComposer = require("eslint-rule-composer");
 const eslint = require("eslint");
-const eslintVersion = eslint.ESLint.version;
+const eslintVersion = eslint?.ESLint.version;
 
 const OPT_OUT_PATTERN = /^[-[(/+`]/; // One of [(/+-`
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |  Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

”ESLint“ class is not exported under Eslint 7, so need to use "?." to avoid program errors
resources: https://github.com/eslint/eslint/blob/v7.0.0/lib/eslint/eslint.js



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15390"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

