### PR TITLE
chore: Enable rule `no-confusing-void-expression`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -65,6 +65,10 @@ module.exports = {
           },
         ],
         "@typescript-eslint/no-unnecessary-type-assertion": "error",
+        "@typescript-eslint/no-confusing-void-expression": [
+          "error",
+          { ignoreArrowShorthand: true },
+        ],
       },
     },
     {

--- a/packages/babel-core/src/config/index.ts
+++ b/packages/babel-core/src/config/index.ts
@@ -54,7 +54,10 @@ const maybeErrback =
       callback = maybeCallback;
       arg = argOrCallback as Arg;
     }
-    return callback ? runner.errback(arg, callback) : runner.sync(arg);
+    if (!callback) {
+      return runner.sync(arg);
+    }
+    runner.errback(arg, callback);
   };
 
 export const loadPartialConfig = maybeErrback(loadPartialConfigRunner);
@@ -73,9 +76,9 @@ export function createConfigItem(
   callback?: (err: Error, val: ConfigItem | null) => void,
 ) {
   if (callback !== undefined) {
-    return createConfigItemRunner.errback(target, options, callback);
+    createConfigItemRunner.errback(target, options, callback);
   } else if (typeof options === "function") {
-    return createConfigItemRunner.errback(target, undefined, callback);
+    createConfigItemRunner.errback(target, undefined, callback);
   } else {
     return createConfigItemRunner.sync(target, options);
   }

--- a/packages/babel-core/src/transform-file.ts
+++ b/packages/babel-core/src/transform-file.ts
@@ -40,7 +40,7 @@ export function transformFile(
 export function transformFile(
   ...args: Parameters<typeof transformFileRunner.errback>
 ) {
-  return transformFileRunner.errback(...args);
+  transformFileRunner.errback(...args);
 }
 
 export function transformFileSync(

--- a/packages/babel-core/src/transformation/index.ts
+++ b/packages/babel-core/src/transformation/index.ts
@@ -94,6 +94,7 @@ function* transformFile(file: File, pluginPasses: PluginPasses): Handler<void> {
     for (const [plugin, pass] of passPairs) {
       const fn = plugin.pre;
       if (fn) {
+        // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
         const result = fn.call(pass, file);
 
         // @ts-expect-error - If we want to support async .pre
@@ -121,6 +122,7 @@ function* transformFile(file: File, pluginPasses: PluginPasses): Handler<void> {
     for (const [plugin, pass] of passPairs) {
       const fn = plugin.post;
       if (fn) {
+        // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
         const result = fn.call(pass, file);
 
         // @ts-expect-error - If we want to support async .post

--- a/packages/babel-core/src/transformation/plugin-pass.ts
+++ b/packages/babel-core/src/transformation/plugin-pass.ts
@@ -38,8 +38,9 @@ export default class PluginPass {
     return this.file.addHelper(name);
   }
 
+  // TODO: Remove this in Babel 8
   addImport() {
-    return this.file.addImport();
+    this.file.addImport();
   }
 
   buildCodeFrameError(

--- a/packages/babel-generator/src/buffer.ts
+++ b/packages/babel-generator/src/buffer.ts
@@ -410,7 +410,10 @@ export default class Buffer {
    * over "();", where previously it would have been a single mapping.
    */
   exactSource(loc: Loc | undefined, cb: () => void) {
-    if (!this._map) return cb();
+    if (!this._map) {
+      cb();
+      return;
+    }
 
     this.source("start", loc);
     // @ts-expect-error identifierName is not defined
@@ -459,9 +462,9 @@ export default class Buffer {
    */
 
   withSource(prop: "start" | "end", loc: Loc, cb: () => void): void {
-    if (!this._map) return cb();
-
-    this.source(prop, loc);
+    if (this._map) {
+      this.source(prop, loc);
+    }
 
     cb();
   }

--- a/packages/babel-generator/src/generators/types.ts
+++ b/packages/babel-generator/src/generators/types.ts
@@ -219,7 +219,7 @@ export function StringLiteral(this: Printer, node: t.StringLiteral) {
         ),
   );
 
-  return this.token(val);
+  this.token(val);
 }
 
 export function BigIntLiteral(this: Printer, node: t.BigIntLiteral) {

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -328,7 +328,10 @@ class Printer {
   }
 
   exactSource(loc: Loc | undefined, cb: () => void) {
-    if (!loc) return cb();
+    if (!loc) {
+      cb();
+      return;
+    }
 
     this._catchUp("start", loc);
 
@@ -361,7 +364,10 @@ class Printer {
     loc: Loc | undefined,
     cb: () => void,
   ): void {
-    if (!loc) return cb();
+    if (!loc) {
+      cb();
+      return;
+    }
 
     this._catchUp(prop, loc);
 
@@ -871,7 +877,7 @@ class Printer {
     opts: PrintSequenceOptions = {},
   ) {
     opts.statement = true;
-    return this.printJoin(nodes, parent, opts);
+    this.printJoin(nodes, parent, opts);
   }
 
   printList(items: t.Node[], parent: t.Node, opts: PrintListOptions = {}) {
@@ -879,7 +885,7 @@ class Printer {
       opts.separator = commaSeparator;
     }
 
-    return this.printJoin(items, parent, opts);
+    this.printJoin(items, parent, opts);
   }
 
   _printNewline(newLine: boolean, opts: AddNewlinesOptions) {

--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -1265,9 +1265,9 @@ export default abstract class ExpressionParser extends LValParser {
 
         if (pipeProposal) {
           return this.parseTopicReference(pipeProposal);
-        } else {
-          throw this.unexpected();
         }
+        this.unexpected();
+        break;
       }
 
       case tt.lt: {
@@ -1277,10 +1277,10 @@ export default abstract class ExpressionParser extends LValParser {
           lookaheadCh === charCodes.greaterThan // Fragment <>
         ) {
           this.expectOnePlugin(["jsx", "flow", "typescript"]);
-          break;
         } else {
-          throw this.unexpected();
+          this.unexpected();
         }
+        break;
       }
 
       default:
@@ -1345,7 +1345,7 @@ export default abstract class ExpressionParser extends LValParser {
 
           return id;
         } else {
-          throw this.unexpected();
+          this.unexpected();
         }
     }
   }
@@ -1383,7 +1383,7 @@ export default abstract class ExpressionParser extends LValParser {
       // Now actually consume the topic token.
       return this.parseTopicReference(pipeProposal);
     } else {
-      throw this.unexpected();
+      this.unexpected();
     }
   }
 
@@ -2387,7 +2387,7 @@ export default abstract class ExpressionParser extends LValParser {
             break;
           }
           default:
-            throw this.unexpected();
+            this.unexpected();
         }
       }
       (prop as any).key = key;
@@ -2751,7 +2751,7 @@ export default abstract class ExpressionParser extends LValParser {
     if (tokenIsKeywordOrIdentifier(type)) {
       name = this.state.value;
     } else {
-      throw this.unexpected();
+      this.unexpected();
     }
 
     const tokenIsKeyword = tokenKeywordOrIdentifierIsKeyword(type);

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -2343,11 +2343,11 @@ export default abstract class StatementParser extends ExpressionParser {
     );
 
     if (hasDefault && parseAfterDefault && !hasStar && !hasSpecifiers) {
-      throw this.unexpected(null, tt.braceL);
+      this.unexpected(null, tt.braceL);
     }
 
     if (hasNamespace && parseAfterNamespace) {
-      throw this.unexpected(null, tt._from);
+      this.unexpected(null, tt._from);
     }
 
     let hasDeclaration;
@@ -2394,7 +2394,7 @@ export default abstract class StatementParser extends ExpressionParser {
       return this.finishNode(node2, "ExportDefaultDeclaration");
     }
 
-    throw this.unexpected(null, tt.braceL);
+    this.unexpected(null, tt.braceL);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/babel-parser/src/parser/util.ts
+++ b/packages/babel-parser/src/parser/util.ts
@@ -101,7 +101,7 @@ export default abstract class UtilParser extends Tokenizer {
       if (toParseError != null) {
         throw this.raise(toParseError, { at: this.state.startLoc });
       }
-      throw this.unexpected(null, token);
+      this.unexpected(null, token);
     }
   }
 

--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -338,7 +338,7 @@ export default (superClass: typeof Parser) =>
           this.flowPragma = null;
         }
       }
-      return super.finishToken(type, val);
+      super.finishToken(type, val);
     }
 
     addComment(comment: N.Comment): void {
@@ -355,7 +355,7 @@ export default (superClass: typeof Parser) =>
           throw new Error("Unexpected flow pragma");
         }
       }
-      return super.addComment(comment);
+      super.addComment(comment);
     }
 
     flowParseTypeInitialiser(tok?: TokenType): N.FlowType {
@@ -493,7 +493,7 @@ export default (superClass: typeof Parser) =>
       } else if (this.match(tt._export)) {
         return this.flowParseDeclareExportDeclaration(node, insideModule);
       } else {
-        throw this.unexpected();
+        this.unexpected();
       }
     }
 
@@ -654,7 +654,7 @@ export default (superClass: typeof Parser) =>
         }
       }
 
-      throw this.unexpected();
+      this.unexpected();
     }
 
     flowParseDeclareModuleExports(
@@ -1685,8 +1685,8 @@ export default (superClass: typeof Parser) =>
               at: this.state.startLoc,
             });
           }
