### PR TITLE
Use `semver` package to compare versions

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -25,7 +25,8 @@
     "@babel/helper-optimise-call-expression": "workspace:^",
     "@babel/helper-replace-supers": "workspace:^",
     "@babel/helper-skip-transparent-expression-wrappers": "workspace:^",
-    "@babel/helper-split-export-declaration": "workspace:^"
+    "@babel/helper-split-export-declaration": "workspace:^",
+    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0"

--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -19,7 +19,8 @@
   ],
   "dependencies": {
     "@babel/helper-annotate-as-pure": "workspace:^",
-    "regexpu-core": "^5.3.1"
+    "regexpu-core": "^5.3.1",
+    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,6 +613,7 @@ __metadata:
     "@babel/helper-split-export-declaration": "workspace:^"
     "@babel/plugin-syntax-class-static-block": ^7.14.5
     "@babel/preset-env": "workspace:^"
+    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   peerDependencies:
     "@babel/core": ^7.0.0
   languageName: unknown
@@ -638,6 +639,7 @@ __metadata:
     "@babel/helper-annotate-as-pure": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
     regexpu-core: ^5.3.1
+    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
   peerDependencies:
     "@babel/core": ^7.0.0
   languageName: unknown


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


The hack we used to parse versions only works with x.y.z versions, and it will break (generating `NaN`s) as soon as we start releasing pre-releases. I found this problem while releasing `7.21.4-esm.x` versions, but it is a blocker for Babel 8 pre-releases.

`semver` is already in the dependencies tree, because it's a dependency of many of our packages including `@babel/core`.