### PR TITLE
Add ESLint-readable package name

### DIFF
--- a/eslint/babel-eslint-parser/src/index.cjs
+++ b/eslint/babel-eslint-parser/src/index.cjs
@@ -5,6 +5,10 @@ const baseParse = require("./parse.cjs");
 const { LocalClient, WorkerClient } = require("./client.cjs");
 const client = new (USE_ESM ? WorkerClient : LocalClient)();
 
+exports.meta = {
+  name: "@babel/eslint-parser"
+};
+
 exports.parse = function (code, options = {}) {
   return baseParse(code, normalizeESLintConfig(options), client);
 };

--- a/eslint/babel-eslint-parser/src/index.cjs
+++ b/eslint/babel-eslint-parser/src/index.cjs
@@ -6,7 +6,7 @@ const { LocalClient, WorkerClient } = require("./client.cjs");
 const client = new (USE_ESM ? WorkerClient : LocalClient)();
 
 exports.meta = {
-  name: "@babel/eslint-parser"
+  name: "@babel/eslint-parser",
 };
 
 exports.parse = function (code, options = {}) {

--- a/eslint/babel-eslint-parser/src/index.cjs
+++ b/eslint/babel-eslint-parser/src/index.cjs
@@ -6,7 +6,8 @@ const { LocalClient, WorkerClient } = require("./client.cjs");
 const client = new (USE_ESM ? WorkerClient : LocalClient)();
 
 exports.meta = {
-  name: "@babel/eslint-parser",
+  name: PACKAGE_JSON.name,
+  version: PACKAGE_JSON.version,
 };
 
 exports.parse = function (code, options = {}) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | n/a
| Major: Breaking Change?  | n/a
| Minor: New Feature?      | n/a
| Tests Added + Pass?      | Yes
| Documentation PR Link    | n/a
| Any Dependency Changes?  | no
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

With flat config in ESLint, there hasn't been a way to serialize custom parsers for use with caching. We are [adding a `meta` key](https://github.com/eslint/eslint/pull/16944) that parsers can implement to provide serialization information to ESLint. This PR just adds a `meta.name` export so ESLint can serialize this parser. (Note: You can also add a `meta.version` if you so please.)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15465"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