-
-          throw this.unexpected();
+          this.unexpected();
+          return;
         case tt.num:
           return this.parseLiteral(
             this.state.value,
@@ -1736,7 +1736,7 @@ export default (superClass: typeof Parser) =>
           }
       }
 
-      throw this.unexpected();
+      this.unexpected();
     }
 
     flowParsePostfixType(): N.FlowTypeAnnotation {
@@ -1900,12 +1900,13 @@ export default (superClass: typeof Parser) =>
       isMethod: boolean = false,
     ): void {
       if (allowExpressionBody) {
-        return this.forwardNoArrowParamsConversionAt(node, () =>
+        this.forwardNoArrowParamsConversionAt(node, () =>
           super.parseFunctionBody(node, true, isMethod),
         );
+        return;
       }
 
-      return super.parseFunctionBody(node, false, isMethod);
+      super.parseFunctionBody(node, false, isMethod);
     }
 
     parseFunctionBodyAndFinish<
@@ -2379,25 +2380,26 @@ export default (superClass: typeof Parser) =>
     getTokenFromCode(code: number): void {
       const next = this.input.charCodeAt(this.state.pos + 1);
       if (code === charCodes.leftCurlyBrace && next === charCodes.verticalBar) {
-        return this.finishOp(tt.braceBarL, 2);
+        this.finishOp(tt.braceBarL, 2);
       } else if (
         this.state.inType &&
         (code === charCodes.greaterThan || code === charCodes.lessThan)
       ) {
-        return this.finishOp(code === charCodes.greaterThan ? tt.gt : tt.lt, 1);
+        this.finishOp(code === charCodes.greaterThan ? tt.gt : tt.lt, 1);
       } else if (this.state.inType && code === charCodes.questionMark) {
         if (next === charCodes.dot) {
-          return this.finishOp(tt.questionDot, 2);
+          this.finishOp(tt.questionDot, 2);
+        } else {
+          // allow double nullable types in Flow: ??string
+          this.finishOp(tt.question, 1);
         }
-        // allow double nullable types in Flow: ??string
-        return this.finishOp(tt.question, 1);
       } else if (
         isIteratorStart(code, next, this.input.charCodeAt(this.state.pos + 2))
       ) {
         this.state.pos += 2; // eat "@@"
-        return this.readIterator();
+        this.readIterator();
       } else {
-        return super.getTokenFromCode(code);
+        super.getTokenFromCode(code);
       }
     }
 
@@ -3149,7 +3151,7 @@ export default (superClass: typeof Parser) =>
         }
       }
 
