### PR TITLE
fix: `traverse.visitors.merge` unable to handle `enter,exit`

### DIFF
--- a/packages/babel-traverse/test/visitors.js
+++ b/packages/babel-traverse/test/visitors.js
@@ -1,0 +1,85 @@
+import { parse } from "@babel/parser";
+
+import _traverse, { visitors } from "../lib/index.js";
+const traverse = _traverse.default || _traverse;
+
+describe("visitors", () => {
+  it("should set `_verified` and `_exploded` to `true` if merging catch-all visitors", () => {
+    const visitor = visitors.merge([{ enter() {} }, { enter() {} }]);
+    expect(visitor._verified).toBe(true);
+    expect(visitor._exploded).toBe(true);
+  });
+
+  it("should work when merging node type visitors", () => {
+    const ast = parse("1");
+    const visitor = visitors.merge([
+      { ArrayExpression() {} },
+      { ArrayExpression() {} },
+    ]);
+    traverse(ast, visitor);
+    expect(visitor).toMatchInlineSnapshot(`
+      Object {
+        "ArrayExpression": Object {
+          "enter": Array [
+            [Function],
+            [Function],
+          ],
+        },
+        "_exploded": true,
+        "_verified": true,
+      }
+    `);
+  });
+
+  it("enter", () => {
+    const ast = parse("1");
+    const visitor = visitors.merge([{ enter() {} }, { enter() {} }]);
+    traverse(ast, visitor);
+    expect(visitor).toMatchInlineSnapshot(`
+      Object {
+        "_exploded": true,
+        "_verified": true,
+        "enter": Array [
+          [Function],
+          [Function],
+        ],
+      }
+    `);
+  });
+
+  it("enter with states", () => {
+    const ast = parse("1");
+    const visitor = visitors.merge([{ enter() {} }, { enter() {} }], [{}, {}]);
+    traverse(ast, visitor);
+    expect(visitor).toMatchInlineSnapshot(`
+      Object {
+        "_exploded": true,
+        "_verified": true,
+        "enter": Array [
+          [Function],
+          [Function],
+        ],
+      }
+    `);
+  });
+
+  it("enter with wrapper", () => {
+    const ast = parse("1");
+    const visitor = visitors.merge(
+      [{ enter() {} }, { enter() {} }],
+      [{}, {}],
+      (stateKey, key, fn) => fn,
+    );
+    traverse(ast, visitor);
+    expect(visitor).toMatchInlineSnapshot(`
+      Object {
+        "_exploded": true,
+        "_verified": true,
+        "enter": Array [
+          [Function],
+          [Function],
+        ],
+      }
+    `);
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15587 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I'm not sure if this will be a breaking change, although it's a bugfix, since the `state` parameter didn't support `enter` and `exit` at all before then.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15593"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

