### PR TITLE
Polish babel-code-frame highlight test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,7 @@ jobs:
         env:
           USE_ESM: true
       - name: Test
-        # Hack: --color has supports-color@5 returned true for GitHub CI
-        # Remove once `chalk` is bumped to 4.0.
-        run: yarn jest --ci --color
+        run: yarn jest --ci
         env:
           BABEL_ENV: test
           USE_ESM: true
@@ -231,12 +229,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Test on node.js ${{ matrix.node-version }}
-        # Hack: --color has supports-color@5 returned true for GitHub CI
-        # Remove once `chalk` is bumped to 4.0.
-
         # Todo(Babel 8): Jest execution path is hardcoded because Yarn 2 does not support node 6
         run: |
-          BABEL_ENV=test node --max-old-space-size=4096 ./node_modules/.bin/jest --ci --color
+          BABEL_ENV=test node --max-old-space-size=4096 ./node_modules/.bin/jest --ci
         env:
           TEST_FUZZ: "${{ (matrix.node-version == '6' || matrix.node-version == '8' || matrix.node-version == '10') && 'false' || 'true' }}"
       - name: Use Node.js latest # For `yarn version` in post actions of the first actions/setup-node
@@ -307,10 +302,8 @@ jobs:
       - name: Generate runtime helpers
         run: make build-plugin-transform-runtime-dist
       - name: Test
-        # Hack: --color has supports-color@5 returned true for GitHub CI
-        # Remove once `chalk` is bumped to 4.0.
         run: |
-          yarn jest --ci --color
+          yarn jest --ci
           yarn test:esm
         env:
           BABEL_ENV: test
@@ -338,9 +331,7 @@ jobs:
       - name: Extract artifacts
         run: tar -xf babel-artifact.tar; rm babel-artifact.tar
       - name: Test on Windows
-        # Hack: --color has supports-color@5 returned true for GitHub CI
-        # Remove once `chalk` is bumped to 4.0.
-        run: yarn jest --ci --color
+        run: yarn jest --ci
         env:
           BABEL_ENV: test
 

--- a/.github/workflows/update-windows-fixtures.yml
+++ b/.github/workflows/update-windows-fixtures.yml
@@ -60,10 +60,8 @@ jobs:
           git reset --hard HEAD
 
       - name: Regenerate fixtures
-        # Hack: --color has supports-color@5 returned true for GitHub CI
-        # Remove once `chalk` is bumped to 4.0.
         run: |
