### PR TITLE
use browserslist's defaults as default targets

### DIFF
--- a/packages/babel-helper-compilation-targets/src/index.ts
+++ b/packages/babel-helper-compilation-targets/src/index.ts
@@ -218,9 +218,8 @@ export default function getTargets(
     });
     if (browsers == null) {
       if (process.env.BABEL_8_BREAKING) {
-        // In Babel 8, if no targets are passed, we use browserslist's defaults
-        // and exclude IE 11.
-        browsers = ["defaults, not ie 11"];
+        // In Babel 8, if no targets are passed, we use browserslist's defaults.
+        browsers = ["defaults"];
       } else {
         // If no targets are passed, we need to overwrite browserslist's defaults
         // so that we enable all transforms (acting like the now deprecated


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The IE 11 has been marked as dead browser in browserslist, so the query `defaults` now excludes IE 11.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15551"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

