### PR TITLE
[babel 8] Other Babel 8 misc changes

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -27,7 +27,7 @@ module.exports = function (api) {
     exclude: [
       "transform-typeof-symbol",
       // We need to enable useBuiltIns
-      "proposal-object-rest-spread",
+      "transform-object-rest-spread",
     ],
   };
 

--- a/packages/babel-core/src/config/files/plugins.ts
+++ b/packages/babel-core/src/config/files/plugins.ts
@@ -217,16 +217,26 @@ function* requireModule(type: string, name: string): Handler<unknown> {
     if (!process.env.BABEL_8_BREAKING) {
       LOADING_MODULES.add(name);
     }
-    return yield* loadCodeDefault(
-      name,
-      `You appear to be using a native ECMAScript module ${type}, ` +
-        "which is only supported when running Babel asynchronously.",
-      // For backward compatibility, we need to support malformed presets
-      // defined as separate named exports rather than a single default
-      // export.
-      // See packages/babel-core/test/fixtures/option-manager/presets/es2015_named.js
-      true,
-    );
+
+    if (process.env.BABEL_8_BREAKING) {
+      return yield* loadCodeDefault(
+        name,
+        `You appear to be using a native ECMAScript module ${type}, ` +
+          "which is only supported when running Babel asynchronously.",
+      );
+    } else {
+      return yield* loadCodeDefault(
+        name,
+        `You appear to be using a native ECMAScript module ${type}, ` +
+          "which is only supported when running Babel asynchronously.",
+        // For backward compatibility, we need to support malformed presets
+        // defined as separate named exports rather than a single default
+        // export.
+        // See packages/babel-core/test/fixtures/option-manager/presets/es2015_named.js
+        // @ts-ignore(Babel 7 vs Babel 8) This param has been removed
+        true,
+      );
+    }
   } catch (err) {
     err.message = `[BABEL]: ${err.message} (While processing: ${name})`;
     throw err;

--- a/packages/babel-core/src/config/item.ts
+++ b/packages/babel-core/src/config/item.ts
@@ -64,7 +64,7 @@ class ConfigItem {
    */
   _descriptor: UnloadedDescriptor;
 
-  // TODO(Babel 8): Check if this symbol needs to be updated
+  // TODO(Babel 9): Check if this symbol needs to be updated
   /**
    * Used to detect ConfigItem instances from other Babel instances.
    */

--- a/packages/babel-core/src/transformation/plugin-pass.ts
+++ b/packages/babel-core/src/transformation/plugin-pass.ts
@@ -48,12 +48,14 @@ export default class PluginPass {
 }
 
 if (!process.env.BABEL_8_BREAKING) {
-  (PluginPass as any).prototype.getModuleName = function getModuleName():
-    | string
-    | undefined {
+  (PluginPass as any).prototype.getModuleName = function getModuleName(
+    this: PluginPass,
+  ): string | undefined {
     return this.file.getModuleName();
   };
-  (PluginPass as any).prototype.addImport = function addImport(): void {
+  (PluginPass as any).prototype.addImport = function addImport(
+    this: PluginPass,
+  ): void {
     this.file.addImport();
   };
 }

--- a/packages/babel-core/src/transformation/plugin-pass.ts
+++ b/packages/babel-core/src/transformation/plugin-pass.ts
@@ -38,11 +38,6 @@ export default class PluginPass {
     return this.file.addHelper(name);
   }
 
-  // TODO: Remove this in Babel 8
-  addImport() {
-    this.file.addImport();
-  }
-
   buildCodeFrameError(
     node: NodeLocation | undefined | null,
     msg: string,
@@ -57,5 +52,8 @@ if (!process.env.BABEL_8_BREAKING) {
     | string
     | undefined {
     return this.file.getModuleName();
+  };
+  (PluginPass as any).prototype.addImport = function addImport(): void {
+    this.file.addImport();
   };
 }

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -38,10 +38,12 @@ export function createClassFeaturePlugin({
   feature,
   loose,
   manipulateOptions,
-  // @ts-ignore(Babel 7 vs Babel 8) TODO(Babel 8): Remove the default value
-  api = { assumption: () => void 0 },
+  api,
   inherits,
 }: Options): PluginObject {
+  if (!process.env.BABEL_8_BREAKING) {
+    api ??= { assumption: () => void 0 as any } as any;
+  }
   const setPublicClassFields = api.assumption("setPublicClassFields");
   const privateFieldsAsSymbols = api.assumption("privateFieldsAsSymbols");
   const privateFieldsAsProperties = api.assumption("privateFieldsAsProperties");

--- a/packages/babel-plugin-transform-arrow-functions/src/index.ts
+++ b/packages/babel-plugin-transform-arrow-functions/src/index.ts
@@ -18,15 +18,23 @@ export default declare((api, options: Options) => {
         // was queued up.
         if (!path.isArrowFunctionExpression()) return;
 
-        path.arrowFunctionToExpression({
-          // While other utils may be fine inserting other arrows to make more transforms possible,
-          // the arrow transform itself absolutely cannot insert new arrow functions.
-          allowInsertArrow: false,
-          noNewArrows,
+        if (process.env.BABEL_8_BREAKING) {
+          path.arrowFunctionToExpression({
+            // While other utils may be fine inserting other arrows to make more transforms possible,
+            // the arrow transform itself absolutely cannot insert new arrow functions.
+            allowInsertArrow: false,
+            noNewArrows,
+          });
+        } else {
+          path.arrowFunctionToExpression({
+            allowInsertArrow: false,
+            noNewArrows,
 
-          // TODO(Babel 8): This is only needed for backward compat with @babel/traverse <7.13.0
-          specCompliant: !noNewArrows,
-        });
+            // This is only needed for backward compat with @babel/traverse <7.13.0
+            // @ts-ignore(Babel 7 vs Babel 8) Removed in Babel 8
+            specCompliant: !noNewArrows,
+          });
+        }
       },
     },
   };

--- a/packages/babel-plugin-transform-for-of/src/index.ts
+++ b/packages/babel-plugin-transform-for-of/src/index.ts
@@ -217,10 +217,12 @@ export default declare((api, options: Options) => {
           return;
         }
 
-        if (!state.availableHelper(builder.helper)) {
-          // Babel <7.9.0 doesn't support this helper
-          transformWithoutHelper(skipIteratorClosing, path, state);
-          return;
+        if (!process.env.BABEL_8_BREAKING) {
+          if (!state.availableHelper(builder.helper)) {
+            // Babel <7.9.0 doesn't support this helper
+            transformWithoutHelper(skipIteratorClosing, path, state);
+            return;
+          }
         }
 
         const { node, parent, scope } = path;

--- a/packages/babel-plugin-transform-for-of/src/index.ts
+++ b/packages/babel-plugin-transform-for-of/src/index.ts
@@ -50,11 +50,13 @@ export default declare((api, options: Options) => {
       );
     }
 
-    // TODO: Remove in Babel 8
-    if (allowArrayLike && /^7\.\d\./.test(api.version)) {
-      throw new Error(
-        `The allowArrayLike is only supported when using @babel/core@^7.10.0`,
-      );
+    if (!process.env.BABEL_8_BREAKING) {
+      // TODO: Remove in Babel 8
+      if (allowArrayLike && /^7\.\d\./.test(api.version)) {
+        throw new Error(
+          `The allowArrayLike is only supported when using @babel/core@^7.10.0`,
+        );
+      }
     }
   }
 

--- a/packages/babel-plugin-transform-for-of/src/no-helper-implementation.ts
+++ b/packages/babel-plugin-transform-for-of/src/no-helper-implementation.ts
@@ -3,7 +3,7 @@ import type { NodePath } from "@babel/traverse";
 
 // This is the legacy implementation, which inlines all the code.
 // It must be kept for compatibility reasons.
-// TODO(Babel 8): Remove this code.
+// TODO(Babel 8): Remove this file.
 
 export default function transformWithoutHelper(
   loose: boolean | void,

--- a/packages/babel-plugin-transform-unicode-escapes/src/index.ts
+++ b/packages/babel-plugin-transform-unicode-escapes/src/index.ts
@@ -9,11 +9,15 @@ export default declare(api => {
   const unicodeEscape = /(\\+)u\{([0-9a-fA-F]+)\}/g;
 
   function escape(code: number) {
-    let str = code.toString(16);
-    // Sigh, node 6 doesn't have padStart
-    // TODO: Remove in Babel 8, when we drop node 6.
-    while (str.length < 4) str = "0" + str;
-    return "\\u" + str;
+    if (process.env.BABEL_8_BREAKING) {
+      return "\\u" + code.toString(16);
+    } else {
+      let str = code.toString(16);
+      // Sigh, node 6 doesn't have padStart
+      // TODO: Remove in Babel 8, when we drop node 6.
+      while (str.length < 4) str = "0" + str;
+      return "\\u" + str;
+    }
   }
 
   function replacer(match: string, backslashes: string[], code: string) {

--- a/packages/babel-plugin-transform-unicode-escapes/src/index.ts
+++ b/packages/babel-plugin-transform-unicode-escapes/src/index.ts
@@ -10,7 +10,7 @@ export default declare(api => {
 
   function escape(code: number) {
     if (process.env.BABEL_8_BREAKING) {
-      return "\\u" + code.toString(16);
+      return "\\u" + code.toString(16).padStart(4, "0");
     } else {
       let str = code.toString(16);
       // Sigh, node 6 doesn't have padStart

--- a/packages/babel-preset-env/src/normalize-options.ts
+++ b/packages/babel-preset-env/src/normalize-options.ts
@@ -82,14 +82,14 @@ const expandIncludesAndExcludes = (
     } else {
       re = filter;
     }
-    const items = filterableItems.filter(
-      item =>
-        re.test(item) ||
-        // For backwards compatibility, we also support matching against the
-        // proposal- name.
-        // TODO(Babel 8): Remove this.
-        re.test(item.replace(/^transform-/, "proposal-")),
-    );
+    const items = filterableItems.filter(item => {
+      return process.env.BABEL_8_BREAKING
+        ? re.test(item)
+        : re.test(item) ||
+            // For backwards compatibility, we also support matching against the
+            // proposal- name.
+            re.test(item.replace(/^transform-/, "proposal-"));
+    });
     if (items.length === 0) invalidFilters.push(filter);
     return items;
   });

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-object-spread/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-object-spread/options.json
@@ -6,7 +6,7 @@
         "useBuiltIns": "usage",
         "corejs": 3,
         "modules": false,
-        "exclude": ["proposal-object-rest-spread"]
+        "exclude": ["transform-object-rest-spread"]
       }
     ]
   ]

--- a/packages/babel-preset-env/test/normalize-options.skip-bundled.js
+++ b/packages/babel-preset-env/test/normalize-options.skip-bundled.js
@@ -6,6 +6,8 @@ import _normalizeOptions, {
 } from "../lib/normalize-options.js";
 const normalizeOptions = _normalizeOptions.default || _normalizeOptions;
 
+const itBabel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
+
 describe("normalize-options", () => {
   describe("normalizeOptions", () => {
     it("should return normalized `include` and `exclude`", () => {
@@ -83,7 +85,7 @@ describe("normalize-options", () => {
 
     it("throws when including module plugins", () => {
       expect(() =>
-        normalizeOptions({ include: ["proposal-dynamic-import"] }),
+        normalizeOptions({ include: ["transform-dynamic-import"] }),
       ).toThrow();
       expect(() =>
         normalizeOptions({ include: ["transform-modules-amd"] }),
@@ -92,7 +94,7 @@ describe("normalize-options", () => {
 
     it("allows exclusion of module plugins", () => {
       expect(() =>
-        normalizeOptions({ exclude: ["proposal-dynamic-import"] }),
+        normalizeOptions({ exclude: ["transform-dynamic-import"] }),
       ).not.toThrow();
       expect(() =>
         normalizeOptions({ exclude: ["transform-modules-commonjs"] }),
@@ -142,7 +144,7 @@ describe("normalize-options", () => {
       ]);
     });
 
-    it("should work both with proposal-* and transform-*", () => {
+    itBabel7("should work both with proposal-* and transform-*", () => {
       expect(
         normalizeOptions({ include: ["proposal-.*-regex"] }).include,
       ).toEqual([

--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -79,7 +79,7 @@ export function visit(this: NodePath): boolean {
     return false;
   }
 
-  if (this.opts.shouldSkip && this.opts.shouldSkip(this)) {
+  if (this.opts.shouldSkip?.(this)) {
     return false;
   }
 
@@ -129,7 +129,7 @@ export function stop(this: NodePath) {
 }
 
 export function setScope(this: NodePath) {
-  if (this.opts && this.opts.noScope) return;
+  if (this.opts?.noScope) return;
 
   let path = this.parentPath;
 
@@ -145,14 +145,14 @@ export function setScope(this: NodePath) {
 
   let target;
   while (path && !target) {
-    if (path.opts && path.opts.noScope) return;
+    if (path.opts?.noScope) return;
 
     target = path.scope;
     path = path.parentPath;
   }
 
   this.scope = this.getScope(target);
-  if (this.scope) this.scope.init();
+  this.scope?.init();
 }
 
 export function setContext<S = unknown>(

--- a/packages/babel-traverse/src/path/conversion.ts
+++ b/packages/babel-traverse/src/path/conversion.ts
@@ -105,14 +105,20 @@ export function ensureBlock(
   return this.node;
 }
 
-/**
- * Keeping this for backward-compatibility. You should use arrowFunctionToExpression() for >=7.x.
- */
-// TODO(Babel 8): Remove this
-export function arrowFunctionToShadowed(this: NodePath) {
-  if (!this.isArrowFunctionExpression()) return;
+declare const USE_ESM: boolean;
 
-  this.arrowFunctionToExpression();
+if (!process.env.BABEL_8_BREAKING) {
+  if (!USE_ESM) {
+    /**
+     * Keeping this for backward-compatibility. You should use arrowFunctionToExpression() for >=7.x.
+     */
+    // eslint-disable-next-line no-restricted-globals
+    exports.arrowFunctionToShadowed = function (this: NodePath) {
+      if (!this.isArrowFunctionExpression()) return;
+
+      this.arrowFunctionToExpression();
+    };
+  }
 }
 
 /**
@@ -150,14 +156,13 @@ export function arrowFunctionToExpression(
   {
     allowInsertArrow = true,
     allowInsertArrowWithRest = allowInsertArrow,
-    /** @deprecated Use `noNewArrows` instead */
-    specCompliant = false,
-    // TODO(Babel 8): Consider defaulting to `false` for spec compliancy
-    noNewArrows = !specCompliant,
+    noNewArrows = process.env.BABEL_8_BREAKING
+      ? // TODO(Babel 8): Consider defaulting to `false` for spec compliancy
+        true
+      : !arguments[0]?.specCompliant,
   }: {
     allowInsertArrow?: boolean | void;
     allowInsertArrowWithRest?: boolean | void;
-    specCompliant?: boolean | void;
     noNewArrows?: boolean;
   } = {},
 ): NodePath<

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -325,14 +325,14 @@ function shouldIgnoreKey(
   if (key === "enter" || key === "exit" || key === "shouldSkip") return true;
 
   // ignore other options
-  if (
-    key === "denylist" ||
-    key === "noScope" ||
-    key === "skipKeys" ||
-    // TODO: Remove in Babel 8
-    key === "blacklist"
-  ) {
+  if (key === "denylist" || key === "noScope" || key === "skipKeys") {
     return true;
+  }
+
+  if (!process.env.BABEL_8_BREAKING) {
+    if (key === "blacklist") {
+      return true;
+    }
   }
 
   return false;

--- a/packages/babel-traverse/test/arrow-transform.js
+++ b/packages/babel-traverse/test/arrow-transform.js
@@ -48,6 +48,8 @@ function wrapMethod(body, methodName, extend) {
   );
 }
 
+const itBabel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
+
 describe("arrow function conversion", () => {
   it("should convert super calls in constructors", () => {
     assertConversion(
@@ -177,7 +179,44 @@ describe("arrow function conversion", () => {
     );
   });
 
-  it("should convert this references in constructors with spec compliance", () => {
+  itBabel7(
+    "should convert this references in constructors with spec compliance",
+    () => {
+      assertConversion(
+        `
+          () => {
+            this;
+          };
+          super();
+          this;
+          () => super();
+          () => this;
+        `,
+        `
+          var _this,
+              _arrowCheckId = {};
+
+          (function () {
+            babelHelpers.newArrowCheck(this, _arrowCheckId);
+
+            _this;
+          }).bind(_arrowCheckId);
+          super();
+          _this = this;
+          this;
+          () => (super(), _this = this);
+          () => this;
+        `,
+        {
+          methodName: "constructor",
+          extend: true,
+          arrowOpts: { specCompliant: true },
+        },
+      );
+    },
+  );
+
+  it("should convert this references in constructors with `noNewArrows: false`", () => {
     assertConversion(
       `
       () => {
@@ -206,7 +245,7 @@ describe("arrow function conversion", () => {
       {
         methodName: "constructor",
         extend: true,
-        arrowOpts: { specCompliant: true },
+        arrowOpts: { noNewArrows: false },
       },
     );
   });
@@ -233,7 +272,34 @@ describe("arrow function conversion", () => {
     );
   });
 
-  it("should convert this references in constructors with spec compliance without extension", () => {
+  itBabel7(
+    "should convert this references in constructors with spec compliance without extension",
+    () => {
+      assertConversion(
+        `
+          () => {
+            this;
+          };
+          this;
+          () => this;
+        `,
+        `
+          var _this = this;
+
+          (function () {
+            babelHelpers.newArrowCheck(this, _this);
+
+            this;
+          }).bind(this);
+          this;
+          () => this;
+        `,
+        { methodName: "constructor", arrowOpts: { specCompliant: true } },
+      );
+    },
+  );
+
+  it("should convert this references in constructors with `noNewArrows: false` without extension", () => {
     assertConversion(
       `
       () => {
@@ -253,7 +319,7 @@ describe("arrow function conversion", () => {
       this;
       () => this;
     `,
-      { methodName: "constructor", arrowOpts: { specCompliant: true } },
+      { methodName: "constructor", arrowOpts: { noNewArrows: false } },
     );
   });
 
@@ -278,7 +344,34 @@ describe("arrow function conversion", () => {
     );
   });
 
-  it("should convert this references in methods with spec compliance", () => {
+  itBabel7(
+    "should convert this references in methods with spec compliance",
+    () => {
+      assertConversion(
+        `
+          () => {
+            this;
+          };
+          this;
+          () => this;
+        `,
+        `
+          var _this = this;
+
+          (function () {
+            babelHelpers.newArrowCheck(this, _this);
+
+            this;
+          }).bind(this);
+          this;
+          () => this;
+        `,
+        { arrowOpts: { specCompliant: true } },
+      );
+    },
+  );
+
+  it("should convert this references in methods with `noNewArrows: false`", () => {
     assertConversion(
       `
       () => {
@@ -298,7 +391,7 @@ describe("arrow function conversion", () => {
       this;
       () => this;
     `,
-      { arrowOpts: { specCompliant: true } },
+      { arrowOpts: { noNewArrows: false } },
     );
   });
 

--- a/packages/babel-types/src/modifications/flow/removeTypeDuplicates.ts
+++ b/packages/babel-types/src/modifications/flow/removeTypeDuplicates.ts
@@ -17,9 +17,10 @@ function getQualifiedName(node: t.GenericTypeAnnotation["id"]): string {
  * Dedupe type annotations.
  */
 export default function removeTypeDuplicates(
-  // todo(babel 8): change type to Array<...>
-  nodes: ReadonlyArray<t.FlowType | false | null | undefined>,
+  nodesIn: ReadonlyArray<t.FlowType | false | null | undefined>,
 ): t.FlowType[] {
+  const nodes = Array.from(nodesIn);
+
   const generics = new Map<string, t.GenericTypeAnnotation>();
   const bases = new Map<t.FlowBaseAnnotation["type"], t.FlowBaseAnnotation>();
 
@@ -49,8 +50,7 @@ export default function removeTypeDuplicates(
 
     if (isUnionTypeAnnotation(node)) {
       if (!typeGroups.has(node.types)) {
-        // todo(babel 8): use .push when nodes is mutable
-        nodes = nodes.concat(node.types);
+        nodes.push(...node.types);
         typeGroups.add(node.types);
       }
       continue;
@@ -64,8 +64,9 @@ export default function removeTypeDuplicates(
         let existing: t.Flow = generics.get(name);
         if (existing.typeParameters) {
           if (node.typeParameters) {
+            existing.typeParameters.params.push(...node.typeParameters.params);
             existing.typeParameters.params = removeTypeDuplicates(
-              existing.typeParameters.params.concat(node.typeParameters.params),
+              existing.typeParameters.params,
             );
           }
         } else {

--- a/packages/babel-types/src/modifications/typescript/removeTypeDuplicates.ts
+++ b/packages/babel-types/src/modifications/typescript/removeTypeDuplicates.ts
@@ -17,8 +17,10 @@ function getQualifiedName(node: t.TSTypeReference["typeName"]): string {
  * Dedupe type annotations.
  */
 export default function removeTypeDuplicates(
-  nodes: Array<t.TSType>,
+  nodesIn: ReadonlyArray<t.TSType>,
 ): Array<t.TSType> {
+  const nodes = Array.from(nodesIn);
+
   const generics = new Map<string, t.TSTypeReference>();
   const bases = new Map<t.TSBaseType["type"], t.TSBaseType>();
 
@@ -63,8 +65,9 @@ export default function removeTypeDuplicates(
         let existing: t.TypeScript = generics.get(name);
         if (existing.typeParameters) {
           if (node.typeParameters) {
+            existing.typeParameters.params.push(...node.typeParameters.params);
             existing.typeParameters.params = removeTypeDuplicates(
-              existing.typeParameters.params.concat(node.typeParameters.params),
+              existing.typeParameters.params,
             );
           }
         } else {

--- a/scripts/integration-tests/e2e-jest.sh
+++ b/scripts/integration-tests/e2e-jest.sh
@@ -15,7 +15,7 @@ source utils/cleanup.sh
 set -x
 
 # Clone jest
-git clone --depth=1 https://github.com/facebook/jest /tmp/jest
+git clone --depth=1 https://github.com/jestjs/jest /tmp/jest
 cd /tmp/jest || exit
 
 # Update @babel/* dependencies
@@ -52,6 +52,9 @@ if [ "$BABEL_8_BREAKING" = true ] ; then
   # Replace isTSX with the JSX plugin
   sed -i "s/isTSX: sourceFilePath.endsWith('x')//g" packages/jest-snapshot/src/InlineSnapshots.ts
   sed -i "s%'TypeScript syntax plugin added by Jest snapshot',%'TypeScript syntax plugin added by Jest snapshot'],[require.resolve('@babel/plugin-syntax-jsx')%g" packages/jest-snapshot/src/InlineSnapshots.ts
+
+  # Delete once https://github.com/jestjs/jest/pull/14109 is merged
+  sed -i "s/blacklist/denylist/g" packages/babel-plugin-jest-hoist/src/index.ts
 
   node -e "
     var pkg = require('./package.json');

--- a/scripts/integration-tests/e2e-vue-cli.sh
+++ b/scripts/integration-tests/e2e-vue-cli.sh
@@ -42,6 +42,9 @@ sed -i 's%toMatch(`regenerator-runtime/runtime`)%toMatch(`@babel/runtime/helpers
 if [ "$BABEL_8_BREAKING" = true ] ; then
   # This option is renamed in Babel 8
   sed -i 's/legacy: decoratorsLegacy !== false/version: decoratorsLegacy === false ? "legacy": "2021-12"/g' packages/@vue/babel-preset-app/index.js
+
+  # Delete once https://github.com/jestjs/jest/pull/14109 is released
+  sed -i "s/blacklist/denylist/g" node_modules/babel-plugin-jest-hoist/build/index.js
 fi
 
 # Test


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

These are almost all the remaining `TODO(Babel 8)` comments :)

What remains to do (in other PRs):
- Some changes for decorators, which will conflict with https://github.com/babel/babel/pull/15570
- Decide if we want the `noNewArrow` assumption to default to `false` (I now think we shouldn't _if they are still compiled by our default targets_)
- https://github.com/babel/babel/pull/12253#discussion_r513086528
- https://github.com/babel/babel/blob/fe429652f00903d88bf05d1d0fa4a9c6ee03db61/packages/babel-traverse/src/path/introspection.ts#L337
- https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-block-scoping/src/annex-B_3_3.ts#L10
- Some changes to types

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15576"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