-          yarn jest -u --ci --color || true
+          yarn jest -u --ci || true
         env:
           BABEL_ENV: test
           OVERWRITE: true

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -19,8 +19,6 @@
     "@babel/highlight": "workspace:^"
   },
   "devDependencies": {
-    "@types/chalk": "^2.0.0",
-    "chalk": "^2.0.0",
     "strip-ansi": "^4.0.0"
   },
   "engines": {

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -1,10 +1,29 @@
-import chalk from "chalk";
 import stripAnsi from "strip-ansi";
-
+import { createRequire } from "module";
 import _codeFrame, { codeFrameColumns } from "../lib/index.js";
 const codeFrame = _codeFrame.default || _codeFrame;
 
+const require = createRequire(import.meta.url);
+const babelHighlightPath = require.resolve("@babel/highlight");
+const chalkPath = require.resolve("chalk", { paths: [babelHighlightPath] });
+const chalk = require(chalkPath);
+
 describe("@babel/code-frame", function () {
+  function stubColorSupport(supported) {
+    let originalChalkLevel;
+    let originalChalkSupportsColor;
+    beforeEach(function () {
+      originalChalkSupportsColor = chalk.supportsColor;
+      originalChalkLevel = chalk.level;
+      chalk.supportsColor = supported;
+      chalk.level = supported ? 1 : 0;
+    });
+
+    afterEach(function () {
+      chalk.supportsColor = originalChalkSupportsColor;
+      chalk.level = originalChalkLevel;
+    });
+  }
   test("basic usage", function () {
     const rawLines = ["class Foo {", "  constructor()", "};"].join("\n");
     expect(codeFrame(rawLines, 2, 16)).toEqual(
@@ -94,53 +113,109 @@ describe("@babel/code-frame", function () {
     );
   });
 
-  test("opts.highlightCode", function () {
-    const rawLines = "console.log('babel')";
-    const result = codeFrame(rawLines, 1, 9, { highlightCode: true });
-    const stripped = stripAnsi(result);
-    expect(result.length).toBeGreaterThan(stripped.length);
-    expect(stripped).toEqual(
-      ["> 1 | console.log('babel')", "    |         ^"].join("\n"),
-    );
-  });
+  describe("when colors are supported", () => {
+    stubColorSupport(true);
 
-  test("opts.highlightCode with multiple columns and lines", function () {
-    // prettier-ignore
-    const rawLines = [
-      "function a(b, c) {",
-      "  return b + c;",
-      "}"
-    ].join("\n");
+    test("opts.highlightCode", function () {
+      const rawLines = "console.log('babel')";
+      const result = codeFrame(rawLines, 1, 9, { highlightCode: true });
+      const stripped = stripAnsi(result);
+      expect(result.length).toBeGreaterThan(stripped.length);
+      expect(stripped).toEqual(
+        ["> 1 | console.log('babel')", "    |         ^"].join("\n"),
+      );
+    });
 
-    const result = codeFrameColumns(
-      rawLines,
-      {
-        start: {
-          line: 1,
-          column: 1,
-        },
-        end: {
-          line: 3,
-          column: 1,
-        },
-      },
-      {
-        highlightCode: true,
-        message: "Message about things",
-      },
-    );
-    const stripped = stripAnsi(result);
-    expect(stripped).toEqual(
+    test("opts.highlightCode with multiple columns and lines", function () {
       // prettier-ignore
-      [
-        "> 1 | function a(b, c) {",
-        "    | ^^^^^^^^^^^^^^^^^^",
-        "> 2 |   return b + c;",
-        "    | ^^^^^^^^^^^^^^^",
-        "> 3 | }",
-        "    | ^ Message about things",
-      ].join('\n'),
-    );
+      const rawLines = [
+        "function a(b, c) {",
+        "  return b + c;",
+        "}"
+      ].join("\n");
+
+      const result = codeFrameColumns(
+        rawLines,
+        {
+          start: {
+            line: 1,
+            column: 1,
+          },
+          end: {
+            line: 3,
+            column: 1,
+          },
+        },
+        {
+          highlightCode: true,
+          message: "Message about things",
+        },
+      );
+      const stripped = stripAnsi(result);
+      expect(result.length).toBeGreaterThan(stripped.length);
+      expect(stripped).toEqual(
+        // prettier-ignore
+        [
+          "> 1 | function a(b, c) {",
+          "    | ^^^^^^^^^^^^^^^^^^",
+          "> 2 |   return b + c;",
+          "    | ^^^^^^^^^^^^^^^",
+          "> 3 | }",
+          "    | ^ Message about things",
+        ].join('\n'),
+      );
+    });
+    test("opts.forceColor", function () {
+      const marker = chalk.red.bold;
+      const gutter = chalk.grey;
+
+      const rawLines = ["", "", "", ""].join("\n");
+      expect(
+        codeFrame(rawLines, 3, null, {
+          linesAbove: 1,
+          linesBelow: 1,
+          forceColor: true,
+        }),
+      ).toEqual(
+        chalk.reset(
+          [
+            " " + gutter(" 2 |"),
+            marker(">") + gutter(" 3 |"),
+            " " + gutter(" 4 |"),
+          ].join("\n"),
+        ),
+      );
+    });
+
+    test("jsx", function () {
+      const gutter = chalk.grey;
+      const yellow = chalk.yellow;
+
+      const rawLines = ["<div />"].join("\n");
+
+      expect(
+        JSON.stringify(
+          codeFrame(rawLines, 0, null, {
+            linesAbove: 1,
+            linesBelow: 1,
+            forceColor: true,
+          }),
+        ),
+      ).toEqual(
+        JSON.stringify(
+          chalk.reset(
+            " " +
+              gutter(" 1 |") +
+              " " +
+              yellow("<") +
+              yellow("div") +
+              " " +
+              yellow("/") +
+              yellow(">"),
+          ),
+        ),
+      );
+    });
   });
 
   test("opts.linesAbove", function () {
@@ -261,58 +336,6 @@ describe("@babel/code-frame", function () {
         { linesAbove: 0, linesBelow: 0 },
       ),
     ).toEqual(["> 2 |   constructor() {"].join("\n"));
-  });
-
-  test("opts.forceColor", function () {
-    const marker = chalk.red.bold;
-    const gutter = chalk.grey;
-
-    const rawLines = ["", "", "", ""].join("\n");
-    expect(
-      codeFrame(rawLines, 3, null, {
-        linesAbove: 1,
-        linesBelow: 1,
-        forceColor: true,
-      }),
-    ).toEqual(
-      chalk.reset(
-        [
-          " " + gutter(" 2 |"),
-          marker(">") + gutter(" 3 |"),
-          " " + gutter(" 4 |"),
-        ].join("\n"),
-      ),
-    );
-  });
-
-  test("jsx", function () {
-    const gutter = chalk.grey;
-    const yellow = chalk.yellow;
-
-    const rawLines = ["<div />"].join("\n");
-
-    expect(
-      JSON.stringify(
-        codeFrame(rawLines, 0, null, {
-          linesAbove: 1,
-          linesBelow: 1,
-          forceColor: true,
-        }),
-      ),
-    ).toEqual(
-      JSON.stringify(
-        chalk.reset(
-          " " +
-            gutter(" 1 |") +
-            " " +
-            yellow("<") +
-            yellow("div") +
-            " " +
-            yellow("/") +
-            yellow(">"),
-        ),
-      ),
-    );
   });
 
   test("basic usage, new API", function () {

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -15,7 +15,7 @@ describe("@babel/code-frame", function () {
     beforeEach(function () {
       originalChalkSupportsColor = chalk.supportsColor;
       originalChalkLevel = chalk.level;
-      chalk.supportsColor = supported;
+      chalk.supportsColor = supported ? { level: 1 } : false;
       chalk.level = supported ? 1 : 0;
     });
 

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -12,16 +12,20 @@ describe("@babel/code-frame", function () {
   function stubColorSupport(supported) {
     let originalChalkLevel;
     let originalChalkSupportsColor;
+    let originalChalkEnabled;
     beforeEach(function () {
       originalChalkSupportsColor = chalk.supportsColor;
       originalChalkLevel = chalk.level;
+      originalChalkEnabled = chalk.enabled;
       chalk.supportsColor = supported ? { level: 1 } : false;
       chalk.level = supported ? 1 : 0;
+      chalk.enabled = supported;
     });
 
     afterEach(function () {
       chalk.supportsColor = originalChalkSupportsColor;
       chalk.level = originalChalkLevel;
+      chalk.enabled = originalChalkEnabled;
     });
   }
   test("basic usage", function () {

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -1,12 +1,9 @@
 import stripAnsi from "strip-ansi";
-import { createRequire } from "module";
+import { getChalk } from "@babel/highlight";
 import _codeFrame, { codeFrameColumns } from "../lib/index.js";
 const codeFrame = _codeFrame.default || _codeFrame;
 
-const require = createRequire(import.meta.url);
-const babelHighlightPath = require.resolve("@babel/highlight");
-const chalkPath = require.resolve("chalk", { paths: [babelHighlightPath] });
-const chalk = require(chalkPath);
+const chalk = getChalk({});
 
 describe("@babel/code-frame", function () {
   function stubColorSupport(supported) {

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -1,8 +1,9 @@
-import chalk from "chalk";
 import stripAnsi from "strip-ansi";
 
 import _highlight, { shouldHighlight, getChalk } from "../lib/index.js";
 const highlight = _highlight.default || _highlight;
+
+const chalk = getChalk({});
 
 describe("@babel/highlight", function () {
   function stubColorSupport(supported) {

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -6,14 +6,18 @@ const highlight = _highlight.default || _highlight;
 
 describe("@babel/highlight", function () {
   function stubColorSupport(supported) {
-    let originalSupportsColor;
+    let originalChalkLevel;
+    let originalChalkSupportsColor;
     beforeEach(function () {
-      originalSupportsColor = chalk.supportsColor;
+      originalChalkSupportsColor = chalk.supportsColor;
+      originalChalkLevel = chalk.level;
       chalk.supportsColor = supported;
+      chalk.level = supported ? 1 : 0;
     });
 
     afterEach(function () {
-      chalk.supportsColor = originalSupportsColor;
+      chalk.supportsColor = originalChalkSupportsColor;
+      chalk.level = originalChalkLevel;
     });
   }
 

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -8,16 +8,20 @@ describe("@babel/highlight", function () {
   function stubColorSupport(supported) {
     let originalChalkLevel;
     let originalChalkSupportsColor;
+    let originalChalkEnabled;
     beforeEach(function () {
       originalChalkSupportsColor = chalk.supportsColor;
       originalChalkLevel = chalk.level;
+      originalChalkEnabled = chalk.enabled;
       chalk.supportsColor = supported ? { level: 1 } : false;
       chalk.level = supported ? 1 : 0;
+      chalk.enabled = supported;
     });
 
     afterEach(function () {
       chalk.supportsColor = originalChalkSupportsColor;
       chalk.level = originalChalkLevel;
+      chalk.enabled = originalChalkEnabled;
     });
   }
 

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -11,7 +11,7 @@ describe("@babel/highlight", function () {
     beforeEach(function () {
       originalChalkSupportsColor = chalk.supportsColor;
       originalChalkLevel = chalk.level;
-      chalk.supportsColor = supported;
+      chalk.supportsColor = supported ? { level: 1 } : false;
       chalk.level = supported ? 1 : 0;
     });
 

--- a/scripts/integration-tests/e2e-jest.sh
+++ b/scripts/integration-tests/e2e-jest.sh
@@ -72,8 +72,8 @@ rm -f packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test
 # The goals of this e2e test are:
 #   1) Check that the typescript compilation isn't completely broken
 #   2) Make sure that we don't accidentally break jest's usage of the Babel API
-CI=true yarn jest --color --maxWorkers=2 --config jest.config.mjs packages
-CI=true yarn jest --color --maxWorkers=2 --config jest.config.mjs e2e/__tests__/babel
-CI=true yarn jest --color --maxWorkers=2 --config jest.config.mjs e2e/__tests__/transform
+CI=true yarn jest --maxWorkers=2 --config jest.config.mjs packages
+CI=true yarn jest --maxWorkers=2 --config jest.config.mjs e2e/__tests__/babel
+CI=true yarn jest --maxWorkers=2 --config jest.config.mjs e2e/__tests__/transform
 
 cleanup

--- a/scripts/integration-tests/e2e-jest.sh
+++ b/scripts/integration-tests/e2e-jest.sh
@@ -72,8 +72,8 @@ rm -f packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test
 # The goals of this e2e test are:
 #   1) Check that the typescript compilation isn't completely broken
 #   2) Make sure that we don't accidentally break jest's usage of the Babel API
-CI=true yarn jest --maxWorkers=2 --config jest.config.mjs packages
-CI=true yarn jest --maxWorkers=2 --config jest.config.mjs e2e/__tests__/babel
-CI=true yarn jest --maxWorkers=2 --config jest.config.mjs e2e/__tests__/transform
+CI=true yarn jest --color --maxWorkers=2 --config jest.config.mjs packages
+CI=true yarn jest --color --maxWorkers=2 --config jest.config.mjs e2e/__tests__/babel
+CI=true yarn jest --color --maxWorkers=2 --config jest.config.mjs e2e/__tests__/transform
 
 cleanup

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,8 +269,6 @@ __metadata:
   resolution: "@babel/code-frame@workspace:packages/babel-code-frame"
   dependencies:
     "@babel/highlight": "workspace:^"
-    "@types/chalk": ^2.0.0
-    chalk: ^2.0.0
     strip-ansi: ^4.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Previously we are enforcing `--color` on CI because the `@babel/color-frame` test implicitly depends on a terminal with color supports. In this PR we enhance the color support stub in the `@babel/highlight` test and obtain `chalk` from the `getChalk` API. Hopefully we can remove `--color` from CI now.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15499"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