-      return super.checkParams(
+      super.checkParams(
         node,
         allowDuplicates,
         isArrowFunction,

--- a/packages/babel-parser/src/plugins/jsx/index.ts
+++ b/packages/babel-parser/src/plugins/jsx/index.ts
@@ -106,12 +106,15 @@ export default (superClass: typeof Parser) =>
             if (this.state.pos === this.state.start) {
               if (ch === charCodes.lessThan && this.state.canStartJSXElement) {
                 ++this.state.pos;
-                return this.finishToken(tt.jsxTagStart);
+                this.finishToken(tt.jsxTagStart);
+              } else {
+                super.getTokenFromCode(ch);
               }
-              return super.getTokenFromCode(ch);
+              return;
             }
             out += this.input.slice(chunkStart, this.state.pos);
-            return this.finishToken(tt.jsxText, out);
+            this.finishToken(tt.jsxText, out);
+            return;
 
           case charCodes.ampersand:
             out += this.input.slice(chunkStart, this.state.pos);
@@ -187,7 +190,7 @@ export default (superClass: typeof Parser) =>
         }
       }
       out += this.input.slice(chunkStart, this.state.pos++);
-      return this.finishToken(tt.string, out);
+      this.finishToken(tt.string, out);
     }
 
     jsxReadEntity(): string {
@@ -254,10 +257,7 @@ export default (superClass: typeof Parser) =>
       do {
         ch = this.input.charCodeAt(++this.state.pos);
       } while (isIdentifierChar(ch) || ch === charCodes.dash);
-      return this.finishToken(
-        tt.jsxName,
-        this.input.slice(start, this.state.pos),
-      );
+      this.finishToken(tt.jsxName, this.input.slice(start, this.state.pos));
     }
 
     // Parse next token as JSX identifier
