### PR TITLE
Use native GitHub markdown `Note` admonition

### DIFF
--- a/doc/design/monorepo.md
+++ b/doc/design/monorepo.md
@@ -1,6 +1,6 @@
 # Why is Babel a monorepo?
 
-> Note: We don't use `lerna` to manage packages inside the monorepo, but yarn workspaces with an additional [custom plugin](https://github.com/nicolo-ribaudo/yarn-plugin-babel-release-tool).
+> **Note** We don't use `lerna` to manage packages inside the monorepo, but yarn workspaces with an additional [custom plugin](https://github.com/nicolo-ribaudo/yarn-plugin-babel-release-tool).
 
 Juggling a multimodule project over multiple repos is like trying to teach a newborn baby how to
 ride a bike.

--- a/eslint/babel-eslint-plugin-development/README.md
+++ b/eslint/babel-eslint-plugin-development/README.md
@@ -26,7 +26,7 @@ Then, load the plugin in your `.eslintrc` configuration file. You can omit the `
 
 ## Supported Rules
 
-> Note: Rules marked with :wrench: are autofixable.
+> **Note** Rules marked with :wrench: are autofixable.
 
 * `@babel/development/no-deprecated-clone` (:wrench:): Disallows using the deprecated
   `t.clone(node)` and `t.cloneDeep(node)` methods from `@babel/types`. Those


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  None
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Not relevant
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

GitHub will render it with an icon. The announcement post: https://github.com/community/community/discussions/16925

| File | Before | After
| --- | --- | --- 
| `doc/design/monorepo.md` | ![image](https://user-images.githubusercontent.com/20454870/220178615-b2cce670-0741-407c-aff5-427443a33a67.png) | ![image](https://user-images.githubusercontent.com/20454870/220178672-a1d7d0c6-ea54-466b-8345-e6dc8379a1a9.png)
| `eslint/babel-eslint-plugin-development/README.md` | ![image](https://user-images.githubusercontent.com/20454870/220178932-e60fdf6e-7a97-42ba-90d5-5b98e9c14c09.png) |![image](https://user-images.githubusercontent.com/20454870/220179013-48beeda3-c1a2-4266-b363-1b371cbfac68.png)


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15443"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

