### PR TITLE
Revert "pin ci latest node version to 19.7 (#15495)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       - name: 'Check or update Yarn cache (fix w/ "yarn install")'
@@ -39,7 +39,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       - name: 'Check for unmet constraints (fix w/ "yarn constraints --fix")'
@@ -62,7 +62,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       - name: Generate coverage report
@@ -82,7 +82,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       - name: Use ESM and build
@@ -110,7 +110,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       - name: Build babel artifacts
@@ -146,7 +146,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       - name: Build babel artifacts
@@ -170,7 +170,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       - name: Install
@@ -200,7 +200,7 @@ jobs:
       - name: Use Node.js latest # Run yarn on latest node
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       - name: Install
@@ -243,7 +243,7 @@ jobs:
         if: matrix.node-version == '6' || matrix.node-version == '8' || matrix.node-version == '10'
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
 
   build-babel8:
     name: Build Babel 8 Artifacts for tests
@@ -327,7 +327,7 @@ jobs:
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       - name: Install
@@ -354,7 +354,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       - name: Install
@@ -383,7 +383,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       # See https://github.com/babel/babel/pull/12906
@@ -489,7 +489,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
           cache: "yarn"
       - name: Install
@@ -514,7 +514,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
       - name: Checkout test runner
         uses: actions/checkout@v3
@@ -551,7 +551,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@v3
         with:
-          node-version: "19.7"
+          node-version: latest
           check-latest: true
       - name: Install
         run: yarn install


### PR DESCRIPTION
This reverts commit d38f415c9f7704a201cbfb1d73e6884738931bb2.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The upstream issue has been fixed in 19.8.1, I will mark as ready when CI is green.