### PR TITLE
temporarily ignore failing e2e prettier tests

### DIFF
--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -43,12 +43,11 @@ yarn lint:typecheck
 echo "export default () => () => {}" > src/main/create-print-pre-check-function.js
 
 # Temporarily ignore tests, use `rm -f path/to/jsfmt.spec.js`
-# https://github.com/babel/babel/pull/15385#issuecomment-1409840781
-
 # https://github.com/babel/babel/pull/15400#issuecomment-1414539133
 # Ignore this test until prettier update the snapshot
 # because prettier has ignored UnexpectedReservedWord error
-rm tests/format/flow-repo/async/await_parse.js
+rm -f tests/format/flow-repo/async/await_parse.js
+rm -f tests/format/misc/errors/js/explicit-resource-management/invalid-using-binding-await.js
 
 yarn test "tests/format/(jsx?|misc|typescript|flow|flow-repo)/" --update-snapshot --runInBand
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15413"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

