### PR TITLE
fix: Handling source maps without `sourcesContent`

### DIFF
--- a/packages/babel-generator/src/source-map.ts
+++ b/packages/babel-generator/src/source-map.ts
@@ -53,12 +53,12 @@ export default class SourceMap {
     if (opts.inputSourceMap) {
       this._inputMap = new TraceMap(opts.inputSourceMap);
       const resolvedSources = this._inputMap.resolvedSources;
-      if (resolvedSources.length && this._inputMap.sourcesContent) {
+      if (resolvedSources.length) {
         for (let i = 0; i < resolvedSources.length; i++) {
           setSourceContent(
             map,
             resolvedSources[i],
-            this._inputMap.sourcesContent[i],
+            this._inputMap.sourcesContent?.[i],
           );
         }
       }

--- a/packages/babel-generator/src/source-map.ts
+++ b/packages/babel-generator/src/source-map.ts
@@ -53,7 +53,7 @@ export default class SourceMap {
     if (opts.inputSourceMap) {
       this._inputMap = new TraceMap(opts.inputSourceMap);
       const resolvedSources = this._inputMap.resolvedSources;
-      if (resolvedSources.length) {
+      if (resolvedSources.length && this._inputMap.sourcesContent) {
         for (let i = 0; i < resolvedSources.length; i++) {
           setSourceContent(
             map,

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -880,6 +880,40 @@ describe("generation", function () {
       });"
     `);
   });
+
+  it("inputSourceMap without sourcesContent", () => {
+    const ast = parse("var t = x => x * x;");
+
+    expect(
+      generate(ast, {
+        sourceMaps: true,
+        inputSourceMap: {
+          version: 3,
+          names: ["t", "x"],
+          sources: ["source-maps/arrow-function/input.js"],
+          mappings:
+            "AAAA,IAAIA,CAAC,GAAG,SAAJA,CAACA,CAAGC,CAAC;EAAA,OAAIA,CAAC,GAAGA,CAAC;AAAA",
+        },
+      }).map,
+    ).toMatchInlineSnapshot(`
+      Object {
+        "file": undefined,
+        "mappings": "AAAA,IAAIA,CAAC,GAAGC,CAAA,IAAAA,CAAA,GAAJA,CAAC",
+        "names": Array [
+          "t",
+          "x",
+        ],
+        "sourceRoot": undefined,
+        "sources": Array [
+          "source-maps/arrow-function/input.js",
+        ],
+        "sourcesContent": Array [
+          null,
+        ],
+        "version": 3,
+      }
+    `);
+  });
 });
 
 describe("programmatic generation", function () {

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -908,7 +908,7 @@ describe("generation", function () {
           "source-maps/arrow-function/input.js",
         ],
         "sourcesContent": Array [
-          null,
+          undefined,
         ],
         "version": 3,
       }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15444 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
ref: https://github.com/babel/babel/pull/15022

@nicolo-ribaudo @JLHwung This seems to be a regression affecting quite a few people, let's release a patch, thanks!

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15445"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

