### PR TITLE
chore: Enable rule `no-import-type-side-effects`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -69,6 +69,7 @@ module.exports = {
           "error",
           { ignoreArrowShorthand: true },
         ],
+        "@typescript-eslint/no-import-type-side-effects": "error",
       },
     },
     {

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -18,7 +18,7 @@ import type { Opts as jsescOptions } from "jsesc";
 import * as generatorFunctions from "./generators";
 import type SourceMap from "./source-map";
 import * as charCodes from "charcodes";
-import { type TraceMap } from "@jridgewell/trace-mapping";
+import type { TraceMap } from "@jridgewell/trace-mapping";
 
 const SCIENTIFIC_NOTATION = /e/i;
 const ZERO_DECIMAL_INTEGER = /\.0+$/;

--- a/packages/babel-parser/src/index.ts
+++ b/packages/babel-parser/src/index.ts
@@ -1,4 +1,4 @@
-import { type Options } from "./options";
+import type { Options } from "./options";
 import {
   hasPlugin,
   validatePlugins,

--- a/packages/babel-parser/src/parser/util.ts
+++ b/packages/babel-parser/src/parser/util.ts
@@ -1,4 +1,4 @@
-import { type Position } from "../util/location";
+import type { Position } from "../util/location";
 import {
   tokenIsLiteralPropertyName,
   tt,

--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -1,4 +1,4 @@
-import { type TokenType } from "../tokenizer/types";
+import type { TokenType } from "../tokenizer/types";
 import type Parser from "../parser";
 import type { ExpressionErrors } from "../parser/util";
 import type * as N from "../types";

--- a/packages/babel-parser/src/plugins/jsx/index.ts
+++ b/packages/babel-parser/src/plugins/jsx/index.ts
@@ -17,7 +17,7 @@ import { isIdentifierChar, isIdentifierStart } from "../../util/identifier";
 import type { Position } from "../../util/location";
 import { isNewLine } from "../../util/whitespace";
 import { Errors, ParseErrorEnum } from "../../parse-error";
-import { type Undone } from "../../parser/node";
+import type { Undone } from "../../parser/node";
 
 /* eslint sort-keys: "error" */
 const JsxErrors = ParseErrorEnum`jsx`({

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -17,7 +17,7 @@ import {
   keywords as keywordTypes,
   type TokenType,
 } from "./types";
-import { type TokContext } from "./context";
+import type { TokContext } from "./context";
 import {
   Errors,
   type ParseError,

--- a/packages/babel-parser/src/tokenizer/state.ts
+++ b/packages/babel-parser/src/tokenizer/state.ts
@@ -6,7 +6,7 @@ import { Position } from "../util/location";
 import { types as ct, type TokContext } from "./context";
 import { tt, type TokenType } from "./types";
 import type { Errors } from "../parse-error";
-import { type ParseError } from "../parse-error";
+import type { ParseError } from "../parse-error";
 
 export type DeferredStrictError =
   | typeof Errors.StrictNumericEscape


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Since we're using `onlyRemoveTypeImports`, we should enable this rule to avoid sending meaningless `import`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15627"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

