### PR TITLE
Use `lt` instead of `lte` to check TS version for .cts config

### DIFF
--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -98,7 +98,7 @@ function loadCtsDefault(filepath: string) {
         } catch (error) {
           if (!hasTsSupport) {
             const packageJson = require("@babel/preset-typescript/package.json");
-            if (semver.lte(packageJson.version, "7.21.4")) {
+            if (semver.lt(packageJson.version, "7.21.4")) {
               console.error(
                 "`.cts` configuration file failed to load, please try to update `@babel/preset-typescript`.",
               );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Very minor, but I noticed it in https://github.com/babel/babel/pull/15511. 7.21.4 should already properly support it, so we shouldn't suggest to upgrade in this case.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15535"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

