### PR TITLE
fix: Reintroduce "require" export for runtime helpers

### DIFF
--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -161,6 +161,8 @@ function writeHelpers(runtimeName, { corejs } = {}) {
     // - Node.js >=13.7.0 and bundlers will successfully load the first
     //   array entry:
     //    * Node.js will always load the CJS file
+    //    * Bundlers without ESM support (e.g. Metro) will load the CJS file
+    //      (these Babel helpers enable subsequent "import"+"require" interop)
     //    * Modern tools when using "import" will load the ESM file
     //    * Everything else (old tools, or require() in tools) will
     //      load the CJS file
@@ -170,7 +172,7 @@ function writeHelpers(runtimeName, { corejs } = {}) {
     //   fallback to the second entry (the CJS file)
     // In Babel 8 we can simplify this.
     helperSubExports[`./${path.posix.join("helpers", helperName)}`] = [
-      { node: cjs, import: esm, default: cjs },
+      { node: cjs, require: cjs, import: esm, default: cjs },
       cjs,
     ];
     // For backward compatibility. We can remove this in Babel 8.

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -21,6 +21,7 @@
     "./helpers/AsyncGenerator": [
       {
         "node": "./helpers/AsyncGenerator.js",
+        "require": "./helpers/AsyncGenerator.js",
         "import": "./helpers/esm/AsyncGenerator.js",
         "default": "./helpers/AsyncGenerator.js"
       },
@@ -30,6 +31,7 @@
     "./helpers/OverloadYield": [
       {
         "node": "./helpers/OverloadYield.js",
+        "require": "./helpers/OverloadYield.js",
         "import": "./helpers/esm/OverloadYield.js",
         "default": "./helpers/OverloadYield.js"
       },
@@ -39,6 +41,7 @@
     "./helpers/applyDecs": [
       {
         "node": "./helpers/applyDecs.js",
+        "require": "./helpers/applyDecs.js",
         "import": "./helpers/esm/applyDecs.js",
         "default": "./helpers/applyDecs.js"
       },
@@ -48,6 +51,7 @@
     "./helpers/applyDecs2203": [
       {
         "node": "./helpers/applyDecs2203.js",
+        "require": "./helpers/applyDecs2203.js",
         "import": "./helpers/esm/applyDecs2203.js",
         "default": "./helpers/applyDecs2203.js"
       },
@@ -57,6 +61,7 @@
     "./helpers/applyDecs2203R": [
       {
         "node": "./helpers/applyDecs2203R.js",
+        "require": "./helpers/applyDecs2203R.js",
         "import": "./helpers/esm/applyDecs2203R.js",
         "default": "./helpers/applyDecs2203R.js"
       },
@@ -66,6 +71,7 @@
     "./helpers/applyDecs2301": [
       {
         "node": "./helpers/applyDecs2301.js",
+        "require": "./helpers/applyDecs2301.js",
         "import": "./helpers/esm/applyDecs2301.js",
         "default": "./helpers/applyDecs2301.js"
       },
@@ -75,6 +81,7 @@
     "./helpers/applyDecs2305": [
       {
         "node": "./helpers/applyDecs2305.js",
+        "require": "./helpers/applyDecs2305.js",
         "import": "./helpers/esm/applyDecs2305.js",
         "default": "./helpers/applyDecs2305.js"
       },
@@ -84,6 +91,7 @@
     "./helpers/asyncGeneratorDelegate": [
       {
         "node": "./helpers/asyncGeneratorDelegate.js",
+        "require": "./helpers/asyncGeneratorDelegate.js",
         "import": "./helpers/esm/asyncGeneratorDelegate.js",
         "default": "./helpers/asyncGeneratorDelegate.js"
       },
@@ -93,6 +101,7 @@
     "./helpers/asyncIterator": [
       {
         "node": "./helpers/asyncIterator.js",
+        "require": "./helpers/asyncIterator.js",
         "import": "./helpers/esm/asyncIterator.js",
         "default": "./helpers/asyncIterator.js"
       },
@@ -102,6 +111,7 @@
     "./helpers/awaitAsyncGenerator": [
       {
         "node": "./helpers/awaitAsyncGenerator.js",
+        "require": "./helpers/awaitAsyncGenerator.js",
         "import": "./helpers/esm/awaitAsyncGenerator.js",
         "default": "./helpers/awaitAsyncGenerator.js"
       },
@@ -111,6 +121,7 @@
     "./helpers/checkInRHS": [
       {
         "node": "./helpers/checkInRHS.js",
+        "require": "./helpers/checkInRHS.js",
         "import": "./helpers/esm/checkInRHS.js",
         "default": "./helpers/checkInRHS.js"
       },
@@ -120,6 +131,7 @@
     "./helpers/defineAccessor": [
       {
         "node": "./helpers/defineAccessor.js",
+        "require": "./helpers/defineAccessor.js",
         "import": "./helpers/esm/defineAccessor.js",
         "default": "./helpers/defineAccessor.js"
       },
@@ -129,6 +141,7 @@
     "./helpers/iterableToArrayLimit": [
       {
         "node": "./helpers/iterableToArrayLimit.js",
+        "require": "./helpers/iterableToArrayLimit.js",
         "import": "./helpers/esm/iterableToArrayLimit.js",
         "default": "./helpers/iterableToArrayLimit.js"
       },
@@ -138,6 +151,7 @@
     "./helpers/iterableToArrayLimitLoose": [
       {
         "node": "./helpers/iterableToArrayLimitLoose.js",
+        "require": "./helpers/iterableToArrayLimitLoose.js",
         "import": "./helpers/esm/iterableToArrayLimitLoose.js",
         "default": "./helpers/iterableToArrayLimitLoose.js"
       },
@@ -147,6 +161,7 @@
     "./helpers/jsx": [
       {
         "node": "./helpers/jsx.js",
+        "require": "./helpers/jsx.js",
         "import": "./helpers/esm/jsx.js",
         "default": "./helpers/jsx.js"
       },
@@ -156,6 +171,7 @@
     "./helpers/objectSpread2": [
       {
         "node": "./helpers/objectSpread2.js",
+        "require": "./helpers/objectSpread2.js",
         "import": "./helpers/esm/objectSpread2.js",
         "default": "./helpers/objectSpread2.js"
       },
@@ -165,6 +181,7 @@
     "./helpers/regeneratorRuntime": [
       {
         "node": "./helpers/regeneratorRuntime.js",
+        "require": "./helpers/regeneratorRuntime.js",
         "import": "./helpers/esm/regeneratorRuntime.js",
         "default": "./helpers/regeneratorRuntime.js"
       },
@@ -174,6 +191,7 @@
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof.js",
+        "require": "./helpers/typeof.js",
         "import": "./helpers/esm/typeof.js",
         "default": "./helpers/typeof.js"
       },
@@ -183,6 +201,7 @@
     "./helpers/wrapRegExp": [
       {
         "node": "./helpers/wrapRegExp.js",
+        "require": "./helpers/wrapRegExp.js",
         "import": "./helpers/esm/wrapRegExp.js",
         "default": "./helpers/wrapRegExp.js"
       },
@@ -192,6 +211,7 @@
     "./helpers/AwaitValue": [
       {
         "node": "./helpers/AwaitValue.js",
+        "require": "./helpers/AwaitValue.js",
         "import": "./helpers/esm/AwaitValue.js",
         "default": "./helpers/AwaitValue.js"
       },
@@ -201,6 +221,7 @@
     "./helpers/wrapAsyncGenerator": [
       {
         "node": "./helpers/wrapAsyncGenerator.js",
+        "require": "./helpers/wrapAsyncGenerator.js",
         "import": "./helpers/esm/wrapAsyncGenerator.js",
         "default": "./helpers/wrapAsyncGenerator.js"
       },
@@ -210,6 +231,7 @@
     "./helpers/asyncToGenerator": [
       {
         "node": "./helpers/asyncToGenerator.js",
+        "require": "./helpers/asyncToGenerator.js",
         "import": "./helpers/esm/asyncToGenerator.js",
         "default": "./helpers/asyncToGenerator.js"
       },
@@ -219,6 +241,7 @@
     "./helpers/classCallCheck": [
       {
         "node": "./helpers/classCallCheck.js",
+        "require": "./helpers/classCallCheck.js",
         "import": "./helpers/esm/classCallCheck.js",
         "default": "./helpers/classCallCheck.js"
       },
@@ -228,6 +251,7 @@
     "./helpers/createClass": [
       {
         "node": "./helpers/createClass.js",
+        "require": "./helpers/createClass.js",
         "import": "./helpers/esm/createClass.js",
         "default": "./helpers/createClass.js"
       },
@@ -237,6 +261,7 @@
     "./helpers/defineEnumerableProperties": [
       {
         "node": "./helpers/defineEnumerableProperties.js",
+        "require": "./helpers/defineEnumerableProperties.js",
         "import": "./helpers/esm/defineEnumerableProperties.js",
         "default": "./helpers/defineEnumerableProperties.js"
       },
@@ -246,6 +271,7 @@
     "./helpers/defaults": [
       {
         "node": "./helpers/defaults.js",
+        "require": "./helpers/defaults.js",
         "import": "./helpers/esm/defaults.js",
         "default": "./helpers/defaults.js"
       },
@@ -255,6 +281,7 @@
     "./helpers/defineProperty": [
       {
         "node": "./helpers/defineProperty.js",
+        "require": "./helpers/defineProperty.js",
         "import": "./helpers/esm/defineProperty.js",
         "default": "./helpers/defineProperty.js"
       },
@@ -264,6 +291,7 @@
     "./helpers/extends": [
       {
         "node": "./helpers/extends.js",
+        "require": "./helpers/extends.js",
         "import": "./helpers/esm/extends.js",
         "default": "./helpers/extends.js"
       },
@@ -273,6 +301,7 @@
     "./helpers/objectSpread": [
       {
         "node": "./helpers/objectSpread.js",
+        "require": "./helpers/objectSpread.js",
         "import": "./helpers/esm/objectSpread.js",
         "default": "./helpers/objectSpread.js"
       },
@@ -282,6 +311,7 @@
     "./helpers/inherits": [
       {
         "node": "./helpers/inherits.js",
+        "require": "./helpers/inherits.js",
         "import": "./helpers/esm/inherits.js",
         "default": "./helpers/inherits.js"
       },
@@ -291,6 +321,7 @@
     "./helpers/inheritsLoose": [
       {
         "node": "./helpers/inheritsLoose.js",
+        "require": "./helpers/inheritsLoose.js",
         "import": "./helpers/esm/inheritsLoose.js",
         "default": "./helpers/inheritsLoose.js"
       },
@@ -300,6 +331,7 @@
     "./helpers/getPrototypeOf": [
       {
         "node": "./helpers/getPrototypeOf.js",
+        "require": "./helpers/getPrototypeOf.js",
         "import": "./helpers/esm/getPrototypeOf.js",
         "default": "./helpers/getPrototypeOf.js"
       },
@@ -309,6 +341,7 @@
     "./helpers/setPrototypeOf": [
       {
         "node": "./helpers/setPrototypeOf.js",
+        "require": "./helpers/setPrototypeOf.js",
         "import": "./helpers/esm/setPrototypeOf.js",
         "default": "./helpers/setPrototypeOf.js"
       },
@@ -318,6 +351,7 @@
     "./helpers/isNativeReflectConstruct": [
       {
         "node": "./helpers/isNativeReflectConstruct.js",
+        "require": "./helpers/isNativeReflectConstruct.js",
         "import": "./helpers/esm/isNativeReflectConstruct.js",
         "default": "./helpers/isNativeReflectConstruct.js"
       },
@@ -327,6 +361,7 @@
     "./helpers/construct": [
       {
         "node": "./helpers/construct.js",
+        "require": "./helpers/construct.js",
         "import": "./helpers/esm/construct.js",
         "default": "./helpers/construct.js"
       },
@@ -336,6 +371,7 @@
     "./helpers/isNativeFunction": [
       {
         "node": "./helpers/isNativeFunction.js",
+        "require": "./helpers/isNativeFunction.js",
         "import": "./helpers/esm/isNativeFunction.js",
         "default": "./helpers/isNativeFunction.js"
       },
@@ -345,6 +381,7 @@
     "./helpers/wrapNativeSuper": [
       {
         "node": "./helpers/wrapNativeSuper.js",
+        "require": "./helpers/wrapNativeSuper.js",
         "import": "./helpers/esm/wrapNativeSuper.js",
         "default": "./helpers/wrapNativeSuper.js"
       },
@@ -354,6 +391,7 @@
     "./helpers/instanceof": [
       {
         "node": "./helpers/instanceof.js",
+        "require": "./helpers/instanceof.js",
         "import": "./helpers/esm/instanceof.js",
         "default": "./helpers/instanceof.js"
       },
@@ -363,6 +401,7 @@
     "./helpers/interopRequireDefault": [
       {
         "node": "./helpers/interopRequireDefault.js",
+        "require": "./helpers/interopRequireDefault.js",
         "import": "./helpers/esm/interopRequireDefault.js",
         "default": "./helpers/interopRequireDefault.js"
       },
@@ -372,6 +411,7 @@
     "./helpers/interopRequireWildcard": [
       {
         "node": "./helpers/interopRequireWildcard.js",
+        "require": "./helpers/interopRequireWildcard.js",
         "import": "./helpers/esm/interopRequireWildcard.js",
         "default": "./helpers/interopRequireWildcard.js"
       },
@@ -381,6 +421,7 @@
     "./helpers/newArrowCheck": [
       {
         "node": "./helpers/newArrowCheck.js",
+        "require": "./helpers/newArrowCheck.js",
         "import": "./helpers/esm/newArrowCheck.js",
         "default": "./helpers/newArrowCheck.js"
       },
@@ -390,6 +431,7 @@
     "./helpers/objectDestructuringEmpty": [
       {
         "node": "./helpers/objectDestructuringEmpty.js",
+        "require": "./helpers/objectDestructuringEmpty.js",
         "import": "./helpers/esm/objectDestructuringEmpty.js",
         "default": "./helpers/objectDestructuringEmpty.js"
       },
@@ -399,6 +441,7 @@
     "./helpers/objectWithoutPropertiesLoose": [
       {
         "node": "./helpers/objectWithoutPropertiesLoose.js",
+        "require": "./helpers/objectWithoutPropertiesLoose.js",
         "import": "./helpers/esm/objectWithoutPropertiesLoose.js",
         "default": "./helpers/objectWithoutPropertiesLoose.js"
       },
@@ -408,6 +451,7 @@
     "./helpers/objectWithoutProperties": [
       {
         "node": "./helpers/objectWithoutProperties.js",
+        "require": "./helpers/objectWithoutProperties.js",
         "import": "./helpers/esm/objectWithoutProperties.js",
         "default": "./helpers/objectWithoutProperties.js"
       },
@@ -417,6 +461,7 @@
     "./helpers/assertThisInitialized": [
       {
         "node": "./helpers/assertThisInitialized.js",
+        "require": "./helpers/assertThisInitialized.js",
         "import": "./helpers/esm/assertThisInitialized.js",
         "default": "./helpers/assertThisInitialized.js"
       },
@@ -426,6 +471,7 @@
     "./helpers/possibleConstructorReturn": [
       {
         "node": "./helpers/possibleConstructorReturn.js",
+        "require": "./helpers/possibleConstructorReturn.js",
         "import": "./helpers/esm/possibleConstructorReturn.js",
         "default": "./helpers/possibleConstructorReturn.js"
       },
@@ -435,6 +481,7 @@
     "./helpers/createSuper": [
       {
         "node": "./helpers/createSuper.js",
+        "require": "./helpers/createSuper.js",
         "import": "./helpers/esm/createSuper.js",
         "default": "./helpers/createSuper.js"
       },
@@ -444,6 +491,7 @@
     "./helpers/superPropBase": [
       {
         "node": "./helpers/superPropBase.js",
+        "require": "./helpers/superPropBase.js",
         "import": "./helpers/esm/superPropBase.js",
         "default": "./helpers/superPropBase.js"
       },
@@ -453,6 +501,7 @@
     "./helpers/get": [
       {
         "node": "./helpers/get.js",
+        "require": "./helpers/get.js",
         "import": "./helpers/esm/get.js",
         "default": "./helpers/get.js"
       },
@@ -462,6 +511,7 @@
     "./helpers/set": [
       {
         "node": "./helpers/set.js",
+        "require": "./helpers/set.js",
         "import": "./helpers/esm/set.js",
         "default": "./helpers/set.js"
       },
@@ -471,6 +521,7 @@
     "./helpers/taggedTemplateLiteral": [
       {
         "node": "./helpers/taggedTemplateLiteral.js",
+        "require": "./helpers/taggedTemplateLiteral.js",
         "import": "./helpers/esm/taggedTemplateLiteral.js",
         "default": "./helpers/taggedTemplateLiteral.js"
       },
@@ -480,6 +531,7 @@
     "./helpers/taggedTemplateLiteralLoose": [
       {
         "node": "./helpers/taggedTemplateLiteralLoose.js",
+        "require": "./helpers/taggedTemplateLiteralLoose.js",
         "import": "./helpers/esm/taggedTemplateLiteralLoose.js",
         "default": "./helpers/taggedTemplateLiteralLoose.js"
       },
@@ -489,6 +541,7 @@
     "./helpers/readOnlyError": [
       {
         "node": "./helpers/readOnlyError.js",
+        "require": "./helpers/readOnlyError.js",
         "import": "./helpers/esm/readOnlyError.js",
         "default": "./helpers/readOnlyError.js"
       },
@@ -498,6 +551,7 @@
     "./helpers/writeOnlyError": [
       {
         "node": "./helpers/writeOnlyError.js",
+        "require": "./helpers/writeOnlyError.js",
         "import": "./helpers/esm/writeOnlyError.js",
         "default": "./helpers/writeOnlyError.js"
       },
@@ -507,6 +561,7 @@
     "./helpers/classNameTDZError": [
       {
         "node": "./helpers/classNameTDZError.js",
+        "require": "./helpers/classNameTDZError.js",
         "import": "./helpers/esm/classNameTDZError.js",
         "default": "./helpers/classNameTDZError.js"
       },
@@ -516,6 +571,7 @@
     "./helpers/temporalUndefined": [
       {
         "node": "./helpers/temporalUndefined.js",
+        "require": "./helpers/temporalUndefined.js",
         "import": "./helpers/esm/temporalUndefined.js",
         "default": "./helpers/temporalUndefined.js"
       },
@@ -525,6 +581,7 @@
     "./helpers/tdz": [
       {
         "node": "./helpers/tdz.js",
+        "require": "./helpers/tdz.js",
         "import": "./helpers/esm/tdz.js",
         "default": "./helpers/tdz.js"
       },
@@ -534,6 +591,7 @@
     "./helpers/temporalRef": [
       {
         "node": "./helpers/temporalRef.js",
+        "require": "./helpers/temporalRef.js",
         "import": "./helpers/esm/temporalRef.js",
         "default": "./helpers/temporalRef.js"
       },
@@ -543,6 +601,7 @@
     "./helpers/slicedToArray": [
       {
         "node": "./helpers/slicedToArray.js",
+        "require": "./helpers/slicedToArray.js",
         "import": "./helpers/esm/slicedToArray.js",
         "default": "./helpers/slicedToArray.js"
       },
@@ -552,6 +611,7 @@
     "./helpers/slicedToArrayLoose": [
       {
         "node": "./helpers/slicedToArrayLoose.js",
+        "require": "./helpers/slicedToArrayLoose.js",
         "import": "./helpers/esm/slicedToArrayLoose.js",
         "default": "./helpers/slicedToArrayLoose.js"
       },
@@ -561,6 +621,7 @@
     "./helpers/toArray": [
       {
         "node": "./helpers/toArray.js",
+        "require": "./helpers/toArray.js",
         "import": "./helpers/esm/toArray.js",
         "default": "./helpers/toArray.js"
       },
@@ -570,6 +631,7 @@
     "./helpers/toConsumableArray": [
       {
         "node": "./helpers/toConsumableArray.js",
+        "require": "./helpers/toConsumableArray.js",
         "import": "./helpers/esm/toConsumableArray.js",
         "default": "./helpers/toConsumableArray.js"
       },
@@ -579,6 +641,7 @@
     "./helpers/arrayWithoutHoles": [
       {
         "node": "./helpers/arrayWithoutHoles.js",
+        "require": "./helpers/arrayWithoutHoles.js",
         "import": "./helpers/esm/arrayWithoutHoles.js",
         "default": "./helpers/arrayWithoutHoles.js"
       },
@@ -588,6 +651,7 @@
     "./helpers/arrayWithHoles": [
       {
         "node": "./helpers/arrayWithHoles.js",
+        "require": "./helpers/arrayWithHoles.js",
         "import": "./helpers/esm/arrayWithHoles.js",
         "default": "./helpers/arrayWithHoles.js"
       },
@@ -597,6 +661,7 @@
     "./helpers/maybeArrayLike": [
       {
         "node": "./helpers/maybeArrayLike.js",
+        "require": "./helpers/maybeArrayLike.js",
         "import": "./helpers/esm/maybeArrayLike.js",
         "default": "./helpers/maybeArrayLike.js"
       },
@@ -606,6 +671,7 @@
     "./helpers/iterableToArray": [
       {
         "node": "./helpers/iterableToArray.js",
+        "require": "./helpers/iterableToArray.js",
         "import": "./helpers/esm/iterableToArray.js",
         "default": "./helpers/iterableToArray.js"
       },
@@ -615,6 +681,7 @@
     "./helpers/unsupportedIterableToArray": [
       {
         "node": "./helpers/unsupportedIterableToArray.js",
+        "require": "./helpers/unsupportedIterableToArray.js",
         "import": "./helpers/esm/unsupportedIterableToArray.js",
         "default": "./helpers/unsupportedIterableToArray.js"
       },
@@ -624,6 +691,7 @@
     "./helpers/arrayLikeToArray": [
       {
         "node": "./helpers/arrayLikeToArray.js",
+        "require": "./helpers/arrayLikeToArray.js",
         "import": "./helpers/esm/arrayLikeToArray.js",
         "default": "./helpers/arrayLikeToArray.js"
       },
@@ -633,6 +701,7 @@
     "./helpers/nonIterableSpread": [
       {
         "node": "./helpers/nonIterableSpread.js",
+        "require": "./helpers/nonIterableSpread.js",
         "import": "./helpers/esm/nonIterableSpread.js",
         "default": "./helpers/nonIterableSpread.js"
       },
@@ -642,6 +711,7 @@
     "./helpers/nonIterableRest": [
       {
         "node": "./helpers/nonIterableRest.js",
+        "require": "./helpers/nonIterableRest.js",
         "import": "./helpers/esm/nonIterableRest.js",
         "default": "./helpers/nonIterableRest.js"
       },
@@ -651,6 +721,7 @@
     "./helpers/createForOfIteratorHelper": [
       {
         "node": "./helpers/createForOfIteratorHelper.js",
+        "require": "./helpers/createForOfIteratorHelper.js",
         "import": "./helpers/esm/createForOfIteratorHelper.js",
         "default": "./helpers/createForOfIteratorHelper.js"
       },
@@ -660,6 +731,7 @@
     "./helpers/createForOfIteratorHelperLoose": [
       {
         "node": "./helpers/createForOfIteratorHelperLoose.js",
+        "require": "./helpers/createForOfIteratorHelperLoose.js",
         "import": "./helpers/esm/createForOfIteratorHelperLoose.js",
         "default": "./helpers/createForOfIteratorHelperLoose.js"
       },
@@ -669,6 +741,7 @@
     "./helpers/skipFirstGeneratorNext": [
       {
         "node": "./helpers/skipFirstGeneratorNext.js",
+        "require": "./helpers/skipFirstGeneratorNext.js",
         "import": "./helpers/esm/skipFirstGeneratorNext.js",
         "default": "./helpers/skipFirstGeneratorNext.js"
       },
@@ -678,6 +751,7 @@
     "./helpers/toPrimitive": [
       {
         "node": "./helpers/toPrimitive.js",
+        "require": "./helpers/toPrimitive.js",
         "import": "./helpers/esm/toPrimitive.js",
         "default": "./helpers/toPrimitive.js"
       },
@@ -687,6 +761,7 @@
     "./helpers/toPropertyKey": [
       {
         "node": "./helpers/toPropertyKey.js",
+        "require": "./helpers/toPropertyKey.js",
         "import": "./helpers/esm/toPropertyKey.js",
         "default": "./helpers/toPropertyKey.js"
       },
@@ -696,6 +771,7 @@
     "./helpers/initializerWarningHelper": [
       {
         "node": "./helpers/initializerWarningHelper.js",
+        "require": "./helpers/initializerWarningHelper.js",
         "import": "./helpers/esm/initializerWarningHelper.js",
         "default": "./helpers/initializerWarningHelper.js"
       },
@@ -705,6 +781,7 @@
     "./helpers/initializerDefineProperty": [
       {
         "node": "./helpers/initializerDefineProperty.js",
+        "require": "./helpers/initializerDefineProperty.js",
         "import": "./helpers/esm/initializerDefineProperty.js",
         "default": "./helpers/initializerDefineProperty.js"
       },
@@ -714,6 +791,7 @@
     "./helpers/applyDecoratedDescriptor": [
       {
         "node": "./helpers/applyDecoratedDescriptor.js",
+        "require": "./helpers/applyDecoratedDescriptor.js",
         "import": "./helpers/esm/applyDecoratedDescriptor.js",
         "default": "./helpers/applyDecoratedDescriptor.js"
       },
@@ -723,6 +801,7 @@
     "./helpers/classPrivateFieldLooseKey": [
       {
         "node": "./helpers/classPrivateFieldLooseKey.js",
+        "require": "./helpers/classPrivateFieldLooseKey.js",
         "import": "./helpers/esm/classPrivateFieldLooseKey.js",
         "default": "./helpers/classPrivateFieldLooseKey.js"
       },
@@ -732,6 +811,7 @@
     "./helpers/classPrivateFieldLooseBase": [
       {
         "node": "./helpers/classPrivateFieldLooseBase.js",
+        "require": "./helpers/classPrivateFieldLooseBase.js",
         "import": "./helpers/esm/classPrivateFieldLooseBase.js",
         "default": "./helpers/classPrivateFieldLooseBase.js"
       },
@@ -741,6 +821,7 @@
     "./helpers/classPrivateFieldGet": [
       {
         "node": "./helpers/classPrivateFieldGet.js",
+        "require": "./helpers/classPrivateFieldGet.js",
         "import": "./helpers/esm/classPrivateFieldGet.js",
         "default": "./helpers/classPrivateFieldGet.js"
       },
@@ -750,6 +831,7 @@
     "./helpers/classPrivateFieldSet": [
       {
         "node": "./helpers/classPrivateFieldSet.js",
+        "require": "./helpers/classPrivateFieldSet.js",
         "import": "./helpers/esm/classPrivateFieldSet.js",
         "default": "./helpers/classPrivateFieldSet.js"
       },
@@ -759,6 +841,7 @@
     "./helpers/classPrivateFieldDestructureSet": [
       {
         "node": "./helpers/classPrivateFieldDestructureSet.js",
+        "require": "./helpers/classPrivateFieldDestructureSet.js",
         "import": "./helpers/esm/classPrivateFieldDestructureSet.js",
         "default": "./helpers/classPrivateFieldDestructureSet.js"
       },
@@ -768,6 +851,7 @@
     "./helpers/classExtractFieldDescriptor": [
       {
         "node": "./helpers/classExtractFieldDescriptor.js",
+        "require": "./helpers/classExtractFieldDescriptor.js",
         "import": "./helpers/esm/classExtractFieldDescriptor.js",
         "default": "./helpers/classExtractFieldDescriptor.js"
       },
@@ -777,6 +861,7 @@
     "./helpers/classStaticPrivateFieldSpecGet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecGet.js",
+        "require": "./helpers/classStaticPrivateFieldSpecGet.js",
         "import": "./helpers/esm/classStaticPrivateFieldSpecGet.js",
         "default": "./helpers/classStaticPrivateFieldSpecGet.js"
       },
@@ -786,6 +871,7 @@
     "./helpers/classStaticPrivateFieldSpecSet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecSet.js",
+        "require": "./helpers/classStaticPrivateFieldSpecSet.js",
         "import": "./helpers/esm/classStaticPrivateFieldSpecSet.js",
         "default": "./helpers/classStaticPrivateFieldSpecSet.js"
       },
@@ -795,6 +881,7 @@
     "./helpers/classStaticPrivateMethodGet": [
       {
         "node": "./helpers/classStaticPrivateMethodGet.js",
+        "require": "./helpers/classStaticPrivateMethodGet.js",
         "import": "./helpers/esm/classStaticPrivateMethodGet.js",
         "default": "./helpers/classStaticPrivateMethodGet.js"
       },
@@ -804,6 +891,7 @@
     "./helpers/classStaticPrivateMethodSet": [
       {
         "node": "./helpers/classStaticPrivateMethodSet.js",
+        "require": "./helpers/classStaticPrivateMethodSet.js",
         "import": "./helpers/esm/classStaticPrivateMethodSet.js",
         "default": "./helpers/classStaticPrivateMethodSet.js"
       },
@@ -813,6 +901,7 @@
     "./helpers/classApplyDescriptorGet": [
       {
         "node": "./helpers/classApplyDescriptorGet.js",
+        "require": "./helpers/classApplyDescriptorGet.js",
         "import": "./helpers/esm/classApplyDescriptorGet.js",
         "default": "./helpers/classApplyDescriptorGet.js"
       },
@@ -822,6 +911,7 @@
     "./helpers/classApplyDescriptorSet": [
       {
         "node": "./helpers/classApplyDescriptorSet.js",
+        "require": "./helpers/classApplyDescriptorSet.js",
         "import": "./helpers/esm/classApplyDescriptorSet.js",
         "default": "./helpers/classApplyDescriptorSet.js"
       },
@@ -831,6 +921,7 @@
     "./helpers/classApplyDescriptorDestructureSet": [
       {
         "node": "./helpers/classApplyDescriptorDestructureSet.js",
+        "require": "./helpers/classApplyDescriptorDestructureSet.js",
         "import": "./helpers/esm/classApplyDescriptorDestructureSet.js",
         "default": "./helpers/classApplyDescriptorDestructureSet.js"
       },
@@ -840,6 +931,7 @@
     "./helpers/classStaticPrivateFieldDestructureSet": [
       {
         "node": "./helpers/classStaticPrivateFieldDestructureSet.js",
+        "require": "./helpers/classStaticPrivateFieldDestructureSet.js",
         "import": "./helpers/esm/classStaticPrivateFieldDestructureSet.js",
         "default": "./helpers/classStaticPrivateFieldDestructureSet.js"
       },
@@ -849,6 +941,7 @@
     "./helpers/classCheckPrivateStaticAccess": [
       {
         "node": "./helpers/classCheckPrivateStaticAccess.js",
+        "require": "./helpers/classCheckPrivateStaticAccess.js",
         "import": "./helpers/esm/classCheckPrivateStaticAccess.js",
         "default": "./helpers/classCheckPrivateStaticAccess.js"
       },
@@ -858,6 +951,7 @@
     "./helpers/classCheckPrivateStaticFieldDescriptor": [
       {
         "node": "./helpers/classCheckPrivateStaticFieldDescriptor.js",
+        "require": "./helpers/classCheckPrivateStaticFieldDescriptor.js",
         "import": "./helpers/esm/classCheckPrivateStaticFieldDescriptor.js",
         "default": "./helpers/classCheckPrivateStaticFieldDescriptor.js"
       },
@@ -867,6 +961,7 @@
     "./helpers/decorate": [
       {
         "node": "./helpers/decorate.js",
+        "require": "./helpers/decorate.js",
         "import": "./helpers/esm/decorate.js",
         "default": "./helpers/decorate.js"
       },
@@ -876,6 +971,7 @@
     "./helpers/classPrivateMethodGet": [
       {
         "node": "./helpers/classPrivateMethodGet.js",
+        "require": "./helpers/classPrivateMethodGet.js",
         "import": "./helpers/esm/classPrivateMethodGet.js",
         "default": "./helpers/classPrivateMethodGet.js"
       },
@@ -885,6 +981,7 @@
     "./helpers/checkPrivateRedeclaration": [
       {
         "node": "./helpers/checkPrivateRedeclaration.js",
+        "require": "./helpers/checkPrivateRedeclaration.js",
         "import": "./helpers/esm/checkPrivateRedeclaration.js",
         "default": "./helpers/checkPrivateRedeclaration.js"
       },
@@ -894,6 +991,7 @@
     "./helpers/classPrivateFieldInitSpec": [
       {
         "node": "./helpers/classPrivateFieldInitSpec.js",
+        "require": "./helpers/classPrivateFieldInitSpec.js",
         "import": "./helpers/esm/classPrivateFieldInitSpec.js",
         "default": "./helpers/classPrivateFieldInitSpec.js"
       },
@@ -903,6 +1001,7 @@
     "./helpers/classPrivateMethodInitSpec": [
       {
         "node": "./helpers/classPrivateMethodInitSpec.js",
+        "require": "./helpers/classPrivateMethodInitSpec.js",
         "import": "./helpers/esm/classPrivateMethodInitSpec.js",
         "default": "./helpers/classPrivateMethodInitSpec.js"
       },
@@ -912,6 +1011,7 @@
     "./helpers/classPrivateMethodSet": [
       {
         "node": "./helpers/classPrivateMethodSet.js",
+        "require": "./helpers/classPrivateMethodSet.js",
         "import": "./helpers/esm/classPrivateMethodSet.js",
         "default": "./helpers/classPrivateMethodSet.js"
       },
@@ -921,6 +1021,7 @@
     "./helpers/identity": [
       {
         "node": "./helpers/identity.js",
+        "require": "./helpers/identity.js",
         "import": "./helpers/esm/identity.js",
         "default": "./helpers/identity.js"
       },

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -20,6 +20,7 @@
     "./helpers/AsyncGenerator": [
       {
         "node": "./helpers/AsyncGenerator.js",
+        "require": "./helpers/AsyncGenerator.js",
         "import": "./helpers/esm/AsyncGenerator.js",
         "default": "./helpers/AsyncGenerator.js"
       },
@@ -29,6 +30,7 @@
     "./helpers/OverloadYield": [
       {
         "node": "./helpers/OverloadYield.js",
+        "require": "./helpers/OverloadYield.js",
         "import": "./helpers/esm/OverloadYield.js",
         "default": "./helpers/OverloadYield.js"
       },
@@ -38,6 +40,7 @@
     "./helpers/applyDecs": [
       {
         "node": "./helpers/applyDecs.js",
+        "require": "./helpers/applyDecs.js",
         "import": "./helpers/esm/applyDecs.js",
         "default": "./helpers/applyDecs.js"
       },
@@ -47,6 +50,7 @@
     "./helpers/applyDecs2203": [
       {
         "node": "./helpers/applyDecs2203.js",
+        "require": "./helpers/applyDecs2203.js",
         "import": "./helpers/esm/applyDecs2203.js",
         "default": "./helpers/applyDecs2203.js"
       },
@@ -56,6 +60,7 @@
     "./helpers/applyDecs2203R": [
       {
         "node": "./helpers/applyDecs2203R.js",
+        "require": "./helpers/applyDecs2203R.js",
         "import": "./helpers/esm/applyDecs2203R.js",
         "default": "./helpers/applyDecs2203R.js"
       },
@@ -65,6 +70,7 @@
     "./helpers/applyDecs2301": [
       {
         "node": "./helpers/applyDecs2301.js",
+        "require": "./helpers/applyDecs2301.js",
         "import": "./helpers/esm/applyDecs2301.js",
         "default": "./helpers/applyDecs2301.js"
       },
@@ -74,6 +80,7 @@
     "./helpers/applyDecs2305": [
       {
         "node": "./helpers/applyDecs2305.js",
+        "require": "./helpers/applyDecs2305.js",
         "import": "./helpers/esm/applyDecs2305.js",
         "default": "./helpers/applyDecs2305.js"
       },
@@ -83,6 +90,7 @@
     "./helpers/asyncGeneratorDelegate": [
       {
         "node": "./helpers/asyncGeneratorDelegate.js",
+        "require": "./helpers/asyncGeneratorDelegate.js",
         "import": "./helpers/esm/asyncGeneratorDelegate.js",
         "default": "./helpers/asyncGeneratorDelegate.js"
       },
@@ -92,6 +100,7 @@
     "./helpers/asyncIterator": [
       {
         "node": "./helpers/asyncIterator.js",
+        "require": "./helpers/asyncIterator.js",
         "import": "./helpers/esm/asyncIterator.js",
         "default": "./helpers/asyncIterator.js"
       },
@@ -101,6 +110,7 @@
     "./helpers/awaitAsyncGenerator": [
       {
         "node": "./helpers/awaitAsyncGenerator.js",
+        "require": "./helpers/awaitAsyncGenerator.js",
         "import": "./helpers/esm/awaitAsyncGenerator.js",
         "default": "./helpers/awaitAsyncGenerator.js"
       },
@@ -110,6 +120,7 @@
     "./helpers/checkInRHS": [
       {
         "node": "./helpers/checkInRHS.js",
+        "require": "./helpers/checkInRHS.js",
         "import": "./helpers/esm/checkInRHS.js",
         "default": "./helpers/checkInRHS.js"
       },
@@ -119,6 +130,7 @@
     "./helpers/defineAccessor": [
       {
         "node": "./helpers/defineAccessor.js",
+        "require": "./helpers/defineAccessor.js",
         "import": "./helpers/esm/defineAccessor.js",
         "default": "./helpers/defineAccessor.js"
       },
@@ -128,6 +140,7 @@
     "./helpers/iterableToArrayLimit": [
       {
         "node": "./helpers/iterableToArrayLimit.js",
+        "require": "./helpers/iterableToArrayLimit.js",
         "import": "./helpers/esm/iterableToArrayLimit.js",
         "default": "./helpers/iterableToArrayLimit.js"
       },
@@ -137,6 +150,7 @@
     "./helpers/iterableToArrayLimitLoose": [
       {
         "node": "./helpers/iterableToArrayLimitLoose.js",
+        "require": "./helpers/iterableToArrayLimitLoose.js",
         "import": "./helpers/esm/iterableToArrayLimitLoose.js",
         "default": "./helpers/iterableToArrayLimitLoose.js"
       },
@@ -146,6 +160,7 @@
     "./helpers/jsx": [
       {
         "node": "./helpers/jsx.js",
+        "require": "./helpers/jsx.js",
         "import": "./helpers/esm/jsx.js",
         "default": "./helpers/jsx.js"
       },
@@ -155,6 +170,7 @@
     "./helpers/objectSpread2": [
       {
         "node": "./helpers/objectSpread2.js",
+        "require": "./helpers/objectSpread2.js",
         "import": "./helpers/esm/objectSpread2.js",
         "default": "./helpers/objectSpread2.js"
       },
@@ -164,6 +180,7 @@
     "./helpers/regeneratorRuntime": [
       {
         "node": "./helpers/regeneratorRuntime.js",
+        "require": "./helpers/regeneratorRuntime.js",
         "import": "./helpers/esm/regeneratorRuntime.js",
         "default": "./helpers/regeneratorRuntime.js"
       },
@@ -173,6 +190,7 @@
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof.js",
+        "require": "./helpers/typeof.js",
         "import": "./helpers/esm/typeof.js",
         "default": "./helpers/typeof.js"
       },
@@ -182,6 +200,7 @@
     "./helpers/wrapRegExp": [
       {
         "node": "./helpers/wrapRegExp.js",
+        "require": "./helpers/wrapRegExp.js",
         "import": "./helpers/esm/wrapRegExp.js",
         "default": "./helpers/wrapRegExp.js"
       },
@@ -191,6 +210,7 @@
     "./helpers/AwaitValue": [
       {
         "node": "./helpers/AwaitValue.js",
+        "require": "./helpers/AwaitValue.js",
         "import": "./helpers/esm/AwaitValue.js",
         "default": "./helpers/AwaitValue.js"
       },
@@ -200,6 +220,7 @@
     "./helpers/wrapAsyncGenerator": [
       {
         "node": "./helpers/wrapAsyncGenerator.js",
+        "require": "./helpers/wrapAsyncGenerator.js",
         "import": "./helpers/esm/wrapAsyncGenerator.js",
         "default": "./helpers/wrapAsyncGenerator.js"
       },
@@ -209,6 +230,7 @@
     "./helpers/asyncToGenerator": [
       {
         "node": "./helpers/asyncToGenerator.js",
+        "require": "./helpers/asyncToGenerator.js",
         "import": "./helpers/esm/asyncToGenerator.js",
         "default": "./helpers/asyncToGenerator.js"
       },
@@ -218,6 +240,7 @@
     "./helpers/classCallCheck": [
       {
         "node": "./helpers/classCallCheck.js",
+        "require": "./helpers/classCallCheck.js",
         "import": "./helpers/esm/classCallCheck.js",
         "default": "./helpers/classCallCheck.js"
       },
@@ -227,6 +250,7 @@
     "./helpers/createClass": [
       {
         "node": "./helpers/createClass.js",
+        "require": "./helpers/createClass.js",
         "import": "./helpers/esm/createClass.js",
         "default": "./helpers/createClass.js"
       },
@@ -236,6 +260,7 @@
     "./helpers/defineEnumerableProperties": [
       {
         "node": "./helpers/defineEnumerableProperties.js",
+        "require": "./helpers/defineEnumerableProperties.js",
         "import": "./helpers/esm/defineEnumerableProperties.js",
         "default": "./helpers/defineEnumerableProperties.js"
       },
@@ -245,6 +270,7 @@
     "./helpers/defaults": [
       {
         "node": "./helpers/defaults.js",
+        "require": "./helpers/defaults.js",
         "import": "./helpers/esm/defaults.js",
         "default": "./helpers/defaults.js"
       },
@@ -254,6 +280,7 @@
     "./helpers/defineProperty": [
       {
         "node": "./helpers/defineProperty.js",
+        "require": "./helpers/defineProperty.js",
         "import": "./helpers/esm/defineProperty.js",
         "default": "./helpers/defineProperty.js"
       },
@@ -263,6 +290,7 @@
     "./helpers/extends": [
       {
         "node": "./helpers/extends.js",
+        "require": "./helpers/extends.js",
         "import": "./helpers/esm/extends.js",
         "default": "./helpers/extends.js"
       },
@@ -272,6 +300,7 @@
     "./helpers/objectSpread": [
       {
         "node": "./helpers/objectSpread.js",
+        "require": "./helpers/objectSpread.js",
         "import": "./helpers/esm/objectSpread.js",
         "default": "./helpers/objectSpread.js"
       },
@@ -281,6 +310,7 @@
     "./helpers/inherits": [
       {
         "node": "./helpers/inherits.js",
+        "require": "./helpers/inherits.js",
         "import": "./helpers/esm/inherits.js",
         "default": "./helpers/inherits.js"
       },
@@ -290,6 +320,7 @@
     "./helpers/inheritsLoose": [
       {
         "node": "./helpers/inheritsLoose.js",
+        "require": "./helpers/inheritsLoose.js",
         "import": "./helpers/esm/inheritsLoose.js",
         "default": "./helpers/inheritsLoose.js"
       },
@@ -299,6 +330,7 @@
     "./helpers/getPrototypeOf": [
       {
         "node": "./helpers/getPrototypeOf.js",
+        "require": "./helpers/getPrototypeOf.js",
         "import": "./helpers/esm/getPrototypeOf.js",
         "default": "./helpers/getPrototypeOf.js"
       },
@@ -308,6 +340,7 @@
     "./helpers/setPrototypeOf": [
       {
         "node": "./helpers/setPrototypeOf.js",
+        "require": "./helpers/setPrototypeOf.js",
         "import": "./helpers/esm/setPrototypeOf.js",
         "default": "./helpers/setPrototypeOf.js"
       },
@@ -317,6 +350,7 @@
     "./helpers/isNativeReflectConstruct": [
       {
         "node": "./helpers/isNativeReflectConstruct.js",
+        "require": "./helpers/isNativeReflectConstruct.js",
         "import": "./helpers/esm/isNativeReflectConstruct.js",
         "default": "./helpers/isNativeReflectConstruct.js"
       },
@@ -326,6 +360,7 @@
     "./helpers/construct": [
       {
         "node": "./helpers/construct.js",
+        "require": "./helpers/construct.js",
         "import": "./helpers/esm/construct.js",
         "default": "./helpers/construct.js"
       },
@@ -335,6 +370,7 @@
     "./helpers/isNativeFunction": [
       {
         "node": "./helpers/isNativeFunction.js",
+        "require": "./helpers/isNativeFunction.js",
         "import": "./helpers/esm/isNativeFunction.js",
         "default": "./helpers/isNativeFunction.js"
       },
@@ -344,6 +380,7 @@
     "./helpers/wrapNativeSuper": [
       {
         "node": "./helpers/wrapNativeSuper.js",
+        "require": "./helpers/wrapNativeSuper.js",
         "import": "./helpers/esm/wrapNativeSuper.js",
         "default": "./helpers/wrapNativeSuper.js"
       },
@@ -353,6 +390,7 @@
     "./helpers/instanceof": [
       {
         "node": "./helpers/instanceof.js",
+        "require": "./helpers/instanceof.js",
         "import": "./helpers/esm/instanceof.js",
         "default": "./helpers/instanceof.js"
       },
@@ -362,6 +400,7 @@
     "./helpers/interopRequireDefault": [
       {
         "node": "./helpers/interopRequireDefault.js",
+        "require": "./helpers/interopRequireDefault.js",
         "import": "./helpers/esm/interopRequireDefault.js",
         "default": "./helpers/interopRequireDefault.js"
       },
@@ -371,6 +410,7 @@
     "./helpers/interopRequireWildcard": [
       {
         "node": "./helpers/interopRequireWildcard.js",
+        "require": "./helpers/interopRequireWildcard.js",
         "import": "./helpers/esm/interopRequireWildcard.js",
         "default": "./helpers/interopRequireWildcard.js"
       },
@@ -380,6 +420,7 @@
     "./helpers/newArrowCheck": [
       {
         "node": "./helpers/newArrowCheck.js",
+        "require": "./helpers/newArrowCheck.js",
         "import": "./helpers/esm/newArrowCheck.js",
         "default": "./helpers/newArrowCheck.js"
       },
@@ -389,6 +430,7 @@
     "./helpers/objectDestructuringEmpty": [
       {
         "node": "./helpers/objectDestructuringEmpty.js",
+        "require": "./helpers/objectDestructuringEmpty.js",
         "import": "./helpers/esm/objectDestructuringEmpty.js",
         "default": "./helpers/objectDestructuringEmpty.js"
       },
@@ -398,6 +440,7 @@
     "./helpers/objectWithoutPropertiesLoose": [
       {
         "node": "./helpers/objectWithoutPropertiesLoose.js",
+        "require": "./helpers/objectWithoutPropertiesLoose.js",
         "import": "./helpers/esm/objectWithoutPropertiesLoose.js",
         "default": "./helpers/objectWithoutPropertiesLoose.js"
       },
@@ -407,6 +450,7 @@
     "./helpers/objectWithoutProperties": [
       {
         "node": "./helpers/objectWithoutProperties.js",
+        "require": "./helpers/objectWithoutProperties.js",
         "import": "./helpers/esm/objectWithoutProperties.js",
         "default": "./helpers/objectWithoutProperties.js"
       },
@@ -416,6 +460,7 @@
     "./helpers/assertThisInitialized": [
       {
         "node": "./helpers/assertThisInitialized.js",
+        "require": "./helpers/assertThisInitialized.js",
         "import": "./helpers/esm/assertThisInitialized.js",
         "default": "./helpers/assertThisInitialized.js"
       },
@@ -425,6 +470,7 @@
     "./helpers/possibleConstructorReturn": [
       {
         "node": "./helpers/possibleConstructorReturn.js",
+        "require": "./helpers/possibleConstructorReturn.js",
         "import": "./helpers/esm/possibleConstructorReturn.js",
         "default": "./helpers/possibleConstructorReturn.js"
       },
@@ -434,6 +480,7 @@
     "./helpers/createSuper": [
       {
         "node": "./helpers/createSuper.js",
+        "require": "./helpers/createSuper.js",
         "import": "./helpers/esm/createSuper.js",
         "default": "./helpers/createSuper.js"
       },
@@ -443,6 +490,7 @@
     "./helpers/superPropBase": [
       {
         "node": "./helpers/superPropBase.js",
+        "require": "./helpers/superPropBase.js",
         "import": "./helpers/esm/superPropBase.js",
         "default": "./helpers/superPropBase.js"
       },
@@ -452,6 +500,7 @@
     "./helpers/get": [
       {
         "node": "./helpers/get.js",
+        "require": "./helpers/get.js",
         "import": "./helpers/esm/get.js",
         "default": "./helpers/get.js"
       },
@@ -461,6 +510,7 @@
     "./helpers/set": [
       {
         "node": "./helpers/set.js",
+        "require": "./helpers/set.js",
         "import": "./helpers/esm/set.js",
         "default": "./helpers/set.js"
       },
@@ -470,6 +520,7 @@
     "./helpers/taggedTemplateLiteral": [
       {
         "node": "./helpers/taggedTemplateLiteral.js",
+        "require": "./helpers/taggedTemplateLiteral.js",
         "import": "./helpers/esm/taggedTemplateLiteral.js",
         "default": "./helpers/taggedTemplateLiteral.js"
       },
@@ -479,6 +530,7 @@
     "./helpers/taggedTemplateLiteralLoose": [
       {
         "node": "./helpers/taggedTemplateLiteralLoose.js",
+        "require": "./helpers/taggedTemplateLiteralLoose.js",
         "import": "./helpers/esm/taggedTemplateLiteralLoose.js",
         "default": "./helpers/taggedTemplateLiteralLoose.js"
       },
@@ -488,6 +540,7 @@
     "./helpers/readOnlyError": [
       {
         "node": "./helpers/readOnlyError.js",
+        "require": "./helpers/readOnlyError.js",
         "import": "./helpers/esm/readOnlyError.js",
         "default": "./helpers/readOnlyError.js"
       },
@@ -497,6 +550,7 @@
     "./helpers/writeOnlyError": [
       {
         "node": "./helpers/writeOnlyError.js",
+        "require": "./helpers/writeOnlyError.js",
         "import": "./helpers/esm/writeOnlyError.js",
         "default": "./helpers/writeOnlyError.js"
       },
@@ -506,6 +560,7 @@
     "./helpers/classNameTDZError": [
       {
         "node": "./helpers/classNameTDZError.js",
+        "require": "./helpers/classNameTDZError.js",
         "import": "./helpers/esm/classNameTDZError.js",
         "default": "./helpers/classNameTDZError.js"
       },
@@ -515,6 +570,7 @@
     "./helpers/temporalUndefined": [
       {
         "node": "./helpers/temporalUndefined.js",
+        "require": "./helpers/temporalUndefined.js",
         "import": "./helpers/esm/temporalUndefined.js",
         "default": "./helpers/temporalUndefined.js"
       },
@@ -524,6 +580,7 @@
     "./helpers/tdz": [
       {
         "node": "./helpers/tdz.js",
+        "require": "./helpers/tdz.js",
         "import": "./helpers/esm/tdz.js",
         "default": "./helpers/tdz.js"
       },
@@ -533,6 +590,7 @@
     "./helpers/temporalRef": [
       {
         "node": "./helpers/temporalRef.js",
+        "require": "./helpers/temporalRef.js",
         "import": "./helpers/esm/temporalRef.js",
         "default": "./helpers/temporalRef.js"
       },
@@ -542,6 +600,7 @@
     "./helpers/slicedToArray": [
       {
         "node": "./helpers/slicedToArray.js",
+        "require": "./helpers/slicedToArray.js",
         "import": "./helpers/esm/slicedToArray.js",
         "default": "./helpers/slicedToArray.js"
       },
@@ -551,6 +610,7 @@
     "./helpers/slicedToArrayLoose": [
       {
         "node": "./helpers/slicedToArrayLoose.js",
+        "require": "./helpers/slicedToArrayLoose.js",
         "import": "./helpers/esm/slicedToArrayLoose.js",
         "default": "./helpers/slicedToArrayLoose.js"
       },
@@ -560,6 +620,7 @@
     "./helpers/toArray": [
       {
         "node": "./helpers/toArray.js",
+        "require": "./helpers/toArray.js",
         "import": "./helpers/esm/toArray.js",
         "default": "./helpers/toArray.js"
       },
@@ -569,6 +630,7 @@
     "./helpers/toConsumableArray": [
       {
         "node": "./helpers/toConsumableArray.js",
+        "require": "./helpers/toConsumableArray.js",
         "import": "./helpers/esm/toConsumableArray.js",
         "default": "./helpers/toConsumableArray.js"
       },
@@ -578,6 +640,7 @@
     "./helpers/arrayWithoutHoles": [
       {
         "node": "./helpers/arrayWithoutHoles.js",
+        "require": "./helpers/arrayWithoutHoles.js",
         "import": "./helpers/esm/arrayWithoutHoles.js",
         "default": "./helpers/arrayWithoutHoles.js"
       },
@@ -587,6 +650,7 @@
     "./helpers/arrayWithHoles": [
       {
         "node": "./helpers/arrayWithHoles.js",
+        "require": "./helpers/arrayWithHoles.js",
         "import": "./helpers/esm/arrayWithHoles.js",
         "default": "./helpers/arrayWithHoles.js"
       },
@@ -596,6 +660,7 @@
     "./helpers/maybeArrayLike": [
       {
         "node": "./helpers/maybeArrayLike.js",
+        "require": "./helpers/maybeArrayLike.js",
         "import": "./helpers/esm/maybeArrayLike.js",
         "default": "./helpers/maybeArrayLike.js"
       },
@@ -605,6 +670,7 @@
     "./helpers/iterableToArray": [
       {
         "node": "./helpers/iterableToArray.js",
+        "require": "./helpers/iterableToArray.js",
         "import": "./helpers/esm/iterableToArray.js",
         "default": "./helpers/iterableToArray.js"
       },
@@ -614,6 +680,7 @@
     "./helpers/unsupportedIterableToArray": [
       {
         "node": "./helpers/unsupportedIterableToArray.js",
+        "require": "./helpers/unsupportedIterableToArray.js",
         "import": "./helpers/esm/unsupportedIterableToArray.js",
         "default": "./helpers/unsupportedIterableToArray.js"
       },
@@ -623,6 +690,7 @@
     "./helpers/arrayLikeToArray": [
       {
         "node": "./helpers/arrayLikeToArray.js",
+        "require": "./helpers/arrayLikeToArray.js",
         "import": "./helpers/esm/arrayLikeToArray.js",
         "default": "./helpers/arrayLikeToArray.js"
       },
@@ -632,6 +700,7 @@
     "./helpers/nonIterableSpread": [
       {
         "node": "./helpers/nonIterableSpread.js",
+        "require": "./helpers/nonIterableSpread.js",
         "import": "./helpers/esm/nonIterableSpread.js",
         "default": "./helpers/nonIterableSpread.js"
       },
@@ -641,6 +710,7 @@
     "./helpers/nonIterableRest": [
       {
         "node": "./helpers/nonIterableRest.js",
+        "require": "./helpers/nonIterableRest.js",
         "import": "./helpers/esm/nonIterableRest.js",
         "default": "./helpers/nonIterableRest.js"
       },
@@ -650,6 +720,7 @@
     "./helpers/createForOfIteratorHelper": [
       {
         "node": "./helpers/createForOfIteratorHelper.js",
+        "require": "./helpers/createForOfIteratorHelper.js",
         "import": "./helpers/esm/createForOfIteratorHelper.js",
         "default": "./helpers/createForOfIteratorHelper.js"
       },
@@ -659,6 +730,7 @@
     "./helpers/createForOfIteratorHelperLoose": [
       {
         "node": "./helpers/createForOfIteratorHelperLoose.js",
+        "require": "./helpers/createForOfIteratorHelperLoose.js",
         "import": "./helpers/esm/createForOfIteratorHelperLoose.js",
         "default": "./helpers/createForOfIteratorHelperLoose.js"
       },
@@ -668,6 +740,7 @@
     "./helpers/skipFirstGeneratorNext": [
       {
         "node": "./helpers/skipFirstGeneratorNext.js",
+        "require": "./helpers/skipFirstGeneratorNext.js",
         "import": "./helpers/esm/skipFirstGeneratorNext.js",
         "default": "./helpers/skipFirstGeneratorNext.js"
       },
@@ -677,6 +750,7 @@
     "./helpers/toPrimitive": [
       {
         "node": "./helpers/toPrimitive.js",
+        "require": "./helpers/toPrimitive.js",
         "import": "./helpers/esm/toPrimitive.js",
         "default": "./helpers/toPrimitive.js"
       },
@@ -686,6 +760,7 @@
     "./helpers/toPropertyKey": [
       {
         "node": "./helpers/toPropertyKey.js",
+        "require": "./helpers/toPropertyKey.js",
         "import": "./helpers/esm/toPropertyKey.js",
         "default": "./helpers/toPropertyKey.js"
       },
@@ -695,6 +770,7 @@
     "./helpers/initializerWarningHelper": [
       {
         "node": "./helpers/initializerWarningHelper.js",
+        "require": "./helpers/initializerWarningHelper.js",
         "import": "./helpers/esm/initializerWarningHelper.js",
         "default": "./helpers/initializerWarningHelper.js"
       },
@@ -704,6 +780,7 @@
     "./helpers/initializerDefineProperty": [
       {
         "node": "./helpers/initializerDefineProperty.js",
+        "require": "./helpers/initializerDefineProperty.js",
         "import": "./helpers/esm/initializerDefineProperty.js",
         "default": "./helpers/initializerDefineProperty.js"
       },
@@ -713,6 +790,7 @@
     "./helpers/applyDecoratedDescriptor": [
       {
         "node": "./helpers/applyDecoratedDescriptor.js",
+        "require": "./helpers/applyDecoratedDescriptor.js",
         "import": "./helpers/esm/applyDecoratedDescriptor.js",
         "default": "./helpers/applyDecoratedDescriptor.js"
       },
@@ -722,6 +800,7 @@
     "./helpers/classPrivateFieldLooseKey": [
       {
         "node": "./helpers/classPrivateFieldLooseKey.js",
+        "require": "./helpers/classPrivateFieldLooseKey.js",
         "import": "./helpers/esm/classPrivateFieldLooseKey.js",
         "default": "./helpers/classPrivateFieldLooseKey.js"
       },
@@ -731,6 +810,7 @@
     "./helpers/classPrivateFieldLooseBase": [
       {
         "node": "./helpers/classPrivateFieldLooseBase.js",
+        "require": "./helpers/classPrivateFieldLooseBase.js",
         "import": "./helpers/esm/classPrivateFieldLooseBase.js",
         "default": "./helpers/classPrivateFieldLooseBase.js"
       },
@@ -740,6 +820,7 @@
     "./helpers/classPrivateFieldGet": [
       {
         "node": "./helpers/classPrivateFieldGet.js",
+        "require": "./helpers/classPrivateFieldGet.js",
         "import": "./helpers/esm/classPrivateFieldGet.js",
         "default": "./helpers/classPrivateFieldGet.js"
       },
@@ -749,6 +830,7 @@
     "./helpers/classPrivateFieldSet": [
       {
         "node": "./helpers/classPrivateFieldSet.js",
+        "require": "./helpers/classPrivateFieldSet.js",
         "import": "./helpers/esm/classPrivateFieldSet.js",
         "default": "./helpers/classPrivateFieldSet.js"
       },
@@ -758,6 +840,7 @@
     "./helpers/classPrivateFieldDestructureSet": [
       {
         "node": "./helpers/classPrivateFieldDestructureSet.js",
+        "require": "./helpers/classPrivateFieldDestructureSet.js",
         "import": "./helpers/esm/classPrivateFieldDestructureSet.js",
         "default": "./helpers/classPrivateFieldDestructureSet.js"
       },
@@ -767,6 +850,7 @@
     "./helpers/classExtractFieldDescriptor": [
       {
         "node": "./helpers/classExtractFieldDescriptor.js",
+        "require": "./helpers/classExtractFieldDescriptor.js",
         "import": "./helpers/esm/classExtractFieldDescriptor.js",
         "default": "./helpers/classExtractFieldDescriptor.js"
       },
@@ -776,6 +860,7 @@
     "./helpers/classStaticPrivateFieldSpecGet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecGet.js",
+        "require": "./helpers/classStaticPrivateFieldSpecGet.js",
         "import": "./helpers/esm/classStaticPrivateFieldSpecGet.js",
         "default": "./helpers/classStaticPrivateFieldSpecGet.js"
       },
@@ -785,6 +870,7 @@
     "./helpers/classStaticPrivateFieldSpecSet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecSet.js",
+        "require": "./helpers/classStaticPrivateFieldSpecSet.js",
         "import": "./helpers/esm/classStaticPrivateFieldSpecSet.js",
         "default": "./helpers/classStaticPrivateFieldSpecSet.js"
       },
@@ -794,6 +880,7 @@
     "./helpers/classStaticPrivateMethodGet": [
       {
         "node": "./helpers/classStaticPrivateMethodGet.js",
+        "require": "./helpers/classStaticPrivateMethodGet.js",
         "import": "./helpers/esm/classStaticPrivateMethodGet.js",
         "default": "./helpers/classStaticPrivateMethodGet.js"
       },
@@ -803,6 +890,7 @@
     "./helpers/classStaticPrivateMethodSet": [
       {
         "node": "./helpers/classStaticPrivateMethodSet.js",
+        "require": "./helpers/classStaticPrivateMethodSet.js",
         "import": "./helpers/esm/classStaticPrivateMethodSet.js",
         "default": "./helpers/classStaticPrivateMethodSet.js"
       },
@@ -812,6 +900,7 @@
     "./helpers/classApplyDescriptorGet": [
       {
         "node": "./helpers/classApplyDescriptorGet.js",
+        "require": "./helpers/classApplyDescriptorGet.js",
         "import": "./helpers/esm/classApplyDescriptorGet.js",
         "default": "./helpers/classApplyDescriptorGet.js"
       },
@@ -821,6 +910,7 @@
     "./helpers/classApplyDescriptorSet": [
       {
         "node": "./helpers/classApplyDescriptorSet.js",
+        "require": "./helpers/classApplyDescriptorSet.js",
         "import": "./helpers/esm/classApplyDescriptorSet.js",
         "default": "./helpers/classApplyDescriptorSet.js"
       },
@@ -830,6 +920,7 @@
     "./helpers/classApplyDescriptorDestructureSet": [
       {
         "node": "./helpers/classApplyDescriptorDestructureSet.js",
+        "require": "./helpers/classApplyDescriptorDestructureSet.js",
         "import": "./helpers/esm/classApplyDescriptorDestructureSet.js",
         "default": "./helpers/classApplyDescriptorDestructureSet.js"
       },
@@ -839,6 +930,7 @@
     "./helpers/classStaticPrivateFieldDestructureSet": [
       {
         "node": "./helpers/classStaticPrivateFieldDestructureSet.js",
+        "require": "./helpers/classStaticPrivateFieldDestructureSet.js",
         "import": "./helpers/esm/classStaticPrivateFieldDestructureSet.js",
         "default": "./helpers/classStaticPrivateFieldDestructureSet.js"
       },
@@ -848,6 +940,7 @@
     "./helpers/classCheckPrivateStaticAccess": [
       {
         "node": "./helpers/classCheckPrivateStaticAccess.js",
+        "require": "./helpers/classCheckPrivateStaticAccess.js",
         "import": "./helpers/esm/classCheckPrivateStaticAccess.js",
         "default": "./helpers/classCheckPrivateStaticAccess.js"
       },
@@ -857,6 +950,7 @@
     "./helpers/classCheckPrivateStaticFieldDescriptor": [
       {
         "node": "./helpers/classCheckPrivateStaticFieldDescriptor.js",
+        "require": "./helpers/classCheckPrivateStaticFieldDescriptor.js",
         "import": "./helpers/esm/classCheckPrivateStaticFieldDescriptor.js",
         "default": "./helpers/classCheckPrivateStaticFieldDescriptor.js"
       },
@@ -866,6 +960,7 @@
     "./helpers/decorate": [
       {
         "node": "./helpers/decorate.js",
+        "require": "./helpers/decorate.js",
         "import": "./helpers/esm/decorate.js",
         "default": "./helpers/decorate.js"
       },
@@ -875,6 +970,7 @@
     "./helpers/classPrivateMethodGet": [
       {
         "node": "./helpers/classPrivateMethodGet.js",
+        "require": "./helpers/classPrivateMethodGet.js",
         "import": "./helpers/esm/classPrivateMethodGet.js",
         "default": "./helpers/classPrivateMethodGet.js"
       },
@@ -884,6 +980,7 @@
     "./helpers/checkPrivateRedeclaration": [
       {
         "node": "./helpers/checkPrivateRedeclaration.js",
+        "require": "./helpers/checkPrivateRedeclaration.js",
         "import": "./helpers/esm/checkPrivateRedeclaration.js",
         "default": "./helpers/checkPrivateRedeclaration.js"
       },
@@ -893,6 +990,7 @@
     "./helpers/classPrivateFieldInitSpec": [
       {
         "node": "./helpers/classPrivateFieldInitSpec.js",
+        "require": "./helpers/classPrivateFieldInitSpec.js",
         "import": "./helpers/esm/classPrivateFieldInitSpec.js",
         "default": "./helpers/classPrivateFieldInitSpec.js"
       },
@@ -902,6 +1000,7 @@
     "./helpers/classPrivateMethodInitSpec": [
       {
         "node": "./helpers/classPrivateMethodInitSpec.js",
+        "require": "./helpers/classPrivateMethodInitSpec.js",
         "import": "./helpers/esm/classPrivateMethodInitSpec.js",
         "default": "./helpers/classPrivateMethodInitSpec.js"
       },
@@ -911,6 +1010,7 @@
     "./helpers/classPrivateMethodSet": [
       {
         "node": "./helpers/classPrivateMethodSet.js",
+        "require": "./helpers/classPrivateMethodSet.js",
         "import": "./helpers/esm/classPrivateMethodSet.js",
         "default": "./helpers/classPrivateMethodSet.js"
       },
@@ -920,6 +1020,7 @@
     "./helpers/identity": [
       {
         "node": "./helpers/identity.js",
+        "require": "./helpers/identity.js",
         "import": "./helpers/esm/identity.js",
         "default": "./helpers/identity.js"
       },

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -20,6 +20,7 @@
     "./helpers/AsyncGenerator": [
       {
         "node": "./helpers/AsyncGenerator.js",
+        "require": "./helpers/AsyncGenerator.js",
         "import": "./helpers/esm/AsyncGenerator.js",
         "default": "./helpers/AsyncGenerator.js"
       },
@@ -29,6 +30,7 @@
     "./helpers/OverloadYield": [
       {
         "node": "./helpers/OverloadYield.js",
+        "require": "./helpers/OverloadYield.js",
         "import": "./helpers/esm/OverloadYield.js",
         "default": "./helpers/OverloadYield.js"
       },
@@ -38,6 +40,7 @@
     "./helpers/applyDecs": [
       {
         "node": "./helpers/applyDecs.js",
+        "require": "./helpers/applyDecs.js",
         "import": "./helpers/esm/applyDecs.js",
         "default": "./helpers/applyDecs.js"
       },
@@ -47,6 +50,7 @@
     "./helpers/applyDecs2203": [
       {
         "node": "./helpers/applyDecs2203.js",
+        "require": "./helpers/applyDecs2203.js",
         "import": "./helpers/esm/applyDecs2203.js",
         "default": "./helpers/applyDecs2203.js"
       },
@@ -56,6 +60,7 @@
     "./helpers/applyDecs2203R": [
       {
         "node": "./helpers/applyDecs2203R.js",
+        "require": "./helpers/applyDecs2203R.js",
         "import": "./helpers/esm/applyDecs2203R.js",
         "default": "./helpers/applyDecs2203R.js"
       },
@@ -65,6 +70,7 @@
     "./helpers/applyDecs2301": [
       {
         "node": "./helpers/applyDecs2301.js",
+        "require": "./helpers/applyDecs2301.js",
         "import": "./helpers/esm/applyDecs2301.js",
         "default": "./helpers/applyDecs2301.js"
       },
@@ -74,6 +80,7 @@
     "./helpers/applyDecs2305": [
       {
         "node": "./helpers/applyDecs2305.js",
+        "require": "./helpers/applyDecs2305.js",
         "import": "./helpers/esm/applyDecs2305.js",
         "default": "./helpers/applyDecs2305.js"
       },
@@ -83,6 +90,7 @@
     "./helpers/asyncGeneratorDelegate": [
       {
         "node": "./helpers/asyncGeneratorDelegate.js",
+        "require": "./helpers/asyncGeneratorDelegate.js",
         "import": "./helpers/esm/asyncGeneratorDelegate.js",
         "default": "./helpers/asyncGeneratorDelegate.js"
       },
@@ -92,6 +100,7 @@
     "./helpers/asyncIterator": [
       {
         "node": "./helpers/asyncIterator.js",
+        "require": "./helpers/asyncIterator.js",
         "import": "./helpers/esm/asyncIterator.js",
         "default": "./helpers/asyncIterator.js"
       },
@@ -101,6 +110,7 @@
     "./helpers/awaitAsyncGenerator": [
       {
         "node": "./helpers/awaitAsyncGenerator.js",
+        "require": "./helpers/awaitAsyncGenerator.js",
         "import": "./helpers/esm/awaitAsyncGenerator.js",
         "default": "./helpers/awaitAsyncGenerator.js"
       },
@@ -110,6 +120,7 @@
     "./helpers/checkInRHS": [
       {
         "node": "./helpers/checkInRHS.js",
+        "require": "./helpers/checkInRHS.js",
         "import": "./helpers/esm/checkInRHS.js",
         "default": "./helpers/checkInRHS.js"
       },
@@ -119,6 +130,7 @@
     "./helpers/defineAccessor": [
       {
         "node": "./helpers/defineAccessor.js",
+        "require": "./helpers/defineAccessor.js",
         "import": "./helpers/esm/defineAccessor.js",
         "default": "./helpers/defineAccessor.js"
       },
@@ -128,6 +140,7 @@
     "./helpers/iterableToArrayLimit": [
       {
         "node": "./helpers/iterableToArrayLimit.js",
+        "require": "./helpers/iterableToArrayLimit.js",
         "import": "./helpers/esm/iterableToArrayLimit.js",
         "default": "./helpers/iterableToArrayLimit.js"
       },
@@ -137,6 +150,7 @@
     "./helpers/iterableToArrayLimitLoose": [
       {
         "node": "./helpers/iterableToArrayLimitLoose.js",
+        "require": "./helpers/iterableToArrayLimitLoose.js",
         "import": "./helpers/esm/iterableToArrayLimitLoose.js",
         "default": "./helpers/iterableToArrayLimitLoose.js"
       },
@@ -146,6 +160,7 @@
     "./helpers/jsx": [
       {
         "node": "./helpers/jsx.js",
+        "require": "./helpers/jsx.js",
         "import": "./helpers/esm/jsx.js",
         "default": "./helpers/jsx.js"
       },
@@ -155,6 +170,7 @@
     "./helpers/objectSpread2": [
       {
         "node": "./helpers/objectSpread2.js",
+        "require": "./helpers/objectSpread2.js",
         "import": "./helpers/esm/objectSpread2.js",
         "default": "./helpers/objectSpread2.js"
       },
@@ -164,6 +180,7 @@
     "./helpers/regeneratorRuntime": [
       {
         "node": "./helpers/regeneratorRuntime.js",
+        "require": "./helpers/regeneratorRuntime.js",
         "import": "./helpers/esm/regeneratorRuntime.js",
         "default": "./helpers/regeneratorRuntime.js"
       },
@@ -173,6 +190,7 @@
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof.js",
+        "require": "./helpers/typeof.js",
         "import": "./helpers/esm/typeof.js",
         "default": "./helpers/typeof.js"
       },
@@ -182,6 +200,7 @@
     "./helpers/wrapRegExp": [
       {
         "node": "./helpers/wrapRegExp.js",
+        "require": "./helpers/wrapRegExp.js",
         "import": "./helpers/esm/wrapRegExp.js",
         "default": "./helpers/wrapRegExp.js"
       },
@@ -191,6 +210,7 @@
     "./helpers/AwaitValue": [
       {
         "node": "./helpers/AwaitValue.js",
+        "require": "./helpers/AwaitValue.js",
         "import": "./helpers/esm/AwaitValue.js",
         "default": "./helpers/AwaitValue.js"
       },
@@ -200,6 +220,7 @@
     "./helpers/wrapAsyncGenerator": [
       {
         "node": "./helpers/wrapAsyncGenerator.js",
+        "require": "./helpers/wrapAsyncGenerator.js",
         "import": "./helpers/esm/wrapAsyncGenerator.js",
         "default": "./helpers/wrapAsyncGenerator.js"
       },
@@ -209,6 +230,7 @@
     "./helpers/asyncToGenerator": [
       {
         "node": "./helpers/asyncToGenerator.js",
+        "require": "./helpers/asyncToGenerator.js",
         "import": "./helpers/esm/asyncToGenerator.js",
         "default": "./helpers/asyncToGenerator.js"
       },
@@ -218,6 +240,7 @@
     "./helpers/classCallCheck": [
       {
         "node": "./helpers/classCallCheck.js",
+        "require": "./helpers/classCallCheck.js",
         "import": "./helpers/esm/classCallCheck.js",
         "default": "./helpers/classCallCheck.js"
       },
@@ -227,6 +250,7 @@
     "./helpers/createClass": [
       {
         "node": "./helpers/createClass.js",
+        "require": "./helpers/createClass.js",
         "import": "./helpers/esm/createClass.js",
         "default": "./helpers/createClass.js"
       },
@@ -236,6 +260,7 @@
     "./helpers/defineEnumerableProperties": [
       {
         "node": "./helpers/defineEnumerableProperties.js",
+        "require": "./helpers/defineEnumerableProperties.js",
         "import": "./helpers/esm/defineEnumerableProperties.js",
         "default": "./helpers/defineEnumerableProperties.js"
       },
@@ -245,6 +270,7 @@
     "./helpers/defaults": [
       {
         "node": "./helpers/defaults.js",
+        "require": "./helpers/defaults.js",
         "import": "./helpers/esm/defaults.js",
         "default": "./helpers/defaults.js"
       },
@@ -254,6 +280,7 @@
     "./helpers/defineProperty": [
       {
         "node": "./helpers/defineProperty.js",
+        "require": "./helpers/defineProperty.js",
         "import": "./helpers/esm/defineProperty.js",
         "default": "./helpers/defineProperty.js"
       },
@@ -263,6 +290,7 @@
     "./helpers/extends": [
       {
         "node": "./helpers/extends.js",
+        "require": "./helpers/extends.js",
         "import": "./helpers/esm/extends.js",
         "default": "./helpers/extends.js"
       },
@@ -272,6 +300,7 @@
     "./helpers/objectSpread": [
       {
         "node": "./helpers/objectSpread.js",
+        "require": "./helpers/objectSpread.js",
         "import": "./helpers/esm/objectSpread.js",
         "default": "./helpers/objectSpread.js"
       },
@@ -281,6 +310,7 @@
     "./helpers/inherits": [
       {
         "node": "./helpers/inherits.js",
+        "require": "./helpers/inherits.js",
         "import": "./helpers/esm/inherits.js",
         "default": "./helpers/inherits.js"
       },
@@ -290,6 +320,7 @@
     "./helpers/inheritsLoose": [
       {
         "node": "./helpers/inheritsLoose.js",
+        "require": "./helpers/inheritsLoose.js",
         "import": "./helpers/esm/inheritsLoose.js",
         "default": "./helpers/inheritsLoose.js"
       },
@@ -299,6 +330,7 @@
     "./helpers/getPrototypeOf": [
       {
         "node": "./helpers/getPrototypeOf.js",
+        "require": "./helpers/getPrototypeOf.js",
         "import": "./helpers/esm/getPrototypeOf.js",
         "default": "./helpers/getPrototypeOf.js"
       },
@@ -308,6 +340,7 @@
     "./helpers/setPrototypeOf": [
       {
         "node": "./helpers/setPrototypeOf.js",
+        "require": "./helpers/setPrototypeOf.js",
         "import": "./helpers/esm/setPrototypeOf.js",
         "default": "./helpers/setPrototypeOf.js"
       },
@@ -317,6 +350,7 @@
     "./helpers/isNativeReflectConstruct": [
       {
         "node": "./helpers/isNativeReflectConstruct.js",
+        "require": "./helpers/isNativeReflectConstruct.js",
         "import": "./helpers/esm/isNativeReflectConstruct.js",
         "default": "./helpers/isNativeReflectConstruct.js"
       },
@@ -326,6 +360,7 @@
     "./helpers/construct": [
       {
         "node": "./helpers/construct.js",
+        "require": "./helpers/construct.js",
         "import": "./helpers/esm/construct.js",
         "default": "./helpers/construct.js"
       },
@@ -335,6 +370,7 @@
     "./helpers/isNativeFunction": [
       {
         "node": "./helpers/isNativeFunction.js",
+        "require": "./helpers/isNativeFunction.js",
         "import": "./helpers/esm/isNativeFunction.js",
         "default": "./helpers/isNativeFunction.js"
       },
@@ -344,6 +380,7 @@
     "./helpers/wrapNativeSuper": [
       {
         "node": "./helpers/wrapNativeSuper.js",
+        "require": "./helpers/wrapNativeSuper.js",
         "import": "./helpers/esm/wrapNativeSuper.js",
         "default": "./helpers/wrapNativeSuper.js"
       },
@@ -353,6 +390,7 @@
     "./helpers/instanceof": [
       {
         "node": "./helpers/instanceof.js",
+        "require": "./helpers/instanceof.js",
         "import": "./helpers/esm/instanceof.js",
         "default": "./helpers/instanceof.js"
       },
@@ -362,6 +400,7 @@
     "./helpers/interopRequireDefault": [
       {
         "node": "./helpers/interopRequireDefault.js",
+        "require": "./helpers/interopRequireDefault.js",
         "import": "./helpers/esm/interopRequireDefault.js",
         "default": "./helpers/interopRequireDefault.js"
       },
@@ -371,6 +410,7 @@
     "./helpers/interopRequireWildcard": [
       {
         "node": "./helpers/interopRequireWildcard.js",
+        "require": "./helpers/interopRequireWildcard.js",
         "import": "./helpers/esm/interopRequireWildcard.js",
         "default": "./helpers/interopRequireWildcard.js"
       },
@@ -380,6 +420,7 @@
     "./helpers/newArrowCheck": [
       {
         "node": "./helpers/newArrowCheck.js",
+        "require": "./helpers/newArrowCheck.js",
         "import": "./helpers/esm/newArrowCheck.js",
         "default": "./helpers/newArrowCheck.js"
       },
@@ -389,6 +430,7 @@
     "./helpers/objectDestructuringEmpty": [
       {
         "node": "./helpers/objectDestructuringEmpty.js",
+        "require": "./helpers/objectDestructuringEmpty.js",
         "import": "./helpers/esm/objectDestructuringEmpty.js",
         "default": "./helpers/objectDestructuringEmpty.js"
       },
@@ -398,6 +440,7 @@
     "./helpers/objectWithoutPropertiesLoose": [
       {
         "node": "./helpers/objectWithoutPropertiesLoose.js",
+        "require": "./helpers/objectWithoutPropertiesLoose.js",
         "import": "./helpers/esm/objectWithoutPropertiesLoose.js",
         "default": "./helpers/objectWithoutPropertiesLoose.js"
       },
@@ -407,6 +450,7 @@
     "./helpers/objectWithoutProperties": [
       {
         "node": "./helpers/objectWithoutProperties.js",
+        "require": "./helpers/objectWithoutProperties.js",
         "import": "./helpers/esm/objectWithoutProperties.js",
         "default": "./helpers/objectWithoutProperties.js"
       },
@@ -416,6 +460,7 @@
     "./helpers/assertThisInitialized": [
       {
         "node": "./helpers/assertThisInitialized.js",
+        "require": "./helpers/assertThisInitialized.js",
         "import": "./helpers/esm/assertThisInitialized.js",
         "default": "./helpers/assertThisInitialized.js"
       },
@@ -425,6 +470,7 @@
     "./helpers/possibleConstructorReturn": [
       {
         "node": "./helpers/possibleConstructorReturn.js",
+        "require": "./helpers/possibleConstructorReturn.js",
         "import": "./helpers/esm/possibleConstructorReturn.js",
         "default": "./helpers/possibleConstructorReturn.js"
       },
@@ -434,6 +480,7 @@
     "./helpers/createSuper": [
       {
         "node": "./helpers/createSuper.js",
+        "require": "./helpers/createSuper.js",
         "import": "./helpers/esm/createSuper.js",
         "default": "./helpers/createSuper.js"
       },
@@ -443,6 +490,7 @@
     "./helpers/superPropBase": [
       {
         "node": "./helpers/superPropBase.js",
+        "require": "./helpers/superPropBase.js",
         "import": "./helpers/esm/superPropBase.js",
         "default": "./helpers/superPropBase.js"
       },
@@ -452,6 +500,7 @@
     "./helpers/get": [
       {
         "node": "./helpers/get.js",
+        "require": "./helpers/get.js",
         "import": "./helpers/esm/get.js",
         "default": "./helpers/get.js"
       },
@@ -461,6 +510,7 @@
     "./helpers/set": [
       {
         "node": "./helpers/set.js",
+        "require": "./helpers/set.js",
         "import": "./helpers/esm/set.js",
         "default": "./helpers/set.js"
       },
@@ -470,6 +520,7 @@
     "./helpers/taggedTemplateLiteral": [
       {
         "node": "./helpers/taggedTemplateLiteral.js",
+        "require": "./helpers/taggedTemplateLiteral.js",
         "import": "./helpers/esm/taggedTemplateLiteral.js",
         "default": "./helpers/taggedTemplateLiteral.js"
       },
@@ -479,6 +530,7 @@
     "./helpers/taggedTemplateLiteralLoose": [
       {
         "node": "./helpers/taggedTemplateLiteralLoose.js",
+        "require": "./helpers/taggedTemplateLiteralLoose.js",
         "import": "./helpers/esm/taggedTemplateLiteralLoose.js",
         "default": "./helpers/taggedTemplateLiteralLoose.js"
       },
@@ -488,6 +540,7 @@
     "./helpers/readOnlyError": [
       {
         "node": "./helpers/readOnlyError.js",
+        "require": "./helpers/readOnlyError.js",
         "import": "./helpers/esm/readOnlyError.js",
         "default": "./helpers/readOnlyError.js"
       },
@@ -497,6 +550,7 @@
     "./helpers/writeOnlyError": [
       {
         "node": "./helpers/writeOnlyError.js",
+        "require": "./helpers/writeOnlyError.js",
         "import": "./helpers/esm/writeOnlyError.js",
         "default": "./helpers/writeOnlyError.js"
       },
@@ -506,6 +560,7 @@
     "./helpers/classNameTDZError": [
       {
         "node": "./helpers/classNameTDZError.js",
+        "require": "./helpers/classNameTDZError.js",
         "import": "./helpers/esm/classNameTDZError.js",
         "default": "./helpers/classNameTDZError.js"
       },
@@ -515,6 +570,7 @@
     "./helpers/temporalUndefined": [
       {
         "node": "./helpers/temporalUndefined.js",
+        "require": "./helpers/temporalUndefined.js",
         "import": "./helpers/esm/temporalUndefined.js",
         "default": "./helpers/temporalUndefined.js"
       },
@@ -524,6 +580,7 @@
     "./helpers/tdz": [
       {
         "node": "./helpers/tdz.js",
+        "require": "./helpers/tdz.js",
         "import": "./helpers/esm/tdz.js",
         "default": "./helpers/tdz.js"
       },
@@ -533,6 +590,7 @@
     "./helpers/temporalRef": [
       {
         "node": "./helpers/temporalRef.js",
+        "require": "./helpers/temporalRef.js",
         "import": "./helpers/esm/temporalRef.js",
         "default": "./helpers/temporalRef.js"
       },
@@ -542,6 +600,7 @@
     "./helpers/slicedToArray": [
       {
         "node": "./helpers/slicedToArray.js",
+        "require": "./helpers/slicedToArray.js",
         "import": "./helpers/esm/slicedToArray.js",
         "default": "./helpers/slicedToArray.js"
       },
@@ -551,6 +610,7 @@
     "./helpers/slicedToArrayLoose": [
       {
         "node": "./helpers/slicedToArrayLoose.js",
+        "require": "./helpers/slicedToArrayLoose.js",
         "import": "./helpers/esm/slicedToArrayLoose.js",
         "default": "./helpers/slicedToArrayLoose.js"
       },
@@ -560,6 +620,7 @@
     "./helpers/toArray": [
       {
         "node": "./helpers/toArray.js",
+        "require": "./helpers/toArray.js",
         "import": "./helpers/esm/toArray.js",
         "default": "./helpers/toArray.js"
       },
@@ -569,6 +630,7 @@
     "./helpers/toConsumableArray": [
       {
         "node": "./helpers/toConsumableArray.js",
+        "require": "./helpers/toConsumableArray.js",
         "import": "./helpers/esm/toConsumableArray.js",
         "default": "./helpers/toConsumableArray.js"
       },
@@ -578,6 +640,7 @@
     "./helpers/arrayWithoutHoles": [
       {
         "node": "./helpers/arrayWithoutHoles.js",
+        "require": "./helpers/arrayWithoutHoles.js",
         "import": "./helpers/esm/arrayWithoutHoles.js",
         "default": "./helpers/arrayWithoutHoles.js"
       },
@@ -587,6 +650,7 @@
     "./helpers/arrayWithHoles": [
       {
         "node": "./helpers/arrayWithHoles.js",
+        "require": "./helpers/arrayWithHoles.js",
         "import": "./helpers/esm/arrayWithHoles.js",
         "default": "./helpers/arrayWithHoles.js"
       },
@@ -596,6 +660,7 @@
     "./helpers/maybeArrayLike": [
       {
         "node": "./helpers/maybeArrayLike.js",
+        "require": "./helpers/maybeArrayLike.js",
         "import": "./helpers/esm/maybeArrayLike.js",
         "default": "./helpers/maybeArrayLike.js"
       },
@@ -605,6 +670,7 @@
     "./helpers/iterableToArray": [
       {
         "node": "./helpers/iterableToArray.js",
+        "require": "./helpers/iterableToArray.js",
         "import": "./helpers/esm/iterableToArray.js",
         "default": "./helpers/iterableToArray.js"
       },
@@ -614,6 +680,7 @@
     "./helpers/unsupportedIterableToArray": [
       {
         "node": "./helpers/unsupportedIterableToArray.js",
+        "require": "./helpers/unsupportedIterableToArray.js",
         "import": "./helpers/esm/unsupportedIterableToArray.js",
         "default": "./helpers/unsupportedIterableToArray.js"
       },
@@ -623,6 +690,7 @@
     "./helpers/arrayLikeToArray": [
       {
         "node": "./helpers/arrayLikeToArray.js",
+        "require": "./helpers/arrayLikeToArray.js",
         "import": "./helpers/esm/arrayLikeToArray.js",
         "default": "./helpers/arrayLikeToArray.js"
       },
@@ -632,6 +700,7 @@
     "./helpers/nonIterableSpread": [
       {
         "node": "./helpers/nonIterableSpread.js",
+        "require": "./helpers/nonIterableSpread.js",
         "import": "./helpers/esm/nonIterableSpread.js",
         "default": "./helpers/nonIterableSpread.js"
       },
@@ -641,6 +710,7 @@
     "./helpers/nonIterableRest": [
       {
         "node": "./helpers/nonIterableRest.js",
+        "require": "./helpers/nonIterableRest.js",
         "import": "./helpers/esm/nonIterableRest.js",
         "default": "./helpers/nonIterableRest.js"
       },
@@ -650,6 +720,7 @@
     "./helpers/createForOfIteratorHelper": [
       {
         "node": "./helpers/createForOfIteratorHelper.js",
+        "require": "./helpers/createForOfIteratorHelper.js",
         "import": "./helpers/esm/createForOfIteratorHelper.js",
         "default": "./helpers/createForOfIteratorHelper.js"
       },
@@ -659,6 +730,7 @@
     "./helpers/createForOfIteratorHelperLoose": [
       {
         "node": "./helpers/createForOfIteratorHelperLoose.js",
+        "require": "./helpers/createForOfIteratorHelperLoose.js",
         "import": "./helpers/esm/createForOfIteratorHelperLoose.js",
         "default": "./helpers/createForOfIteratorHelperLoose.js"
       },
@@ -668,6 +740,7 @@
     "./helpers/skipFirstGeneratorNext": [
       {
         "node": "./helpers/skipFirstGeneratorNext.js",
+        "require": "./helpers/skipFirstGeneratorNext.js",
         "import": "./helpers/esm/skipFirstGeneratorNext.js",
         "default": "./helpers/skipFirstGeneratorNext.js"
       },
@@ -677,6 +750,7 @@
     "./helpers/toPrimitive": [
       {
         "node": "./helpers/toPrimitive.js",
+        "require": "./helpers/toPrimitive.js",
         "import": "./helpers/esm/toPrimitive.js",
         "default": "./helpers/toPrimitive.js"
       },
@@ -686,6 +760,7 @@
     "./helpers/toPropertyKey": [
       {
         "node": "./helpers/toPropertyKey.js",
+        "require": "./helpers/toPropertyKey.js",
         "import": "./helpers/esm/toPropertyKey.js",
         "default": "./helpers/toPropertyKey.js"
       },
@@ -695,6 +770,7 @@
     "./helpers/initializerWarningHelper": [
       {
         "node": "./helpers/initializerWarningHelper.js",
+        "require": "./helpers/initializerWarningHelper.js",
         "import": "./helpers/esm/initializerWarningHelper.js",
         "default": "./helpers/initializerWarningHelper.js"
       },
@@ -704,6 +780,7 @@
     "./helpers/initializerDefineProperty": [
       {
         "node": "./helpers/initializerDefineProperty.js",
+        "require": "./helpers/initializerDefineProperty.js",
         "import": "./helpers/esm/initializerDefineProperty.js",
         "default": "./helpers/initializerDefineProperty.js"
       },
@@ -713,6 +790,7 @@
     "./helpers/applyDecoratedDescriptor": [
       {
         "node": "./helpers/applyDecoratedDescriptor.js",
+        "require": "./helpers/applyDecoratedDescriptor.js",
         "import": "./helpers/esm/applyDecoratedDescriptor.js",
         "default": "./helpers/applyDecoratedDescriptor.js"
       },
@@ -722,6 +800,7 @@
     "./helpers/classPrivateFieldLooseKey": [
       {
         "node": "./helpers/classPrivateFieldLooseKey.js",
+        "require": "./helpers/classPrivateFieldLooseKey.js",
         "import": "./helpers/esm/classPrivateFieldLooseKey.js",
         "default": "./helpers/classPrivateFieldLooseKey.js"
       },
@@ -731,6 +810,7 @@
     "./helpers/classPrivateFieldLooseBase": [
       {
         "node": "./helpers/classPrivateFieldLooseBase.js",
+        "require": "./helpers/classPrivateFieldLooseBase.js",
         "import": "./helpers/esm/classPrivateFieldLooseBase.js",
         "default": "./helpers/classPrivateFieldLooseBase.js"
       },
@@ -740,6 +820,7 @@
     "./helpers/classPrivateFieldGet": [
       {
         "node": "./helpers/classPrivateFieldGet.js",
+        "require": "./helpers/classPrivateFieldGet.js",
         "import": "./helpers/esm/classPrivateFieldGet.js",
         "default": "./helpers/classPrivateFieldGet.js"
       },
@@ -749,6 +830,7 @@
     "./helpers/classPrivateFieldSet": [
       {
         "node": "./helpers/classPrivateFieldSet.js",
+        "require": "./helpers/classPrivateFieldSet.js",
         "import": "./helpers/esm/classPrivateFieldSet.js",
         "default": "./helpers/classPrivateFieldSet.js"
       },
@@ -758,6 +840,7 @@
     "./helpers/classPrivateFieldDestructureSet": [
       {
         "node": "./helpers/classPrivateFieldDestructureSet.js",
+        "require": "./helpers/classPrivateFieldDestructureSet.js",
         "import": "./helpers/esm/classPrivateFieldDestructureSet.js",
         "default": "./helpers/classPrivateFieldDestructureSet.js"
       },
@@ -767,6 +850,7 @@
     "./helpers/classExtractFieldDescriptor": [
       {
         "node": "./helpers/classExtractFieldDescriptor.js",
+        "require": "./helpers/classExtractFieldDescriptor.js",
         "import": "./helpers/esm/classExtractFieldDescriptor.js",
         "default": "./helpers/classExtractFieldDescriptor.js"
       },
@@ -776,6 +860,7 @@
     "./helpers/classStaticPrivateFieldSpecGet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecGet.js",
+        "require": "./helpers/classStaticPrivateFieldSpecGet.js",
         "import": "./helpers/esm/classStaticPrivateFieldSpecGet.js",
         "default": "./helpers/classStaticPrivateFieldSpecGet.js"
       },
@@ -785,6 +870,7 @@
     "./helpers/classStaticPrivateFieldSpecSet": [
       {
         "node": "./helpers/classStaticPrivateFieldSpecSet.js",
+        "require": "./helpers/classStaticPrivateFieldSpecSet.js",
         "import": "./helpers/esm/classStaticPrivateFieldSpecSet.js",
         "default": "./helpers/classStaticPrivateFieldSpecSet.js"
       },
@@ -794,6 +880,7 @@
     "./helpers/classStaticPrivateMethodGet": [
       {
         "node": "./helpers/classStaticPrivateMethodGet.js",
+        "require": "./helpers/classStaticPrivateMethodGet.js",
         "import": "./helpers/esm/classStaticPrivateMethodGet.js",
         "default": "./helpers/classStaticPrivateMethodGet.js"
       },
@@ -803,6 +890,7 @@
     "./helpers/classStaticPrivateMethodSet": [
       {
         "node": "./helpers/classStaticPrivateMethodSet.js",
+        "require": "./helpers/classStaticPrivateMethodSet.js",
         "import": "./helpers/esm/classStaticPrivateMethodSet.js",
         "default": "./helpers/classStaticPrivateMethodSet.js"
       },
@@ -812,6 +900,7 @@
     "./helpers/classApplyDescriptorGet": [
       {
         "node": "./helpers/classApplyDescriptorGet.js",
+        "require": "./helpers/classApplyDescriptorGet.js",
         "import": "./helpers/esm/classApplyDescriptorGet.js",
         "default": "./helpers/classApplyDescriptorGet.js"
       },
@@ -821,6 +910,7 @@
     "./helpers/classApplyDescriptorSet": [
       {
         "node": "./helpers/classApplyDescriptorSet.js",
+        "require": "./helpers/classApplyDescriptorSet.js",
         "import": "./helpers/esm/classApplyDescriptorSet.js",
         "default": "./helpers/classApplyDescriptorSet.js"
       },
@@ -830,6 +920,7 @@
     "./helpers/classApplyDescriptorDestructureSet": [
       {
         "node": "./helpers/classApplyDescriptorDestructureSet.js",
+        "require": "./helpers/classApplyDescriptorDestructureSet.js",
         "import": "./helpers/esm/classApplyDescriptorDestructureSet.js",
         "default": "./helpers/classApplyDescriptorDestructureSet.js"
       },
@@ -839,6 +930,7 @@
     "./helpers/classStaticPrivateFieldDestructureSet": [
       {
         "node": "./helpers/classStaticPrivateFieldDestructureSet.js",
+        "require": "./helpers/classStaticPrivateFieldDestructureSet.js",
         "import": "./helpers/esm/classStaticPrivateFieldDestructureSet.js",
         "default": "./helpers/classStaticPrivateFieldDestructureSet.js"
       },
@@ -848,6 +940,7 @@
     "./helpers/classCheckPrivateStaticAccess": [
       {
         "node": "./helpers/classCheckPrivateStaticAccess.js",
+        "require": "./helpers/classCheckPrivateStaticAccess.js",
         "import": "./helpers/esm/classCheckPrivateStaticAccess.js",
         "default": "./helpers/classCheckPrivateStaticAccess.js"
       },
@@ -857,6 +950,7 @@
     "./helpers/classCheckPrivateStaticFieldDescriptor": [
       {
         "node": "./helpers/classCheckPrivateStaticFieldDescriptor.js",
+        "require": "./helpers/classCheckPrivateStaticFieldDescriptor.js",
         "import": "./helpers/esm/classCheckPrivateStaticFieldDescriptor.js",
         "default": "./helpers/classCheckPrivateStaticFieldDescriptor.js"
       },
@@ -866,6 +960,7 @@
     "./helpers/decorate": [
       {
         "node": "./helpers/decorate.js",
+        "require": "./helpers/decorate.js",
         "import": "./helpers/esm/decorate.js",
         "default": "./helpers/decorate.js"
       },
@@ -875,6 +970,7 @@
     "./helpers/classPrivateMethodGet": [
       {
         "node": "./helpers/classPrivateMethodGet.js",
+        "require": "./helpers/classPrivateMethodGet.js",
         "import": "./helpers/esm/classPrivateMethodGet.js",
         "default": "./helpers/classPrivateMethodGet.js"
       },
@@ -884,6 +980,7 @@
     "./helpers/checkPrivateRedeclaration": [
       {
         "node": "./helpers/checkPrivateRedeclaration.js",
+        "require": "./helpers/checkPrivateRedeclaration.js",
         "import": "./helpers/esm/checkPrivateRedeclaration.js",
         "default": "./helpers/checkPrivateRedeclaration.js"
       },
@@ -893,6 +990,7 @@
     "./helpers/classPrivateFieldInitSpec": [
       {
         "node": "./helpers/classPrivateFieldInitSpec.js",
+        "require": "./helpers/classPrivateFieldInitSpec.js",
         "import": "./helpers/esm/classPrivateFieldInitSpec.js",
         "default": "./helpers/classPrivateFieldInitSpec.js"
       },
@@ -902,6 +1000,7 @@
     "./helpers/classPrivateMethodInitSpec": [
       {
         "node": "./helpers/classPrivateMethodInitSpec.js",
+        "require": "./helpers/classPrivateMethodInitSpec.js",
         "import": "./helpers/esm/classPrivateMethodInitSpec.js",
         "default": "./helpers/classPrivateMethodInitSpec.js"
       },
@@ -911,6 +1010,7 @@
     "./helpers/classPrivateMethodSet": [
       {
         "node": "./helpers/classPrivateMethodSet.js",
+        "require": "./helpers/classPrivateMethodSet.js",
         "import": "./helpers/esm/classPrivateMethodSet.js",
         "default": "./helpers/classPrivateMethodSet.js"
       },
@@ -920,6 +1020,7 @@
     "./helpers/identity": [
       {
         "node": "./helpers/identity.js",
+        "require": "./helpers/identity.js",
         "import": "./helpers/esm/identity.js",
         "default": "./helpers/identity.js"
       },


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | See package.json diffs
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

## Change

Restores the `"require"` conditional export for each `@babel/runtime` helper, matched before the `"import"` resolution.

This is a more defensive/maximally compatible `"exports"` setup for this package, preferring `"require"` for bundlers which assert both `"require"` and `"import"` conditions — and then consume either module type via Babel (e.g. Metro).

In particular, `@babel/runtime` is somewhat of a special package, as it ***implements*** interop between CJS/MJS module formats — this change fixes module interop behaviour for React Native ⬇️.

## Motivation

In React Native 0.72, we're shipping [experimental Package Exports support](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0534-metro-package-exports-support.md) to users. Metro, our JavaScript bundler, does not yet fully handle ESM and doesn't dynamically switch between `"import"`/`"require"` exports conditions during resolution. Instead, we match **both** `"import"` and `"require"` in an effort to maximise library compatibility for users.

**This works in practice due to the use of Babel's transforms and runtime**, allowing module types to work interchangeably — however unfortunately fails here on the Metro-driven require of the `@babel/runtime` helpers themselves.

- [Relevant assumptions in Metro RFC](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0534-metro-package-exports-support.md#conditional-exports-import-and-require)
- (This is conceptually similar to TypeScript's [`--moduleResolution bundler`](https://github.com/microsoft/TypeScript/pull/51669).)

**Problem**: When `"exports"` is enabled in Metro with recent versions of `@babel/runtime`, the ESM versions are resolved (via the `"import"` condition) which do not perform the necessary ESM -> CJS module interop at runtime.

See related [facebook/metro](https://github.com/facebook/metro) issue:

- https://github.com/facebook/metro/issues/984

<img width="250" alt="image" src="https://github.com/babel/babel/assets/2547783/09b876d1-6059-40bf-b3de-94920602e203">

- This failure case is similar to https://github.com/babel/babel/pull/12865

### Alternatives

- Our fallback approach is to include a specific exception for `@babel/runtime` in Metro's resolver to prevent asserting the `"import"` condition name on these modules.
- Metro's loose support for `"import"` may be the wrong approach. We could drop our default condition set to `["require", "react-native"]` — however will lose compatibility with some ESM-only packages that Babel could handle (e.g. previously via `"main"` with no platform distinction).
- **In future**, Metro will support resolving `"require"`/`"import"` dynamically — however we require a workaround today.

## Test plan

### This repo

```
make build
```

✅ Observe `package.json` changes

### End-to-end fix

```sh
npx clear-npx-cache
npx react-native@0.72.0-rc.3 init TestApp072
cd TestApp072/
nvim metro.config.js # Enable resolver.unstable_enablePackageExports
nvim node_modules/@babel/runtime/package.json # Replace contents
yarn start
```

<img width="250" alt="image" src="https://github.com/babel/babel/assets/2547783/7dc4d8f0-d7cb-4c58-a438-3117ef78ae53">

✅ App builds
✅ Updates via Fast Refresh work

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15643"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