@@ -491,7 +491,7 @@ export default (superClass: typeof Parser) =>
             }
             // istanbul ignore next - should never happen
             default:
-              throw this.unexpected();
+              this.unexpected();
           }
         }
 
@@ -584,24 +584,28 @@ export default (superClass: typeof Parser) =>
       const context = this.curContext();
 
       if (context === tc.j_expr) {
-        return this.jsxReadToken();
+        this.jsxReadToken();
+        return;
       }
 
       if (context === tc.j_oTag || context === tc.j_cTag) {
         if (isIdentifierStart(code)) {
-          return this.jsxReadWord();
+          this.jsxReadWord();
+          return;
         }
 
         if (code === charCodes.greaterThan) {
           ++this.state.pos;
-          return this.finishToken(tt.jsxTagEnd);
+          this.finishToken(tt.jsxTagEnd);
+          return;
         }
 
         if (
           (code === charCodes.quotationMark || code === charCodes.apostrophe) &&
           context === tc.j_oTag
         ) {
-          return this.jsxReadString(code);
+          this.jsxReadString(code);
+          return;
         }
       }
 
@@ -611,10 +615,11 @@ export default (superClass: typeof Parser) =>
         this.input.charCodeAt(this.state.pos + 1) !== charCodes.exclamationMark
       ) {
         ++this.state.pos;
-        return this.finishToken(tt.jsxTagStart);
+        this.finishToken(tt.jsxTagStart);
+        return;
       }
 
-      return super.getTokenFromCode(code);
+      super.getTokenFromCode(code);
     }
 
     updateContext(prevType: TokenType): void {

--- a/packages/babel-parser/src/plugins/placeholders.ts
+++ b/packages/babel-parser/src/plugins/placeholders.ts
@@ -78,10 +78,10 @@ export default (superClass: typeof Parser) =>
         code === charCodes.percentSign &&
         this.input.charCodeAt(this.state.pos + 1) === charCodes.percentSign
       ) {
-        return this.finishOp(tt.placeholder, 2);
+        this.finishOp(tt.placeholder, 2);
+      } else {
+        super.getTokenFromCode(code);
       }
