### PR TITLE
(tests) Log `transform-` instead of `proposal-` in `preset-env`

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -358,13 +358,18 @@ async function run(task: Test) {
     }
 
     if (validateLogs) {
+      const normalizationOpts = {
+        normalizePathSeparator: true,
+        normalizePresetEnvDebug: task.taskDir.includes("babel-preset-env"),
+      };
+
       validateFile(
-        normalizeOutput(actualLogs.stdout, /* normalizePathSeparator */ true),
+        normalizeOutput(actualLogs.stdout, normalizationOpts),
         stdout.loc,
         stdout.code,
       );
       validateFile(
-        normalizeOutput(actualLogs.stderr, /* normalizePathSeparator */ true),
+        normalizeOutput(actualLogs.stderr, normalizationOpts),
         stderr.loc,
         stderr.code,
       );
@@ -412,7 +417,10 @@ function escapeRegExp(string: string) {
   return string.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
 }
 
-function normalizeOutput(code: string, normalizePathSeparator?: boolean) {
+function normalizeOutput(
+  code: string,
+  { normalizePathSeparator = false, normalizePresetEnvDebug = false } = {},
+) {
   const projectRoot = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "../../../",
@@ -446,7 +454,9 @@ function normalizeOutput(code: string, normalizePathSeparator?: boolean) {
   // the output logs so that we don't have to duplicate all the debug fixtures for
   // the two different Babel versions.
   // TODO(Babel 8): Remove this.
-  result = result.replace(/(\s+)proposal-/gm, "$1transform-");
+  if (normalizePresetEnvDebug) {
+    result = result.replace(/(\s+)proposal-/gm, "$1transform-");
+  }
 
   return result;
 }

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -441,6 +441,13 @@ function normalizeOutput(code: string, normalizePathSeparator?: boolean) {
       );
     }
   }
+
+  // In Babel 8, preset-env logs transform- instead of proposal-. Manually rewrite
+  // the output logs so that we don't have to duplicate all the debug fixtures for
+  // the two different Babel versions.
+  // TODO(Babel 8): Remove this.
+  result = result.replace(/(\s+)proposal-/gm, "$1transform-");
+
   return result;
 }
 

--- a/packages/babel-preset-env/src/debug.ts
+++ b/packages/babel-preset-env/src/debug.ts
@@ -3,7 +3,6 @@ import {
   type Targets,
   type Target,
 } from "@babel/helper-compilation-targets";
-import compatData from "@babel/compat-data/plugins";
 
 // Outputs a message that shows which target(s) caused an item to be included:
 // transform-foo { "edge":"13", "firefox":"49", "ie":"10" }
@@ -15,18 +14,6 @@ export const logPlugin = (
   const filteredList = getInclusionReasons(item, targetVersions, list);
 
   const support = list[item];
-
-  // TODO(Babel 8): Remove this. It's needed to keep outputting proposal-
-  // in the debug log.
-  if (item.startsWith("transform-")) {
-    const proposalName = `proposal-${item.slice(10)}`;
-    if (
-      proposalName === "proposal-dynamic-import" ||
-      Object.prototype.hasOwnProperty.call(compatData, proposalName)
-    ) {
-      item = proposalName;
-    }
-  }
 
   if (!support) {
     console.log(`  ${item}`);

--- a/packages/babel-preset-env/src/debug.ts
+++ b/packages/babel-preset-env/src/debug.ts
@@ -3,6 +3,7 @@ import {
   type Targets,
   type Target,
 } from "@babel/helper-compilation-targets";
+import compatData from "@babel/compat-data/plugins";
 
 // Outputs a message that shows which target(s) caused an item to be included:
 // transform-foo { "edge":"13", "firefox":"49", "ie":"10" }
@@ -14,6 +15,19 @@ export const logPlugin = (
   const filteredList = getInclusionReasons(item, targetVersions, list);
 
   const support = list[item];
+
+  if (!process.env.BABEL_8_BREAKING) {
+    // It's needed to keep outputting proposal- in the debug log.
+    if (item.startsWith("transform-")) {
+      const proposalName = `proposal-${item.slice(10)}`;
+      if (
+        proposalName === "proposal-dynamic-import" ||
+        Object.prototype.hasOwnProperty.call(compatData, proposalName)
+      ) {
+        item = proposalName;
+      }
+    }
+  }
 
   if (!support) {
     console.log(`  ${item}`);

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
@@ -16,29 +16,29 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
-  proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
-  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
-  proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
-  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
-  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
-  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
-  proposal-optional-chaining { android, chrome < 91, edge < 91, firefox < 74, ios < 13.4, node < 16.9, opera < 77, safari < 13.1, samsung < 16 }
-  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
-  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
+  transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
+  transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
+  transform-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  transform-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  transform-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
+  transform-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  transform-optional-chaining { android, chrome < 91, edge < 91, firefox < 74, ios < 13.4, node < 16.9, opera < 77, safari < 13.1, samsung < 16 }
+  transform-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  transform-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
   transform-parameters { edge < 18, ios, safari }
-  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
-  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  transform-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
   transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
-  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-async-to-generator { ios < 11, safari < 11 }
   transform-template-literals { ios < 13, safari < 13 }
   transform-function-name { edge < 79 }
   transform-unicode-regex { ios < 12, safari < 12 }
   transform-block-scoping { ios < 11, safari < 11 }
-  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
@@ -16,23 +16,23 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
-  proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
-  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
-  proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
-  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
-  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
-  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
-  proposal-optional-chaining { android, chrome < 80, edge < 80, firefox < 74, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
-  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
-  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
-  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
-  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
+  transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
+  transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
+  transform-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  transform-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  transform-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
+  transform-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  transform-optional-chaining { android, chrome < 80, edge < 80, firefox < 74, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  transform-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  transform-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  transform-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  transform-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
   transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
-  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-unicode-regex { ios < 12, safari < 12 }
-  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
   bugfix/transform-async-arrows-in-class { ios < 11, safari < 11 }
   bugfix/transform-edge-default-parameters { edge < 18 }
   bugfix/transform-edge-function-name { edge < 79 }
@@ -41,6 +41,6 @@ Using plugins:
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios, safari }
   bugfix/transform-tagged-template-caching { ios < 13, safari < 13 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
   transform-parameters { chrome < 49 }
-  proposal-async-generator-functions { chrome < 63 }
-  proposal-object-rest-spread { chrome < 60 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   transform-async-to-generator { chrome < 55 }
   transform-exponentiation-operator { chrome < 52 }
@@ -43,8 +43,8 @@ Using plugins:
   transform-block-scoping { chrome < 49 }
   transform-new-target { chrome < 46 }
   transform-regenerator { chrome < 50 }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
@@ -8,28 +8,28 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { edge < 94 }
-  proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 79 }
-  proposal-private-methods { edge < 84 }
-  proposal-numeric-separator { edge < 79 }
-  proposal-logical-assignment-operators { edge < 85 }
-  proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge < 80 }
-  proposal-json-strings { edge < 79 }
-  proposal-optional-catch-binding { edge < 79 }
+  transform-class-static-block { edge < 94 }
+  transform-private-property-in-object { edge < 91 }
+  transform-class-properties { edge < 79 }
+  transform-private-methods { edge < 84 }
+  transform-numeric-separator { edge < 79 }
+  transform-logical-assignment-operators { edge < 85 }
+  transform-nullish-coalescing-operator { edge < 80 }
+  transform-optional-chaining { edge < 80 }
+  transform-json-strings { edge < 79 }
+  transform-optional-catch-binding { edge < 79 }
   transform-parameters { edge < 15 }
-  proposal-async-generator-functions { edge < 79 }
-  proposal-object-rest-spread { edge < 79 }
+  transform-async-generator-functions { edge < 79 }
+  transform-object-rest-spread { edge < 79 }
   transform-dotall-regex { edge < 79 }
-  proposal-unicode-property-regex { edge < 79 }
+  transform-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   transform-async-to-generator { edge < 15 }
   transform-for-of { edge < 15 }
   transform-destructuring { edge < 15 }
-  proposal-export-namespace-from { edge < 79 }
+  transform-export-namespace-from { edge < 79 }
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
@@ -8,25 +8,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { edge < 94 }
-  proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 79 }
-  proposal-private-methods { edge < 84 }
-  proposal-numeric-separator { edge < 79 }
-  proposal-logical-assignment-operators { edge < 85 }
-  proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge < 80 }
-  proposal-json-strings { edge < 79 }
-  proposal-optional-catch-binding { edge < 79 }
-  proposal-async-generator-functions { edge < 79 }
-  proposal-object-rest-spread { edge < 79 }
+  transform-class-static-block { edge < 94 }
+  transform-private-property-in-object { edge < 91 }
+  transform-class-properties { edge < 79 }
+  transform-private-methods { edge < 84 }
+  transform-numeric-separator { edge < 79 }
+  transform-logical-assignment-operators { edge < 85 }
+  transform-nullish-coalescing-operator { edge < 80 }
+  transform-optional-chaining { edge < 80 }
+  transform-json-strings { edge < 79 }
+  transform-optional-catch-binding { edge < 79 }
+  transform-async-generator-functions { edge < 79 }
+  transform-object-rest-spread { edge < 79 }
   transform-dotall-regex { edge < 79 }
-  proposal-unicode-property-regex { edge < 79 }
+  transform-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
-  proposal-export-namespace-from { edge < 79 }
+  transform-export-namespace-from { edge < 79 }
   bugfix/transform-edge-default-parameters { edge < 18 }
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
@@ -8,25 +8,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { edge < 94 }
-  proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 79 }
-  proposal-private-methods { edge < 84 }
-  proposal-numeric-separator { edge < 79 }
-  proposal-logical-assignment-operators { edge < 85 }
-  proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge < 91 }
-  proposal-json-strings { edge < 79 }
-  proposal-optional-catch-binding { edge < 79 }
+  transform-class-static-block { edge < 94 }
+  transform-private-property-in-object { edge < 91 }
+  transform-class-properties { edge < 79 }
+  transform-private-methods { edge < 84 }
+  transform-numeric-separator { edge < 79 }
+  transform-logical-assignment-operators { edge < 85 }
+  transform-nullish-coalescing-operator { edge < 80 }
+  transform-optional-chaining { edge < 91 }
+  transform-json-strings { edge < 79 }
+  transform-optional-catch-binding { edge < 79 }
   transform-parameters { edge < 18 }
-  proposal-async-generator-functions { edge < 79 }
-  proposal-object-rest-spread { edge < 79 }
+  transform-async-generator-functions { edge < 79 }
+  transform-object-rest-spread { edge < 79 }
   transform-dotall-regex { edge < 79 }
-  proposal-unicode-property-regex { edge < 79 }
+  transform-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   transform-function-name { edge < 79 }
-  proposal-export-namespace-from { edge < 79 }
+  transform-export-namespace-from { edge < 79 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
@@ -8,25 +8,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { edge < 94 }
-  proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 79 }
-  proposal-private-methods { edge < 84 }
-  proposal-numeric-separator { edge < 79 }
-  proposal-logical-assignment-operators { edge < 85 }
-  proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge < 80 }
-  proposal-json-strings { edge < 79 }
-  proposal-optional-catch-binding { edge < 79 }
-  proposal-async-generator-functions { edge < 79 }
-  proposal-object-rest-spread { edge < 79 }
+  transform-class-static-block { edge < 94 }
+  transform-private-property-in-object { edge < 91 }
+  transform-class-properties { edge < 79 }
+  transform-private-methods { edge < 84 }
+  transform-numeric-separator { edge < 79 }
+  transform-logical-assignment-operators { edge < 85 }
+  transform-nullish-coalescing-operator { edge < 80 }
+  transform-optional-chaining { edge < 80 }
+  transform-json-strings { edge < 79 }
+  transform-optional-catch-binding { edge < 79 }
+  transform-async-generator-functions { edge < 79 }
+  transform-object-rest-spread { edge < 79 }
   transform-dotall-regex { edge < 79 }
