### PR TITLE
DEPRECATED_KEYS & DEPRECATED_ALIASES are undefined

### DIFF
--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -101,11 +101,11 @@ export function explode(visitor: Visitor) {
 
     let aliases = FLIPPED_ALIAS_KEYS[nodeType];
 
-    if (nodeType in DEPRECATED_KEYS) {
+    if (DEPRECATED_KEYS && nodeType in DEPRECATED_KEYS) {
       const deprecatedKey = DEPRECATED_KEYS[nodeType];
       deprecationWarning(nodeType, deprecatedKey, "Visitor ");
       aliases = [deprecatedKey];
-    } else if (nodeType in DEPRECATED_ALIASES) {
+    } else if (DEPRECATED_ALIASES && nodeType in DEPRECATED_ALIASES) {
       const deprecatedAlias =
         DEPRECATED_ALIASES[nodeType as keyof typeof DEPRECATED_ALIASES];
       deprecationWarning(nodeType, deprecatedAlias, "Visitor ");


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Bug Fix
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

When developing locally, for some reason, DEPRECATED_ALIASES is `undefined` which makes the `in` operator fail.

I've had to add a guard for this locally, and though to submit this PR to guard against `DEPRECATED_KEYS` being `undefined` as well

I'm unsure if this is the correct fix for this, or if there's some other issue at play here. But at the very least, I hope this PR helps identify the issue wherever it may be

Many thanks for providing this awesome library!

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15564"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

