### PR TITLE
Fix compact printing of non-null assertion operators

### DIFF
--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -244,20 +244,20 @@ class Printer {
   token(str: string, maybeNewline = false): void {
     this._maybePrintInnerComments();
 
-    // space is mandatory to avoid outputting <!--
-    // http://javascript.spec.whatwg.org/#comment-syntax
     const lastChar = this.getLastChar();
     const strFirst = str.charCodeAt(0);
     if (
-      (lastChar === charCodes.exclamationMark && str === "--") ||
+      (lastChar === charCodes.exclamationMark &&
+        // space is mandatory to avoid outputting <!--
+        // http://javascript.spec.whatwg.org/#comment-syntax
+        (str === "--" ||
+          // Needs spaces to avoid changing a! == 0 to a!== 0
+          strFirst === charCodes.equalsTo)) ||
       // Need spaces for operators of the same kind to avoid: `a+++b`
       (strFirst === charCodes.plusSign && lastChar === charCodes.plusSign) ||
       (strFirst === charCodes.dash && lastChar === charCodes.dash) ||
       // Needs spaces to avoid changing '34' to '34.', which would still be a valid number.
-      (strFirst === charCodes.dot && this._endsWithInteger) ||
-      // Needs spaces to avoid changing a! == 0 to a!== 0
-      (strFirst === charCodes.equalsTo &&
-        lastChar === charCodes.exclamationMark)
+      (strFirst === charCodes.dot && this._endsWithInteger)
     ) {
       this._space();
     }

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -254,7 +254,10 @@ class Printer {
       (strFirst === charCodes.plusSign && lastChar === charCodes.plusSign) ||
       (strFirst === charCodes.dash && lastChar === charCodes.dash) ||
       // Needs spaces to avoid changing '34' to '34.', which would still be a valid number.
-      (strFirst === charCodes.dot && this._endsWithInteger)
+      (strFirst === charCodes.dot && this._endsWithInteger) ||
+      // Needs spaces to avoid changing a! == 0 to a!== 0
+      (strFirst === charCodes.equalsTo &&
+        lastChar === charCodes.exclamationMark)
     ) {
       this._space();
     }

--- a/packages/babel-generator/test/fixtures/typescript/types-non-null-assertion-compact/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-non-null-assertion-compact/input.js
@@ -1,4 +1,5 @@
-let foo = 1;
+let foo;
+foo! = 1;
 if (foo! === 0) {
   console.log();
 }

--- a/packages/babel-generator/test/fixtures/typescript/types-non-null-assertion-compact/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-non-null-assertion-compact/input.js
@@ -1,0 +1,4 @@
+let foo = 1;
+if (foo! === 0) {
+  console.log();
+}

--- a/packages/babel-generator/test/fixtures/typescript/types-non-null-assertion-compact/options.json
+++ b/packages/babel-generator/test/fixtures/typescript/types-non-null-assertion-compact/options.json
@@ -1,0 +1,5 @@
+{
+  "compact": true,
+  "sourceType": "module",
+  "plugins": ["typescript"]
+}

--- a/packages/babel-generator/test/fixtures/typescript/types-non-null-assertion-compact/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-non-null-assertion-compact/output.js
@@ -1,1 +1,1 @@
-let foo=1;if(foo! ===0){console.log();}
+let foo;foo! =1;if(foo! ===0){console.log();}

--- a/packages/babel-generator/test/fixtures/typescript/types-non-null-assertion-compact/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-non-null-assertion-compact/output.js
@@ -1,0 +1,1 @@
+let foo=1;if(foo! ===0){console.log();}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

Adds a failing test for TypeScript non-null assertion operators with `compact: true` output

https://www.typescriptlang.org/play?#code/DYUwLgBAZg9jEF4IEYDcAoAllCAKWMAhIgkgAwCUEA3uhBAMYwB2AzjKAHTAwDmuFDAF90QA



<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15496"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

