### PR TITLE
Reduce warnings for deprecated node aliases

### DIFF
--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -4,6 +4,7 @@ import {
   DEPRECATED_ALIASES,
   FLIPPED_ALIAS_KEYS,
   TYPES,
+  __internal__deprecationWarning as deprecationWarning,
 } from "@babel/types";
 import type { NodePath, Visitor } from "./index";
 
@@ -102,16 +103,12 @@ export function explode(visitor: Visitor) {
 
     if (nodeType in DEPRECATED_KEYS) {
       const deprecatedKey = DEPRECATED_KEYS[nodeType];
-      console.trace(
-        `Visitor defined for ${nodeType} but it has been renamed to ${deprecatedKey}`,
-      );
+      deprecationWarning(nodeType, deprecatedKey, "Visitor ");
       aliases = [deprecatedKey];
     } else if (nodeType in DEPRECATED_ALIASES) {
       const deprecatedAlias =
         DEPRECATED_ALIASES[nodeType as keyof typeof DEPRECATED_ALIASES];
-      console.trace(
-        `Visitor defined for ${nodeType} but it has been renamed to ${deprecatedAlias}`,
-      );
+      deprecationWarning(nodeType, deprecatedAlias, "Visitor ");
       aliases = FLIPPED_ALIAS_KEYS[deprecatedAlias];
     }
 

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -340,32 +340,36 @@ describe("traverse", function () {
   describe("traverse.explode", () => {
     describe("deprecated types and aliases", () => {
       beforeAll(() => {
-        jest.spyOn(console, "trace").mockImplementation(() => {});
+        jest.spyOn(console, "warn").mockImplementation(() => {});
       });
       afterAll(() => {
-        console.trace.mockClear();
+        console.warn.mockClear();
       });
-      it("should warn for deprecated node types", () => {
+      it("should warn for deprecated node types", function testFn1() {
         const visitNumericLiteral = () => {};
         const visitor = {
           NumberLiteral: visitNumericLiteral,
         };
         traverse.explode(visitor);
-        expect(console.trace).toHaveBeenCalledWith(
-          "Visitor defined for NumberLiteral but it has been renamed to NumericLiteral",
+        expect(console.warn).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /Visitor `NumberLiteral` has been deprecated, please migrate to `NumericLiteral`[^]+at.+testFn1/,
+          ),
         );
         expect(visitor).toHaveProperty("NumericLiteral.enter", [
           visitNumericLiteral,
         ]);
       });
-      it("should warn for deprecated aliases", () => {
+      it("should warn for deprecated aliases", function testFn2() {
         const visitImportOrExportDeclaration = () => {};
         const visitor = {
           ModuleDeclaration: visitImportOrExportDeclaration,
         };
         traverse.explode(visitor);
-        expect(console.trace).toHaveBeenCalledWith(
-          "Visitor defined for ModuleDeclaration but it has been renamed to ImportOrExportDeclaration",
+        expect(console.warn).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /Visitor `ModuleDeclaration` has been deprecated, please migrate to `ImportOrExportDeclaration`[^]+at.+testFn2/,
+          ),
         );
         expect(visitor).toHaveProperty("ImportDeclaration.enter", [
           visitImportOrExportDeclaration,

--- a/packages/babel-types/scripts/generators/asserts.js
+++ b/packages/babel-types/scripts/generators/asserts.js
@@ -26,6 +26,7 @@ export default function generateAsserts() {
  */
 import is from "../../validators/is";
 import type * as t from "../..";
+import deprecationWarning from "../../utils/deprecationWarning";
 
 function assert(type: string, node: any, opts?: any): void {
   if (!is(type, node, opts)) {
@@ -56,7 +57,7 @@ function assert(type: string, node: any, opts?: any): void {
   Object.keys(deprecatedNodeTypesAndAliases).forEach(type => {
     const newType = deprecatedNodeTypesAndAliases[type];
     output += `export function assert${type}(node: any, opts: any): void {
-  console.trace("\`assert${type}\` has been deprecated, please migrate to \`assert${newType}\`.");
+      deprecationWarning("assert${type}", "assert${newType}");
   assert("${type}", node, opts);
 }\n`;
   });

--- a/packages/babel-types/scripts/generators/builders.js
+++ b/packages/babel-types/scripts/generators/builders.js
@@ -91,6 +91,7 @@ function generateLowercaseBuilders() {
  */
 import validateNode from "../validateNode";
 import type * as t from "../..";
+import deprecationWarning from "../../utils/deprecationWarning";
 `;
 
   const reservedNames = new Set(["super", "import"]);
@@ -150,7 +151,7 @@ import type * as t from "../..";
     const formattedNewBuilderName = formatBuilderName(newType);
     output += `/** @deprecated */
 function ${type}(${generateBuilderArgs(newType).join(", ")}) {
-  console.trace("The node type ${type} has been renamed to ${newType}");
+  deprecationWarning("${type}", "${newType}", "The node type ");
   return ${formattedNewBuilderName}(${BUILDER_KEYS[newType].join(", ")});
 }
 export { ${type} as ${formattedBuilderName} };\n`;

--- a/packages/babel-types/scripts/generators/validators.js
+++ b/packages/babel-types/scripts/generators/validators.js
@@ -72,7 +72,9 @@ export default function generateValidators() {
  * To re-generate run 'make build'
  */
 import shallowEqual from "../../utils/shallowEqual";
-import type * as t from "../..";\n\n`;
+import type * as t from "../..";
+import deprecationWarning from "../../utils/deprecationWarning";
+\n`;
 
   Object.keys(VISITOR_KEYS).forEach(type => {
     output += addIsHelper(type);
@@ -87,16 +89,17 @@ import type * as t from "../..";\n\n`;
     });
 
   Object.keys(DEPRECATED_KEYS).forEach(type => {
-    const newType = DEPRECATED_KEYS[type];
-    const deprecated = `console.trace("\`is${type}\` has been deprecated, please migrate to \`is${newType}\`.");`;
-    output += addIsHelper(type, null, deprecated);
+    output += addIsHelper(
+      type,
+      null,
+      `deprecationWarning("is${type}", "is${DEPRECATED_KEYS[type]}")`
+    );
   });
 
   Object.keys(DEPRECATED_ALIASES).forEach(type => {
     const newType = DEPRECATED_ALIASES[type];
-    const deprecated = `console.trace("\`is${type}\` has been deprecated, please migrate to \`is${newType}\`.");`;
     output += `export function is${type}(node: object | null | undefined, opts?: object | null): node is t.${newType} {
-  ${deprecated}
+  deprecationWarning("is${type}", "is${newType}");
   return is${newType}(node, opts);
 }
 `;

--- a/packages/babel-types/src/asserts/generated/index.ts
+++ b/packages/babel-types/src/asserts/generated/index.ts
@@ -4,6 +4,7 @@
  */
 import is from "../../validators/is";
 import type * as t from "../..";
+import deprecationWarning from "../../utils/deprecationWarning";
 
 function assert(type: string, node: any, opts?: any): void {
   if (!is(type, node, opts)) {
@@ -1803,32 +1804,25 @@ export function assertTSBaseType(
   assert("TSBaseType", node, opts);
 }
 export function assertNumberLiteral(node: any, opts: any): void {
-  console.trace(
-    "`assertNumberLiteral` has been deprecated, please migrate to `assertNumericLiteral`.",
-  );
+  deprecationWarning("assertNumberLiteral", "assertNumericLiteral");
   assert("NumberLiteral", node, opts);
 }
 export function assertRegexLiteral(node: any, opts: any): void {
-  console.trace(
-    "`assertRegexLiteral` has been deprecated, please migrate to `assertRegExpLiteral`.",
-  );
+  deprecationWarning("assertRegexLiteral", "assertRegExpLiteral");
   assert("RegexLiteral", node, opts);
 }
 export function assertRestProperty(node: any, opts: any): void {
-  console.trace(
-    "`assertRestProperty` has been deprecated, please migrate to `assertRestElement`.",
-  );
+  deprecationWarning("assertRestProperty", "assertRestElement");
   assert("RestProperty", node, opts);
 }
 export function assertSpreadProperty(node: any, opts: any): void {
-  console.trace(
-    "`assertSpreadProperty` has been deprecated, please migrate to `assertSpreadElement`.",
-  );
+  deprecationWarning("assertSpreadProperty", "assertSpreadElement");
   assert("SpreadProperty", node, opts);
 }
 export function assertModuleDeclaration(node: any, opts: any): void {
-  console.trace(
-    "`assertModuleDeclaration` has been deprecated, please migrate to `assertImportOrExportDeclaration`.",
+  deprecationWarning(
+    "assertModuleDeclaration",
+    "assertImportOrExportDeclaration",
   );
   assert("ModuleDeclaration", node, opts);
 }

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -4,6 +4,7 @@
  */
 import validateNode from "../validateNode";
 import type * as t from "../..";
+import deprecationWarning from "../../utils/deprecationWarning";
 export function arrayExpression(
   elements: Array<null | t.Expression | t.SpreadElement> = [],
 ): t.ArrayExpression {
@@ -2515,29 +2516,25 @@ export function tsTypeParameter(
 export { tsTypeParameter as tSTypeParameter };
 /** @deprecated */
 function NumberLiteral(value: number) {
-  console.trace(
-    "The node type NumberLiteral has been renamed to NumericLiteral",
-  );
+  deprecationWarning("NumberLiteral", "NumericLiteral", "The node type ");
   return numericLiteral(value);
 }
 export { NumberLiteral as numberLiteral };
 /** @deprecated */
 function RegexLiteral(pattern: string, flags: string = "") {
-  console.trace("The node type RegexLiteral has been renamed to RegExpLiteral");
+  deprecationWarning("RegexLiteral", "RegExpLiteral", "The node type ");
   return regExpLiteral(pattern, flags);
 }
 export { RegexLiteral as regexLiteral };
 /** @deprecated */
 function RestProperty(argument: t.LVal) {
-  console.trace("The node type RestProperty has been renamed to RestElement");
+  deprecationWarning("RestProperty", "RestElement", "The node type ");
   return restElement(argument);
 }
 export { RestProperty as restProperty };
 /** @deprecated */
 function SpreadProperty(argument: t.Expression) {
-  console.trace(
-    "The node type SpreadProperty has been renamed to SpreadElement",
-  );
+  deprecationWarning("SpreadProperty", "SpreadElement", "The node type ");
   return spreadElement(argument);
 }
 export { SpreadProperty as spreadProperty };

--- a/packages/babel-types/src/index.ts
+++ b/packages/babel-types/src/index.ts
@@ -102,3 +102,6 @@ export const react = {
 };
 
 export * from "./ast-types/generated";
+
+// this is used by @babel/traverse to warn about deprecated visitors
+export { default as __internal__deprecationWarning } from "./utils/deprecationWarning";

--- a/packages/babel-types/src/utils/deprecationWarning.ts
+++ b/packages/babel-types/src/utils/deprecationWarning.ts
@@ -1,0 +1,33 @@
+const warnings = new Set();
+
+export default function deprecationWarning(
+  oldName: string,
+  newName: string,
+  prefix: string = "",
+) {
+  if (warnings.has(oldName)) return;
+  warnings.add(oldName);
+
+  const stack = captureShortStackTrace(1, 2);
+  console.warn(
+    `${prefix}\`${oldName}\` has been deprecated, please migrate to \`${newName}\`\n${stack}`,
+  );
+}
+
+function captureShortStackTrace(skip: number, length: number) {
+  const { stackTraceLimit, prepareStackTrace } = Error;
+  let stackTrace: NodeJS.CallSite[];
+  // We add 1 to also take into account this function.
+  Error.stackTraceLimit = 1 + skip + length;
+  Error.prepareStackTrace = function (err, stack) {
+    stackTrace = stack;
+  };
+  new Error().stack;
+  Error.stackTraceLimit = stackTraceLimit;
+  Error.prepareStackTrace = prepareStackTrace;
+
+  return stackTrace
+    .slice(1 + skip, 1 + skip + length)
+    .map(frame => `    at ${frame}`)
+    .join("\n");
+}

--- a/packages/babel-types/src/validators/generated/index.ts
+++ b/packages/babel-types/src/validators/generated/index.ts
@@ -4,6 +4,7 @@
  */
 import shallowEqual from "../../utils/shallowEqual";
 import type * as t from "../..";
+import deprecationWarning from "../../utils/deprecationWarning";
 
 export function isArrayExpression(
   node: object | null | undefined,
@@ -5786,9 +5787,7 @@ export function isNumberLiteral(
   node: object | null | undefined,
   opts?: object | null,
 ): boolean {
-  console.trace(
-    "`isNumberLiteral` has been deprecated, please migrate to `isNumericLiteral`.",
-  );
+  deprecationWarning("isNumberLiteral", "isNumericLiteral");
   if (!node) return false;
 
   const nodeType = (node as t.Node).type;
@@ -5806,9 +5805,7 @@ export function isRegexLiteral(
   node: object | null | undefined,
   opts?: object | null,
 ): boolean {
-  console.trace(
-    "`isRegexLiteral` has been deprecated, please migrate to `isRegExpLiteral`.",
-  );
+  deprecationWarning("isRegexLiteral", "isRegExpLiteral");
   if (!node) return false;
 
   const nodeType = (node as t.Node).type;
@@ -5826,9 +5823,7 @@ export function isRestProperty(
   node: object | null | undefined,
   opts?: object | null,
 ): boolean {
-  console.trace(
-    "`isRestProperty` has been deprecated, please migrate to `isRestElement`.",
-  );
+  deprecationWarning("isRestProperty", "isRestElement");
   if (!node) return false;
 
   const nodeType = (node as t.Node).type;
@@ -5846,9 +5841,7 @@ export function isSpreadProperty(
   node: object | null | undefined,
   opts?: object | null,
 ): boolean {
-  console.trace(
-    "`isSpreadProperty` has been deprecated, please migrate to `isSpreadElement`.",
-  );
+  deprecationWarning("isSpreadProperty", "isSpreadElement");
   if (!node) return false;
 
   const nodeType = (node as t.Node).type;
@@ -5866,8 +5859,6 @@ export function isModuleDeclaration(
   node: object | null | undefined,
   opts?: object | null,
 ): node is t.ImportOrExportDeclaration {
-  console.trace(
-    "`isModuleDeclaration` has been deprecated, please migrate to `isImportOrExportDeclaration`.",
-  );
+  deprecationWarning("isModuleDeclaration", "isImportOrExportDeclaration");
   return isImportOrExportDeclaration(node, opts);
 }


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Warning for deprecated nodes or aliases can be very noisy. We use `console.trace` so that users know which of their dependencies is using it, but it causes ~10 stack frames per usage of the deprecated aliases by default. With this PR:
- we use `console.warn` instead of `console.trace`, since we are emitting a warning
- we only output 2 stack frames: last one in user code, and the first one inside Babel
- we only warn once per deprecated alias, instead of once _per usage_ per deprecated alias

Ref https://github.com/babel/babel/pull/15266, https://github.com/lodash/babel-plugin-lodash/issues/259

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15448"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

