### PR TITLE
chore: Remove meaningless `typeof undefined`

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -238,9 +238,7 @@ const TSErrors = ParseErrorEnum`typescript`({
 
 // Doesn't handle "void" or "null" because those are keywords, not identifiers.
 // It also doesn't handle "intrinsic", since usually it's not a keyword.
-function keywordTypeFromName(
-  value: string,
-): N.TsKeywordTypeType | typeof undefined {
+function keywordTypeFromName(value: string): N.TsKeywordTypeType | undefined {
   switch (value) {
     case "any":
       return "TSAnyKeyword";
@@ -1790,7 +1788,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       }
     }
 
-    tsEatThenParseType(token: TokenType): N.TsType | typeof undefined {
+    tsEatThenParseType(token: TokenType): N.TsType | undefined {
       return !this.match(token) ? undefined : this.tsNextThenParseType();
     }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

https://github.com/babel/babel/pull/15379
I found in https://github.com/babel/babel/pull/15379 that `typeof undefined` is equivalent to `any`, which doesn't seem to make sense, let's remove them.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15395"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

