### PR TITLE
Skip node deprecation warnings when used by an old `@babel` package

### DIFF
--- a/packages/babel-traverse/test/helpers/@babel/fake-babel-package/index.js
+++ b/packages/babel-traverse/test/helpers/@babel/fake-babel-package/index.js
@@ -1,0 +1,3 @@
+export function callFromAtBabelPackage(fn, arg) {
+  return fn(arg);
+}

--- a/packages/babel-types/src/utils/deprecationWarning.ts
+++ b/packages/babel-types/src/utils/deprecationWarning.ts
@@ -8,9 +8,16 @@ export default function deprecationWarning(
   if (warnings.has(oldName)) return;
   warnings.add(oldName);
 
-  const stack = captureShortStackTrace(1, 2);
+  const { internal, trace } = captureShortStackTrace(1, 2);
+  if (internal) {
+    // If usage comes from an internal package, there is no point in warning because
+    // 1. The new version of the package will already use the new API
+    // 2. When the deprecation will become an error (in a future major version), users
+    //    will have to update every package anyway.
+    return;
+  }
   console.warn(
-    `${prefix}\`${oldName}\` has been deprecated, please migrate to \`${newName}\`\n${stack}`,
+    `${prefix}\`${oldName}\` has been deprecated, please migrate to \`${newName}\`\n${trace}`,
   );
 }
 
@@ -26,8 +33,11 @@ function captureShortStackTrace(skip: number, length: number) {
   Error.stackTraceLimit = stackTraceLimit;
   Error.prepareStackTrace = prepareStackTrace;
 
-  return stackTrace
-    .slice(1 + skip, 1 + skip + length)
-    .map(frame => `    at ${frame}`)
-    .join("\n");
+  if (!stackTrace) return { internal: false, trace: "" };
+
+  const shortStackTrace = stackTrace.slice(1 + skip, 1 + skip + length);
+  return {
+    internal: /[\\/]@babel[\\/]/.test(shortStackTrace[1].getFileName()),
+    trace: shortStackTrace.map(frame => `    at ${frame}`).join("\n"),
+  };
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I was reading https://github.com/GoogleChrome/workbox/issues/3182, and I realized that forcing our users to update to the latest version of the packages updated by https://github.com/babel/babel/pull/15236 is not "polite" (even if it's not a breaking change, because it's just a warning and not an error).

This PR disables the warning if the usage of the deprecated node comes from a `@babel/` package. This is safe to do, because when the warning will become an error (for example, in Babel 8), our users will have to update to the next major of the various packages anyway.

Note that we will see the warnings during development if one our our packages in the monorepo uses a deprecated node, because their folder names are `babel-*` and not `@babel/*`.

Follow up to #15448.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15484"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

