### PR TITLE
Add syntax import meta to preset env

### DIFF
--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -43,6 +43,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
     "@babel/plugin-syntax-import-assertions": "workspace:^",
+    "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/plugin-syntax-json-strings": "^7.8.3",
     "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
     "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",

--- a/packages/babel-preset-env/src/available-plugins.ts
+++ b/packages/babel-preset-env/src/available-plugins.ts
@@ -6,6 +6,7 @@ import syntaxClassStaticBlock from "@babel/plugin-syntax-class-static-block";
 import syntaxDynamicImport from "@babel/plugin-syntax-dynamic-import";
 import syntaxExportNamespaceFrom from "@babel/plugin-syntax-export-namespace-from";
 import syntaxImportAssertions from "@babel/plugin-syntax-import-assertions";
+import syntaxImportMeta from "@babel/plugin-syntax-import-meta";
 import syntaxJsonStrings from "@babel/plugin-syntax-json-strings";
 import syntaxLogicalAssignmentOperators from "@babel/plugin-syntax-logical-assignment-operators";
 import syntaxNullishCoalescingOperator from "@babel/plugin-syntax-nullish-coalescing-operator";
@@ -89,6 +90,7 @@ export default {
   "syntax-dynamic-import": () => syntaxDynamicImport,
   "syntax-export-namespace-from": () => syntaxExportNamespaceFrom,
   "syntax-import-assertions": () => syntaxImportAssertions,
+  "syntax-import-meta": () => syntaxImportMeta,
   "syntax-json-strings": () => syntaxJsonStrings,
   "syntax-logical-assignment-operators": () => syntaxLogicalAssignmentOperators,
   "syntax-nullish-coalescing-operator": () => syntaxNullishCoalescingOperator,

--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -170,6 +170,11 @@ export const getModulesPluginNames = ({
     modulesPluginNames.push("syntax-top-level-await");
   }
 
+  if (!process.env.BABEL_8_BREAKING) {
+    // Enable import meta for @babel/core < 7.10
+    modulesPluginNames.push("syntax-import-meta");
+  }
+
   return modulesPluginNames;
 };
 

--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -170,10 +170,8 @@ export const getModulesPluginNames = ({
     modulesPluginNames.push("syntax-top-level-await");
   }
 
-  if (!process.env.BABEL_8_BREAKING) {
-    // Enable import meta for @babel/core < 7.10
-    modulesPluginNames.push("syntax-import-meta");
-  }
+  // Enable import meta for @babel/core < 7.10
+  modulesPluginNames.push("syntax-import-meta");
 
   return modulesPluginNames;
 };

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-babel-7/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-babel-7/stdout.txt
@@ -42,5 +42,6 @@ Using plugins:
   bugfix/transform-tagged-template-caching { ios < 13, safari < 13 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes-babel-7/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes-babel-7/stdout.txt
@@ -40,5 +40,6 @@ Using plugins:
   transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
@@ -40,5 +40,6 @@ Using plugins:
   transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
@@ -42,5 +42,6 @@ Using plugins:
   bugfix/transform-tagged-template-caching { ios < 13, safari < 13 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
@@ -46,5 +46,6 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-70/stdout.txt
@@ -23,5 +23,6 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-14/stdout.txt
@@ -31,5 +31,6 @@ Using plugins:
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-15/stdout.txt
@@ -28,5 +28,6 @@ Using plugins:
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17-no-bugfixes/stdout.txt
@@ -28,5 +28,6 @@ Using plugins:
   transform-export-namespace-from { edge < 79 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-17/stdout.txt
@@ -28,5 +28,6 @@ Using plugins:
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-edge-18/stdout.txt
@@ -27,5 +27,6 @@ Using plugins:
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14-no-bugfixes/stdout.txt
@@ -31,5 +31,6 @@ Using plugins:
   transform-export-namespace-from { edge < 79 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-14/stdout.txt
@@ -31,5 +31,6 @@ Using plugins:
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-function-name-edge-15/stdout.txt
@@ -28,5 +28,6 @@ Using plugins:
   bugfix/transform-edge-function-name { edge < 79 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
@@ -32,5 +32,6 @@ Using plugins:
   transform-export-namespace-from { safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
@@ -33,5 +33,6 @@ Using plugins:
   bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
@@ -29,5 +29,6 @@ Using plugins:
   bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
@@ -41,5 +41,6 @@ Using plugins:
   bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15-no-bugfixes/stdout.txt
@@ -22,5 +22,6 @@ Using plugins:
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15/stdout.txt
@@ -22,5 +22,6 @@ Using plugins:
   transform-export-namespace-from { safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
@@ -21,5 +21,6 @@ Using plugins:
   transform-modules-commonjs
   transform-dynamic-import
   transform-export-namespace-from { }
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
@@ -22,5 +22,6 @@ Using plugins:
   transform-modules-commonjs
   transform-dynamic-import
   transform-export-namespace-from { }
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -39,6 +39,7 @@ Using plugins:
   transform-block-scoping { ios < 11, safari < 11 }
   transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
   syntax-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -41,6 +41,7 @@ Using plugins:
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios, safari }
   bugfix/transform-tagged-template-caching { ios < 13, safari < 13 }
   syntax-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -39,6 +39,7 @@ Using plugins:
   transform-block-scoping { ios < 11, safari < 11 }
   transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
   syntax-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -41,6 +41,7 @@ Using plugins:
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios, safari }
   bugfix/transform-tagged-template-caching { ios < 13, safari < 13 }
   syntax-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslist-env/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslist-env/stdout.txt
@@ -48,5 +48,6 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-android-3/stdout.txt
@@ -52,5 +52,6 @@ Using plugins:
   transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
@@ -30,5 +30,6 @@ Using plugins:
   transform-export-namespace-from { ios, safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
@@ -30,5 +30,6 @@ Using plugins:
   transform-export-namespace-from { ios, safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
@@ -29,5 +29,6 @@ Using plugins:
   transform-export-namespace-from { ios, safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/corejs-without-usebuiltins/stdout.txt
@@ -52,5 +52,6 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-android/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
@@ -36,6 +36,7 @@ Using plugins:
   transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-reserved-words { }
   transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-no-import/stdout.txt
@@ -31,6 +31,7 @@ Using plugins:
   transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-proposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-shippedProposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
@@ -54,6 +54,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-strings/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-all/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-android/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-babel-polyfill/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
@@ -36,6 +36,7 @@ Using plugins:
   transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es-proposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-es/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-reserved-words { }
   transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-no-import/stdout.txt
@@ -31,6 +31,7 @@ Using plugins:
   transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-proposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-runtime-only/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-entries/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
@@ -54,6 +54,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -25,6 +25,7 @@ Using plugins:
   transform-export-namespace-from { samsung < 11.0 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stable/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-stage/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-strings/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-web/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-no-import/stdout.txt
@@ -31,6 +31,7 @@ Using plugins:
   transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-shippedProposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-reserved-words { }
   transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
@@ -32,5 +32,6 @@ Using plugins:
   transform-export-namespace-from { firefox < 80, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-modules-commonjs
   transform-dynamic-import
   transform-export-namespace-from { }
+  syntax-import-meta
   syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
@@ -22,6 +22,7 @@ Using plugins:
   transform-modules-commonjs
   transform-dynamic-import
   transform-export-namespace-from { }
+  syntax-import-meta
   syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets-shadowed/stdout.txt
@@ -26,5 +26,6 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
@@ -23,5 +23,6 @@ Using plugins:
   transform-modules-commonjs
   transform-dynamic-import
   transform-export-namespace-from { }
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-1/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-chrome-71-2/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-with-import/stdout.txt
@@ -26,6 +26,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-1/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-chrome-71-2/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-with-import/stdout.txt
@@ -26,6 +26,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslist-env/stdout.txt
@@ -48,5 +48,6 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
@@ -52,5 +52,6 @@ Using plugins:
   transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -30,5 +30,6 @@ Using plugins:
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios, safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -30,5 +30,6 @@ Using plugins:
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios, safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -29,5 +29,6 @@ Using plugins:
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios, safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
@@ -52,5 +52,6 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -36,6 +36,7 @@ Using plugins:
   transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-reserved-words { }
   transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
@@ -31,6 +31,7 @@ Using plugins:
   transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -54,6 +54,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { android < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -36,6 +36,7 @@ Using plugins:
   transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-reserved-words { }
   transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
@@ -31,6 +31,7 @@ Using plugins:
   transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
@@ -54,6 +54,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios, safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -25,6 +25,7 @@ Using plugins:
   transform-export-namespace-from { samsung < 11.0 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
@@ -31,6 +31,7 @@ Using plugins:
   transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
@@ -52,6 +52,7 @@ Using plugins:
   transform-export-namespace-from { ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-reserved-words { }
   transform-export-namespace-from { chrome < 72 }
   syntax-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, ie, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
@@ -33,5 +33,6 @@ Using plugins:
   bugfix/transform-async-arrows-in-class { node < 7.6 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-80/stdout.txt
@@ -24,6 +24,7 @@ Using plugins:
   transform-modules-commonjs
   transform-dynamic-import
   transform-export-namespace-from { }
+  syntax-import-meta
   syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/shippedProposals-chrome-84/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-modules-commonjs
   transform-dynamic-import
   transform-export-namespace-from { }
+  syntax-import-meta
   syntax-import-assertions
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets-shadowed/stdout.txt
@@ -26,5 +26,6 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/top-level-targets/stdout.txt
@@ -24,5 +24,6 @@ Using plugins:
   transform-modules-commonjs
   transform-dynamic-import
   transform-export-namespace-from { }
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs2: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
@@ -26,6 +26,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -23,6 +23,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
   syntax-import-assertions
 corejs3: `DEBUG` option
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
@@ -26,6 +26,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
@@ -50,6 +50,7 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, firefox < 80, ie }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12-babel-7/stdout.txt
@@ -23,5 +23,6 @@ Using plugins:
   transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/class-features-node-12/stdout.txt
@@ -23,5 +23,6 @@ Using plugins:
   transform-export-namespace-from { node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
@@ -32,5 +32,6 @@ Using plugins:
   transform-export-namespace-from { safari }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
@@ -33,5 +33,6 @@ Using plugins:
   bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
   transform-dynamic-import
+  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/import-meta.js
+++ b/packages/babel-preset-env/test/import-meta.js
@@ -1,0 +1,32 @@
+import env from "../lib/index.js";
+import * as babel from "@babel/core";
+
+const itBabel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
+
+describe("preset-env", () => {
+  function extractParserOptions(api, { ref }) {
+    return {
+      manipulateOptions(opts, parserOpts) {
+        ref.parserOpts = parserOpts;
+      },
+      visitor: {},
+    };
+  }
+
+  itBabel7(
+    "should enable the 'importMeta' parser plugin for old parser versions",
+    () => {
+      const ref = {};
+      babel.transformSync("", {
+        configFile: false,
+        presets: [env],
+        plugins: [[extractParserOptions, { ref }]],
+        caller: {
+          name: "test",
+        },
+      });
+
+      expect(ref.parserOpts.plugins).toContain("importMeta");
+    },
+  );
+});

--- a/packages/babel-preset-env/test/import-meta.js
+++ b/packages/babel-preset-env/test/import-meta.js
@@ -1,8 +1,6 @@
 import env from "../lib/index.js";
 import * as babel from "@babel/core";
 
-const itBabel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
-
 describe("preset-env", () => {
   function extractParserOptions(api, { ref }) {
     return {
@@ -13,20 +11,17 @@ describe("preset-env", () => {
     };
   }
 
-  itBabel7(
-    "should enable the 'importMeta' parser plugin for old parser versions",
-    () => {
-      const ref = {};
-      babel.transformSync("", {
-        configFile: false,
-        presets: [env],
-        plugins: [[extractParserOptions, { ref }]],
-        caller: {
-          name: "test",
-        },
-      });
+  it("should enable the 'importMeta' parser plugin for old parser versions", () => {
+    const ref = {};
+    babel.transformSync("", {
+      configFile: false,
+      presets: [env],
+      plugins: [[extractParserOptions, { ref }]],
+      caller: {
+        name: "test",
+      },
+    });
 
-      expect(ref.parserOpts.plugins).toContain("importMeta");
-    },
-  );
+    expect(ref.parserOpts.plugins).toContain("importMeta");
+  });
 });

--- a/packages/babel-preset-env/test/index.skip-bundled.js
+++ b/packages/babel-preset-env/test/index.skip-bundled.js
@@ -71,7 +71,15 @@ describe("babel-preset-env", () => {
             shouldTransformDynamicImport: false,
             shouldTransformExportNamespaceFrom: false,
           }),
-        ).toEqual(["syntax-dynamic-import", "syntax-export-namespace-from"]);
+        ).toEqual(
+          process.env.BABEL_8_BREAKING
+            ? ["syntax-dynamic-import", "syntax-export-namespace-from"]
+            : [
+                "syntax-dynamic-import",
+                "syntax-export-namespace-from",
+                "syntax-import-meta",
+              ],
+        );
       });
     });
     describe("modules is not set to false", () => {
@@ -85,7 +93,15 @@ describe("babel-preset-env", () => {
               shouldTransformDynamicImport: false,
               shouldTransformExportNamespaceFrom: false,
             }),
-          ).toEqual(["syntax-dynamic-import", "syntax-export-namespace-from"]);
+          ).toEqual(
+            process.env.BABEL_8_BREAKING
+              ? ["syntax-dynamic-import", "syntax-export-namespace-from"]
+              : [
+                  "syntax-dynamic-import",
+                  "syntax-export-namespace-from",
+                  "syntax-import-meta",
+                ],
+          );
         });
       });
       describe("ESMs should be transformed", () => {
@@ -99,11 +115,20 @@ describe("babel-preset-env", () => {
                 shouldTransformDynamicImport: false,
                 shouldTransformExportNamespaceFrom: false,
               }),
-            ).toEqual([
-              "transform-modules-commonjs",
-              "syntax-dynamic-import",
-              "syntax-export-namespace-from",
-            ]);
+            ).toEqual(
+              process.env.BABEL_8_BREAKING
+                ? [
+                    "transform-modules-commonjs",
+                    "syntax-dynamic-import",
+                    "syntax-export-namespace-from",
+                  ]
+                : [
+                    "transform-modules-commonjs",
+                    "syntax-dynamic-import",
+                    "syntax-export-namespace-from",
+                    "syntax-import-meta",
+                  ],
+            );
           });
         });
         describe("dynamic imports should be transformed", () => {
@@ -116,11 +141,20 @@ describe("babel-preset-env", () => {
                 shouldTransformDynamicImport: true,
                 shouldTransformExportNamespaceFrom: false,
               }),
-            ).toEqual([
-              "transform-modules-systemjs",
-              "transform-dynamic-import",
-              "syntax-export-namespace-from",
-            ]);
+            ).toEqual(
+              process.env.BABEL_8_BREAKING
+                ? [
+                    "transform-modules-systemjs",
+                    "transform-dynamic-import",
+                    "syntax-export-namespace-from",
+                  ]
+                : [
+                    "transform-modules-systemjs",
+                    "transform-dynamic-import",
+                    "syntax-export-namespace-from",
+                    "syntax-import-meta",
+                  ],
+            );
           });
           describe("export namespace from should be transformed", () => {
             it("works", () => {
@@ -132,11 +166,20 @@ describe("babel-preset-env", () => {
                   shouldTransformDynamicImport: true,
                   shouldTransformExportNamespaceFrom: true,
                 }),
-              ).toEqual([
-                "transform-modules-systemjs",
-                "transform-dynamic-import",
-                "transform-export-namespace-from",
-              ]);
+              ).toEqual(
+                process.env.BABEL_8_BREAKING
+                  ? [
+                      "transform-modules-systemjs",
+                      "transform-dynamic-import",
+                      "transform-export-namespace-from",
+                    ]
+                  : [
+                      "transform-modules-systemjs",
+                      "transform-dynamic-import",
+                      "transform-export-namespace-from",
+                      "syntax-import-meta",
+                    ],
+              );
             });
           });
         });

