### PR TITLE
refactor: introduce `lookaheadInLineCharCode`

### DIFF
--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -1287,8 +1287,7 @@ export default abstract class ExpressionParser extends LValParser {
         if (tokenIsIdentifier(type)) {
           if (
             this.isContextual(tt._module) &&
-            this.lookaheadCharCode() === charCodes.leftCurlyBrace &&
-            !this.hasFollowingLineBreak()
+            this.lookaheadInLineCharCode() === charCodes.leftCurlyBrace
           ) {
             return this.parseModuleExpression();
           }

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -329,10 +329,11 @@ export default abstract class StatementParser extends ExpressionParser {
 
   /**
    * Assuming we have seen a contextual `using` and declaration is allowed, check if it
-   * starts a variable declaration so that it should be interpreted as a keyword.
+   * starts a variable declaration in the same line so that it should be interpreted as
+   * a keyword.
    */
-  hasFollowingBindingIdentifier(): boolean {
-    const next = this.nextTokenStart();
+  hasInLineFollowingBindingIdentifier(): boolean {
+    const next = this.nextTokenInLineStart();
     const nextCh = this.codePointAtPos(next);
     return this.chStartsBindingIdentifier(nextCh, next);
   }
@@ -485,9 +486,8 @@ export default abstract class StatementParser extends ExpressionParser {
       case tt._using:
         // using [no LineTerminator here][lookahead != `await`] BindingList[+Using]
         if (
-          this.hasFollowingLineBreak() ||
           this.state.containsEsc ||
-          !this.hasFollowingBindingIdentifier()
+          !this.hasInLineFollowingBindingIdentifier()
         ) {
           break;
         }
@@ -914,12 +914,11 @@ export default abstract class StatementParser extends ExpressionParser {
 
     const startsWithLet = this.isContextual(tt._let);
     const startsWithUsing =
-      this.isContextual(tt._using) && !this.hasFollowingLineBreak();
+      this.isContextual(tt._using) &&
+      this.hasInLineFollowingBindingIdentifier();
     const isLetOrUsing =
       (startsWithLet && this.hasFollowingBindingAtom()) ||
-      (startsWithUsing &&
-        this.hasFollowingBindingIdentifier() &&
-        this.startsUsingForOf());
+      (startsWithUsing && this.startsUsingForOf());
     if (this.match(tt._var) || this.match(tt._const) || isLetOrUsing) {
       const initNode = this.startNode<N.VariableDeclaration>();
       const kind = this.state.value;

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -29,6 +29,7 @@ import {
   isNewLine,
   isWhitespace,
   skipWhiteSpace,
+  skipWhiteSpaceInLine,
 } from "../util/whitespace";
 import State from "./state";
 import type { LookaheadState, DeferredStrictError } from "./state";
@@ -193,6 +194,34 @@ export default abstract class Tokenizer extends CommentsParser {
 
   lookaheadCharCode(): number {
     return this.input.charCodeAt(this.nextTokenStart());
+  }
+
+  /**
+   * Similar to nextToken, but it will stop at line break when it is seen before the next token
+   *
+   * @returns {number} position of the next token start or line break, whichever is seen first.
+   * @memberof Tokenizer
+   */
+  nextTokenInLineStart(): number {
+    return this.nextTokenInLineStartSince(this.state.pos);
+  }
+
+  nextTokenInLineStartSince(pos: number): number {
+    skipWhiteSpaceInLine.lastIndex = pos;
+    return skipWhiteSpaceInLine.test(this.input)
+      ? skipWhiteSpaceInLine.lastIndex
+      : pos;
+  }
+
+  /**
+   * Similar to lookaheadCharCode, but it will return the char code of line break if it is
+   * seen before the next token
+   *
+   * @returns {number} char code of the next token start or line break, whichever is seen first.
+   * @memberof Tokenizer
+   */
+  lookaheadInLineCharCode(): number {
+    return this.input.charCodeAt(this.nextTokenInLineStart());
   }
 
   codePointAtPos(pos: number): number {

--- a/packages/babel-parser/src/util/whitespace.ts
+++ b/packages/babel-parser/src/util/whitespace.ts
@@ -22,7 +22,7 @@ export function isNewLine(code: number): boolean {
 export const skipWhiteSpace = /(?:\s|\/\/.*|\/\*[^]*?\*\/)*/g;
 
 export const skipWhiteSpaceInLine =
-  /(?:[^\S\n\r\u2028\u2029]|\/\/.*|\/\*.*?\*\/)*/y;
+  /(?:[^\S\n\r\u2028\u2029]|\/\/.*|\/\*.*?\*\/)*/g;
 
 // Skip whitespace and single-line comments, including /* no newline here */.
 // After this RegExp matches, its lastIndex points to a line terminator, or


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we are introducing a new variant of `lookaheadCharCode`: `lookaheadInLineCharCode`. It works similar to `lookaheadCharCode` but will stop if a line break is seen before any source characters. It allows us to consolidate the `lookaheadCharCode` and `hasFollowingLineBreak` calls into a single lookahead operation, effectively reduces the lookahead overhead.

This PR is in preparation of the support for the [Async Explicit Resource Management proposal](https://github.com/tc39/proposal-async-explicit-resource-management).