### PR TITLE
Preserve class elements comments in class transform

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -557,14 +557,17 @@ function buildPrivateFieldInitLoose(
   const { id } = privateNamesMap.get(prop.node.key.id.name);
   const value = prop.node.value || prop.scope.buildUndefinedNode();
 
-  return template.statement.ast`
+  return inheritPropComments(
+    template.statement.ast`
     Object.defineProperty(${ref}, ${t.cloneNode(id)}, {
       // configurable is false by default
       // enumerable is false by default
       writable: true,
       value: ${value}
     });
-  `;
+  `,
+    prop,
+  );
 }
 
 function buildPrivateInstanceFieldInitSpec(
@@ -578,24 +581,30 @@ function buildPrivateInstanceFieldInitSpec(
 
   if (!process.env.BABEL_8_BREAKING) {
     if (!state.availableHelper("classPrivateFieldInitSpec")) {
-      return template.statement.ast`${t.cloneNode(id)}.set(${ref}, {
+      return inheritPropComments(
+        template.statement.ast`${t.cloneNode(id)}.set(${ref}, {
         // configurable is always false for private elements
         // enumerable is always false for private elements
         writable: true,
         value: ${value},
-      })`;
+      })`,
+        prop,
+      );
     }
   }
 
   const helper = state.addHelper("classPrivateFieldInitSpec");
-  return template.statement.ast`${helper}(
+  return inheritPropComments(
+    template.statement.ast`${helper}(
     ${t.thisExpression()},
     ${t.cloneNode(id)},
     {
       writable: true,
       value: ${value}
     },
-  )`;
+  )`,
+    prop,
+  );
 }
 
 function buildPrivateStaticFieldInitSpec(
@@ -614,7 +623,8 @@ function buildPrivateStaticFieldInitSpec(
       initAdded: true,
     });
 
-    return template.statement.ast`
+    return inheritPropComments(
+      template.statement.ast`
       var ${t.cloneNode(id)} = {
         // configurable is false by default
         // enumerable is false by default
@@ -622,18 +632,23 @@ function buildPrivateStaticFieldInitSpec(
         get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
         set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
       }
-    `;
+    `,
+      prop,
+    );
   }
 
   const value = prop.node.value || prop.scope.buildUndefinedNode();
-  return template.statement.ast`
+  return inheritPropComments(
+    template.statement.ast`
     var ${t.cloneNode(id)} = {
       // configurable is false by default
       // enumerable is false by default
       writable: true,
       value: ${value}
     };
-  `;
+  `,
+    prop,
+  );
 }
 
 function buildPrivateMethodInitLoose(
@@ -646,14 +661,17 @@ function buildPrivateMethodInitLoose(
   if (initAdded) return;
 
   if (methodId) {
-    return template.statement.ast`
+    return inheritPropComments(
+      template.statement.ast`
         Object.defineProperty(${ref}, ${id}, {
           // configurable is false by default
           // enumerable is false by default
           // writable is false by default
           value: ${methodId.name}
         });
-      `;
+      `,
+      prop,
+    );
   }
   const isAccessor = getId || setId;
   if (isAccessor) {
@@ -662,7 +680,8 @@ function buildPrivateMethodInitLoose(
       initAdded: true,
     });
 
-    return template.statement.ast`
+    return inheritPropComments(
+      template.statement.ast`
       Object.defineProperty(${ref}, ${id}, {
         // configurable is false by default
         // enumerable is false by default
@@ -670,7 +689,9 @@ function buildPrivateMethodInitLoose(
         get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
         set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
       });
-    `;
+    `,
+      prop,
+    );
   }
 }
 
@@ -719,24 +740,30 @@ function buildPrivateAccessorInitialization(
 
   if (!process.env.BABEL_8_BREAKING) {
     if (!state.availableHelper("classPrivateFieldInitSpec")) {
-      return template.statement.ast`
+      return inheritPropComments(
+        template.statement.ast`
       ${id}.set(${ref}, {
         get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
         set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
       });
-    `;
+    `,
+        prop,
+      );
     }
   }
 
   const helper = state.addHelper("classPrivateFieldInitSpec");