-  proposal-unicode-property-regex { edge < 79 }
+  transform-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
-  proposal-export-namespace-from { edge < 79 }
+  transform-export-namespace-from { edge < 79 }
   bugfix/transform-edge-default-parameters { edge < 18 }
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { edge < 94 }
-  proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 79 }
-  proposal-private-methods { edge < 84 }
-  proposal-numeric-separator { edge < 79 }
-  proposal-logical-assignment-operators { edge < 85 }
-  proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge < 80 }
-  proposal-json-strings { edge < 79 }
-  proposal-optional-catch-binding { edge < 79 }
-  proposal-async-generator-functions { edge < 79 }
-  proposal-object-rest-spread { edge < 79 }
+  transform-class-static-block { edge < 94 }
+  transform-private-property-in-object { edge < 91 }
+  transform-class-properties { edge < 79 }
+  transform-private-methods { edge < 84 }
+  transform-numeric-separator { edge < 79 }
+  transform-logical-assignment-operators { edge < 85 }
+  transform-nullish-coalescing-operator { edge < 80 }
+  transform-optional-chaining { edge < 80 }
+  transform-json-strings { edge < 79 }
+  transform-optional-catch-binding { edge < 79 }
+  transform-async-generator-functions { edge < 79 }
+  transform-object-rest-spread { edge < 79 }
   transform-dotall-regex { edge < 79 }
-  proposal-unicode-property-regex { edge < 79 }
+  transform-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
-  proposal-export-namespace-from { edge < 79 }
+  transform-export-namespace-from { edge < 79 }
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
@@ -8,28 +8,28 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { edge < 94 }
-  proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 79 }
-  proposal-private-methods { edge < 84 }
-  proposal-numeric-separator { edge < 79 }
-  proposal-logical-assignment-operators { edge < 85 }
-  proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge < 91 }
-  proposal-json-strings { edge < 79 }
-  proposal-optional-catch-binding { edge < 79 }
+  transform-class-static-block { edge < 94 }
+  transform-private-property-in-object { edge < 91 }
+  transform-class-properties { edge < 79 }
+  transform-private-methods { edge < 84 }
+  transform-numeric-separator { edge < 79 }
+  transform-logical-assignment-operators { edge < 85 }
+  transform-nullish-coalescing-operator { edge < 80 }
+  transform-optional-chaining { edge < 91 }
+  transform-json-strings { edge < 79 }
+  transform-optional-catch-binding { edge < 79 }
   transform-parameters { edge < 18 }
-  proposal-async-generator-functions { edge < 79 }
-  proposal-object-rest-spread { edge < 79 }
+  transform-async-generator-functions { edge < 79 }
+  transform-object-rest-spread { edge < 79 }
   transform-dotall-regex { edge < 79 }
-  proposal-unicode-property-regex { edge < 79 }
+  transform-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   transform-async-to-generator { edge < 15 }
   transform-function-name { edge < 79 }
   transform-for-of { edge < 15 }
   transform-destructuring { edge < 15 }
-  proposal-export-namespace-from { edge < 79 }
+  transform-export-namespace-from { edge < 79 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
@@ -8,28 +8,28 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { edge < 94 }
-  proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 79 }
-  proposal-private-methods { edge < 84 }
-  proposal-numeric-separator { edge < 79 }
-  proposal-logical-assignment-operators { edge < 85 }
-  proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge < 80 }
-  proposal-json-strings { edge < 79 }
-  proposal-optional-catch-binding { edge < 79 }
+  transform-class-static-block { edge < 94 }
+  transform-private-property-in-object { edge < 91 }
+  transform-class-properties { edge < 79 }
+  transform-private-methods { edge < 84 }
+  transform-numeric-separator { edge < 79 }
+  transform-logical-assignment-operators { edge < 85 }
+  transform-nullish-coalescing-operator { edge < 80 }
+  transform-optional-chaining { edge < 80 }
+  transform-json-strings { edge < 79 }
+  transform-optional-catch-binding { edge < 79 }
   transform-parameters { edge < 15 }
-  proposal-async-generator-functions { edge < 79 }
-  proposal-object-rest-spread { edge < 79 }
+  transform-async-generator-functions { edge < 79 }
+  transform-object-rest-spread { edge < 79 }
   transform-dotall-regex { edge < 79 }
-  proposal-unicode-property-regex { edge < 79 }
+  transform-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
   transform-async-to-generator { edge < 15 }
   transform-for-of { edge < 15 }
   transform-destructuring { edge < 15 }
-  proposal-export-namespace-from { edge < 79 }
+  transform-export-namespace-from { edge < 79 }
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
@@ -8,25 +8,25 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { edge < 94 }
-  proposal-private-property-in-object { edge < 91 }
-  proposal-class-properties { edge < 79 }
-  proposal-private-methods { edge < 84 }
-  proposal-numeric-separator { edge < 79 }
-  proposal-logical-assignment-operators { edge < 85 }
-  proposal-nullish-coalescing-operator { edge < 80 }
-  proposal-optional-chaining { edge < 80 }
-  proposal-json-strings { edge < 79 }
-  proposal-optional-catch-binding { edge < 79 }
-  proposal-async-generator-functions { edge < 79 }
-  proposal-object-rest-spread { edge < 79 }
+  transform-class-static-block { edge < 94 }
+  transform-private-property-in-object { edge < 91 }
+  transform-class-properties { edge < 79 }
+  transform-private-methods { edge < 84 }
+  transform-numeric-separator { edge < 79 }
+  transform-logical-assignment-operators { edge < 85 }
+  transform-nullish-coalescing-operator { edge < 80 }
+  transform-optional-chaining { edge < 80 }
+  transform-json-strings { edge < 79 }
+  transform-optional-catch-binding { edge < 79 }
+  transform-async-generator-functions { edge < 79 }
+  transform-object-rest-spread { edge < 79 }
   transform-dotall-regex { edge < 79 }
-  proposal-unicode-property-regex { edge < 79 }
+  transform-unicode-property-regex { edge < 79 }
   transform-named-capturing-groups-regex { edge < 79 }
-  proposal-export-namespace-from { edge < 79 }
+  transform-export-namespace-from { edge < 79 }
   bugfix/transform-edge-default-parameters { edge < 18 }
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
@@ -8,29 +8,29 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { safari }
-  proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 14.1 }
-  proposal-private-methods { safari < 15 }
-  proposal-numeric-separator { safari < 13 }
-  proposal-logical-assignment-operators { safari < 14 }
-  proposal-nullish-coalescing-operator { safari < 13.1 }
-  proposal-optional-chaining { safari < 13.1 }
-  proposal-json-strings { safari < 12 }
-  proposal-optional-catch-binding { safari < 11.1 }
+  transform-class-static-block { safari }
+  transform-private-property-in-object { safari < 15 }
+  transform-class-properties { safari < 14.1 }
+  transform-private-methods { safari < 15 }
+  transform-numeric-separator { safari < 13 }
+  transform-logical-assignment-operators { safari < 14 }
+  transform-nullish-coalescing-operator { safari < 13.1 }
+  transform-optional-chaining { safari < 13.1 }
+  transform-json-strings { safari < 12 }
+  transform-optional-catch-binding { safari < 11.1 }
   transform-parameters { safari }
-  proposal-async-generator-functions { safari < 12 }
-  proposal-object-rest-spread { safari < 11.1 }
+  transform-async-generator-functions { safari < 12 }
+  transform-object-rest-spread { safari < 11.1 }
   transform-dotall-regex { safari < 11.1 }
-  proposal-unicode-property-regex { safari < 11.1 }
+  transform-unicode-property-regex { safari < 11.1 }
   transform-named-capturing-groups-regex { safari < 11.1 }
   transform-async-to-generator { safari < 11 }
   transform-exponentiation-operator { safari < 10.1 }
   transform-template-literals { safari < 13 }
   transform-unicode-regex { safari < 12 }
   transform-block-scoping { safari < 11 }
-  proposal-export-namespace-from { safari }
+  transform-export-namespace-from { safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
@@ -8,30 +8,30 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { safari }
-  proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 14.1 }
-  proposal-private-methods { safari < 15 }
-  proposal-numeric-separator { safari < 13 }
-  proposal-logical-assignment-operators { safari < 14 }
-  proposal-nullish-coalescing-operator { safari < 13.1 }
-  proposal-optional-chaining { safari < 13.1 }
-  proposal-json-strings { safari < 12 }
-  proposal-optional-catch-binding { safari < 11.1 }
-  proposal-async-generator-functions { safari < 12 }
-  proposal-object-rest-spread { safari < 11.1 }
+  transform-class-static-block { safari }
+  transform-private-property-in-object { safari < 15 }
+  transform-class-properties { safari < 14.1 }
+  transform-private-methods { safari < 15 }
+  transform-numeric-separator { safari < 13 }
+  transform-logical-assignment-operators { safari < 14 }
+  transform-nullish-coalescing-operator { safari < 13.1 }
+  transform-optional-chaining { safari < 13.1 }
+  transform-json-strings { safari < 12 }
+  transform-optional-catch-binding { safari < 11.1 }
+  transform-async-generator-functions { safari < 12 }
+  transform-object-rest-spread { safari < 11.1 }
   transform-dotall-regex { safari < 11.1 }
-  proposal-unicode-property-regex { safari < 11.1 }
+  transform-unicode-property-regex { safari < 11.1 }
   transform-named-capturing-groups-regex { safari < 11.1 }
   transform-async-to-generator { safari < 10.1 }
   transform-exponentiation-operator { safari < 10.1 }
   transform-unicode-regex { safari < 12 }
-  proposal-export-namespace-from { safari }
+  transform-export-namespace-from { safari }
   bugfix/transform-safari-block-shadowing { safari < 11 }
   bugfix/transform-safari-for-shadowing { safari < 11 }
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { safari }
   bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
@@ -8,26 +8,26 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { safari }
-  proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 14.1 }
-  proposal-private-methods { safari < 15 }
-  proposal-numeric-separator { safari < 13 }
-  proposal-logical-assignment-operators { safari < 14 }
-  proposal-nullish-coalescing-operator { safari < 13.1 }
-  proposal-optional-chaining { safari < 13.1 }
-  proposal-json-strings { safari < 12 }
-  proposal-optional-catch-binding { safari < 11.1 }
-  proposal-async-generator-functions { safari < 12 }
-  proposal-object-rest-spread { safari < 11.1 }
+  transform-class-static-block { safari }
+  transform-private-property-in-object { safari < 15 }
+  transform-class-properties { safari < 14.1 }
+  transform-private-methods { safari < 15 }
+  transform-numeric-separator { safari < 13 }
+  transform-logical-assignment-operators { safari < 14 }
+  transform-nullish-coalescing-operator { safari < 13.1 }
+  transform-optional-chaining { safari < 13.1 }
+  transform-json-strings { safari < 12 }
+  transform-optional-catch-binding { safari < 11.1 }
+  transform-async-generator-functions { safari < 12 }
+  transform-object-rest-spread { safari < 11.1 }
   transform-dotall-regex { safari < 11.1 }
-  proposal-unicode-property-regex { safari < 11.1 }
+  transform-unicode-property-regex { safari < 11.1 }
   transform-named-capturing-groups-regex { safari < 11.1 }
   transform-unicode-regex { safari < 12 }
-  proposal-export-namespace-from { safari }
+  transform-export-namespace-from { safari }
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { safari }
   bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { safari }
-  proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 14.1 }
-  proposal-private-methods { safari < 15 }
-  proposal-numeric-separator { safari < 13 }
-  proposal-logical-assignment-operators { safari < 14 }
-  proposal-nullish-coalescing-operator { safari < 13.1 }
-  proposal-optional-chaining { safari < 13.1 }
-  proposal-json-strings { safari < 12 }
-  proposal-optional-catch-binding { safari < 11.1 }
+  transform-class-static-block { safari }
+  transform-private-property-in-object { safari < 15 }
+  transform-class-properties { safari < 14.1 }
+  transform-private-methods { safari < 15 }
+  transform-numeric-separator { safari < 13 }
+  transform-logical-assignment-operators { safari < 14 }
+  transform-nullish-coalescing-operator { safari < 13.1 }
+  transform-optional-chaining { safari < 13.1 }
+  transform-json-strings { safari < 12 }
+  transform-optional-catch-binding { safari < 11.1 }
   transform-parameters { safari < 10 }
-  proposal-async-generator-functions { safari < 12 }
-  proposal-object-rest-spread { safari < 11.1 }
+  transform-async-generator-functions { safari < 12 }
+  transform-object-rest-spread { safari < 11.1 }
   transform-dotall-regex { safari < 11.1 }
-  proposal-unicode-property-regex { safari < 11.1 }
+  transform-unicode-property-regex { safari < 11.1 }
   transform-named-capturing-groups-regex { safari < 11.1 }
   transform-async-to-generator { safari < 10.1 }
   transform-exponentiation-operator { safari < 10.1 }
