### PR TITLE
Fix Edge Case For Template Strings Having An "undefined" Label During Token Conversion

### DIFF
--- a/eslint/babel-eslint-parser/src/convert/convertTokens.cjs
+++ b/eslint/babel-eslint-parser/src/convert/convertTokens.cjs
@@ -1,5 +1,7 @@
 const ESLINT_VERSION = require("../utils/eslint-version.cjs");
 
+const TEMPLATE_LABEL = "Template";
+
 function convertTemplateType(tokens, tl) {
   let curlyBrace = null;
   let templateTokens = [];
@@ -20,7 +22,9 @@ function convertTemplateType(tokens, tl) {
     }, "");
 
     result.push({
-      type: "Template",
+      type: {
+        label: TEMPLATE_LABEL,
+      },
       value: value,
       start: start.start,
       end: end.end,
@@ -181,7 +185,11 @@ function convertToken(token, source, tl) {
     token.value = `${token.value}n`;
   } else if (label === tl.privateName) {
     token.type = "PrivateIdentifier";
-  } else if (label === tl.templateNonTail || label === tl.templateTail) {
+  } else if (
+    label === tl.templateNonTail ||
+    label === tl.templateTail ||
+    label === TEMPLATE_LABEL
+  ) {
     token.type = "Template";
   }
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/discussions/15552
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


Hey Babel ESLint folks I am working on a potentially sharp edge case in _eslint/babel-eslint-parser/src/convert/convertTokens.cjs_ wherein we always [monkeypatch](https://github.com/babel/babel/blob/c45fa427ba64974277d657d70906469a6408a9e5/eslint/babel-eslint-parser/src/convert/convertTokens.cjs#L3-L85) :monkey: Template types into the Token List, but we follow the _final?_ form of the AST which means that we have the potential ([Ex: 7.17.0](https://github.com/matty-at-rdc/literally-what) -- doubleAt breaking my heart due to eslint parser being having a dep on babel core at >= 7.11.0) where developers can get dependencies out of sync and and be left with a valid dependency manifest and lockfile and still get into trouble.

The **"root"** of this problem is that the monkeypatched Template type has no `label`[ field to be extracted and thus becomes extracted as ](https://github.com/babel/babel/blob/c45fa427ba64974277d657d70906469a6408a9e5/eslint/babel-eslint-parser/src/convert/convertTokens.cjs#L88-L89)`undefined` and while this is expected-ish behavior as demonstrated the consistent ASTs between espree and babel it means that if any token from `tl` is undefined by virtue of being out of sync due to semver in transitive deps using `^`, but locked version in peer deps then you can end up in the siutation I did wherein the following occurs:

- Template type has no label[ field to be extracted and thus becomes extracted as ](https://github.com/babel/babel/blob/c45fa427ba64974277d657d70906469a6408a9e5/eslint/babel-eslint-parser/src/convert/convertTokens.cjs#L88-L89)undefined
- Deps: babe/core & babel/parser (both at > 7.11 and valid according to peer Deps reqs in eslint-parser package.json) is lockfiled
- babel/parser at pre 7.17.0 doesn't know what doubleAt is and is thus undefined
- Which means that we end up categorizing  Template types as the default for when [this ](https://github.com/babel/babel/blob/c45fa427ba64974277d657d70906469a6408a9e5/eslint/babel-eslint-parser/src/convert/convertTokens.cjs#L98-L145)if[ statement](https://github.com/babel/babel/blob/c45fa427ba64974277d657d70906469a6408a9e5/eslint/babel-eslint-parser/src/convert/convertTokens.cjs#L98-L145) passes and therefore converts Template types to.... Punctuator types ([ref](https://github.com/babel/babel/blob/c45fa427ba64974277d657d70906469a6408a9e5/eslint/babel-eslint-parser/src/convert/convertTokens.cjs#L147))

I see two solutions... but I'm so new to this it's embarrassing :flushed: so please throw all the :books: at me!

**A:** [Simply update the peerDep on babel/co](https://github.com/babel/babel/blob/e54375e46fd783ed084f75fa1103aaf80945e2ef/eslint/babel-eslint-parser/package.json#L30)re to be higher and remember to do this when new tokens are added to an upstream dep (typically babel/parser :shrug:)

**B:** Give the monkeypatched Template type a type field which IS NOT a string, but an object which includes label (temporarily of course) and then add a case for it [here](https://github.com/babel/babel/blob/c45fa427ba64974277d657d70906469a6408a9e5/eslint/babel-eslint-parser/src/convert/convertTokens.cjs#L184-L186).

This PR shows how one **might** go about approach B.