--- a/packages/babel-preset-env/test/index.skip-bundled.js
+++ b/packages/babel-preset-env/test/index.skip-bundled.js
@@ -71,15 +71,11 @@ describe("babel-preset-env", () => {
             shouldTransformDynamicImport: false,
             shouldTransformExportNamespaceFrom: false,
           }),
-        ).toEqual(
-          process.env.BABEL_8_BREAKING
-            ? ["syntax-dynamic-import", "syntax-export-namespace-from"]
-            : [
-                "syntax-dynamic-import",
-                "syntax-export-namespace-from",
-                "syntax-import-meta",
-              ],
-        );
+        ).toEqual([
+          "syntax-dynamic-import",
+          "syntax-export-namespace-from",
+          "syntax-import-meta",
+        ]);
       });
     });
     describe("modules is not set to false", () => {
@@ -93,15 +89,11 @@ describe("babel-preset-env", () => {
               shouldTransformDynamicImport: false,
               shouldTransformExportNamespaceFrom: false,
             }),
-          ).toEqual(
-            process.env.BABEL_8_BREAKING
-              ? ["syntax-dynamic-import", "syntax-export-namespace-from"]
-              : [
-                  "syntax-dynamic-import",
-                  "syntax-export-namespace-from",
-                  "syntax-import-meta",
-                ],
-          );
+          ).toEqual([
+            "syntax-dynamic-import",
+            "syntax-export-namespace-from",
+            "syntax-import-meta",
+          ]);
         });
       });
       describe("ESMs should be transformed", () => {
@@ -115,20 +107,12 @@ describe("babel-preset-env", () => {
                 shouldTransformDynamicImport: false,
                 shouldTransformExportNamespaceFrom: false,
               }),
-            ).toEqual(
-              process.env.BABEL_8_BREAKING
-                ? [
-                    "transform-modules-commonjs",
-                    "syntax-dynamic-import",
-                    "syntax-export-namespace-from",
-                  ]
-                : [
-                    "transform-modules-commonjs",
-                    "syntax-dynamic-import",
-                    "syntax-export-namespace-from",
-                    "syntax-import-meta",
-                  ],
-            );
+            ).toEqual([
+              "transform-modules-commonjs",
+              "syntax-dynamic-import",
+              "syntax-export-namespace-from",
+              "syntax-import-meta",
+            ]);
           });
         });
         describe("dynamic imports should be transformed", () => {
@@ -141,20 +125,12 @@ describe("babel-preset-env", () => {
                 shouldTransformDynamicImport: true,
                 shouldTransformExportNamespaceFrom: false,
               }),
-            ).toEqual(
-              process.env.BABEL_8_BREAKING
-                ? [
-                    "transform-modules-systemjs",
-                    "transform-dynamic-import",
-                    "syntax-export-namespace-from",
-                  ]
-                : [
-                    "transform-modules-systemjs",
-                    "transform-dynamic-import",
-                    "syntax-export-namespace-from",
-                    "syntax-import-meta",
-                  ],
-            );
+            ).toEqual([
+              "transform-modules-systemjs",
+              "transform-dynamic-import",
+              "syntax-export-namespace-from",
+              "syntax-import-meta",
+            ]);
           });
           describe("export namespace from should be transformed", () => {
             it("works", () => {
@@ -166,20 +142,12 @@ describe("babel-preset-env", () => {
                   shouldTransformDynamicImport: true,
                   shouldTransformExportNamespaceFrom: true,
                 }),
-              ).toEqual(
-                process.env.BABEL_8_BREAKING
-                  ? [
-                      "transform-modules-systemjs",
-                      "transform-dynamic-import",
-                      "transform-export-namespace-from",
-                    ]
-                  : [
-                      "transform-modules-systemjs",
-                      "transform-dynamic-import",
-                      "transform-export-namespace-from",
-                      "syntax-import-meta",
-                    ],
-              );
+              ).toEqual([
+                "transform-modules-systemjs",
+                "transform-dynamic-import",
+                "transform-export-namespace-from",
+                "syntax-import-meta",
+              ]);
             });
           });
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,7 +2017,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/plugin-syntax-import-meta@npm:^7.8.3":
+"@babel/plugin-syntax-import-meta@npm:^7.10.4, @babel/plugin-syntax-import-meta@npm:^7.8.3":
   version: 7.10.4
   resolution: "@babel/plugin-syntax-import-meta@npm:7.10.4"
   dependencies:
@@ -3474,6 +3474,7 @@ __metadata:
     "@babel/plugin-syntax-dynamic-import": ^7.8.3
     "@babel/plugin-syntax-export-namespace-from": ^7.8.3
     "@babel/plugin-syntax-import-assertions": "workspace:^"
+    "@babel/plugin-syntax-import-meta": ^7.10.4
     "@babel/plugin-syntax-json-strings": ^7.8.3
     "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
     "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15578 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Added `syntax-import-meta` to `preset-env`, so that the `import.meta` parsing will be enabled when `preset-env` is used with `@babel/core` < 7.10.0. For most users using `@babel/core` 7.10.0 or above, this PR introduces no changes.

I am marking this PR as bug fixes because the syntax plugin has been materialized since 7.10.0, so it fixes a compatibility issue affecting older `@babel/core` versions.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15580"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

