### PR TITLE
chore: Improve `jsonCompatibleStrings` deprecation

### DIFF
--- a/packages/babel-generator/src/generators/types.ts
+++ b/packages/babel-generator/src/generators/types.ts
@@ -209,15 +209,7 @@ export function StringLiteral(this: Printer, node: t.StringLiteral) {
     return;
   }
 
-  const val = jsesc(
-    node.value,
-    process.env.BABEL_8_BREAKING
-      ? this.format.jsescOption
-      : Object.assign(
-          this.format.jsescOption,
-          this.format.jsonCompatibleStrings && { json: true },
-        ),
-  );
+  const val = jsesc(node.value, this.format.jsescOption);
 
   return this.token(val);
 }

--- a/packages/babel-generator/src/index.ts
+++ b/packages/babel-generator/src/index.ts
@@ -78,6 +78,9 @@ function normalizeOptions(
   if (!process.env.BABEL_8_BREAKING) {
     format.decoratorsBeforeExport = opts.decoratorsBeforeExport;
     format.jsonCompatibleStrings = opts.jsonCompatibleStrings;
+    if (format.jsonCompatibleStrings) {
+      format.jsescOption.json = true;
+    }
   }
 
   if (format.minified) {

--- a/packages/babel-generator/src/index.ts
+++ b/packages/babel-generator/src/index.ts
@@ -77,10 +77,7 @@ function normalizeOptions(
 
   if (!process.env.BABEL_8_BREAKING) {
     format.decoratorsBeforeExport = opts.decoratorsBeforeExport;
-    format.jsonCompatibleStrings = opts.jsonCompatibleStrings;
-    if (format.jsonCompatibleStrings) {
-      format.jsescOption.json = true;
-    }
+    format.jsescOption.json = opts.jsonCompatibleStrings;
   }
 
   if (format.minified) {

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -64,6 +64,9 @@ export type Format = {
   };
   recordAndTupleSyntaxType: RecordAndTuplePluginOptions["syntaxType"];
   jsescOption: jsescOptions;
+  /**
+   * @deprecated Removed in Babel 8, use `jsescOption` instead
+   */
   jsonCompatibleStrings?: boolean;
   /**
    * For use with the Hack-style pipe operator.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15480"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