@@ -37,9 +37,9 @@ Using plugins:
   transform-block-scoping { safari < 10 }
   transform-new-target { safari < 10 }
   transform-regenerator { safari < 10 }
-  proposal-export-namespace-from { safari }
+  transform-export-namespace-from { safari }
   bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15-no-bugfixes/stdout.txt
@@ -8,7 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { safari }
+  transform-class-static-block { safari }
   syntax-private-property-in-object
   syntax-class-properties
   syntax-numeric-separator
@@ -18,9 +18,9 @@ Using plugins:
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { safari }
+  transform-export-namespace-from { safari }
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15/stdout.txt
@@ -8,7 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { safari }
+  transform-class-static-block { safari }
   syntax-private-property-in-object
   syntax-class-properties
   syntax-numeric-separator
@@ -19,8 +19,8 @@ Using plugins:
   transform-parameters { safari }
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { safari }
+  transform-export-namespace-from { safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
@@ -8,18 +8,18 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
   syntax-class-properties
   syntax-numeric-separator
   syntax-nullish-coalescing-operator
-  proposal-optional-chaining { chrome < 91 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
   transform-modules-commonjs
-  proposal-dynamic-import
-  proposal-export-namespace-from { }
+  transform-dynamic-import
+  transform-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
@@ -8,8 +8,8 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
   syntax-class-properties
   syntax-numeric-separator
   syntax-nullish-coalescing-operator
@@ -20,7 +20,7 @@ Using plugins:
   syntax-object-rest-spread
   bugfix/transform-v8-spread-parameters-in-optional-chaining { chrome < 91 }
   transform-modules-commonjs
-  proposal-dynamic-import
-  proposal-export-namespace-from { }
+  transform-dynamic-import
+  transform-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -16,28 +16,28 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
-  proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
-  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
-  proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
-  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
-  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
-  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
-  proposal-optional-chaining { android, chrome < 91, edge < 91, firefox < 74, ios < 13.4, node < 16.9, opera < 77, safari < 13.1, samsung < 16 }
-  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
-  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
+  transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
+  transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
+  transform-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  transform-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  transform-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
+  transform-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  transform-optional-chaining { android, chrome < 91, edge < 91, firefox < 74, ios < 13.4, node < 16.9, opera < 77, safari < 13.1, samsung < 16 }
+  transform-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  transform-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
   transform-parameters { edge < 18, ios, safari }
-  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
-  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  transform-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
   transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
-  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-async-to-generator { ios < 11, safari < 11 }
   transform-template-literals { ios < 13, safari < 13 }
   transform-function-name { edge < 79 }
   transform-unicode-regex { ios < 12, safari < 12 }
   transform-block-scoping { ios < 11, safari < 11 }
-  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
   syntax-dynamic-import
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -16,23 +16,23 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
-  proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
-  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
-  proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
-  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
-  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
-  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
-  proposal-optional-chaining { android, chrome < 80, edge < 80, firefox < 74, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
-  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
-  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
-  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
-  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
+  transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
+  transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
+  transform-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  transform-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  transform-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
+  transform-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  transform-optional-chaining { android, chrome < 80, edge < 80, firefox < 74, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  transform-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  transform-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  transform-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  transform-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
   transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
-  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-unicode-regex { ios < 12, safari < 12 }
-  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
   bugfix/transform-async-arrows-in-class { ios < 11, safari < 11 }
   bugfix/transform-edge-default-parameters { edge < 18 }
   bugfix/transform-edge-function-name { edge < 79 }

--- a/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -16,28 +16,28 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
-  proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
-  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
-  proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
-  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
-  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
-  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
-  proposal-optional-chaining { android, chrome < 91, edge < 91, firefox < 74, ios < 13.4, node < 16.9, opera < 77, safari < 13.1, samsung < 16 }
-  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
-  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
+  transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
+  transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
+  transform-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  transform-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  transform-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
+  transform-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  transform-optional-chaining { android, chrome < 91, edge < 91, firefox < 74, ios < 13.4, node < 16.9, opera < 77, safari < 13.1, samsung < 16 }
+  transform-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  transform-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
   transform-parameters { edge < 18, ios, safari }
-  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
-  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  transform-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
   transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
-  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-async-to-generator { ios < 11, safari < 11 }
   transform-template-literals { ios < 13, safari < 13 }
   transform-function-name { edge < 79 }
   transform-unicode-regex { ios < 12, safari < 12 }
   transform-block-scoping { ios < 11, safari < 11 }
-  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
   syntax-dynamic-import
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -16,23 +16,23 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
-  proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
-  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
-  proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
-  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
-  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
-  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
-  proposal-optional-chaining { android, chrome < 80, edge < 80, firefox < 74, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
-  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
-  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
-  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
-  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
+  transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
+  transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
+  transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
+  transform-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
+  transform-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
+  transform-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
+  transform-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  transform-optional-chaining { android, chrome < 80, edge < 80, firefox < 74, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
+  transform-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
+  transform-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
+  transform-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
+  transform-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
   transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
-  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
+  transform-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
   transform-unicode-regex { ios < 12, safari < 12 }
-  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
+  transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
   bugfix/transform-async-arrows-in-class { ios < 11, safari < 11 }
   bugfix/transform-edge-default-parameters { edge < 18 }
   bugfix/transform-edge-function-name { edge < 79 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslist-env/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslist-env/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -45,8 +45,8 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-android-3/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { android }
-  proposal-private-property-in-object { android }
-  proposal-class-properties { android }
-  proposal-private-methods { android }
-  proposal-numeric-separator { android }
-  proposal-logical-assignment-operators { android }
-  proposal-nullish-coalescing-operator { android }
-  proposal-optional-chaining { android }
-  proposal-json-strings { android }
-  proposal-optional-catch-binding { android }
+  transform-class-static-block { android }
+  transform-private-property-in-object { android }
+  transform-class-properties { android }
+  transform-private-methods { android }
+  transform-numeric-separator { android }
+  transform-logical-assignment-operators { android }
+  transform-nullish-coalescing-operator { android }
+  transform-optional-chaining { android }
+  transform-json-strings { android }
+  transform-optional-catch-binding { android }
   transform-parameters { android }
-  proposal-async-generator-functions { android }
-  proposal-object-rest-spread { android }
+  transform-async-generator-functions { android }
+  transform-object-rest-spread { android }
   transform-dotall-regex { android }
-  proposal-unicode-property-regex { android }
+  transform-unicode-property-regex { android }
   transform-named-capturing-groups-regex { android }
   transform-async-to-generator { android }
   transform-exponentiation-operator { android }
@@ -49,8 +49,8 @@ Using plugins:
   transform-member-expression-literals { android < 4 }
   transform-property-literals { android < 4 }
   transform-reserved-words { android < 4.4 }
-  proposal-export-namespace-from { android < 72 }
+  transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
@@ -15,10 +15,10 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ios, safari }
-  proposal-private-property-in-object { ios < 15 }
-  proposal-class-properties { ios < 15 }
-  proposal-private-methods { ios < 15 }
+  transform-class-static-block { ios, safari }
+  transform-private-property-in-object { ios < 15 }
+  transform-class-properties { ios < 15 }
+  transform-private-methods { ios < 15 }
   syntax-numeric-separator
   syntax-nullish-coalescing-operator
   syntax-optional-chaining
@@ -27,8 +27,8 @@ Using plugins:
   transform-parameters { ios, safari }
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { ios, safari }
+  transform-export-namespace-from { ios, safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
@@ -15,10 +15,10 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ios, safari }
-  proposal-private-property-in-object { ios < 15 }
-  proposal-class-properties { ios < 15 }
-  proposal-private-methods { ios < 15 }
+  transform-class-static-block { ios, safari }
+  transform-private-property-in-object { ios < 15 }
+  transform-class-properties { ios < 15 }
+  transform-private-methods { ios < 15 }
   syntax-numeric-separator
   syntax-nullish-coalescing-operator
   syntax-optional-chaining
@@ -27,8 +27,8 @@ Using plugins:
   transform-parameters { ios, safari }
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { ios, safari }
+  transform-export-namespace-from { ios, safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
@@ -15,7 +15,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ios, safari }
+  transform-class-static-block { ios, safari }
   syntax-private-property-in-object
   syntax-class-properties
   syntax-numeric-separator
@@ -26,8 +26,8 @@ Using plugins:
   transform-parameters { ios, safari }
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { ios, safari }
+  transform-export-namespace-from { ios, safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/corejs-without-usebuiltins/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,8 +49,8 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-android/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { android }
-  proposal-private-property-in-object { android }
-  proposal-class-properties { android }
-  proposal-private-methods { android }
-  proposal-numeric-separator { android }
-  proposal-logical-assignment-operators { android }
-  proposal-nullish-coalescing-operator { android }
-  proposal-optional-chaining { android }
-  proposal-json-strings { android }
-  proposal-optional-catch-binding { android }
+  transform-class-static-block { android }
+  transform-private-property-in-object { android }
+  transform-class-properties { android }
+  transform-private-methods { android }
+  transform-numeric-separator { android }
+  transform-logical-assignment-operators { android }
+  transform-nullish-coalescing-operator { android }
+  transform-optional-chaining { android }
+  transform-json-strings { android }
+  transform-optional-catch-binding { android }
   transform-parameters { android }
-  proposal-async-generator-functions { android }
-  proposal-object-rest-spread { android }
+  transform-async-generator-functions { android }
+  transform-object-rest-spread { android }
   transform-dotall-regex { android }
-  proposal-unicode-property-regex { android }
+  transform-unicode-property-regex { android }
   transform-named-capturing-groups-regex { android }
   transform-async-to-generator { android }
   transform-exponentiation-operator { android }
@@ -47,9 +47,9 @@ Using plugins:
   transform-new-target { android }
   transform-regenerator { android }
   transform-reserved-words { android < 4.4 }
-  proposal-export-namespace-from { android < 72 }
+  transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { electron < 15.0 }
-  proposal-private-property-in-object { electron < 13.0 }
-  proposal-class-properties { electron < 6.0 }
-  proposal-private-methods { electron < 10.0 }
-  proposal-numeric-separator { electron < 6.0 }
-  proposal-logical-assignment-operators { electron < 10.0 }
-  proposal-nullish-coalescing-operator { electron < 8.0 }
-  proposal-optional-chaining { electron < 13.0 }
-  proposal-json-strings { electron < 3.0 }
-  proposal-optional-catch-binding { electron < 3.0 }
+  transform-class-static-block { electron < 15.0 }
+  transform-private-property-in-object { electron < 13.0 }
+  transform-class-properties { electron < 6.0 }
+  transform-private-methods { electron < 10.0 }
+  transform-numeric-separator { electron < 6.0 }
+  transform-logical-assignment-operators { electron < 10.0 }
+  transform-nullish-coalescing-operator { electron < 8.0 }
+  transform-optional-chaining { electron < 13.0 }
+  transform-json-strings { electron < 3.0 }
+  transform-optional-catch-binding { electron < 3.0 }
   transform-parameters { electron < 0.37 }
-  proposal-async-generator-functions { electron < 3.0 }
-  proposal-object-rest-spread { electron < 2.0 }
+  transform-async-generator-functions { electron < 3.0 }
+  transform-object-rest-spread { electron < 2.0 }
   transform-dotall-regex { electron < 3.0 }
-  proposal-unicode-property-regex { electron < 3.0 }
+  transform-unicode-property-regex { electron < 3.0 }
   transform-named-capturing-groups-regex { electron < 3.0 }
   transform-async-to-generator { electron < 1.6 }
   transform-exponentiation-operator { electron < 1.3 }
@@ -33,9 +33,9 @@ Using plugins:
   transform-destructuring { electron < 1.2 }
   transform-block-scoping { electron < 0.37 }
   transform-regenerator { electron < 1.1 }
-  proposal-export-namespace-from { electron < 5.0 }
+  transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
   transform-parameters { }
-  proposal-async-generator-functions { chrome < 63 }
-  proposal-object-rest-spread { chrome < 60 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   transform-async-to-generator { }
   transform-exponentiation-operator { }
@@ -49,7 +49,7 @@ Using plugins:
   transform-member-expression-literals { }
   transform-property-literals { }
   transform-reserved-words { }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
@@ -8,29 +8,29 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { node < 16.11 }
-  proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 12 }
-  proposal-private-methods { node < 14.6 }
-  proposal-numeric-separator { node < 12.5 }
-  proposal-logical-assignment-operators { node < 15 }
-  proposal-nullish-coalescing-operator { node < 14 }
-  proposal-optional-chaining { node < 16.9 }
-  proposal-json-strings { node < 10 }
-  proposal-optional-catch-binding { node < 10 }
-  proposal-async-generator-functions { node < 10 }
-  proposal-object-rest-spread { node < 8.3 }
+  transform-class-static-block { node < 16.11 }
+  transform-private-property-in-object { node < 16.9 }
+  transform-class-properties { node < 12 }
+  transform-private-methods { node < 14.6 }
+  transform-numeric-separator { node < 12.5 }
+  transform-logical-assignment-operators { node < 15 }
+  transform-nullish-coalescing-operator { node < 14 }
+  transform-optional-chaining { node < 16.9 }
+  transform-json-strings { node < 10 }
+  transform-optional-catch-binding { node < 10 }
+  transform-async-generator-functions { node < 10 }
+  transform-object-rest-spread { node < 8.3 }
   transform-dotall-regex { node < 8.10 }
-  proposal-unicode-property-regex { node < 10 }
+  transform-unicode-property-regex { node < 10 }
   transform-named-capturing-groups-regex { node < 10 }
   transform-async-to-generator { node < 7.6 }
   transform-exponentiation-operator { node < 7 }
   transform-function-name { node < 6.5 }
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
-  proposal-export-namespace-from { node < 13.2 }
+  transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
@@ -13,21 +13,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
-  proposal-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
-  proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
-  proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
-  proposal-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
-  proposal-optional-chaining { chrome < 91, edge < 91, firefox < 74, ie, ios < 13.4, safari < 13.1 }
-  proposal-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
-  proposal-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
+  transform-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
+  transform-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
+  transform-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
+  transform-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
+  transform-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
+  transform-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
+  transform-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
+  transform-optional-chaining { chrome < 91, edge < 91, firefox < 74, ie, ios < 13.4, safari < 13.1 }
+  transform-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
+  transform-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
   transform-parameters { edge < 18, firefox < 53, ie, ios, safari }
-  proposal-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
-  proposal-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
+  transform-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
+  transform-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
   transform-dotall-regex { chrome < 62, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
-  proposal-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
   transform-named-capturing-groups-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
   transform-async-to-generator { chrome < 55, edge < 15, firefox < 52, ie, ios < 11, safari < 11 }
   transform-exponentiation-operator { edge < 14, firefox < 52, ie, ios < 10.3, safari < 10.1 }
@@ -51,9 +51,9 @@ Using plugins:
   transform-typeof-symbol { ie, safari < 9 }
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
-  proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
+  transform-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
@@ -11,21 +11,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, electron < 15.0, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
-  proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
-  proposal-optional-chaining { chrome < 91, electron < 13.0, ie, node < 16.9 }
-  proposal-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-class-static-block { chrome < 94, electron < 15.0, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
+  transform-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
+  transform-optional-chaining { chrome < 91, electron < 13.0, ie, node < 16.9 }
+  transform-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
   transform-parameters { electron < 0.37, ie }
-  proposal-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, electron < 3.0, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, electron < 3.0, ie, node < 10 }
   transform-async-to-generator { chrome < 55, electron < 1.6, ie, node < 7.6 }
   transform-exponentiation-operator { electron < 1.3, ie, node < 7 }
@@ -49,9 +49,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }
-  proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 91, ie, node < 16.9 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 91, ie, node < 16.9 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 91, ie, node < 16.9 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 91, ie, node < 16.9 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-android/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { android }
-  proposal-private-property-in-object { android }
-  proposal-class-properties { android }
-  proposal-private-methods { android }
-  proposal-numeric-separator { android }
-  proposal-logical-assignment-operators { android }
-  proposal-nullish-coalescing-operator { android }
-  proposal-optional-chaining { android }
-  proposal-json-strings { android }
-  proposal-optional-catch-binding { android }
+  transform-class-static-block { android }
+  transform-private-property-in-object { android }
+  transform-class-properties { android }
+  transform-private-methods { android }
+  transform-numeric-separator { android }
+  transform-logical-assignment-operators { android }
+  transform-nullish-coalescing-operator { android }
+  transform-optional-chaining { android }
+  transform-json-strings { android }
+  transform-optional-catch-binding { android }
   transform-parameters { android }
-  proposal-async-generator-functions { android }
-  proposal-object-rest-spread { android }
+  transform-async-generator-functions { android }
+  transform-object-rest-spread { android }
   transform-dotall-regex { android }
-  proposal-unicode-property-regex { android }
+  transform-unicode-property-regex { android }
   transform-named-capturing-groups-regex { android }
   transform-async-to-generator { android }
   transform-exponentiation-operator { android }
@@ -47,9 +47,9 @@ Using plugins:
   transform-new-target { android }
   transform-regenerator { android }
   transform-reserved-words { android < 4.4 }
-  proposal-export-namespace-from { android < 72 }
+  transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-babel-polyfill/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { electron < 15.0 }
-  proposal-private-property-in-object { electron < 13.0 }
-  proposal-class-properties { electron < 6.0 }
-  proposal-private-methods { electron < 10.0 }
-  proposal-numeric-separator { electron < 6.0 }
-  proposal-logical-assignment-operators { electron < 10.0 }
-  proposal-nullish-coalescing-operator { electron < 8.0 }
-  proposal-optional-chaining { electron < 13.0 }
-  proposal-json-strings { electron < 3.0 }
-  proposal-optional-catch-binding { electron < 3.0 }
+  transform-class-static-block { electron < 15.0 }
+  transform-private-property-in-object { electron < 13.0 }
+  transform-class-properties { electron < 6.0 }
+  transform-private-methods { electron < 10.0 }
+  transform-numeric-separator { electron < 6.0 }
+  transform-logical-assignment-operators { electron < 10.0 }
+  transform-nullish-coalescing-operator { electron < 8.0 }
+  transform-optional-chaining { electron < 13.0 }
+  transform-json-strings { electron < 3.0 }
+  transform-optional-catch-binding { electron < 3.0 }
   transform-parameters { electron < 0.37 }
-  proposal-async-generator-functions { electron < 3.0 }
-  proposal-object-rest-spread { electron < 2.0 }
+  transform-async-generator-functions { electron < 3.0 }
+  transform-object-rest-spread { electron < 2.0 }
   transform-dotall-regex { electron < 3.0 }
-  proposal-unicode-property-regex { electron < 3.0 }
+  transform-unicode-property-regex { electron < 3.0 }
   transform-named-capturing-groups-regex { electron < 3.0 }
   transform-async-to-generator { electron < 1.6 }
   transform-exponentiation-operator { electron < 1.3 }
@@ -33,9 +33,9 @@ Using plugins:
   transform-destructuring { electron < 1.2 }
   transform-block-scoping { electron < 0.37 }
   transform-regenerator { electron < 1.1 }
-  proposal-export-namespace-from { electron < 5.0 }
+  transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
   transform-parameters { }
-  proposal-async-generator-functions { chrome < 63 }
-  proposal-object-rest-spread { chrome < 60 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   transform-async-to-generator { }
   transform-exponentiation-operator { }
@@ -49,7 +49,7 @@ Using plugins:
   transform-member-expression-literals { }
   transform-property-literals { }
   transform-reserved-words { }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
@@ -8,29 +8,29 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { node < 16.11 }
-  proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 12 }
-  proposal-private-methods { node < 14.6 }
-  proposal-numeric-separator { node < 12.5 }
-  proposal-logical-assignment-operators { node < 15 }
-  proposal-nullish-coalescing-operator { node < 14 }
-  proposal-optional-chaining { node < 16.9 }
-  proposal-json-strings { node < 10 }
-  proposal-optional-catch-binding { node < 10 }
-  proposal-async-generator-functions { node < 10 }
-  proposal-object-rest-spread { node < 8.3 }
+  transform-class-static-block { node < 16.11 }
+  transform-private-property-in-object { node < 16.9 }
+  transform-class-properties { node < 12 }
+  transform-private-methods { node < 14.6 }
+  transform-numeric-separator { node < 12.5 }
+  transform-logical-assignment-operators { node < 15 }
+  transform-nullish-coalescing-operator { node < 14 }
+  transform-optional-chaining { node < 16.9 }
+  transform-json-strings { node < 10 }
+  transform-optional-catch-binding { node < 10 }
+  transform-async-generator-functions { node < 10 }
+  transform-object-rest-spread { node < 8.3 }
   transform-dotall-regex { node < 8.10 }
-  proposal-unicode-property-regex { node < 10 }
+  transform-unicode-property-regex { node < 10 }
   transform-named-capturing-groups-regex { node < 10 }
   transform-async-to-generator { node < 7.6 }
   transform-exponentiation-operator { node < 7 }
   transform-function-name { node < 6.5 }
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
-  proposal-export-namespace-from { node < 13.2 }
+  transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
@@ -13,21 +13,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
-  proposal-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
-  proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
-  proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
-  proposal-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
-  proposal-optional-chaining { chrome < 91, edge < 91, firefox < 74, ie, ios < 13.4, safari < 13.1 }
-  proposal-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
-  proposal-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
+  transform-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
+  transform-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
+  transform-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
+  transform-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
+  transform-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
+  transform-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
+  transform-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
+  transform-optional-chaining { chrome < 91, edge < 91, firefox < 74, ie, ios < 13.4, safari < 13.1 }
+  transform-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
+  transform-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
   transform-parameters { edge < 18, firefox < 53, ie, ios, safari }
-  proposal-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
-  proposal-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
+  transform-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
+  transform-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
   transform-dotall-regex { chrome < 62, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
-  proposal-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
   transform-named-capturing-groups-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
   transform-async-to-generator { chrome < 55, edge < 15, firefox < 52, ie, ios < 11, safari < 11 }
   transform-exponentiation-operator { edge < 14, firefox < 52, ie, ios < 10.3, safari < 10.1 }
@@ -51,9 +51,9 @@ Using plugins:
   transform-typeof-symbol { ie, safari < 9 }
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
-  proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
+  transform-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -8,23 +8,23 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { samsung < 17 }
-  proposal-private-property-in-object { samsung < 16 }
-  proposal-class-properties { samsung < 11 }
-  proposal-private-methods { samsung < 14 }
-  proposal-numeric-separator { samsung < 11 }
-  proposal-logical-assignment-operators { samsung < 14 }
-  proposal-nullish-coalescing-operator { samsung < 13 }
-  proposal-optional-chaining { samsung < 16 }
-  proposal-json-strings { samsung < 9 }
-  proposal-optional-catch-binding { samsung < 9 }
+  transform-class-static-block { samsung < 17 }
+  transform-private-property-in-object { samsung < 16 }
+  transform-class-properties { samsung < 11 }
+  transform-private-methods { samsung < 14 }
+  transform-numeric-separator { samsung < 11 }
+  transform-logical-assignment-operators { samsung < 14 }
+  transform-nullish-coalescing-operator { samsung < 13 }
+  transform-optional-chaining { samsung < 16 }
+  transform-json-strings { samsung < 9 }
+  transform-optional-catch-binding { samsung < 9 }
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-unicode-property-regex { samsung < 9 }
+  transform-unicode-property-regex { samsung < 9 }
   transform-named-capturing-groups-regex { samsung < 9 }
-  proposal-export-namespace-from { samsung < 11.0 }
+  transform-export-namespace-from { samsung < 11.0 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
@@ -11,21 +11,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, electron < 15.0, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
-  proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
-  proposal-optional-chaining { chrome < 91, electron < 13.0, ie, node < 16.9 }
-  proposal-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-class-static-block { chrome < 94, electron < 15.0, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
+  transform-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
+  transform-optional-chaining { chrome < 91, electron < 13.0, ie, node < 16.9 }
+  transform-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
   transform-parameters { electron < 0.37, ie }
-  proposal-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, electron < 3.0, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, electron < 3.0, ie, node < 10 }
   transform-async-to-generator { chrome < 55, electron < 1.6, ie, node < 7.6 }
   transform-exponentiation-operator { electron < 1.3, ie, node < 7 }
@@ -49,9 +49,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }
-  proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 91, ie, node < 16.9 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 91, ie, node < 16.9 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 91, ie, node < 16.9 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 91, ie, node < 16.9 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 91, ie, node < 16.9 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 91, ie, node < 16.9 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 91, ie, node < 16.9 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 91, ie, node < 16.9 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
@@ -8,29 +8,29 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { node < 16.11 }
-  proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 12 }
-  proposal-private-methods { node < 14.6 }
-  proposal-numeric-separator { node < 12.5 }
-  proposal-logical-assignment-operators { node < 15 }
-  proposal-nullish-coalescing-operator { node < 14 }
-  proposal-optional-chaining { node < 16.9 }
-  proposal-json-strings { node < 10 }
-  proposal-optional-catch-binding { node < 10 }
-  proposal-async-generator-functions { node < 10 }
-  proposal-object-rest-spread { node < 8.3 }
+  transform-class-static-block { node < 16.11 }
+  transform-private-property-in-object { node < 16.9 }
+  transform-class-properties { node < 12 }
+  transform-private-methods { node < 14.6 }
+  transform-numeric-separator { node < 12.5 }
+  transform-logical-assignment-operators { node < 15 }
+  transform-nullish-coalescing-operator { node < 14 }
+  transform-optional-chaining { node < 16.9 }
+  transform-json-strings { node < 10 }
+  transform-optional-catch-binding { node < 10 }
+  transform-async-generator-functions { node < 10 }
+  transform-object-rest-spread { node < 8.3 }
   transform-dotall-regex { node < 8.10 }
-  proposal-unicode-property-regex { node < 10 }
+  transform-unicode-property-regex { node < 10 }
   transform-named-capturing-groups-regex { node < 10 }
   transform-async-to-generator { node < 7.6 }
   transform-exponentiation-operator { node < 7 }
   transform-function-name { node < 6.5 }
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
-  proposal-export-namespace-from { node < 13.2 }
+  transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-shippedProposals/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
   transform-parameters { }
-  proposal-async-generator-functions { chrome < 63 }
-  proposal-object-rest-spread { chrome < 60 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   transform-async-to-generator { }
   transform-exponentiation-operator { }
@@ -49,7 +49,7 @@ Using plugins:
   transform-member-expression-literals { }
   transform-property-literals { }
   transform-reserved-words { }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 91, ie, node < 16.9 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 91, ie, node < 16.9 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
@@ -9,28 +9,28 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { firefox < 93, node < 16.11 }
-  proposal-private-property-in-object { firefox < 90, node < 16.9 }
-  proposal-class-properties { firefox < 90, node < 12 }
-  proposal-private-methods { firefox < 90, node < 14.6 }
-  proposal-numeric-separator { firefox < 70, node < 12.5 }
-  proposal-logical-assignment-operators { firefox < 79, node < 15 }
-  proposal-nullish-coalescing-operator { firefox < 72, node < 14 }
-  proposal-optional-chaining { firefox < 74, node < 16.9 }
-  proposal-json-strings { firefox < 62, node < 10 }
-  proposal-optional-catch-binding { firefox < 58, node < 10 }
-  proposal-async-generator-functions { firefox < 57, node < 10 }
-  proposal-object-rest-spread { firefox < 55, node < 8.3 }
+  transform-class-static-block { firefox < 93, node < 16.11 }
+  transform-private-property-in-object { firefox < 90, node < 16.9 }
+  transform-class-properties { firefox < 90, node < 12 }
+  transform-private-methods { firefox < 90, node < 14.6 }
+  transform-numeric-separator { firefox < 70, node < 12.5 }
+  transform-logical-assignment-operators { firefox < 79, node < 15 }
+  transform-nullish-coalescing-operator { firefox < 72, node < 14 }
+  transform-optional-chaining { firefox < 74, node < 16.9 }
+  transform-json-strings { firefox < 62, node < 10 }
+  transform-optional-catch-binding { firefox < 58, node < 10 }
+  transform-async-generator-functions { firefox < 57, node < 10 }
+  transform-object-rest-spread { firefox < 55, node < 8.3 }
   transform-dotall-regex { firefox < 78, node < 8.10 }
-  proposal-unicode-property-regex { firefox < 78, node < 10 }
+  transform-unicode-property-regex { firefox < 78, node < 10 }
   transform-named-capturing-groups-regex { firefox < 78, node < 10 }
   transform-literals { firefox < 53 }
   transform-function-name { firefox < 53 }
   transform-for-of { firefox < 53 }
   transform-unicode-escapes { firefox < 53 }
   transform-destructuring { firefox < 53 }
-  proposal-export-namespace-from { firefox < 80, node < 13.2 }
+  transform-export-namespace-from { firefox < 80, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
   syntax-class-properties
-  proposal-private-methods { chrome < 84 }
+  transform-private-methods { chrome < 84 }
   syntax-numeric-separator
-  proposal-logical-assignment-operators { chrome < 85 }
+  transform-logical-assignment-operators { chrome < 85 }
   syntax-nullish-coalescing-operator
-  proposal-optional-chaining { chrome < 91 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
   transform-modules-commonjs
-  proposal-dynamic-import
-  proposal-export-namespace-from { }
+  transform-dynamic-import
+  transform-export-namespace-from { }
   syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
   syntax-class-properties
   syntax-numeric-separator
-  proposal-logical-assignment-operators { chrome < 85 }
+  transform-logical-assignment-operators { chrome < 85 }
   syntax-nullish-coalescing-operator
-  proposal-optional-chaining { chrome < 91 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
   transform-modules-commonjs
-  proposal-dynamic-import
-  proposal-export-namespace-from { }
+  transform-dynamic-import
+  transform-export-namespace-from { }
   syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
@@ -8,23 +8,23 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
-  proposal-async-generator-functions { chrome < 63 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
+  transform-async-generator-functions { chrome < 63 }
   syntax-object-rest-spread
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
   syntax-class-properties
-  proposal-private-methods { chrome < 84 }
+  transform-private-methods { chrome < 84 }
   syntax-numeric-separator
-  proposal-logical-assignment-operators { chrome < 85 }
+  transform-logical-assignment-operators { chrome < 85 }
   syntax-nullish-coalescing-operator
-  proposal-optional-chaining { chrome < 91 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
   transform-modules-commonjs
-  proposal-dynamic-import
-  proposal-export-namespace-from { }
+  transform-dynamic-import
+  transform-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
-  proposal-async-generator-functions { chrome < 63 }
-  proposal-object-rest-spread { chrome < 60 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
-  proposal-async-generator-functions { chrome < 63 }
-  proposal-object-rest-spread { chrome < 60 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 91, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 91, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -45,8 +45,8 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { android }
-  proposal-private-property-in-object { android }
-  proposal-class-properties { android }
-  proposal-private-methods { android }
-  proposal-numeric-separator { android }
-  proposal-logical-assignment-operators { android }
-  proposal-nullish-coalescing-operator { android }
-  proposal-optional-chaining { android }
-  proposal-json-strings { android }
-  proposal-optional-catch-binding { android }
+  transform-class-static-block { android }
+  transform-private-property-in-object { android }
+  transform-class-properties { android }
+  transform-private-methods { android }
+  transform-numeric-separator { android }
+  transform-logical-assignment-operators { android }
+  transform-nullish-coalescing-operator { android }
+  transform-optional-chaining { android }
+  transform-json-strings { android }
+  transform-optional-catch-binding { android }
   transform-parameters { android }
-  proposal-async-generator-functions { android }
-  proposal-object-rest-spread { android }
+  transform-async-generator-functions { android }
+  transform-object-rest-spread { android }
   transform-dotall-regex { android }
-  proposal-unicode-property-regex { android }
+  transform-unicode-property-regex { android }
   transform-named-capturing-groups-regex { android }
   transform-async-to-generator { android }
   transform-exponentiation-operator { android }
@@ -49,8 +49,8 @@ Using plugins:
   transform-member-expression-literals { android < 4 }
   transform-property-literals { android < 4 }
   transform-reserved-words { android < 4.4 }
-  proposal-export-namespace-from { android < 72 }
+  transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -15,10 +15,10 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ios, safari }
-  proposal-private-property-in-object { ios < 15 }
-  proposal-class-properties { ios < 15 }
-  proposal-private-methods { ios < 15 }
+  transform-class-static-block { ios, safari }
+  transform-private-property-in-object { ios < 15 }
+  transform-class-properties { ios < 15 }
+  transform-private-methods { ios < 15 }
   syntax-numeric-separator
   syntax-nullish-coalescing-operator
   syntax-optional-chaining
@@ -26,9 +26,9 @@ Using plugins:
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { ios, safari }
+  transform-export-namespace-from { ios, safari }
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios, safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -15,10 +15,10 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ios, safari }
-  proposal-private-property-in-object { ios < 15 }
-  proposal-class-properties { ios < 15 }
-  proposal-private-methods { ios < 15 }
+  transform-class-static-block { ios, safari }
+  transform-private-property-in-object { ios < 15 }
+  transform-class-properties { ios < 15 }
+  transform-private-methods { ios < 15 }
   syntax-numeric-separator
   syntax-nullish-coalescing-operator
   syntax-optional-chaining
@@ -26,9 +26,9 @@ Using plugins:
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { ios, safari }
+  transform-export-namespace-from { ios, safari }
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios, safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -15,7 +15,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ios, safari }
+  transform-class-static-block { ios, safari }
   syntax-private-property-in-object
   syntax-class-properties
   syntax-numeric-separator
@@ -25,9 +25,9 @@ Using plugins:
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { ios, safari }
+  transform-export-namespace-from { ios, safari }
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios, safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,8 +49,8 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { android }
-  proposal-private-property-in-object { android }
-  proposal-class-properties { android }
-  proposal-private-methods { android }
-  proposal-numeric-separator { android }
-  proposal-logical-assignment-operators { android }
-  proposal-nullish-coalescing-operator { android }
-  proposal-optional-chaining { android }
-  proposal-json-strings { android }
-  proposal-optional-catch-binding { android }
+  transform-class-static-block { android }
+  transform-private-property-in-object { android }
+  transform-class-properties { android }
+  transform-private-methods { android }
+  transform-numeric-separator { android }
+  transform-logical-assignment-operators { android }
+  transform-nullish-coalescing-operator { android }
+  transform-optional-chaining { android }
+  transform-json-strings { android }
+  transform-optional-catch-binding { android }
   transform-parameters { android }
-  proposal-async-generator-functions { android }
-  proposal-object-rest-spread { android }
+  transform-async-generator-functions { android }
+  transform-object-rest-spread { android }
   transform-dotall-regex { android }
-  proposal-unicode-property-regex { android }
+  transform-unicode-property-regex { android }
   transform-named-capturing-groups-regex { android }
   transform-async-to-generator { android }
   transform-exponentiation-operator { android }
@@ -47,9 +47,9 @@ Using plugins:
   transform-new-target { android }
   transform-regenerator { android }
   transform-reserved-words { android < 4.4 }
-  proposal-export-namespace-from { android < 72 }
+  transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { electron < 15.0 }
-  proposal-private-property-in-object { electron < 13.0 }
-  proposal-class-properties { electron < 6.0 }
-  proposal-private-methods { electron < 10.0 }
-  proposal-numeric-separator { electron < 6.0 }
-  proposal-logical-assignment-operators { electron < 10.0 }
-  proposal-nullish-coalescing-operator { electron < 8.0 }
-  proposal-optional-chaining { electron < 8.0 }
-  proposal-json-strings { electron < 3.0 }
-  proposal-optional-catch-binding { electron < 3.0 }
+  transform-class-static-block { electron < 15.0 }
+  transform-private-property-in-object { electron < 13.0 }
+  transform-class-properties { electron < 6.0 }
+  transform-private-methods { electron < 10.0 }
+  transform-numeric-separator { electron < 6.0 }
+  transform-logical-assignment-operators { electron < 10.0 }
+  transform-nullish-coalescing-operator { electron < 8.0 }
+  transform-optional-chaining { electron < 8.0 }
+  transform-json-strings { electron < 3.0 }
+  transform-optional-catch-binding { electron < 3.0 }
   transform-parameters { electron < 0.37 }
-  proposal-async-generator-functions { electron < 3.0 }
-  proposal-object-rest-spread { electron < 2.0 }
+  transform-async-generator-functions { electron < 3.0 }
+  transform-object-rest-spread { electron < 2.0 }
   transform-dotall-regex { electron < 3.0 }
-  proposal-unicode-property-regex { electron < 3.0 }
+  transform-unicode-property-regex { electron < 3.0 }
   transform-named-capturing-groups-regex { electron < 3.0 }
   transform-async-to-generator { electron < 1.6 }
   transform-exponentiation-operator { electron < 1.3 }
@@ -33,9 +33,9 @@ Using plugins:
   transform-destructuring { electron < 1.2 }
   transform-block-scoping { electron < 0.37 }
   transform-regenerator { electron < 1.1 }
-  proposal-export-namespace-from { electron < 5.0 }
+  transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
   transform-parameters { }
-  proposal-async-generator-functions { chrome < 63 }
-  proposal-object-rest-spread { chrome < 60 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   transform-async-to-generator { }
   transform-exponentiation-operator { }
@@ -49,7 +49,7 @@ Using plugins:
   transform-member-expression-literals { }
   transform-property-literals { }
   transform-reserved-words { }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
@@ -8,29 +8,29 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { node < 16.11 }
-  proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 12 }
-  proposal-private-methods { node < 14.6 }
-  proposal-numeric-separator { node < 12.5 }
-  proposal-logical-assignment-operators { node < 15 }
-  proposal-nullish-coalescing-operator { node < 14 }
-  proposal-optional-chaining { node < 14 }
-  proposal-json-strings { node < 10 }
-  proposal-optional-catch-binding { node < 10 }
-  proposal-async-generator-functions { node < 10 }
-  proposal-object-rest-spread { node < 8.3 }
+  transform-class-static-block { node < 16.11 }
+  transform-private-property-in-object { node < 16.9 }
+  transform-class-properties { node < 12 }
+  transform-private-methods { node < 14.6 }
+  transform-numeric-separator { node < 12.5 }
+  transform-logical-assignment-operators { node < 15 }
+  transform-nullish-coalescing-operator { node < 14 }
+  transform-optional-chaining { node < 14 }
+  transform-json-strings { node < 10 }
+  transform-optional-catch-binding { node < 10 }
+  transform-async-generator-functions { node < 10 }
+  transform-object-rest-spread { node < 8.3 }
   transform-dotall-regex { node < 8.10 }
-  proposal-unicode-property-regex { node < 10 }
+  transform-unicode-property-regex { node < 10 }
   transform-named-capturing-groups-regex { node < 10 }
   transform-async-to-generator { node < 7.6 }
   transform-exponentiation-operator { node < 7 }
   transform-function-name { node < 6.5 }
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
-  proposal-export-namespace-from { node < 13.2 }
+  transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -13,21 +13,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
-  proposal-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
-  proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
-  proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
-  proposal-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
-  proposal-optional-chaining { chrome < 80, edge < 80, firefox < 74, ie, ios < 13.4, safari < 13.1 }
-  proposal-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
-  proposal-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
+  transform-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
+  transform-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
+  transform-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
+  transform-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
+  transform-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
+  transform-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
+  transform-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
+  transform-optional-chaining { chrome < 80, edge < 80, firefox < 74, ie, ios < 13.4, safari < 13.1 }
+  transform-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
+  transform-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
   transform-parameters { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
-  proposal-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
-  proposal-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
+  transform-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
+  transform-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
   transform-dotall-regex { chrome < 62, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
-  proposal-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
   transform-named-capturing-groups-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
   transform-async-to-generator { chrome < 55, edge < 15, firefox < 52, ie, ios < 10.3, safari < 10.1 }
   transform-exponentiation-operator { edge < 14, firefox < 52, ie, ios < 10.3, safari < 10.1 }
@@ -51,9 +51,9 @@ Using plugins:
   transform-typeof-symbol { ie, safari < 9 }
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
-  proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
+  transform-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -11,21 +11,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, electron < 15.0, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
-  proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
-  proposal-optional-chaining { chrome < 80, electron < 8.0, ie, node < 14 }
-  proposal-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-class-static-block { chrome < 94, electron < 15.0, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
+  transform-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
+  transform-optional-chaining { chrome < 80, electron < 8.0, ie, node < 14 }
+  transform-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
   transform-parameters { electron < 0.37, ie }
-  proposal-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, electron < 3.0, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, electron < 3.0, ie, node < 10 }
   transform-async-to-generator { chrome < 55, electron < 1.6, ie, node < 7.6 }
   transform-exponentiation-operator { electron < 1.3, ie, node < 7 }
@@ -49,9 +49,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }
-  proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 80, ie, node < 14 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 80, ie, node < 14 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 80, ie, node < 14 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 80, ie, node < 14 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { android }
-  proposal-private-property-in-object { android }
-  proposal-class-properties { android }
-  proposal-private-methods { android }
-  proposal-numeric-separator { android }
-  proposal-logical-assignment-operators { android }
-  proposal-nullish-coalescing-operator { android }
-  proposal-optional-chaining { android }
-  proposal-json-strings { android }
-  proposal-optional-catch-binding { android }
+  transform-class-static-block { android }
+  transform-private-property-in-object { android }
+  transform-class-properties { android }
+  transform-private-methods { android }
+  transform-numeric-separator { android }
+  transform-logical-assignment-operators { android }
+  transform-nullish-coalescing-operator { android }
+  transform-optional-chaining { android }
+  transform-json-strings { android }
+  transform-optional-catch-binding { android }
   transform-parameters { android }
-  proposal-async-generator-functions { android }
-  proposal-object-rest-spread { android }
+  transform-async-generator-functions { android }
+  transform-object-rest-spread { android }
   transform-dotall-regex { android }
-  proposal-unicode-property-regex { android }
+  transform-unicode-property-regex { android }
   transform-named-capturing-groups-regex { android }
   transform-async-to-generator { android }
   transform-exponentiation-operator { android }
@@ -47,9 +47,9 @@ Using plugins:
   transform-new-target { android }
   transform-regenerator { android }
   transform-reserved-words { android < 4.4 }
-  proposal-export-namespace-from { android < 72 }
+  transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { electron < 15.0 }
-  proposal-private-property-in-object { electron < 13.0 }
-  proposal-class-properties { electron < 6.0 }
-  proposal-private-methods { electron < 10.0 }
-  proposal-numeric-separator { electron < 6.0 }
-  proposal-logical-assignment-operators { electron < 10.0 }
-  proposal-nullish-coalescing-operator { electron < 8.0 }
-  proposal-optional-chaining { electron < 8.0 }
-  proposal-json-strings { electron < 3.0 }
-  proposal-optional-catch-binding { electron < 3.0 }
+  transform-class-static-block { electron < 15.0 }
+  transform-private-property-in-object { electron < 13.0 }
+  transform-class-properties { electron < 6.0 }
+  transform-private-methods { electron < 10.0 }
+  transform-numeric-separator { electron < 6.0 }
+  transform-logical-assignment-operators { electron < 10.0 }
+  transform-nullish-coalescing-operator { electron < 8.0 }
+  transform-optional-chaining { electron < 8.0 }
+  transform-json-strings { electron < 3.0 }
+  transform-optional-catch-binding { electron < 3.0 }
   transform-parameters { electron < 0.37 }
-  proposal-async-generator-functions { electron < 3.0 }
-  proposal-object-rest-spread { electron < 2.0 }
+  transform-async-generator-functions { electron < 3.0 }
+  transform-object-rest-spread { electron < 2.0 }
   transform-dotall-regex { electron < 3.0 }
-  proposal-unicode-property-regex { electron < 3.0 }
+  transform-unicode-property-regex { electron < 3.0 }
   transform-named-capturing-groups-regex { electron < 3.0 }
   transform-async-to-generator { electron < 1.6 }
   transform-exponentiation-operator { electron < 1.3 }
@@ -33,9 +33,9 @@ Using plugins:
   transform-destructuring { electron < 1.2 }
   transform-block-scoping { electron < 0.37 }
   transform-regenerator { electron < 1.1 }
-  proposal-export-namespace-from { electron < 5.0 }
+  transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
   transform-parameters { }
-  proposal-async-generator-functions { chrome < 63 }
-  proposal-object-rest-spread { chrome < 60 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   transform-async-to-generator { }
   transform-exponentiation-operator { }
@@ -49,7 +49,7 @@ Using plugins:
   transform-member-expression-literals { }
   transform-property-literals { }
   transform-reserved-words { }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
@@ -8,29 +8,29 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { node < 16.11 }
-  proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 12 }
-  proposal-private-methods { node < 14.6 }
-  proposal-numeric-separator { node < 12.5 }
-  proposal-logical-assignment-operators { node < 15 }
-  proposal-nullish-coalescing-operator { node < 14 }
-  proposal-optional-chaining { node < 14 }
-  proposal-json-strings { node < 10 }
-  proposal-optional-catch-binding { node < 10 }
-  proposal-async-generator-functions { node < 10 }
-  proposal-object-rest-spread { node < 8.3 }
+  transform-class-static-block { node < 16.11 }
+  transform-private-property-in-object { node < 16.9 }
+  transform-class-properties { node < 12 }
+  transform-private-methods { node < 14.6 }
+  transform-numeric-separator { node < 12.5 }
+  transform-logical-assignment-operators { node < 15 }
+  transform-nullish-coalescing-operator { node < 14 }
+  transform-optional-chaining { node < 14 }
+  transform-json-strings { node < 10 }
+  transform-optional-catch-binding { node < 10 }
+  transform-async-generator-functions { node < 10 }
+  transform-object-rest-spread { node < 8.3 }
   transform-dotall-regex { node < 8.10 }
-  proposal-unicode-property-regex { node < 10 }
+  transform-unicode-property-regex { node < 10 }
   transform-named-capturing-groups-regex { node < 10 }
   transform-async-to-generator { node < 7.6 }
   transform-exponentiation-operator { node < 7 }
   transform-function-name { node < 6.5 }
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
-  proposal-export-namespace-from { node < 13.2 }
+  transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
@@ -13,21 +13,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
-  proposal-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
-  proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
-  proposal-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
-  proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
-  proposal-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
-  proposal-optional-chaining { chrome < 80, edge < 80, firefox < 74, ie, ios < 13.4, safari < 13.1 }
-  proposal-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
-  proposal-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
+  transform-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios, safari }
+  transform-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
+  transform-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 15, safari < 14.1 }
+  transform-private-methods { chrome < 84, edge < 84, firefox < 90, ie, ios < 15, safari < 15 }
+  transform-numeric-separator { chrome < 75, edge < 79, firefox < 70, ie, ios < 13, safari < 13 }
+  transform-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ie, ios < 14, safari < 14 }
+  transform-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, safari < 13.1 }
+  transform-optional-chaining { chrome < 80, edge < 80, firefox < 74, ie, ios < 13.4, safari < 13.1 }
+  transform-json-strings { chrome < 66, edge < 79, firefox < 62, ie, ios < 12, safari < 12 }
+  transform-optional-catch-binding { chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, safari < 11.1 }
   transform-parameters { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
-  proposal-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
-  proposal-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
+  transform-async-generator-functions { chrome < 63, edge < 79, firefox < 57, ie, ios < 12, safari < 12 }
+  transform-object-rest-spread { chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1 }
   transform-dotall-regex { chrome < 62, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
-  proposal-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
+  transform-unicode-property-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
   transform-named-capturing-groups-regex { chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, safari < 11.1 }
   transform-async-to-generator { chrome < 55, edge < 15, firefox < 52, ie, ios < 10.3, safari < 10.1 }
   transform-exponentiation-operator { edge < 14, firefox < 52, ie, ios < 10.3, safari < 10.1 }
@@ -51,9 +51,9 @@ Using plugins:
   transform-typeof-symbol { ie, safari < 9 }
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }
-  proposal-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
+  transform-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -8,23 +8,23 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { samsung < 17 }
-  proposal-private-property-in-object { samsung < 16 }
-  proposal-class-properties { samsung < 11 }
-  proposal-private-methods { samsung < 14 }
-  proposal-numeric-separator { samsung < 11 }
-  proposal-logical-assignment-operators { samsung < 14 }
-  proposal-nullish-coalescing-operator { samsung < 13 }
-  proposal-optional-chaining { samsung < 13 }
-  proposal-json-strings { samsung < 9 }
-  proposal-optional-catch-binding { samsung < 9 }
+  transform-class-static-block { samsung < 17 }
+  transform-private-property-in-object { samsung < 16 }
+  transform-class-properties { samsung < 11 }
+  transform-private-methods { samsung < 14 }
+  transform-numeric-separator { samsung < 11 }
+  transform-logical-assignment-operators { samsung < 14 }
+  transform-nullish-coalescing-operator { samsung < 13 }
+  transform-optional-chaining { samsung < 13 }
+  transform-json-strings { samsung < 9 }
+  transform-optional-catch-binding { samsung < 9 }
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-unicode-property-regex { samsung < 9 }
+  transform-unicode-property-regex { samsung < 9 }
   transform-named-capturing-groups-regex { samsung < 9 }
-  proposal-export-namespace-from { samsung < 11.0 }
+  transform-export-namespace-from { samsung < 11.0 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -11,21 +11,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, electron < 15.0, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
-  proposal-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
-  proposal-optional-chaining { chrome < 80, electron < 8.0, ie, node < 14 }
-  proposal-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-class-static-block { chrome < 94, electron < 15.0, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, electron < 13.0, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, electron < 6.0, ie, node < 12 }
+  transform-private-methods { chrome < 84, electron < 10.0, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, electron < 6.0, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, electron < 10.0, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, electron < 8.0, ie, node < 14 }
+  transform-optional-chaining { chrome < 80, electron < 8.0, ie, node < 14 }
+  transform-json-strings { chrome < 66, electron < 3.0, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, electron < 3.0, ie, node < 10 }
   transform-parameters { electron < 0.37, ie }
-  proposal-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, electron < 3.0, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, electron < 2.0, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, electron < 3.0, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, electron < 3.0, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, electron < 3.0, ie, node < 10 }
   transform-async-to-generator { chrome < 55, electron < 1.6, ie, node < 7.6 }
   transform-exponentiation-operator { electron < 1.3, ie, node < 7 }
@@ -49,9 +49,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }
-  proposal-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 80, ie, node < 14 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 80, ie, node < 14 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 80, ie, node < 14 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 80, ie, node < 14 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 80, ie, node < 14 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 80, ie, node < 14 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 80, ie, node < 14 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 80, ie, node < 14 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
@@ -8,29 +8,29 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { node < 16.11 }
-  proposal-private-property-in-object { node < 16.9 }
-  proposal-class-properties { node < 12 }
-  proposal-private-methods { node < 14.6 }
-  proposal-numeric-separator { node < 12.5 }
-  proposal-logical-assignment-operators { node < 15 }
-  proposal-nullish-coalescing-operator { node < 14 }
-  proposal-optional-chaining { node < 14 }
-  proposal-json-strings { node < 10 }
-  proposal-optional-catch-binding { node < 10 }
-  proposal-async-generator-functions { node < 10 }
-  proposal-object-rest-spread { node < 8.3 }
+  transform-class-static-block { node < 16.11 }
+  transform-private-property-in-object { node < 16.9 }
+  transform-class-properties { node < 12 }
+  transform-private-methods { node < 14.6 }
+  transform-numeric-separator { node < 12.5 }
+  transform-logical-assignment-operators { node < 15 }
+  transform-nullish-coalescing-operator { node < 14 }
+  transform-optional-chaining { node < 14 }
+  transform-json-strings { node < 10 }
+  transform-optional-catch-binding { node < 10 }
+  transform-async-generator-functions { node < 10 }
+  transform-object-rest-spread { node < 8.3 }
   transform-dotall-regex { node < 8.10 }
-  proposal-unicode-property-regex { node < 10 }
+  transform-unicode-property-regex { node < 10 }
   transform-named-capturing-groups-regex { node < 10 }
   transform-async-to-generator { node < 7.6 }
   transform-exponentiation-operator { node < 7 }
   transform-function-name { node < 6.5 }
   transform-for-of { node < 6.5 }
   transform-destructuring { node < 6.5 }
-  proposal-export-namespace-from { node < 13.2 }
+  transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { ie }
-  proposal-private-property-in-object { ie }
-  proposal-class-properties { ie }
-  proposal-private-methods { ie }
-  proposal-numeric-separator { ie }
-  proposal-logical-assignment-operators { ie }
-  proposal-nullish-coalescing-operator { ie }
-  proposal-optional-chaining { ie }
-  proposal-json-strings { ie }
-  proposal-optional-catch-binding { ie }
+  transform-class-static-block { ie }
+  transform-private-property-in-object { ie }
+  transform-class-properties { ie }
+  transform-private-methods { ie }
+  transform-numeric-separator { ie }
+  transform-logical-assignment-operators { ie }
+  transform-nullish-coalescing-operator { ie }
+  transform-optional-chaining { ie }
+  transform-json-strings { ie }
+  transform-optional-catch-binding { ie }
   transform-parameters { ie }
-  proposal-async-generator-functions { ie }
-  proposal-object-rest-spread { ie }
+  transform-async-generator-functions { ie }
+  transform-object-rest-spread { ie }
   transform-dotall-regex { ie }
-  proposal-unicode-property-regex { ie }
+  transform-unicode-property-regex { ie }
   transform-named-capturing-groups-regex { ie }
   transform-async-to-generator { ie }
   transform-exponentiation-operator { ie }
@@ -49,9 +49,9 @@ Using plugins:
   transform-member-expression-literals { ie < 9 }
   transform-property-literals { ie < 9 }
   transform-reserved-words { ie < 9 }
-  proposal-export-namespace-from { ie }
+  transform-export-namespace-from { ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 91 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
   transform-parameters { }
-  proposal-async-generator-functions { chrome < 63 }
-  proposal-object-rest-spread { chrome < 60 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
   transform-async-to-generator { }
   transform-exponentiation-operator { }
@@ -49,7 +49,7 @@ Using plugins:
   transform-member-expression-literals { }
   transform-property-literals { }
   transform-reserved-words { }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, ie, node < 16.11 }
-  proposal-private-property-in-object { chrome < 91, ie, node < 16.9 }
-  proposal-class-properties { chrome < 74, ie, node < 12 }
-  proposal-private-methods { chrome < 84, ie, node < 14.6 }
-  proposal-numeric-separator { chrome < 75, ie, node < 12.5 }
-  proposal-logical-assignment-operators { chrome < 85, ie, node < 15 }
-  proposal-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
-  proposal-optional-chaining { chrome < 80, ie, node < 14 }
-  proposal-json-strings { chrome < 66, ie, node < 10 }
-  proposal-optional-catch-binding { chrome < 66, ie, node < 10 }
+  transform-class-static-block { chrome < 94, ie, node < 16.11 }
+  transform-private-property-in-object { chrome < 91, ie, node < 16.9 }
+  transform-class-properties { chrome < 74, ie, node < 12 }
+  transform-private-methods { chrome < 84, ie, node < 14.6 }
+  transform-numeric-separator { chrome < 75, ie, node < 12.5 }
+  transform-logical-assignment-operators { chrome < 85, ie, node < 15 }
+  transform-nullish-coalescing-operator { chrome < 80, ie, node < 14 }
+  transform-optional-chaining { chrome < 80, ie, node < 14 }
+  transform-json-strings { chrome < 66, ie, node < 10 }
+  transform-optional-catch-binding { chrome < 66, ie, node < 10 }
   transform-parameters { ie }
-  proposal-async-generator-functions { chrome < 63, ie, node < 10 }
-  proposal-object-rest-spread { chrome < 60, ie, node < 8.3 }
+  transform-async-generator-functions { chrome < 63, ie, node < 10 }
+  transform-object-rest-spread { chrome < 60, ie, node < 8.3 }
   transform-dotall-regex { chrome < 62, ie, node < 8.10 }
-  proposal-unicode-property-regex { chrome < 64, ie, node < 10 }
+  transform-unicode-property-regex { chrome < 64, ie, node < 10 }
   transform-named-capturing-groups-regex { chrome < 64, ie, node < 10 }
   transform-async-to-generator { chrome < 55, ie, node < 7.6 }
   transform-exponentiation-operator { ie, node < 7 }
@@ -48,9 +48,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { ie }
-  proposal-export-namespace-from { chrome < 72, ie, node < 13.2 }
+  transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
@@ -9,29 +9,29 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { firefox < 93, node < 16.11 }
-  proposal-private-property-in-object { firefox < 90, node < 16.9 }
-  proposal-class-properties { firefox < 90, node < 12 }
-  proposal-private-methods { firefox < 90, node < 14.6 }
-  proposal-numeric-separator { firefox < 70, node < 12.5 }
-  proposal-logical-assignment-operators { firefox < 79, node < 15 }
-  proposal-nullish-coalescing-operator { firefox < 72, node < 14 }
-  proposal-optional-chaining { firefox < 74, node < 14 }
-  proposal-json-strings { firefox < 62, node < 10 }
-  proposal-optional-catch-binding { firefox < 58, node < 10 }
-  proposal-async-generator-functions { firefox < 57, node < 10 }
-  proposal-object-rest-spread { firefox < 55, node < 8.3 }
+  transform-class-static-block { firefox < 93, node < 16.11 }
+  transform-private-property-in-object { firefox < 90, node < 16.9 }
+  transform-class-properties { firefox < 90, node < 12 }
+  transform-private-methods { firefox < 90, node < 14.6 }
+  transform-numeric-separator { firefox < 70, node < 12.5 }
+  transform-logical-assignment-operators { firefox < 79, node < 15 }
+  transform-nullish-coalescing-operator { firefox < 72, node < 14 }
+  transform-optional-chaining { firefox < 74, node < 14 }
+  transform-json-strings { firefox < 62, node < 10 }
+  transform-optional-catch-binding { firefox < 58, node < 10 }
+  transform-async-generator-functions { firefox < 57, node < 10 }
+  transform-object-rest-spread { firefox < 55, node < 8.3 }
   transform-dotall-regex { firefox < 78, node < 8.10 }
-  proposal-unicode-property-regex { firefox < 78, node < 10 }
+  transform-unicode-property-regex { firefox < 78, node < 10 }
   transform-named-capturing-groups-regex { firefox < 78, node < 10 }
   transform-literals { firefox < 53 }
   transform-function-name { firefox < 53 }
   transform-for-of { firefox < 53 }
   transform-unicode-escapes { firefox < 53 }
   transform-destructuring { firefox < 53 }
-  proposal-export-namespace-from { firefox < 80, node < 13.2 }
+  transform-export-namespace-from { firefox < 80, node < 13.2 }
   bugfix/transform-async-arrows-in-class { node < 7.6 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
   syntax-class-properties
-  proposal-private-methods { chrome < 84 }
+  transform-private-methods { chrome < 84 }
   syntax-numeric-separator
-  proposal-logical-assignment-operators { chrome < 85 }
+  transform-logical-assignment-operators { chrome < 85 }
   syntax-nullish-coalescing-operator
   syntax-optional-chaining
   syntax-json-strings
@@ -22,8 +22,8 @@ Using plugins:
   syntax-object-rest-spread
   bugfix/transform-v8-spread-parameters-in-optional-chaining { chrome < 91 }
   transform-modules-commonjs
-  proposal-dynamic-import
-  proposal-export-namespace-from { }
+  transform-dynamic-import
+  transform-export-namespace-from { }
   syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
@@ -8,11 +8,11 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
   syntax-class-properties
   syntax-numeric-separator
-  proposal-logical-assignment-operators { chrome < 85 }
+  transform-logical-assignment-operators { chrome < 85 }
   syntax-nullish-coalescing-operator
   syntax-optional-chaining
   syntax-json-strings
@@ -21,8 +21,8 @@ Using plugins:
   syntax-object-rest-spread
   bugfix/transform-v8-spread-parameters-in-optional-chaining { chrome < 91 }
   transform-modules-commonjs
-  proposal-dynamic-import
-  proposal-export-namespace-from { }
+  transform-dynamic-import
+  transform-export-namespace-from { }
   syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
@@ -8,23 +8,23 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
-  proposal-async-generator-functions { chrome < 63 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
+  transform-async-generator-functions { chrome < 63 }
   syntax-object-rest-spread
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
   syntax-class-properties
-  proposal-private-methods { chrome < 84 }
+  transform-private-methods { chrome < 84 }
   syntax-numeric-separator
-  proposal-logical-assignment-operators { chrome < 85 }
+  transform-logical-assignment-operators { chrome < 85 }
   syntax-nullish-coalescing-operator
   syntax-optional-chaining
   syntax-json-strings
@@ -22,7 +22,7 @@ Using plugins:
   syntax-object-rest-spread
   bugfix/transform-v8-spread-parameters-in-optional-chaining { chrome < 91 }
   transform-modules-commonjs
-  proposal-dynamic-import
-  proposal-export-namespace-from { }
+  transform-dynamic-import
+  transform-export-namespace-from { }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
-  proposal-async-generator-functions { chrome < 63 }
-  proposal-object-rest-spread { chrome < 60 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -8,21 +8,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94 }
-  proposal-private-property-in-object { chrome < 91 }
-  proposal-class-properties { chrome < 74 }
-  proposal-private-methods { chrome < 84 }
-  proposal-numeric-separator { chrome < 75 }
-  proposal-logical-assignment-operators { chrome < 85 }
-  proposal-nullish-coalescing-operator { chrome < 80 }
-  proposal-optional-chaining { chrome < 80 }
-  proposal-json-strings { chrome < 66 }
-  proposal-optional-catch-binding { chrome < 66 }
-  proposal-async-generator-functions { chrome < 63 }
-  proposal-object-rest-spread { chrome < 60 }
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 80 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
-  proposal-unicode-property-regex { chrome < 64 }
+  transform-unicode-property-regex { chrome < 64 }
   transform-named-capturing-groups-regex { chrome < 64 }
-  proposal-export-namespace-from { chrome < 72 }
+  transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
@@ -10,21 +10,21 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { chrome < 94, firefox < 93, ie }
-  proposal-private-property-in-object { chrome < 91, firefox < 90, ie }
-  proposal-class-properties { chrome < 74, firefox < 90, ie }
-  proposal-private-methods { chrome < 84, firefox < 90, ie }
-  proposal-numeric-separator { chrome < 75, firefox < 70, ie }
-  proposal-logical-assignment-operators { chrome < 85, firefox < 79, ie }
-  proposal-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
-  proposal-optional-chaining { chrome < 80, firefox < 74, ie }
-  proposal-json-strings { chrome < 66, firefox < 62, ie }
-  proposal-optional-catch-binding { chrome < 66, firefox < 58, ie }
+  transform-class-static-block { chrome < 94, firefox < 93, ie }
+  transform-private-property-in-object { chrome < 91, firefox < 90, ie }
+  transform-class-properties { chrome < 74, firefox < 90, ie }
+  transform-private-methods { chrome < 84, firefox < 90, ie }
+  transform-numeric-separator { chrome < 75, firefox < 70, ie }
+  transform-logical-assignment-operators { chrome < 85, firefox < 79, ie }
+  transform-nullish-coalescing-operator { chrome < 80, firefox < 72, ie }
+  transform-optional-chaining { chrome < 80, firefox < 74, ie }
+  transform-json-strings { chrome < 66, firefox < 62, ie }
+  transform-optional-catch-binding { chrome < 66, firefox < 58, ie }
   transform-parameters { firefox < 53, ie }
-  proposal-async-generator-functions { chrome < 63, firefox < 57, ie }
-  proposal-object-rest-spread { chrome < 60, firefox < 55, ie }
+  transform-async-generator-functions { chrome < 63, firefox < 57, ie }
+  transform-object-rest-spread { chrome < 60, firefox < 55, ie }
   transform-dotall-regex { chrome < 62, firefox < 78, ie }
-  proposal-unicode-property-regex { chrome < 64, firefox < 78, ie }
+  transform-unicode-property-regex { chrome < 64, firefox < 78, ie }
   transform-named-capturing-groups-regex { chrome < 64, firefox < 78, ie }
   transform-async-to-generator { chrome < 55, firefox < 52, ie }
   transform-exponentiation-operator { firefox < 52, ie }
@@ -47,9 +47,9 @@ Using plugins:
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }
-  proposal-export-namespace-from { chrome < 72, firefox < 80, ie }
+  transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { node < 16.11 }
-  proposal-private-property-in-object { node < 16.9 }
+  transform-class-static-block { node < 16.11 }
+  transform-private-property-in-object { node < 16.9 }
   syntax-class-properties
-  proposal-private-methods { node < 14.6 }
-  proposal-numeric-separator { node < 12.5 }
-  proposal-logical-assignment-operators { node < 15 }
-  proposal-nullish-coalescing-operator { node < 14 }
-  proposal-optional-chaining { node < 16.9 }
+  transform-private-methods { node < 14.6 }
+  transform-numeric-separator { node < 12.5 }
+  transform-logical-assignment-operators { node < 15 }
+  transform-nullish-coalescing-operator { node < 14 }
+  transform-optional-chaining { node < 16.9 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { node < 13.2 }
+  transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { node < 16.11 }
-  proposal-private-property-in-object { node < 16.9 }
+  transform-class-static-block { node < 16.11 }
+  transform-private-property-in-object { node < 16.9 }
   syntax-class-properties
-  proposal-private-methods { node < 14.6 }
-  proposal-numeric-separator { node < 12.5 }
-  proposal-logical-assignment-operators { node < 15 }
-  proposal-nullish-coalescing-operator { node < 14 }
-  proposal-optional-chaining { node < 14 }
+  transform-private-methods { node < 14.6 }
+  transform-numeric-separator { node < 12.5 }
+  transform-logical-assignment-operators { node < 15 }
+  transform-nullish-coalescing-operator { node < 14 }
+  transform-optional-chaining { node < 14 }
   syntax-json-strings
   syntax-optional-catch-binding
   syntax-async-generators
   syntax-object-rest-spread
-  proposal-export-namespace-from { node < 13.2 }
+  transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
@@ -8,29 +8,29 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { safari }
-  proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 14.1 }
-  proposal-private-methods { safari < 15 }
-  proposal-numeric-separator { safari < 13 }
-  proposal-logical-assignment-operators { safari < 14 }
-  proposal-nullish-coalescing-operator { safari < 13.1 }
-  proposal-optional-chaining { safari < 13.1 }
-  proposal-json-strings { safari < 12 }
-  proposal-optional-catch-binding { safari < 11.1 }
+  transform-class-static-block { safari }
+  transform-private-property-in-object { safari < 15 }
+  transform-class-properties { safari < 14.1 }
+  transform-private-methods { safari < 15 }
+  transform-numeric-separator { safari < 13 }
+  transform-logical-assignment-operators { safari < 14 }
+  transform-nullish-coalescing-operator { safari < 13.1 }
+  transform-optional-chaining { safari < 13.1 }
+  transform-json-strings { safari < 12 }
+  transform-optional-catch-binding { safari < 11.1 }
   transform-parameters { safari }
-  proposal-async-generator-functions { safari < 12 }
-  proposal-object-rest-spread { safari < 11.1 }
+  transform-async-generator-functions { safari < 12 }
+  transform-object-rest-spread { safari < 11.1 }
   transform-dotall-regex { safari < 11.1 }
-  proposal-unicode-property-regex { safari < 11.1 }
+  transform-unicode-property-regex { safari < 11.1 }
   transform-named-capturing-groups-regex { safari < 11.1 }
   transform-async-to-generator { safari < 11 }
   transform-exponentiation-operator { safari < 10.1 }
   transform-template-literals { safari < 13 }
   transform-unicode-regex { safari < 12 }
   transform-block-scoping { safari < 11 }
-  proposal-export-namespace-from { safari }
+  transform-export-namespace-from { safari }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
@@ -8,30 +8,30 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  proposal-class-static-block { safari }
-  proposal-private-property-in-object { safari < 15 }
-  proposal-class-properties { safari < 14.1 }
-  proposal-private-methods { safari < 15 }
-  proposal-numeric-separator { safari < 13 }
-  proposal-logical-assignment-operators { safari < 14 }
-  proposal-nullish-coalescing-operator { safari < 13.1 }
-  proposal-optional-chaining { safari < 13.1 }
-  proposal-json-strings { safari < 12 }
-  proposal-optional-catch-binding { safari < 11.1 }
-  proposal-async-generator-functions { safari < 12 }
-  proposal-object-rest-spread { safari < 11.1 }
+  transform-class-static-block { safari }
+  transform-private-property-in-object { safari < 15 }
+  transform-class-properties { safari < 14.1 }
+  transform-private-methods { safari < 15 }
+  transform-numeric-separator { safari < 13 }
+  transform-logical-assignment-operators { safari < 14 }
+  transform-nullish-coalescing-operator { safari < 13.1 }
+  transform-optional-chaining { safari < 13.1 }
+  transform-json-strings { safari < 12 }
+  transform-optional-catch-binding { safari < 11.1 }
+  transform-async-generator-functions { safari < 12 }
+  transform-object-rest-spread { safari < 11.1 }
   transform-dotall-regex { safari < 11.1 }
-  proposal-unicode-property-regex { safari < 11.1 }
+  transform-unicode-property-regex { safari < 11.1 }
   transform-named-capturing-groups-regex { safari < 11.1 }
   transform-async-to-generator { safari < 10.1 }
   transform-exponentiation-operator { safari < 10.1 }
   transform-unicode-regex { safari < 12 }
-  proposal-export-namespace-from { safari }
+  transform-export-namespace-from { safari }
   bugfix/transform-safari-block-shadowing { safari < 11 }
   bugfix/transform-safari-for-shadowing { safari < 11 }
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { safari }
   bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
-  proposal-dynamic-import
+  transform-dynamic-import
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/index.skip-bundled.js
+++ b/packages/babel-preset-env/test/index.skip-bundled.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/extensions
 import compatData from "@babel/compat-data/plugins";
+import * as babel from "@babel/core";
 
 import * as babelPresetEnv from "../lib/index.js";
 
@@ -33,6 +34,9 @@ if (/* commonjs */ _transformations.default) {
   pluginCoreJS3 = _pluginCoreJS3_esm;
   pluginRegenerator = _pluginRegenerator_esm;
 }
+
+const itBabel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
+const itBabel8 = process.env.BABEL_8_BREAKING ? it : it.skip;
 
 describe("babel-preset-env", () => {
   describe("transformIncludesAndExcludes", () => {
@@ -308,5 +312,41 @@ describe("babel-preset-env", () => {
       .sort();
 
     expect(arrAvailablePlugins).toEqual(expect.arrayContaining(arrCompatData));
+  });
+
+  describe("debug", () => {
+    let log;
+    beforeEach(() => {
+      log = jest.spyOn(console, "log").mockImplementation(() => {});
+    });
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    itBabel7(
+      "logs proposal- for packages that were proposals during the Babel 7 lifetime",
+      () => {
+        babel.transformSync("code", {
+          configFile: false,
+          browserslistConfigFile: false,
+          presets: [[babelPresetEnv.default, { debug: true }]],
+        });
+        expect(log).toHaveBeenCalledWith(expect.stringContaining("proposal-"));
+      },
+    );
+
+    itBabel8(
+      "logs transform- for packages that were proposals during the Babel 7 lifetime",
+      () => {
+        babel.transformSync("code", {
+          configFile: false,
+          browserslistConfigFile: false,
+          presets: [[babelPresetEnv.default, { debug: true }]],
+        });
+        expect(log).not.toHaveBeenCalledWith(
+          expect.stringContaining("proposal-"),
+        );
+      },
+    );
   });
 });

--- a/packages/babel-preset-env/test/index.skip-bundled.js
+++ b/packages/babel-preset-env/test/index.skip-bundled.js
@@ -320,7 +320,7 @@ describe("babel-preset-env", () => {
       log = jest.spyOn(console, "log").mockImplementation(() => {});
     });
     afterEach(() => {
-      jest.restoreAllMocks();
+      log.restoreMock();
     });
 
     itBabel7(

--- a/packages/babel-preset-env/test/index.skip-bundled.js
+++ b/packages/babel-preset-env/test/index.skip-bundled.js
@@ -320,7 +320,7 @@ describe("babel-preset-env", () => {
       log = jest.spyOn(console, "log").mockImplementation(() => {});
     });
     afterEach(() => {
-      log.restoreMock();
+      log.mockRestore();
     });
 
     itBabel7(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The main reason for this PR is to reduce the output difference between Babel 8 and Babel 7, which is quite annoying (I noticed it while reviewing https://github.com/babel/babel/pull/15068)

As mentioned in https://github.com/babel/babel/pull/14976#discussion_r979299470, this change is only about how we present the log and I don't think it counts as a breaking change.

Users can already use options like `"exclude": ["transform-class-static-blocks"]` (even if technically the npm package name uses `-proposal-`), so it's ok to also use it in the debug logs. Most users should only use the preset and not the individual packages anyway, and this hides from them the distinction between "transform" and "proposal that become Stage 4 since when the plugin was released", which is just historical and doesn't matter in practice.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15473"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