-
-      return super.getTokenFromCode(code);
     }
 
     /* ============================================================ *

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -1182,7 +1182,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
             // For compatibility to estree we cannot call parseLiteral directly here
             return super.parseExprAtom();
           default:
-            throw this.unexpected();
+            this.unexpected();
         }
       })();
       return this.finishNode(node, "TSLiteralType");
@@ -1221,7 +1221,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
             const node = this.startNode<N.TsLiteralType>();
             const nextToken = this.lookahead();
             if (nextToken.type !== tt.num && nextToken.type !== tt.bigint) {
-              throw this.unexpected();
+              this.unexpected();
             }
             // @ts-expect-error: parseMaybeUnary must returns unary expression
             node.literal = this.parseMaybeUnary();
@@ -1283,7 +1283,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         }
       }
 
-      throw this.unexpected();
+      this.unexpected();
     }
 
     tsParseArrayTypeOrHigher(): N.TsType {
@@ -1968,7 +1968,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       this.expectContextual(tt._require);
       this.expect(tt.parenL);
       if (!this.match(tt.string)) {
-        throw this.unexpected();
+        this.unexpected();
       }
       // For compatibility to estree we cannot call parseLiteral directly here
       node.expression = super.parseExprAtom() as N.StringLiteral;
@@ -3751,13 +3751,15 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     getTokenFromCode(code: number): void {
       if (this.state.inType) {
         if (code === charCodes.greaterThan) {
-          return this.finishOp(tt.gt, 1);
+          this.finishOp(tt.gt, 1);
+          return;
         }
         if (code === charCodes.lessThan) {
-          return this.finishOp(tt.lt, 1);
+          this.finishOp(tt.lt, 1);
+          return;
         }
       }
-      return super.getTokenFromCode(code);
+      super.getTokenFromCode(code);
     }
 
     // used after we have finished parsing types

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -231,9 +231,7 @@ export default abstract class Tokenizer extends CommentsParser {
     return this.state.context[this.state.context.length - 1];
   }
 
-  // Read a single token, updating the parser object's token-related
-  // properties.
-
+  // Read a single token, updating the parser object's token-related properties.
   nextToken(): void {
     this.skipSpace();
     this.state.start = this.state.pos;
@@ -679,7 +677,7 @@ export default abstract class Tokenizer extends CommentsParser {
       // `^^^` is forbidden and must be separated by a space.
       const lookaheadCh = this.input.codePointAt(this.state.pos);
       if (lookaheadCh === charCodes.caret) {
-        throw this.unexpected();
+        this.unexpected();
       }
     }
     // '^'
@@ -825,7 +823,6 @@ export default abstract class Tokenizer extends CommentsParser {
       case charCodes.dot:
         this.readToken_dot();
         return;
-
       // Punctuation tokens.
       case charCodes.leftParenthesis:
         ++this.state.pos;

--- a/packages/babel-plugin-transform-destructuring/src/util.ts
+++ b/packages/babel-plugin-transform-destructuring/src/util.ts
@@ -439,7 +439,8 @@ export class DestructuringTransformer {
     // eg: let [a, b] = [1, 2];
 
     if (this.canUnpackArrayPattern(pattern, arrayRef)) {
-      return this.pushUnpackedArrayPattern(pattern, arrayRef);
+      this.pushUnpackedArrayPattern(pattern, arrayRef);
+      return;
     }
 
     // if we have a rest then we need all the elements so don't tell

--- a/packages/babel-plugin-transform-react-constant-elements/src/index.ts
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.ts
@@ -92,14 +92,18 @@ export default declare((api, options: Options) => {
         path.skip();
       };
 
-      if (path.isJSXClosingElement()) return skip();
+      if (path.isJSXClosingElement()) {
+        skip();
+        return;
+      }
 
       // Elements with refs are not safe to hoist.
       if (
         path.isJSXIdentifier({ name: "ref" }) &&
         path.parentPath.isJSXAttribute({ name: path.node })
       ) {
-        return stop();
+        stop();
+        return;
       }
 
       // Ignore JSX expressions and immutable values.
@@ -123,10 +127,14 @@ export default declare((api, options: Options) => {
       const { mutablePropsAllowed } = state;
       if (mutablePropsAllowed && path.isFunction()) {
         path.traverse(targetScopeVisitor, state);
-        return skip();
+        skip();
+        return;
       }
 
-      if (!path.isPure()) return stop();
+      if (!path.isPure()) {
+        stop();
+        return;
+      }
 
       // If it's not immutable, it may still be a pure expression, such as string concatenation.
       // It is still safe to hoist that, so long as its result is immutable.
@@ -142,7 +150,8 @@ export default declare((api, options: Options) => {
           (typeof value !== "object" && typeof value !== "function")
         ) {
           // It evaluated to an immutable value, so we can hoist it.
-          return skip();
+          skip();
+          return;
         }
       } else if (t.isIdentifier(expressionResult.deopt)) {
         // It's safe to hoist here if the deopt reason is an identifier (e.g. func param).

--- a/packages/babel-plugin-transform-typescript/src/namespace.ts
+++ b/packages/babel-plugin-transform-typescript/src/namespace.ts
@@ -108,7 +108,7 @@ function handleVariableDeclaration(
 }
 
 function buildNestedAmbientModuleError(path: NodePath, node: t.Node) {
-  throw path.hub.buildError(
+  return path.hub.buildError(
     node,
     "Ambient modules cannot be nested in other modules or namespaces.",
     Error,

--- a/packages/babel-standalone/src/transformScriptTags.ts
+++ b/packages/babel-standalone/src/transformScriptTags.ts
@@ -125,7 +125,7 @@ function load(
       }
     }
   };
-  return xhr.send(null);
+  xhr.send(null);
 }
 
 /**

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -78,7 +78,8 @@ traverse.verify = visitors.verify;
 traverse.explode = visitors.explode;
 
 traverse.cheap = function (node: t.Node, enter: (node: t.Node) => void) {
-  return traverseFast(node, enter);
+  traverseFast(node, enter);
+  return;
 };
 
 traverse.node = function (

--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -214,14 +214,16 @@ export function _resyncKey(this: NodePath) {
   if (Array.isArray(this.container)) {
     for (let i = 0; i < this.container.length; i++) {
       if (this.container[i] === this.node) {
-        return this.setKey(i);
+        this.setKey(i);
+        return;
       }
     }
   } else {
     for (const key of Object.keys(this.container)) {
       // @ts-expect-error this.key should present in this.container
       if (this.container[key] === this.node) {
-        return this.setKey(key);
+        this.setKey(key);
+        return;
       }
     }
   }

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -632,7 +632,7 @@ export default class Scope {
       if (process.env.BABEL_8_BREAKING) {
         renamer.rename();
       } else {
-        // @ts-expect-error: babel 7->8
+        // @ts-ignore(Babel 7 vs Babel 8)
         renamer.rename(arguments[2]);
       }
     }

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -629,7 +629,7 @@ export default class Scope {
     if (binding) {
       newName ||= this.generateUidIdentifier(oldName).name;
       const renamer = new Renamer(binding, oldName, newName);
-      return process.env.BABEL_8_BREAKING
+      process.env.BABEL_8_BREAKING
         ? renamer.rename()
         : // @ts-expect-error: babel 7->8
           renamer.rename(arguments[2]);

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -632,7 +632,7 @@ export default class Scope {
       if (process.env.BABEL_8_BREAKING) {
         renamer.rename();
       } else {
-        // @ts-ignore(Babel 7 vs Babel 8)
+        // @ts-ignore(Babel 7 vs Babel 8) TODO: Delete this
         renamer.rename(arguments[2]);
       }
     }

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -629,10 +629,12 @@ export default class Scope {
     if (binding) {
       newName ||= this.generateUidIdentifier(oldName).name;
       const renamer = new Renamer(binding, oldName, newName);
-      process.env.BABEL_8_BREAKING
-        ? renamer.rename()
-        : // @ts-expect-error: babel 7->8
-          renamer.rename(arguments[2]);
+      if (process.env.BABEL_8_BREAKING) {
+        renamer.rename();
+      } else {
+        // @ts-expect-error: babel 7->8
+        renamer.rename(arguments[2]);
+      }
     }
   }
 

--- a/packages/babel-types/src/definitions/utils.ts
+++ b/packages/babel-types/src/definitions/utils.ts
@@ -292,7 +292,7 @@ export function defineAliasedType(...aliases: string[]) {
     }
     const additional = aliases.filter(a => !defined.includes(a));
     defined.unshift(...additional);
-    return defineType(type, opts);
+    defineType(type, opts);
   };
 }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Initially I wanted to wait for https://github.com/typescript-eslint/typescript-eslint/issues/6187 and https://github.com/typescript-eslint/typescript-eslint/issues/6150 to be fixed, but today I was bothered again while reading the `parser` code, so I manually modified them.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15485"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

