### PR TITLE
Avoid unnecessary code for unused lazy imports

### DIFF
--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
@@ -132,6 +132,7 @@ export default function rewriteLiveReferences(
     exported, // local name => exported name list
     buildImportReference: ([source, importName, localName], identNode) => {
       const meta = metadata.source.get(source);
+      meta.referenced = true;
 
       if (localName) {
         if (meta.lazy) {

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.ts
@@ -240,6 +240,12 @@ export default declare((api, options: Options) => {
 
               header = t.expressionStatement(loadExpr);
             } else {
+              // A lazy import that is never referenced can be safely
+              // omitted, since it wouldn't be executed anyway.
+              if (metadata.lazy && !metadata.referenced) {
+                continue;
+              }
+
               const init =
                 wrapInterop(path, loadExpr, metadata.interop) || loadExpr;
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/unused/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/unused/input.mjs
@@ -1,0 +1,16 @@
+import { a } from "a";
+import b from "b";
+import * as c from "c";
+
+// This is included explicitly for the side effects, so we keep it
+import "d";
+
+// Only f is unused, we must keep the require call
+import { e, f } from "e";
+e;
+
+// The first import is unused, but we keep the require call
+// because of the second one
+import { g } from "g";
+import { h } from "g";
+h;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/unused/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/lazy-dep/unused/output.js
@@ -1,0 +1,27 @@
+"use strict";
+
+require("d");
+function _e() {
+  const data = require("e");
+  _e = function () {
+    return data;
+  };
+  return data;
+}
+function _g() {
+  const data = require("g");
+  _g = function () {
+    return data;
+  };
+  return data;
+}
+// This is included explicitly for the side effects, so we keep it
+
+// Only f is unused, we must keep the require call
+
+_e().e;
+
+// The first import is unused, but we keep the require call
+// because of the second one
+
+_g().h;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Thanks to https://github.com/babel/babel/issues/15446, I noticed that out released code include this:
```js
function _module() {
  const data = require("module");
  _module = function () {
    return data;
  };
  return data;
}
```

even if that `_module()` function is then not used anywhere.

Babel generates that code when there is a `import Module from "module"` import, and it's then unused because all the usages of `Module` are stripped away at build time. With this PR, we avoid injecting any code for lazy imports that are not actually used, since it's code that would never be executed at runtime anyway.

As before, we continue emitting eager imports for `import "x"` since these import statements are explicitly used for side effects.

I have a feeling that #15446 is caused by trying to bundle `@babel/core` with a webpack version that throws by default when trying to include some node-specific modules. That issue is not a bug with Babel, but once we merge this PR and we release a Babel version compiled with this PR (so in at least two releases), that issue will be fixed because the dead require call will be removed.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15449"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

