### PR TITLE
polish: improve "`await` as identifier" error in modules

### DIFF
--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -2793,7 +2793,26 @@ export default abstract class ExpressionParser extends LValParser {
       return;
     }
 
-    if (word === "yield") {
+    if (checkKeywords && isKeyword(word)) {
+      this.raise(Errors.UnexpectedKeyword, {
+        at: startLoc,
+        keyword: word,
+      });
+      return;
+    }
+
+    const reservedTest = !this.state.strict
+      ? isReservedWord
+      : isBinding
+      ? isStrictBindReservedWord
+      : isStrictReservedWord;
+
+    if (reservedTest(word, this.inModule)) {
+      this.raise(Errors.UnexpectedReservedWord, {
+        at: startLoc,
+        reservedWord: word,
+      });
+    } else if (word === "yield") {
       if (this.prodParam.hasYield) {
         this.raise(Errors.YieldBindingIdentifier, { at: startLoc });
         return;
@@ -2817,27 +2836,6 @@ export default abstract class ExpressionParser extends LValParser {
         this.raise(Errors.ArgumentsInClass, { at: startLoc });
         return;
       }
-    }
-
-    if (checkKeywords && isKeyword(word)) {
-      this.raise(Errors.UnexpectedKeyword, {
-        at: startLoc,
-        keyword: word,
-      });
-      return;
-    }
-
-    const reservedTest = !this.state.strict
-      ? isReservedWord
-      : isBinding
-      ? isStrictBindReservedWord
-      : isStrictReservedWord;
-
-    if (reservedTest(word, this.inModule)) {
-      this.raise(Errors.UnexpectedReservedWord, {
-        at: startLoc,
-        reservedWord: word,
-      });
     }
   }
 

--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -2812,6 +2812,7 @@ export default abstract class ExpressionParser extends LValParser {
         at: startLoc,
         reservedWord: word,
       });
+      return;
     } else if (word === "yield") {
       if (this.prodParam.hasYield) {
         this.raise(Errors.YieldBindingIdentifier, { at: startLoc });

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/359/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/359/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":20,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":20,"index":20}},
   "errors": [
-    "SyntaxError: Can not use 'await' as identifier inside an async function. (1:6)"
+    "SyntaxError: Unexpected reserved word 'await'. (1:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/361/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/361/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":24,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":24,"index":24}},
   "errors": [
-    "SyntaxError: Can not use 'await' as identifier inside an async function. (1:8)"
+    "SyntaxError: Unexpected reserved word 'await'. (1:8)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/365/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/365/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":19,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":19,"index":19}},
   "errors": [
-    "SyntaxError: Can not use 'await' as identifier inside an async function. (1:9)"
+    "SyntaxError: Unexpected reserved word 'await'. (1:9)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/367/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/367/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
   "errors": [
-    "SyntaxError: Can not use 'await' as identifier inside an async function. (1:6)"
+    "SyntaxError: Unexpected reserved word 'await'. (1:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-using-binding-await-module/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-using-binding-await-module/output.json
@@ -2,10 +2,10 @@
   "type": "File",
   "start":0,"end":113,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":12,"column":1,"index":113}},
   "errors": [
-    "SyntaxError: Can not use 'await' as identifier inside an async function. (2:8)",
-    "SyntaxError: Can not use 'await' as identifier inside an async function. (5:8)",
-    "SyntaxError: Can not use 'await' as identifier inside an async function. (8:11)",
-    "SyntaxError: Can not use 'await' as identifier inside an async function. (11:13)"
+    "SyntaxError: Unexpected reserved word 'await'. (2:8)",
+    "SyntaxError: Unexpected reserved word 'await'. (5:8)",
+    "SyntaxError: Unexpected reserved word 'await'. (8:11)",
+    "SyntaxError: Unexpected reserved word 'await'. (11:13)"
   ],
   "program": {
     "type": "Program",

--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -47,6 +47,11 @@ echo "export default () => () => {}" > src/main/create-print-pre-check-function.
 rm tests/format/js/exports/jsfmt.spec.js
 rm tests/format/js/export-extension/jsfmt.spec.js
 
+# https://github.com/babel/babel/pull/15400#issuecomment-1414539133
+# Ignore this test until prettier update the snapshot
+# because prettier has ignored UnexpectedReservedWord error
+rm tests/format/flow-repo/async/await_parse.js
+
 yarn test "tests/format/(jsx?|misc|typescript|flow|flow-repo)/" --update-snapshot --runInBand
 
 cleanup


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixed https://github.com/babel/babel/pull/15391#discussion_r1093638233
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Moved reserved word checking before await as identifier checking so it will throw "Unexpected reserved word 'await'" when sourceType is module, aligning with V8's current behaviour.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15400"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

