### PR TITLE
fix: enable transform-block-scoping with generators feature (#12806)

### DIFF
--- a/packages/babel-compat-data/data/plugin-bugfixes.json
+++ b/packages/babel-compat-data/data/plugin-bugfixes.json
@@ -170,15 +170,15 @@
     "electron": "1.2"
   },
   "transform-block-scoping": {
-    "chrome": "49",
-    "opera": "36",
+    "chrome": "50",
+    "opera": "37",
     "edge": "14",
-    "firefox": "51",
+    "firefox": "53",
     "safari": "10",
     "node": "6",
     "deno": "1",
     "ios": "10",
     "samsung": "5",
-    "electron": "0.37"
+    "electron": "1.1"
   }
 }

--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -566,16 +566,16 @@
     "electron": "1.2"
   },
   "transform-block-scoping": {
-    "chrome": "49",
-    "opera": "36",
+    "chrome": "50",
+    "opera": "37",
     "edge": "14",
-    "firefox": "51",
+    "firefox": "53",
     "safari": "11",
     "node": "6",
     "deno": "1",
     "ios": "11",
     "samsung": "5",
-    "electron": "0.37"
+    "electron": "1.1"
   },
   "transform-typeof-symbol": {
     "chrome": "38",

--- a/packages/babel-compat-data/scripts/data/plugin-features.js
+++ b/packages/babel-compat-data/scripts/data/plugin-features.js
@@ -102,7 +102,7 @@ const es2015 = {
     features: ["destructuring, assignment", "destructuring, declarations"],
   },
   "transform-block-scoping": {
-    features: ["const", "let"],
+    features: ["const", "let", "generators"],
   },
   "transform-typeof-symbol": {
     features: ["Symbol / typeof support"],

--- a/packages/babel-compat-data/scripts/data/plugin-features.js
+++ b/packages/babel-compat-data/scripts/data/plugin-features.js
@@ -102,7 +102,13 @@ const es2015 = {
     features: ["destructuring, assignment", "destructuring, declarations"],
   },
   "transform-block-scoping": {
-    features: ["const", "let", "generators"],
+    features: [
+      "const",
+      "let",
+      // regenerator-transform doesn't support let/const,
+      // so we must compile them when compiling generators.
+      "generators",
+    ],
   },
   "transform-typeof-symbol": {
     features: ["Symbol / typeof support"],

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
@@ -31,7 +31,7 @@ Using plugins:
   transform-sticky-regex { electron < 0.37 }
   transform-unicode-regex { electron < 1.1 }
   transform-destructuring { electron < 1.2 }
-  transform-block-scoping { electron < 0.37 }
+  transform-block-scoping { electron < 1.1 }
   transform-regenerator { electron < 1.1 }
   transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
@@ -47,7 +47,7 @@ Using plugins:
   transform-unicode-regex { ie, ios < 12, safari < 12 }
   transform-spread { ie, ios < 10, safari < 10 }
   transform-destructuring { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
-  transform-block-scoping { edge < 14, firefox < 51, ie, ios < 11, safari < 11 }
+  transform-block-scoping { edge < 14, firefox < 53, ie, ios < 11, safari < 11 }
   transform-typeof-symbol { ie, safari < 9 }
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
@@ -45,7 +45,7 @@ Using plugins:
   transform-unicode-regex { electron < 1.1, ie }
   transform-spread { ie }
   transform-destructuring { electron < 1.2, ie, node < 6.5 }
-  transform-block-scoping { electron < 0.37, ie }
+  transform-block-scoping { electron < 1.1, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
@@ -31,7 +31,7 @@ Using plugins:
   transform-sticky-regex { electron < 0.37 }
   transform-unicode-regex { electron < 1.1 }
   transform-destructuring { electron < 1.2 }
-  transform-block-scoping { electron < 0.37 }
+  transform-block-scoping { electron < 1.1 }
   transform-regenerator { electron < 1.1 }
   transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
@@ -47,7 +47,7 @@ Using plugins:
   transform-unicode-regex { ie, ios < 12, safari < 12 }
   transform-spread { ie, ios < 10, safari < 10 }
   transform-destructuring { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
-  transform-block-scoping { edge < 14, firefox < 51, ie, ios < 11, safari < 11 }
+  transform-block-scoping { edge < 14, firefox < 53, ie, ios < 11, safari < 11 }
   transform-typeof-symbol { ie, safari < 9 }
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
@@ -45,7 +45,7 @@ Using plugins:
   transform-unicode-regex { electron < 1.1, ie }
   transform-spread { ie }
   transform-destructuring { electron < 1.2, ie, node < 6.5 }
-  transform-block-scoping { electron < 0.37, ie }
+  transform-block-scoping { electron < 1.1, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/plugins-only/stdout.txt
@@ -29,6 +29,7 @@ Using plugins:
   transform-for-of { firefox < 53 }
   transform-unicode-escapes { firefox < 53 }
   transform-destructuring { firefox < 53 }
+  transform-block-scoping { firefox < 53 }
   transform-export-namespace-from { firefox < 80, node < 13.2 }
   transform-modules-commonjs
   transform-dynamic-import

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-none-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-proposals-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs2-shippedProposals-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-none-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-proposals-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-shippedProposals-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/usage-no-corejs-none-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -31,7 +31,7 @@ Using plugins:
   transform-sticky-regex { electron < 0.37 }
   transform-unicode-regex { electron < 1.1 }
   transform-destructuring { electron < 1.2 }
-  transform-block-scoping { electron < 0.37 }
+  transform-block-scoping { electron < 1.1 }
   transform-regenerator { electron < 1.1 }
   transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -47,7 +47,7 @@ Using plugins:
   transform-unicode-regex { ie, ios < 12, safari < 12 }
   transform-spread { ie, ios < 10, safari < 10 }
   transform-destructuring { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
-  transform-block-scoping { edge < 14, firefox < 51, ie, ios < 10, safari < 10 }
+  transform-block-scoping { edge < 14, firefox < 53, ie, ios < 10, safari < 10 }
   transform-typeof-symbol { ie, safari < 9 }
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -45,7 +45,7 @@ Using plugins:
   transform-unicode-regex { electron < 1.1, ie }
   transform-spread { ie }
   transform-destructuring { electron < 1.2, ie, node < 6.5 }
-  transform-block-scoping { electron < 0.37, ie }
+  transform-block-scoping { electron < 1.1, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -31,7 +31,7 @@ Using plugins:
   transform-sticky-regex { electron < 0.37 }
   transform-unicode-regex { electron < 1.1 }
   transform-destructuring { electron < 1.2 }
-  transform-block-scoping { electron < 0.37 }
+  transform-block-scoping { electron < 1.1 }
   transform-regenerator { electron < 1.1 }
   transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
@@ -47,7 +47,7 @@ Using plugins:
   transform-unicode-regex { ie, ios < 12, safari < 12 }
   transform-spread { ie, ios < 10, safari < 10 }
   transform-destructuring { edge < 15, firefox < 53, ie, ios < 10, safari < 10 }
-  transform-block-scoping { edge < 14, firefox < 51, ie, ios < 10, safari < 10 }
+  transform-block-scoping { edge < 14, firefox < 53, ie, ios < 10, safari < 10 }
   transform-typeof-symbol { ie, safari < 9 }
   transform-new-target { edge < 14, ie, ios < 10, safari < 10 }
   transform-regenerator { firefox < 53, ie, ios < 10, safari < 10 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -45,7 +45,7 @@ Using plugins:
   transform-unicode-regex { electron < 1.1, ie }
   transform-spread { ie }
   transform-destructuring { electron < 1.2, ie, node < 6.5 }
-  transform-block-scoping { electron < 0.37, ie }
+  transform-block-scoping { electron < 1.1, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
@@ -29,6 +29,7 @@ Using plugins:
   transform-for-of { firefox < 53 }
   transform-unicode-escapes { firefox < 53 }
   transform-destructuring { firefox < 53 }
+  transform-block-scoping { firefox < 53 }
   transform-export-namespace-from { firefox < 80, node < 13.2 }
   bugfix/transform-async-arrows-in-class { node < 7.6 }
   transform-modules-commonjs

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
@@ -43,7 +43,7 @@ Using plugins:
   transform-unicode-regex { ie }
   transform-spread { ie }
   transform-destructuring { firefox < 53, ie }
-  transform-block-scoping { firefox < 51, ie }
+  transform-block-scoping { firefox < 53, ie }
   transform-typeof-symbol { ie }
   transform-new-target { ie }
   transform-regenerator { firefox < 53, ie }

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generato-babel-7/input.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generato-babel-7/input.js
@@ -1,0 +1,6 @@
+async function test() {
+  const obj = {};
+  for (const ch of ["good", "bad"]) {
+    obj[ch] = () => ch;
+  }
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generato-babel-7/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generato-babel-7/options.json
@@ -1,5 +1,5 @@
 {
-  "BABEL_8_BREAKING": true,
+  "BABEL_8_BREAKING": false,
   "validateLogs": true,
   "presets": [
     [

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generato-babel-7/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generato-babel-7/output.js
@@ -1,0 +1,42 @@
+function test() {
+  return _test.apply(this, arguments);
+}
+function _test() {
+  _test = babelHelpers.asyncToGenerator( /*#__PURE__*/babelHelpers.regeneratorRuntime().mark(function _callee() {
+    var obj, _loop, _i, _arr;
+    return babelHelpers.regeneratorRuntime().wrap(function _callee$(_context2) {
+      while (1) switch (_context2.prev = _context2.next) {
+        case 0:
+          obj = {};
+          _loop = /*#__PURE__*/babelHelpers.regeneratorRuntime().mark(function _loop() {
+            var ch;
+            return babelHelpers.regeneratorRuntime().wrap(function _loop$(_context) {
+              while (1) switch (_context.prev = _context.next) {
+                case 0:
+                  ch = _arr[_i];
+                  obj[ch] = () => ch;
+                case 2:
+                case "end":
+                  return _context.stop();
+              }
+            }, _loop);
+          });
+          _i = 0, _arr = ["good", "bad"];
+        case 3:
+          if (!(_i < _arr.length)) {
+            _context2.next = 8;
+            break;
+          }
+          return _context2.delegateYield(_loop(), "t0", 5);
+        case 5:
+          _i++;
+          _context2.next = 3;
+          break;
+        case 8:
+        case "end":
+          return _context2.stop();
+      }
+    }, _callee);
+  }));
+  return _test.apply(this, arguments);
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generato-babel-7/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generato-babel-7/stdout.txt
@@ -1,0 +1,39 @@
+@babel/preset-env: `DEBUG` option
+
+Using targets:
+{
+  "chrome": "49"
+}
+
+Using modules transform: auto
+
+Using plugins:
+  transform-class-static-block { chrome < 94 }
+  transform-private-property-in-object { chrome < 91 }
+  transform-class-properties { chrome < 74 }
+  transform-private-methods { chrome < 84 }
+  transform-numeric-separator { chrome < 75 }
+  transform-logical-assignment-operators { chrome < 85 }
+  transform-nullish-coalescing-operator { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
+  transform-json-strings { chrome < 66 }
+  transform-optional-catch-binding { chrome < 66 }
+  transform-async-generator-functions { chrome < 63 }
+  transform-object-rest-spread { chrome < 60 }
+  transform-dotall-regex { chrome < 62 }
+  transform-unicode-property-regex { chrome < 64 }
+  transform-named-capturing-groups-regex { chrome < 64 }
+  transform-async-to-generator { chrome < 55 }
+  transform-exponentiation-operator { chrome < 52 }
+  transform-function-name { chrome < 51 }
+  transform-for-of { chrome < 51 }
+  transform-unicode-regex { chrome < 50 }
+  transform-destructuring { chrome < 51 }
+  transform-block-scoping { chrome < 50 }
+  transform-regenerator { chrome < 50 }
+  transform-export-namespace-from { chrome < 72 }
+  transform-modules-commonjs
+  transform-dynamic-import
+  syntax-import-meta
+
+Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generator/input.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generator/input.js
@@ -1,0 +1,6 @@
+async function test() {
+  const obj = {};
+  for (const ch of ["good", "bad"]) {
+    obj[ch] = () => ch;
+  }
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generator/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generator/options.json
@@ -1,0 +1,12 @@
+{
+  "validateLogs": true,
+  "presets": [
+    [
+      "env",
+      {
+        "debug": true,
+        "targets": ["Chrome 49"]
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generator/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generator/output.js
@@ -1,0 +1,42 @@
+function test() {
+  return _test.apply(this, arguments);
+}
+function _test() {
+  _test = babelHelpers.asyncToGenerator( /*#__PURE__*/babelHelpers.regeneratorRuntime().mark(function _callee() {
+    var obj, _loop, _i, _arr;
+    return babelHelpers.regeneratorRuntime().wrap(function _callee$(_context2) {
+      while (1) switch (_context2.prev = _context2.next) {
+        case 0:
+          obj = {};
+          _loop = /*#__PURE__*/babelHelpers.regeneratorRuntime().mark(function _loop() {
+            var ch;
+            return babelHelpers.regeneratorRuntime().wrap(function _loop$(_context) {
+              while (1) switch (_context.prev = _context.next) {
+                case 0:
+                  ch = _arr[_i];
+                  obj[ch] = () => ch;
+                case 2:
+                case "end":
+                  return _context.stop();
+              }
+            }, _loop);
+          });
+          _i = 0, _arr = ["good", "bad"];
+        case 3:
+          if (!(_i < _arr.length)) {
+            _context2.next = 8;
+            break;
+          }
+          return _context2.delegateYield(_loop(), "t0", 5);
+        case 5:
+          _i++;
+          _context2.next = 3;
+          break;
+        case 8:
+        case "end":
+          return _context2.stop();
+      }
+    }, _callee);
+  }));
+  return _test.apply(this, arguments);
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generator/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generator/stdout.txt
@@ -15,7 +15,7 @@ Using plugins:
   transform-numeric-separator { chrome < 75 }
   transform-logical-assignment-operators { chrome < 85 }
   transform-nullish-coalescing-operator { chrome < 80 }
-  transform-optional-chaining { chrome < 91 }
+  transform-optional-chaining { chrome < 80 }
   transform-json-strings { chrome < 66 }
   transform-optional-catch-binding { chrome < 66 }
   transform-async-generator-functions { chrome < 63 }

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generator/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/block-scoping-inside-generator/stdout.txt
@@ -2,7 +2,7 @@
 
 Using targets:
 {
-  "chrome": "40"
+  "chrome": "49"
 }
 
 Using modules transform: auto
@@ -15,10 +15,9 @@ Using plugins:
   transform-numeric-separator { chrome < 75 }
   transform-logical-assignment-operators { chrome < 85 }
   transform-nullish-coalescing-operator { chrome < 80 }
-  transform-optional-chaining { chrome < 80 }
+  transform-optional-chaining { chrome < 91 }
   transform-json-strings { chrome < 66 }
   transform-optional-catch-binding { chrome < 66 }
-  transform-parameters { chrome < 49 }
   transform-async-generator-functions { chrome < 63 }
   transform-object-rest-spread { chrome < 60 }
   transform-dotall-regex { chrome < 62 }
@@ -26,22 +25,11 @@ Using plugins:
   transform-named-capturing-groups-regex { chrome < 64 }
   transform-async-to-generator { chrome < 55 }
   transform-exponentiation-operator { chrome < 52 }
-  transform-template-literals { chrome < 41 }
-  transform-literals { chrome < 44 }
   transform-function-name { chrome < 51 }
-  transform-block-scoped-functions { chrome < 41 }
-  transform-classes { chrome < 46 }
-  transform-object-super { chrome < 46 }
-  transform-shorthand-properties { chrome < 43 }
-  transform-duplicate-keys { chrome < 42 }
-  transform-computed-properties { chrome < 44 }
   transform-for-of { chrome < 51 }
-  transform-sticky-regex { chrome < 49 }
-  transform-unicode-escapes { chrome < 44 }
   transform-unicode-regex { chrome < 50 }
-  transform-spread { chrome < 46 }
+  transform-destructuring { chrome < 51 }
   transform-block-scoping { chrome < 50 }
-  transform-new-target { chrome < 46 }
   transform-regenerator { chrome < 50 }
   transform-export-namespace-from { chrome < 72 }
   transform-modules-commonjs


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Workaround for #12806
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | -
| Minor: New Feature?      | -
| Tests Added + Pass?      | 👍
| Documentation PR Link    | -
| Any Dependency Changes?  | -
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This adds `generators` to `transform-block-scoping` features:

https://github.com/babel/babel/blob/29426297d64315661b6407f331c304bba598d271/packages/babel-compat-data/scripts/data/plugin-features.js#L104-L106

as asked by @nicolo-ribaudo in #12806, and adds a regression test for Chrome 49 preset.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15606"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