-  return template.statement.ast`${helper}(
+  return inheritPropComments(
+    template.statement.ast`${helper}(
     ${t.thisExpression()},
     ${t.cloneNode(id)},
     {
       get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
       set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
     },
-  )`;
+  )`,
+    prop,
+  );
 }
 
 function buildPrivateInstanceMethodInitalization(
@@ -750,15 +777,21 @@ function buildPrivateInstanceMethodInitalization(
 
   if (!process.env.BABEL_8_BREAKING) {
     if (!state.availableHelper("classPrivateMethodInitSpec")) {
-      return template.statement.ast`${id}.add(${ref})`;
+      return inheritPropComments(
+        template.statement.ast`${id}.add(${ref})`,
+        prop,
+      );
     }
   }
 
   const helper = state.addHelper("classPrivateMethodInitSpec");
-  return template.statement.ast`${helper}(
+  return inheritPropComments(
+    template.statement.ast`${helper}(
     ${t.thisExpression()},
     ${t.cloneNode(id)}
-  )`;
+  )`,
+    prop,
+  );
 }
 
 function buildPublicFieldInitLoose(
@@ -768,12 +801,15 @@ function buildPublicFieldInitLoose(
   const { key, computed } = prop.node;
   const value = prop.node.value || prop.scope.buildUndefinedNode();
 
-  return t.expressionStatement(
-    t.assignmentExpression(
-      "=",
-      t.memberExpression(ref, key, computed || t.isLiteral(key)),
-      value,
+  return inheritPropComments(
+    t.expressionStatement(
+      t.assignmentExpression(
+        "=",
+        t.memberExpression(ref, key, computed || t.isLiteral(key)),
+        value,
+      ),
     ),
+    prop,
   );
 }
 
@@ -785,14 +821,17 @@ function buildPublicFieldInitSpec(
   const { key, computed } = prop.node;
   const value = prop.node.value || prop.scope.buildUndefinedNode();
 
-  return t.expressionStatement(
-    t.callExpression(state.addHelper("defineProperty"), [
-      ref,
-      computed || t.isLiteral(key)
-        ? key
-        : t.stringLiteral((key as t.Identifier).name),
-      value,
-    ]),
+  return inheritPropComments(
+    t.expressionStatement(
+      t.callExpression(state.addHelper("defineProperty"), [
+        ref,
+        computed || t.isLiteral(key)
+          ? key
+          : t.stringLiteral((key as t.Identifier).name),
+        value,
+      ]),
+    ),
+    prop,
   );
 }
 
@@ -814,7 +853,8 @@ function buildPrivateStaticMethodInitLoose(
       initAdded: true,
     });
 
-    return template.statement.ast`
+    return inheritPropComments(
+      template.statement.ast`
       Object.defineProperty(${ref}, ${id}, {
         // configurable is false by default
         // enumerable is false by default
@@ -822,17 +862,22 @@ function buildPrivateStaticMethodInitLoose(
         get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
         set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
       })
-    `;
+    `,
+      prop,
+    );
   }
 
-  return template.statement.ast`
+  return inheritPropComments(
+    template.statement.ast`
     Object.defineProperty(${ref}, ${id}, {
       // configurable is false by default
       // enumerable is false by default
       // writable is false by default
       value: ${methodId.name}
     });
-  `;
+  `,
+    prop,
+  );
 }
 
 function buildPrivateMethodDeclaration(
@@ -872,13 +917,16 @@ function buildPrivateMethodDeclaration(
     declId = id;
   }
 
-  return t.functionDeclaration(
-    t.cloneNode(declId),
-    // @ts-expect-error params for ClassMethod has TSParameterProperty
-    params,
-    body,
-    generator,
-    async,
+  return inheritPropComments(
+    t.functionDeclaration(
+      t.cloneNode(declId),
+      // @ts-expect-error params for ClassMethod has TSParameterProperty
+      params,
+      body,
+      generator,
+      async,
+    ),
+    prop,
   );
 }
 
@@ -994,6 +1042,12 @@ function isNameOrLength({ key, computed }: t.ClassProperty) {
   return false;
 }
 
+function inheritPropComments<T extends t.Node>(node: T, prop: PropPath) {
+  t.inheritLeadingComments(node, prop.node);
+  t.inheritInnerComments(node, prop.node);
+  return node;
+}
+
 export function buildFieldsInitNodes(
   ref: t.Identifier,
   superRef: t.Expression | undefined,
@@ -1056,9 +1110,14 @@ export function buildFieldsInitNodes(
         // We special-case the single expression case to avoid the iife, since
         // it's common.
         if (blockBody.length === 1 && t.isExpressionStatement(blockBody[0])) {
-          staticNodes.push(blockBody[0]);
+          staticNodes.push(inheritPropComments(blockBody[0], prop));
         } else {
-          staticNodes.push(template.statement.ast`(() => { ${blockBody} })()`);
+          staticNodes.push(
+            inheritPropComments(
+              template.statement.ast`(() => { ${blockBody} })()`,
+              prop,
+            ),
+          );
         }
         break;
       }

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -1113,9 +1113,9 @@ export function buildFieldsInitNodes(
           staticNodes.push(inheritPropComments(blockBody[0], prop));
         } else {
           staticNodes.push(
-            inheritPropComments(
+            t.inheritsComments(
               template.statement.ast`(() => { ${blockBody} })()`,
-              prop,
+              prop.node,
             ),
           );
         }

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -559,13 +559,13 @@ function buildPrivateFieldInitLoose(
 
   return inheritPropComments(
     template.statement.ast`
-    Object.defineProperty(${ref}, ${t.cloneNode(id)}, {
-      // configurable is false by default
-      // enumerable is false by default
-      writable: true,
-      value: ${value}
-    });
-  `,
+      Object.defineProperty(${ref}, ${t.cloneNode(id)}, {
+        // configurable is false by default
+        // enumerable is false by default
+        writable: true,
+        value: ${value}
+      });
+    `,
     prop,
   );
 }
@@ -583,11 +583,11 @@ function buildPrivateInstanceFieldInitSpec(
     if (!state.availableHelper("classPrivateFieldInitSpec")) {
       return inheritPropComments(
         template.statement.ast`${t.cloneNode(id)}.set(${ref}, {
-        // configurable is always false for private elements
-        // enumerable is always false for private elements
-        writable: true,
-        value: ${value},
-      })`,
+          // configurable is always false for private elements
+          // enumerable is always false for private elements
+          writable: true,
+          value: ${value},
+        })`,
         prop,
       );
     }
@@ -596,13 +596,13 @@ function buildPrivateInstanceFieldInitSpec(
   const helper = state.addHelper("classPrivateFieldInitSpec");
   return inheritPropComments(
     template.statement.ast`${helper}(
-    ${t.thisExpression()},
-    ${t.cloneNode(id)},
-    {
-      writable: true,
-      value: ${value}
-    },
-  )`,
+      ${t.thisExpression()},
+      ${t.cloneNode(id)},
+      {
+        writable: true,
+        value: ${value}
+      },
+    )`,
     prop,
   );
 }
@@ -625,14 +625,14 @@ function buildPrivateStaticFieldInitSpec(
 
     return inheritPropComments(
       template.statement.ast`
-      var ${t.cloneNode(id)} = {
-        // configurable is false by default
-        // enumerable is false by default
-        // writable is false by default
-        get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
-        set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
-      }
-    `,
+        var ${t.cloneNode(id)} = {
+          // configurable is false by default
+          // enumerable is false by default
+          // writable is false by default
+          get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
+          set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
+        }
+      `,
       prop,
     );
   }
@@ -640,13 +640,13 @@ function buildPrivateStaticFieldInitSpec(
   const value = prop.node.value || prop.scope.buildUndefinedNode();
   return inheritPropComments(
     template.statement.ast`
-    var ${t.cloneNode(id)} = {
-      // configurable is false by default
-      // enumerable is false by default
-      writable: true,
-      value: ${value}
-    };
-  `,
+      var ${t.cloneNode(id)} = {
+        // configurable is false by default
+        // enumerable is false by default
+        writable: true,
+        value: ${value}
+      };
+    `,
     prop,
   );
 }
@@ -682,14 +682,14 @@ function buildPrivateMethodInitLoose(
 
     return inheritPropComments(
       template.statement.ast`
-      Object.defineProperty(${ref}, ${id}, {
-        // configurable is false by default
-        // enumerable is false by default
-        // writable is false by default
-        get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
-        set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
-      });
-    `,
+        Object.defineProperty(${ref}, ${id}, {
+          // configurable is false by default
+          // enumerable is false by default
+          // writable is false by default
+          get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
+          set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
+        });
+      `,
       prop,
     );
   }
@@ -742,11 +742,11 @@ function buildPrivateAccessorInitialization(
     if (!state.availableHelper("classPrivateFieldInitSpec")) {
       return inheritPropComments(
         template.statement.ast`
-      ${id}.set(${ref}, {
-        get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
-        set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
-      });
-    `,
+          ${id}.set(${ref}, {
+            get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
+            set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
+          });
+        `,
         prop,
       );
     }
@@ -755,13 +755,13 @@ function buildPrivateAccessorInitialization(
   const helper = state.addHelper("classPrivateFieldInitSpec");
   return inheritPropComments(
     template.statement.ast`${helper}(
-    ${t.thisExpression()},
-    ${t.cloneNode(id)},
-    {
-      get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
-      set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
-    },
-  )`,
+      ${t.thisExpression()},
+      ${t.cloneNode(id)},
+      {
+        get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
+        set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
+      },
+    )`,
     prop,
   );
 }
@@ -787,9 +787,9 @@ function buildPrivateInstanceMethodInitalization(
   const helper = state.addHelper("classPrivateMethodInitSpec");
   return inheritPropComments(
     template.statement.ast`${helper}(
-    ${t.thisExpression()},
-    ${t.cloneNode(id)}
-  )`,
+      ${t.thisExpression()},
+      ${t.cloneNode(id)}
+    )`,
     prop,
   );
 }
@@ -855,27 +855,27 @@ function buildPrivateStaticMethodInitLoose(
 
     return inheritPropComments(
       template.statement.ast`
-      Object.defineProperty(${ref}, ${id}, {
-        // configurable is false by default
-        // enumerable is false by default
-        // writable is false by default
-        get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
-        set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
-      })
-    `,
+        Object.defineProperty(${ref}, ${id}, {
+          // configurable is false by default
+          // enumerable is false by default
+          // writable is false by default
+          get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
+          set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
+        })
+      `,
       prop,
     );
   }
 
   return inheritPropComments(
     template.statement.ast`
-    Object.defineProperty(${ref}, ${id}, {
-      // configurable is false by default
-      // enumerable is false by default
-      // writable is false by default
-      value: ${methodId.name}
-    });
-  `,
+      Object.defineProperty(${ref}, ${id}, {
+        // configurable is false by default
+        // enumerable is false by default
+        // writable is false by default
+        value: ${methodId.name}
+      });
+    `,
     prop,
   );
 }
@@ -1042,6 +1042,17 @@ function isNameOrLength({ key, computed }: t.ClassProperty) {
   return false;
 }
 
+/**
+ * Inherit comments from class members. This is a reduced version of
+ * t.inheritsComments: the trailing comments are not inherited because
+ * for most class members except the last one, their trailing comments are
+ * the next sibiling's leading comments.
+ *
+ * @template T transformed class member type
+ * @param {T} node transformed class member
+ * @param {PropPath} prop class member
+ * @returns transformed class member type with comments inherited
+ */
 function inheritPropComments<T extends t.Node>(node: T, prop: PropPath) {
   t.inheritLeadingComments(node, prop.node);
   t.inheritInnerComments(node, prop.node);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/compile-to-class/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/compile-to-class/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before a */
+  a;
+  /* after a */
+
+  /* before b */
+  static b;
+  /* after b */
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/compile-to-class/preserve-comments/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/compile-to-class/preserve-comments/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["proposal-class-properties"]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/compile-to-class/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/compile-to-class/preserve-comments/output.js
@@ -1,0 +1,10 @@
+class C {
+  constructor() {
+    /* before a */
+    babelHelpers.defineProperty(this, "a", void 0);
+  }
+  /* after b */
+}
+/* after a */
+/* before b */
+babelHelpers.defineProperty(C, "b", void 0);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before a */
+  #a;
+  /* after a */
+
+  /* before b */
+  static #b;
+  /* after b */
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/preserve-comments/output.js
@@ -1,0 +1,18 @@
+var _a = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("a");
+var _b = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("b");
+var C = /*#__PURE__*/babelHelpers.createClass(function C() {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, C);
+  /* before a */
+  Object.defineProperty(this, _a, {
+    writable: true,
+    value: void 0
+  });
+} /* after b */);
+/* after a */
+/* before b */
+Object.defineProperty(C, _b, {
+  writable: true,
+  value: void 0
+});

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before a */
+  #a;
+  /* after a */
+
+  /* before b */
+  static #b;
+  /* after b */
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/preserve-comments/output.js
@@ -1,0 +1,17 @@
+var _a = /*#__PURE__*/new WeakMap();
+var C = /*#__PURE__*/babelHelpers.createClass(function C() {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, C);
+  /* before a */
+  babelHelpers.classPrivateFieldInitSpec(this, _a, {
+    writable: true,
+    value: void 0
+  });
+} /* after b */);
+/* after a */
+/* before b */
+var _b = {
+  writable: true,
+  value: void 0
+};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before a */
+  a;
+  /* after a */
+
+  /* before b */
+  static b;
+  /* after b */
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/preserve-comments/output.js
@@ -1,0 +1,10 @@
+var C = /*#__PURE__*/babelHelpers.createClass(function C() {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, C);
+  /* before a */
+  this.a = void 0;
+} /* after b */);
+/* after a */
+/* before b */
+C.b = void 0;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before a */
+  a;
+  /* after a */
+
+  /* before b */
+  static b;
+  /* after b */
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/preserve-comments/output.js
@@ -1,0 +1,10 @@
+var C = /*#__PURE__*/babelHelpers.createClass(function C() {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, C);
+  /* before a */
+  babelHelpers.defineProperty(this, "a", void 0);
+} /* after b */);
+/* after a */
+/* before b */
+babelHelpers.defineProperty(C, "b", void 0);

--- a/packages/babel-plugin-proposal-class-static-block/src/index.ts
+++ b/packages/babel-plugin-proposal-class-static-block/src/index.ts
@@ -64,7 +64,10 @@ export default declare(({ types: t, template, assertVersion }) => {
           // We special-case the single expression case to avoid the iife, since
           // it's common.
           if (blockBody.length === 1 && t.isExpressionStatement(blockBody[0])) {
-            replacement = blockBody[0].expression;
+            replacement = t.inheritsComments(
+              blockBody[0].expression,
+              blockBody[0],
+            );
           } else {
             replacement = template.expression.ast`(() => { ${blockBody} })()`;
           }

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/preserve-comments/input.js
@@ -1,0 +1,22 @@
+class C {
+  /* before 1 */
+  static {}
+  /* after 1 */
+
+  /* before 2 */
+  static {
+    /* before this.foo */
+    this.foo = 42;
+    /* after this.foo */
+  }
+  /* after 2 */
+
+  /* before 3 */
+  static {
+    /* before this.bar */
+    this.bar = 42;
+    this.bar = 42;
+    /* after this.bar */
+  }
+  /* after 3 */
+}

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/class-static-block/preserve-comments/output.js
@@ -1,0 +1,18 @@
+class C {
+  /* before 1 */
+  static #_ = (() => {})();
+  /* after 1 */
+  /* before 2 */
+  static #_2 = /* before this.foo */
+  this.foo = 42
+  /* after this.foo */;
+  /* after 2 */
+  /* before 3 */
+  static #_3 = (() => {
+    /* before this.bar */
+    this.bar = 42;
+    this.bar = 42;
+    /* after this.bar */
+  })();
+  /* after 3 */
+}

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/name-conflict/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/name-conflict/output.js
@@ -4,5 +4,7 @@ Object.defineProperty(Foo, _, {
   writable: true,
   value: 42
 });
+// static block can not be tranformed as `#_` here
+
 Foo.foo = babelHelpers.classPrivateFieldLooseBase(Foo, _)[_];
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/preserve-comments/input.js
@@ -1,0 +1,22 @@
+class C {
+  /* before 1 */
+  static {}
+  /* after 1 */
+
+  /* before 2 */
+  static {
+    /* before this.foo */
+    this.foo = 42;
+    /* after this.foo */
+  }
+  /* after 2 */
+
+  /* before 3 */
+  static {
+    /* before this.bar */
+    this.bar = 42;
+    this.bar = 42;
+    /* after this.bar */
+  }
+  /* after 3 */
+}

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration-loose/preserve-comments/output.js
@@ -1,0 +1,16 @@
+class C {}
+/* before 1 */
+(() => {})();
+/* after 1 */
+/* before 2 */
+/* before this.foo */C.foo = 42;
+/* after this.foo */
+/* after 2 */
+/* before 3 */
+(() => {
+  /* before this.bar */
+  C.bar = 42;
+  C.bar = 42;
+  /* after this.bar */
+})();
+/* after 3 */

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/name-conflict/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/name-conflict/output.js
@@ -3,5 +3,7 @@ var _ = {
   writable: true,
   value: 42
 };
+// static block can not be tranformed as `#_` here
+
 Foo.foo = babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _);
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/preserve-comments/input.js
@@ -1,0 +1,22 @@
+class C {
+  /* before 1 */
+  static {}
+  /* after 1 */
+
+  /* before 2 */
+  static {
+    /* before this.foo */
+    this.foo = 42;
+    /* after this.foo */
+  }
+  /* after 2 */
+
+  /* before 3 */
+  static {
+    /* before this.bar */
+    this.bar = 42;
+    this.bar = 42;
+    /* after this.bar */
+  }
+  /* after 3 */
+}

--- a/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-class-static-block/test/fixtures/integration/preserve-comments/output.js
@@ -1,0 +1,16 @@
+class C {}
+/* before 1 */
+(() => {})();
+/* after 1 */
+/* before 2 */
+/* before this.foo */C.foo = 42;
+/* after this.foo */
+/* after 2 */
+/* before 3 */
+(() => {
+  /* before this.bar */
+  C.bar = 42;
+  C.bar = 42;
+  /* after this.bar */
+})();
+/* after 3 */

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before get a */
+  get #a() { return 42 };
+  /* after get a */
+
+  /* before set a */
+  set #a(v) {}
+  /* after set a */
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/preserve-comments/output.js
@@ -1,0 +1,17 @@
+var _a = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("a");
+class C {
+  constructor() {
+    /* before get a */
+    Object.defineProperty(this, _a, {
+      get: _get_a,
+      set: _set_a
+    });
+  }
+  /* after set a */
+}
+function _get_a() {
+  return 42;
+}
+/* after get a */
+/* before set a */
+function _set_a(v) {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before get a */
+  get #a() { return 42 };
+  /* after get a */
+
+  /* before set a */
+  set #a(v) {}
+  /* after set a */
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-privateFieldsAsProperties/preserve-comments/output.js
@@ -1,0 +1,17 @@
+var _a = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("a");
+class C {
+  constructor() {
+    /* before get a */
+    Object.defineProperty(this, _a, {
+      get: _get_a,
+      set: _set_a
+    });
+  }
+  /* after set a */
+}
+function _get_a() {
+  return 42;
+}
+/* after get a */
+/* before set a */
+function _set_a(v) {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before get a */
+  get #a() { return 42 };
+  /* after get a */
+
+  /* before set a */
+  set #a(v) {}
+  /* after set a */
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/preserve-comments/output.js
@@ -1,0 +1,17 @@
+var _a = /*#__PURE__*/new WeakMap();
+class C {
+  constructor() {
+    /* before get a */
+    babelHelpers.classPrivateFieldInitSpec(this, _a, {
+      get: _get_a,
+      set: _set_a
+    });
+  }
+  /* after set a */
+}
+function _get_a() {
+  return 42;
+}
+/* after get a */
+/* before set a */
+function _set_a(v) {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/preserve-comments/input.js
@@ -1,0 +1,5 @@
+class C {
+  /* before a */
+  #a() {};
+  /* after a */
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/preserve-comments/output.js
@@ -1,0 +1,10 @@
+var _a = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("a");
+class C {
+  constructor() {
+    /* before a */
+    Object.defineProperty(this, _a, {
+      value: _a2
+    });
+  }
+} /* after a */
+function _a2() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/preserve-comments/input.js
@@ -1,0 +1,5 @@
+class C {
+  /* before a */
+  #a() {};
+  /* after a */
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/preserve-comments/output.js
@@ -1,0 +1,8 @@
+var _a = /*#__PURE__*/new WeakSet();
+class C {
+  constructor() {
+    /* before a */
+    babelHelpers.classPrivateMethodInitSpec(this, _a);
+  }
+} /* after a */
+function _a2() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/preserve-comments/input.js
@@ -1,0 +1,5 @@
+class C {
+  /* before a */
+  static #a() {};
+  /* after a */
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/preserve-comments/output.js
@@ -1,0 +1,10 @@
+var _a = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("a");
+class C {
+
+  /* after a */
+}
+/* before a */
+function _a2() {}
+Object.defineProperty(C, _a, {
+  value: _a2
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/preserve-comments/input.js
@@ -1,0 +1,5 @@
+class C {
+  /* before a */
+  static #a() {};
+  /* after a */
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/preserve-comments/output.js
@@ -1,0 +1,6 @@
+class C {
+
+  /* after a */
+}
+/* before a */
+function _a() {}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before get a */
+  static get #a() { return 42 };
+  /* after get a */
+
+  /* before set a */
+  static set #a(v) {}
+  /* after set a */
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-loose/preserve-comments/output.js
@@ -1,0 +1,13 @@
+var _a = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("a");
+class C {}
+/* before get a */
+function _get_a() {
+  return 42;
+}
+/* after get a */
+/* before set a */
+function _set_a(v) {}
+Object.defineProperty(C, _a, {
+  get: _get_a,
+  set: _set_a
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before get a */
+  static get #a() { return 42 };
+  /* after get a */
+
+  /* before set a */
+  static set #a(v) {}
+  /* after set a */
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/preserve-comments/output.js
@@ -1,0 +1,13 @@
+var _a = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("a");
+class C {}
+/* before get a */
+function _get_a() {
+  return 42;
+}
+/* after get a */
+/* before set a */
+function _set_a(v) {}
+Object.defineProperty(C, _a, {
+  get: _get_a,
+  set: _set_a
+});

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/preserve-comments/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before get a */
+  static get #a() { return 42 };
+  /* after get a */
+
+  /* before set a */
+  static set #a(v) {}
+  /* after set a */
+}

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/preserve-comments/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/static-accessors/preserve-comments/output.js
@@ -1,0 +1,12 @@
+class C {}
+/* before get a */
+function _get_a() {
+  return 42;
+}
+/* after get a */
+/* before set a */
+function _set_a(v) {}
+var _a = {
+  get: _get_a,
+  set: _set_a
+};

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/preserve-comments/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before get a */
+  get a() { return 42 }
+  /* after get a */
+
+  /* before set a */
+  set a(v) {}
+  /* after set a */
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/preserve-comments/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/preserve-comments/output.js
@@ -1,0 +1,18 @@
+let C = /*#__PURE__*/function () {
+  "use strict";
+
+  function C() {}
+  babelHelpers.createClass(C, [{
+    key: "a",
+    get: /* before get a */
+    function () {
+      return 42;
+    }
+    /* after get a */
+
+    /* before set a */,
+    set: function (v) {}
+    /* after set a */
+  }]);
+  return C;
+}();

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/preserve-comments/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/preserve-comments/input.js
@@ -1,0 +1,9 @@
+class C {
+  /* before get a */
+  get a() { return 42 }
+  /* after get a */
+
+  /* before set a */
+  set a(v) {}
+  /* after set a */
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/preserve-comments/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/preserve-comments/output.js
@@ -1,0 +1,20 @@
+let C = /*#__PURE__*/function () {
+  "use strict";
+
+  function C() {
+    babelHelpers.classCallCheck(this, C);
+  }
+  babelHelpers.createClass(C, [{
+    key: "a",
+    get: /* before get a */
+    function () {
+      return 42;
+    }
+    /* after get a */
+
+    /* before set a */,
+    set: function (v) {}
+    /* after set a */
+  }]);
+  return C;
+}();

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/preserve-comments/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/preserve-comments/input.js
@@ -1,0 +1,5 @@
+class C {
+  /* before a */
+  a() {}
+  /* after a */
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/preserve-comments/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/preserve-comments/output.js
@@ -1,0 +1,10 @@
+var C = /*#__PURE__*/function () {
+  "use strict";
+
+  function C() {}
+  var _proto = C.prototype;
+  /* before a */
+  _proto.a = function a() {}
+  /* after a */;
+  return C;
+}();

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/preserve-comments/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/preserve-comments/input.js
@@ -1,0 +1,5 @@
+class C {
+  /* before a */
+  a() {}
+  /* after a */
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/preserve-comments/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/preserve-comments/output.js
@@ -1,0 +1,14 @@
+var C = /*#__PURE__*/function () {
+  "use strict";
+
+  function C() {
+    babelHelpers.classCallCheck(this, C);
+  }
+  babelHelpers.createClass(C, [{
+    key: "a",
+    value: /* before a */
+    function a() {}
+    /* after a */
+  }]);
+  return C;
+}();

--- a/packages/babel-plugin-transform-new-target/test/fixtures/general/class-properties-loose/output.js
+++ b/packages/babel-plugin-transform-new-target/test/fixtures/general/class-properties-loose/output.js
@@ -10,6 +10,7 @@ class Foo {
     };
     this.Bar = (_class = class {
       constructor() {
+        // should not replace
         this.q = this.constructor;
       } // should not replace
     }, _class.p = void 0, _class.p1 = class {

--- a/packages/babel-plugin-transform-new-target/test/fixtures/general/class-properties/output.js
+++ b/packages/babel-plugin-transform-new-target/test/fixtures/general/class-properties/output.js
@@ -10,6 +10,7 @@ class Foo {
     });
     this.Bar = (_class = class {
       constructor() {
+        // should not replace
         babelHelpers.defineProperty(this, "q", this.constructor);
       } // should not replace
     }, babelHelpers.defineProperty(_class, "p", void 0), babelHelpers.defineProperty(_class, "p1", class {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8507 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we try to preserve surrounding member comments in class transforms. Currently the NodePath API `replaceWith` and `replaceWithMultiple` already forward comments from the old node to new node. But in the class transform we are constructing new nodes from the immediate children of member nodes, so we have to explicitly forward such comments.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15406"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

