### PR TITLE
Fix backward compat for semver checks in class&regexp feat plugins

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -96,6 +96,15 @@ export function createClassFeaturePlugin({
     pre(file) {
       enableFeature(file, feature, loose);
 
+      if (!process.env.BABEL_8_BREAKING) {
+        // Until 7.21.4, we used to encode the version as a number.
+        // If file.get(versionKey) is a number, it has thus been
+        // set by an older version of this plugin.
+        if (typeof file.get(versionKey) === "number") {
+          file.set(versionKey, PACKAGE_JSON.version);
+          return;
+        }
+      }
       if (
         !file.get(versionKey) ||
         semver.lt(file.get(versionKey), PACKAGE_JSON.version)

--- a/packages/babel-helper-create-regexp-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-regexp-features-plugin/src/index.ts
@@ -82,8 +82,17 @@ export function createRegExpFeaturePlugin({
         }
       }
 
+      if (!process.env.BABEL_8_BREAKING) {
+        // Until 7.21.4, we used to encode the version as a number.
+        // If file.get(versionKey) is a number, it has thus been
+        // set by an older version of this plugin.
+        if (typeof file.get(versionKey) === "number") {
+          file.set(versionKey, PACKAGE_JSON.version);
+          return;
+        }
+      }
       if (
-        !file.has(versionKey) ||
+        !file.get(versionKey) ||
         semver.lt(file.get(versionKey), PACKAGE_JSON.version)
       ) {
         file.set(versionKey, PACKAGE_JSON.version);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15604
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

https://github.com/babel/babel/pull/15548 changed the protocol we use to communicate the version across different instances of `@babel/helper-create-class-features-plugin` and `@babel/helper-create-regexp-features-plugin`. This PR restores compatibility when using two versions of this "plugin group", one <=7.21.4 and one >7.21.4.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15605"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

