### PR TITLE
Create `@babel/plugin-proposal-import-attributes-to-assertions`

### DIFF
--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/.npmignore
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/.npmignore
@@ -1,0 +1,3 @@
+src
+test
+*.log

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/README.md
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/README.md
@@ -1,0 +1,19 @@
+# @babel/plugin-proposal-import-attributes-to-assertions
+
+> Transform optional chaining operators to workaround https://crbug.com/v8/11558
+
+See our website [@babel/plugin-proposal-import-attributes-to-assertions](https://babeljs.io/docs/en/babel-plugin-proposal-import-attributes-to-assertions) for more information.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @babel/plugin-proposal-import-attributes-to-assertions
+```
+
+or using yarn:
+
+```sh
+yarn add @babel/plugin-proposal-import-attributes-to-assertions --dev
+```

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/package.json
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@babel/plugin-proposal-import-attributes-to-assertions",
+  "version": "7.21.8",
+  "description": "Transform the Import Attributes proposal (`import ... from '...' with { ... }`) to the previous version known as Import Assertions (`import ... from '...' assert { ... }`).",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-import-attributes-to-assertions"
+  },
+  "homepage": "https://babel.dev/docs/en/next/babel-plugin-proposal-import-attributes-to-assertions",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./package.json": "./package.json"
+  },
+  "keywords": [
+    "babel-plugin",
+    "import",
+    "attributes",
+    "assertions",
+    "proposal",
+    "stage-3"
+  ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "workspace:^",
+    "@babel/plugin-syntax-import-attributes": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.22.0"
+  },
+  "devDependencies": {
+    "@babel/core": "workspace:^",
+    "@babel/helper-plugin-test-runner": "workspace:^"
+  },
+  "engines": {
+    "node": ">=6.9.0"
+  },
+  "author": "The Babel Team (https://babel.dev/team)",
+  "type": "commonjs",
+  "conditions": {
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  }
+}

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/src/index.ts
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/src/index.ts
@@ -1,0 +1,33 @@
+import { declare } from "@babel/helper-plugin-utils";
+import type { NodePath } from "@babel/traverse";
+import type * as t from "@babel/types";
+import syntaxImportAttributes from "@babel/plugin-syntax-import-attributes";
+
+export default declare(api => {
+  api.assertVersion(7);
+
+  return {
+    name: "proposal-import-attributes-to-assertions",
+
+    inherits: syntaxImportAttributes,
+
+    manipulateOptions({ generatorOpts }) {
+      generatorOpts.importAttributesKeyword = "assert";
+    },
+
+    visitor: {
+      "ImportDeclaration|ExportNamedDeclaration|ExportAllDeclaration"(
+        path: NodePath<
+          | t.ImportDeclaration
+          | t.ExportNamedDeclaration
+          | t.ExportAllDeclaration
+        >,
+      ) {
+        const { node } = path;
+        if (!node.attributes) return;
+        node.assertions = node.attributes;
+        node.attributes = null;
+      },
+    },
+  };
+});

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/test/fixtures/basic/exports/input.js
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/test/fixtures/basic/exports/input.js
@@ -1,0 +1,2 @@
+export { a } from "a" with { type: "json" };
+export * as ns from "c" with { type: "json" };

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/test/fixtures/basic/exports/output.mjs
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/test/fixtures/basic/exports/output.mjs
@@ -1,0 +1,2 @@
+export { a } from "a" assert { type: "json" };
+export * as ns from "c" assert { type: "json" };

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/test/fixtures/basic/imports/input.js
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/test/fixtures/basic/imports/input.js
@@ -1,0 +1,4 @@
+import { a } from "a" with { type: "json" };
+import b from "b" with { type: "json" };
+import * as ns from "c" with { type: "json" };
+import "d" with { type: "json" };

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/test/fixtures/basic/imports/output.mjs
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/test/fixtures/basic/imports/output.mjs
@@ -1,0 +1,4 @@
+import { a } from "a" assert { type: "json" };
+import b from "b" assert { type: "json" };
+import * as ns from "c" assert { type: "json" };
+import "d" assert { type: "json" };

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/test/fixtures/options.json
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/test/fixtures/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["proposal-import-attributes-to-assertions"]
+}

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/test/index.js
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/test/index.js
@@ -1,0 +1,3 @@
+import runner from "@babel/helper-plugin-test-runner";
+
+runner(import.meta.url);

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/test/package.json
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/test/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,6 +54,7 @@
     "./packages/babel-plugin-proposal-export-namespace-from/src/**/*.ts",
     "./packages/babel-plugin-proposal-function-bind/src/**/*.ts",
     "./packages/babel-plugin-proposal-function-sent/src/**/*.ts",
+    "./packages/babel-plugin-proposal-import-attributes-to-assertions/src/**/*.ts",
     "./packages/babel-plugin-proposal-json-strings/src/**/*.ts",
     "./packages/babel-plugin-proposal-logical-assignment-operators/src/**/*.ts",
     "./packages/babel-plugin-proposal-nullish-coalescing-operator/src/**/*.ts",
@@ -328,6 +329,9 @@
       ],
       "@babel/plugin-proposal-function-sent": [
         "./packages/babel-plugin-proposal-function-sent/src"
+      ],
+      "@babel/plugin-proposal-import-attributes-to-assertions": [
+        "./packages/babel-plugin-proposal-import-attributes-to-assertions/src"
       ],
       "@babel/plugin-proposal-json-strings": [
         "./packages/babel-plugin-proposal-json-strings/src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1473,6 +1473,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@babel/plugin-proposal-import-attributes-to-assertions@workspace:packages/babel-plugin-proposal-import-attributes-to-assertions":
+  version: 0.0.0-use.local
+  resolution: "@babel/plugin-proposal-import-attributes-to-assertions@workspace:packages/babel-plugin-proposal-import-attributes-to-assertions"
+  dependencies:
+    "@babel/core": "workspace:^"
+    "@babel/helper-plugin-test-runner": "workspace:^"
+    "@babel/helper-plugin-utils": "workspace:^"
+    "@babel/plugin-syntax-import-attributes": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.22.0
+  languageName: unknown
+  linkType: soft
+
 "@babel/plugin-proposal-json-strings@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-proposal-json-strings@npm:7.18.6"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR includes commits from https://github.com/babel/babel/pull/15536, please only review the last commit.

The documentation of this package will need to have a warning such as
> ⚠️ This plugin will generate code that is not compatible with the current ECMAScript specification or with any currently proposed addition to it. Only use it when necessary for compatibility with other tools that don't support the [Import Attributes](https://github.com/tc39/proposal-import-attributes) syntax (`import ... from "..." with { ... }`) but support the old Import Assertions syntax (`import ... from "..." assert { ... }`).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15620"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

