### PR TITLE
Handle `.overrides` and `.env` when resolving plugins/presets from fixture options

### DIFF
--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -362,6 +362,17 @@ export function resolveOptionPluginOrPreset(
   options: any,
   optionsDir: string,
 ): {} {
+  if (options.overrides) {
+    for (const subOption of options.overrides) {
+      resolveOptionPluginOrPreset(subOption, optionsDir);
+    }
+  }
+  if (options.env) {
+    for (const envName in options.env) {
+      if (!{}.hasOwnProperty.call(options.env, envName)) continue;
+      resolveOptionPluginOrPreset(options.env[envName], optionsDir);
+    }
+  }
   if (options.plugins) {
     options.plugins = wrapPackagesArray("plugin", options.plugins, optionsDir);
   }

--- a/packages/babel-preset-typescript/test/fixtures/opts/allExtensions-true-isTSX-true/options.json
+++ b/packages/babel-preset-typescript/test/fixtures/opts/allExtensions-true-isTSX-true/options.json
@@ -5,8 +5,8 @@
       "include": "*.vue",
       "sourceType": "module",
       "presets": [
-        ["@babel/preset-react"],
-        ["@babel/preset-typescript", { "allExtensions": true, "isTSX": true }]
+        ["react"],
+        ["typescript", { "allExtensions": true, "isTSX": true }]
       ]
     }
   ]

--- a/packages/babel-preset-typescript/test/fixtures/opts/ignoreExtensions/options.json
+++ b/packages/babel-preset-typescript/test/fixtures/opts/ignoreExtensions/options.json
@@ -4,10 +4,7 @@
     {
       "include": "*.vue",
       "sourceType": "module",
-      "presets": [
-        ["@babel/preset-react"],
-        ["@babel/preset-typescript", { "ignoreExtensions": true }]
-      ]
+      "presets": [["react"], ["typescript", { "ignoreExtensions": true }]]
     }
   ]
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Babel 8 test is failing when built with `BABEL_8_BREAKING` flag stripped
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I have not completely figured out why the [PR CI](https://github.com/babel/babel/actions/runs/4682757591/jobs/8297074223) of 15562 was passing but the main branch after merged, is failing. The fact that the test case can pass when `overrides` is removed points to an oversight in the `resolveOptionPluginOrPreset` of the fixtures helper. In this PR it handles `.overrides` and `.env` as well.

In the future we may need to handle `.extends` as well, but for the time being this PR is sufficient.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15568"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

