### PR TITLE
Remove makefile workaround from Travis CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,6 @@ FLOW_COMMIT = 92bbb5e9dacb8185aa73ea343954d0434b42c40b
 TEST262_COMMIT = a29788dd5d4d7664478985928e82f2a1cd7fb37d
 TYPESCRIPT_COMMIT = ce85d647ef88183c019588bcf398320ce29b625a
 
-# Fix color output until TravisCI fixes https://github.com/travis-ci/travis-ci/issues/7967
-export FORCE_COLOR = true
-
 SOURCES = packages codemods eslint
 
 COMMA := ,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We don't use Travis CI anymore. Ref https://github.com/babel/babel/pull/10336

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15437"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

