### PR TITLE
[babel 8] Remove old error plugin mappings for default syntax

### DIFF
--- a/packages/babel-core/src/parser/util/missing-plugin-helper.ts
+++ b/packages/babel-core/src/parser/util/missing-plugin-helper.ts
@@ -136,163 +136,161 @@ const pluginNameMap: Record<
       url: "https://github.com/babel/babel/tree/main/packages/babel-preset-typescript",
     },
   },
-
-  // TODO: This plugins are now supported by default by @babel/parser: they can
-  // be removed from this list. Although removing them isn't a breaking change,
-  // it's better to keep a nice error message for users using older versions of
-  // the parser. They can be removed in Babel 8.
-  asyncGenerators: {
-    syntax: {
-      name: "@babel/plugin-syntax-async-generators",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-async-generators",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-async-generator-functions",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-async-generator-functions",
-    },
-  },
-  classProperties: {
-    syntax: {
-      name: "@babel/plugin-syntax-class-properties",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-class-properties",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-class-properties",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-class-properties",
-    },
-  },
-  classPrivateProperties: {
-    syntax: {
-      name: "@babel/plugin-syntax-class-properties",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-class-properties",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-class-properties",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-class-properties",
-    },
-  },
-  classPrivateMethods: {
-    syntax: {
-      name: "@babel/plugin-syntax-class-properties",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-class-properties",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-private-methods",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-private-methods",
-    },
-  },
-  classStaticBlock: {
-    syntax: {
-      name: "@babel/plugin-syntax-class-static-block",
-      url: "https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-syntax-class-static-block",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-class-static-block",
-      url: "https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-proposal-class-static-block",
-    },
-  },
-  dynamicImport: {
-    syntax: {
-      name: "@babel/plugin-syntax-dynamic-import",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-dynamic-import",
-    },
-  },
-  exportNamespaceFrom: {
-    syntax: {
-      name: "@babel/plugin-syntax-export-namespace-from",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-export-namespace-from",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-export-namespace-from",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-export-namespace-from",
-    },
-  },
-  importMeta: {
-    syntax: {
-      name: "@babel/plugin-syntax-import-meta",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-import-meta",
-    },
-  },
-  logicalAssignment: {
-    syntax: {
-      name: "@babel/plugin-syntax-logical-assignment-operators",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-logical-assignment-operators",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-logical-assignment-operators",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-logical-assignment-operators",
-    },
-  },
-  moduleStringNames: {
-    syntax: {
-      name: "@babel/plugin-syntax-module-string-names",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-module-string-names",
-    },
-  },
-  numericSeparator: {
-    syntax: {
-      name: "@babel/plugin-syntax-numeric-separator",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-numeric-separator",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-numeric-separator",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-numeric-separator",
-    },
-  },
-  nullishCoalescingOperator: {
-    syntax: {
-      name: "@babel/plugin-syntax-nullish-coalescing-operator",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-nullish-coalescing-operator",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-nullish-coalescing-operator",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-nullish-coalescing-opearator",
-    },
-  },
-  objectRestSpread: {
-    syntax: {
-      name: "@babel/plugin-syntax-object-rest-spread",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-object-rest-spread",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-object-rest-spread",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-object-rest-spread",
-    },
-  },
-  optionalCatchBinding: {
-    syntax: {
-      name: "@babel/plugin-syntax-optional-catch-binding",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-optional-catch-binding",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-optional-catch-binding",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-optional-catch-binding",
-    },
-  },
-  optionalChaining: {
-    syntax: {
-      name: "@babel/plugin-syntax-optional-chaining",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-optional-chaining",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-optional-chaining",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-optional-chaining",
-    },
-  },
-  privateIn: {
-    syntax: {
-      name: "@babel/plugin-syntax-private-property-in-object",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-private-property-in-object",
-    },
-    transform: {
-      name: "@babel/plugin-proposal-private-property-in-object",
-      url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-private-property-in-object",
-    },
-  },
 };
 
-//todo: we don't have plugin-syntax-private-property-in-object
-pluginNameMap.privateIn.syntax = pluginNameMap.privateIn.transform;
+if (!process.env.BABEL_8_BREAKING) {
+  // TODO: This plugins are now supported by default by @babel/parser.
+  Object.assign(pluginNameMap, {
+    asyncGenerators: {
+      syntax: {
+        name: "@babel/plugin-syntax-async-generators",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-async-generators",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-async-generator-functions",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-async-generator-functions",
+      },
+    },
+    classProperties: {
+      syntax: {
+        name: "@babel/plugin-syntax-class-properties",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-class-properties",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-class-properties",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-class-properties",
+      },
+    },
+    classPrivateProperties: {
+      syntax: {
+        name: "@babel/plugin-syntax-class-properties",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-class-properties",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-class-properties",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-class-properties",
+      },
+    },
+    classPrivateMethods: {
+      syntax: {
+        name: "@babel/plugin-syntax-class-properties",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-class-properties",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-private-methods",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-private-methods",
+      },
+    },
+    classStaticBlock: {
+      syntax: {
+        name: "@babel/plugin-syntax-class-static-block",
+        url: "https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-syntax-class-static-block",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-class-static-block",
+        url: "https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-proposal-class-static-block",
+      },
+    },
+    dynamicImport: {
+      syntax: {
+        name: "@babel/plugin-syntax-dynamic-import",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-dynamic-import",
+      },
+    },
+    exportNamespaceFrom: {
+      syntax: {
+        name: "@babel/plugin-syntax-export-namespace-from",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-export-namespace-from",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-export-namespace-from",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-export-namespace-from",
+      },
+    },
+    importMeta: {
+      syntax: {
+        name: "@babel/plugin-syntax-import-meta",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-import-meta",
+      },
+    },
+    logicalAssignment: {
+      syntax: {
+        name: "@babel/plugin-syntax-logical-assignment-operators",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-logical-assignment-operators",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-logical-assignment-operators",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-logical-assignment-operators",
+      },
+    },
+    moduleStringNames: {
+      syntax: {
+        name: "@babel/plugin-syntax-module-string-names",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-module-string-names",
+      },
+    },
+    numericSeparator: {
+      syntax: {
+        name: "@babel/plugin-syntax-numeric-separator",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-numeric-separator",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-numeric-separator",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-numeric-separator",
+      },
+    },
+    nullishCoalescingOperator: {
+      syntax: {
+        name: "@babel/plugin-syntax-nullish-coalescing-operator",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-nullish-coalescing-operator",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-nullish-coalescing-operator",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-nullish-coalescing-opearator",
+      },
+    },
+    objectRestSpread: {
+      syntax: {
+        name: "@babel/plugin-syntax-object-rest-spread",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-object-rest-spread",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-object-rest-spread",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-object-rest-spread",
+      },
+    },
+    optionalCatchBinding: {
+      syntax: {
+        name: "@babel/plugin-syntax-optional-catch-binding",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-optional-catch-binding",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-optional-catch-binding",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-optional-catch-binding",
+      },
+    },
+    optionalChaining: {
+      syntax: {
+        name: "@babel/plugin-syntax-optional-chaining",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-optional-chaining",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-optional-chaining",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-optional-chaining",
+      },
+    },
+    privateIn: {
+      syntax: {
+        name: "@babel/plugin-syntax-private-property-in-object",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-private-property-in-object",
+      },
+      transform: {
+        name: "@babel/plugin-proposal-private-property-in-object",
+        url: "https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-private-property-in-object",
+      },
+    },
+  });
+}
 
 const getNameURLCombination = ({ name, url }: { name: string; url: string }) =>
   `${name} (${url})`;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Backport #11234

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15526"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

