### PR TITLE
fix: Template `export { x }` stuck in infinite loop

### DIFF
--- a/packages/babel-template/src/parse.ts
+++ b/packages/babel-template/src/parse.ts
@@ -12,7 +12,7 @@ import {
   traverse,
 } from "@babel/types";
 import type * as t from "@babel/types";
-import type { TraversalAncestors, TraversalHandler } from "@babel/types";
+import type { TraversalAncestors } from "@babel/types";
 import { parse } from "@babel/parser";
 import { codeFrameColumns } from "@babel/code-frame";
 import type { TemplateOpts, ParserOpts } from "./options";
@@ -54,28 +54,19 @@ export default function parseAndBuildMetadata<T>(
 
   formatter.validate(ast);
 
-  const syntactic: MetadataState["syntactic"] = {
-    placeholders: [],
-    placeholderNames: new Set(),
-  };
-  const legacy: MetadataState["legacy"] = {
-    placeholders: [],
-    placeholderNames: new Set(),
-  };
-  const isLegacyRef: MetadataState["isLegacyRef"] = { value: undefined };
-
-  traverse(ast, placeholderVisitorHandler as TraversalHandler<any>, {
-    syntactic,
-    legacy,
-    isLegacyRef,
+  const state: MetadataState = {
+    syntactic: { placeholders: [], placeholderNames: new Set() },
+    legacy: { placeholders: [], placeholderNames: new Set() },
     placeholderWhitelist,
     placeholderPattern,
     syntacticPlaceholders,
-  });
+  };
+
+  traverse(ast, placeholderVisitorHandler, state);
 
   return {
     ast,
-    ...(isLegacyRef.value ? legacy : syntactic),
+    ...(state.syntactic.placeholders.length ? state.syntactic : state.legacy),
   };
 }
 
@@ -86,30 +77,29 @@ function placeholderVisitorHandler(
 ) {
   let name: string;
 
+  let hasSyntacticPlaceholders = state.syntactic.placeholders.length > 0;
+
   if (isPlaceholder(node)) {
     if (state.syntacticPlaceholders === false) {
       throw new Error(
         "%%foo%%-style placeholders can't be used when " +
           "'.syntacticPlaceholders' is false.",
       );
-    } else {
-      name = node.name.name;
-      state.isLegacyRef.value = false;
     }
-  } else if (state.isLegacyRef.value === false || state.syntacticPlaceholders) {
+    name = node.name.name;
+    hasSyntacticPlaceholders = true;
+  } else if (hasSyntacticPlaceholders || state.syntacticPlaceholders) {
     return;
   } else if (isIdentifier(node) || isJSXIdentifier(node)) {
     name = node.name;
-    state.isLegacyRef.value = true;
   } else if (isStringLiteral(node)) {
     name = node.value;
-    state.isLegacyRef.value = true;
   } else {
     return;
   }
 
   if (
-    !state.isLegacyRef.value &&
+    hasSyntacticPlaceholders &&
     (state.placeholderPattern != null || state.placeholderWhitelist != null)
   ) {
     // This check is also in options.js. We need it there to handle the default
@@ -121,7 +111,7 @@ function placeholderVisitorHandler(
   }
 
   if (
-    state.isLegacyRef.value &&
+    !hasSyntacticPlaceholders &&
     (state.placeholderPattern === false ||
       !(state.placeholderPattern || PATTERN).test(name)) &&
     !state.placeholderWhitelist?.has(name)
@@ -155,7 +145,7 @@ function placeholderVisitorHandler(
     type = "other";
   }
 
-  const { placeholders, placeholderNames } = state.isLegacyRef.value
+  const { placeholders, placeholderNames } = !hasSyntacticPlaceholders
     ? state.legacy
     : state.syntactic;
 
@@ -193,9 +183,6 @@ type MetadataState = {
   legacy: {
     placeholders: Array<Placeholder>;
     placeholderNames: Set<string>;
-  };
-  isLegacyRef: {
-    value?: boolean;
   };
   placeholderWhitelist?: Set<string>;
   placeholderPattern?: RegExp | false;

--- a/packages/babel-template/test/index.js
+++ b/packages/babel-template/test/index.js
@@ -271,6 +271,64 @@ describe("@babel/template", function () {
 
       expect(generator(result).code).toEqual("<div>{'content'}</div>");
     });
+
+    it("should work with `export { x }`", () => {
+      const result = template.ast`
+        export { ${t.identifier("x")} }
+        $$$$BABEL_TPL$0;
+      `;
+      expect(result).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "declaration": null,
+            "loc": undefined,
+            "source": null,
+            "specifiers": Array [
+              Object {
+                "exported": Object {
+                  "name": "x",
+                  "type": "Identifier",
+                },
+                "loc": undefined,
+                "local": Object {
+                  "name": "x",
+                  "type": "Identifier",
+                },
+                "type": "ExportSpecifier",
+              },
+            ],
+            "type": "ExportNamedDeclaration",
+          },
+          Object {
+            "expression": Object {
+              "loc": undefined,
+              "name": "$$$$BABEL_TPL$0",
+              "type": "Identifier",
+            },
+            "loc": undefined,
+            "type": "ExpressionStatement",
+          },
+        ]
+      `);
+    });
+
+    it("should work with `const a = { x }`", () => {
+      const result = template.ast`
+        {
+          const a = { ${t.identifier("x")} };
+          $$$$BABEL_TPL$0;
+        }
+      `;
+
+      expect(generator(result).code).toMatchInlineSnapshot(`
+        "{
+          const a = {
+            x
+          };
+          $$$$BABEL_TPL$0;
+        }"
+      `);
+    });
   });
 
   describe(".syntacticPlaceholders", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15525 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Thanks @await-ovo!

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15534"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

