### PR TITLE
disallow mixins/implements in flow interface

### DIFF
--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -692,16 +692,13 @@ export default (superClass: typeof Parser) =>
       node: Undone<N.FlowDeclareInterface>,
     ): N.FlowDeclareInterface {
       this.next();
-      this.flowParseInterfaceish(node);
+      this.flowParseInterfaceish(node, /* isClass */ false);
       return this.finishNode(node, "DeclareInterface");
     }
 
     // Interfaces
 
-    flowParseInterfaceish(
-      node: Undone<N.FlowDeclare>,
-      isClass: boolean = false,
-    ): void {
+    flowParseInterfaceish(node: Undone<N.FlowDeclare>, isClass: boolean): void {
       node.id = this.flowParseRestrictedIdentifier(
         /* liberal */ !isClass,
         /* declaration */ true,
@@ -729,18 +726,18 @@ export default (superClass: typeof Parser) =>
         } while (!isClass && this.eat(tt.comma));
       }
 
-      if (this.isContextual(tt._mixins)) {
-        this.next();
-        do {
-          node.mixins.push(this.flowParseInterfaceExtends());
-        } while (this.eat(tt.comma));
-      }
+      if (isClass) {
+        if (this.eatContextual(tt._mixins)) {
+          do {
+            node.mixins.push(this.flowParseInterfaceExtends());
+          } while (this.eat(tt.comma));
+        }
 
-      if (this.isContextual(tt._implements)) {
-        this.next();
-        do {
-          node.implements.push(this.flowParseInterfaceExtends());
-        } while (this.eat(tt.comma));
+        if (this.eatContextual(tt._implements)) {
+          do {
+            node.implements.push(this.flowParseInterfaceExtends());
+          } while (this.eat(tt.comma));
+        }
       }
 
       node.body = this.flowParseObjectType({
@@ -766,7 +763,7 @@ export default (superClass: typeof Parser) =>
     }
 
     flowParseInterface(node: Undone<N.FlowInterface>): N.FlowInterface {
-      this.flowParseInterfaceish(node);
+      this.flowParseInterfaceish(node, /* isClass */ false);
       return this.finishNode(node, "InterfaceDeclaration");
     }
 

--- a/packages/babel-parser/test/fixtures/flow/interface-types/invalid-declare-implements/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/invalid-declare-implements/input.js
@@ -1,0 +1,1 @@
+declare interface A implements I { p: string }

--- a/packages/babel-parser/test/fixtures/flow/interface-types/invalid-declare-implements/options.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/invalid-declare-implements/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token, expected \"{\" (1:20)"
+}

--- a/packages/babel-parser/test/fixtures/flow/interface-types/invalid-declare-mixins/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/invalid-declare-mixins/input.js
@@ -1,0 +1,1 @@
+declare interface A mixins M { p: string }

--- a/packages/babel-parser/test/fixtures/flow/interface-types/invalid-declare-mixins/options.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/invalid-declare-mixins/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token, expected \"{\" (1:20)"
+}

--- a/packages/babel-parser/test/fixtures/flow/interface-types/invalid-implements/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/invalid-implements/input.js
@@ -1,0 +1,1 @@
+interface A implements I { p: string }

--- a/packages/babel-parser/test/fixtures/flow/interface-types/invalid-implements/options.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/invalid-implements/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token, expected \"{\" (1:12)"
+}

--- a/packages/babel-parser/test/fixtures/flow/interface-types/invalid-mixins/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/invalid-mixins/input.js
@@ -1,0 +1,1 @@
+interface A mixins M { p: string }

--- a/packages/babel-parser/test/fixtures/flow/interface-types/invalid-mixins/options.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/invalid-mixins/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token, expected \"{\" (1:12)"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/15387
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The reference parser is not recovering from this error ([Flow Playground](https://flow.org/try/#0JYOwLgpgTgZghgYwgAgILOAWwA4BsKYTgDOyAQsgN4C+AsAFCiSyIrqbAAeopFNDAEwgJccKCibR4SNBhz5CJclTr0hIsRPBTWsjtxC8VQA)), so here we just throw on such cases.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15479"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

