### PR TITLE
Define and narrow types under babel-traverse

### DIFF
--- a/packages/babel-traverse/src/cache.ts
+++ b/packages/babel-traverse/src/cache.ts
@@ -1,5 +1,9 @@
-export let path = new WeakMap();
-export let scope = new WeakMap();
+import type { Node } from "@babel/types";
+import type NodePath from "./path";
+import type Scope from "./scope";
+
+export let path: WeakMap<Node, Map<Node, NodePath>> = new WeakMap();
+export let scope: WeakMap<Node, Scope> = new WeakMap();
 
 export function clear() {
   clearPath();

--- a/packages/babel-traverse/src/context.ts
+++ b/packages/babel-traverse/src/context.ts
@@ -8,7 +8,7 @@ import type { Visitor } from "./types";
 export default class TraversalContext<S = unknown> {
   constructor(
     scope: Scope,
-    opts: ExplodedTraverseOptions,
+    opts: ExplodedTraverseOptions<S>,
     state: S,
     parentPath: NodePath,
   ) {
@@ -21,7 +21,7 @@ export default class TraversalContext<S = unknown> {
   declare parentPath: NodePath;
   declare scope: Scope;
   declare state: S;
-  declare opts: ExplodedTraverseOptions;
+  declare opts: ExplodedTraverseOptions<S>;
   queue: Array<NodePath> | null = null;
   priorityQueue: Array<NodePath> | null = null;
 

--- a/packages/babel-traverse/src/context.ts
+++ b/packages/babel-traverse/src/context.ts
@@ -1,14 +1,14 @@
 import NodePath from "./path";
 import { VISITOR_KEYS } from "@babel/types";
 import type Scope from "./scope";
-import type { TraverseOptions } from ".";
+import type { ExplodedTraverseOptions } from ".";
 import type * as t from "@babel/types";
 import type { Visitor } from "./types";
 
 export default class TraversalContext<S = unknown> {
   constructor(
     scope: Scope,
-    opts: TraverseOptions,
+    opts: ExplodedTraverseOptions,
     state: S,
     parentPath: NodePath,
   ) {
@@ -21,7 +21,7 @@ export default class TraversalContext<S = unknown> {
   declare parentPath: NodePath;
   declare scope: Scope;
   declare state: S;
-  declare opts: TraverseOptions;
+  declare opts: ExplodedTraverseOptions;
   queue: Array<NodePath> | null = null;
   priorityQueue: Array<NodePath> | null = null;
 

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -9,10 +9,10 @@ import type * as t from "@babel/types";
 import * as cache from "./cache";
 import type NodePath from "./path";
 import type { default as Scope, Binding } from "./scope";
-import type { Visitor } from "./types";
+import type { ExplodedVisitor, Visitor } from "./types";
 import { traverseNode } from "./traverse-node";
 
-export type { Visitor, Binding };
+export type { ExplodedVisitor, Visitor, Binding };
 export { default as NodePath } from "./path";
 export { default as Scope } from "./scope";
 export { default as Hub } from "./hub";
@@ -26,6 +26,9 @@ export type TraverseOptions<S = t.Node> = {
   denylist?: string[];
   shouldSkip?: (node: NodePath) => boolean;
 } & Visitor<S>;
+
+export type ExplodedTraverseOptions<S = t.Node> = TraverseOptions<S> &
+  ExplodedVisitor<S>;
 
 function traverse<S>(
   parent: t.Node,
@@ -69,7 +72,7 @@ function traverse<Options extends TraverseOptions>(
 
   visitors.explode(opts as Visitor);
 
-  traverseNode(parent, opts, scope, state, parentPath);
+  traverseNode(parent, opts as ExplodedVisitor, scope, state, parentPath);
 }
 
 export default traverse;
@@ -85,7 +88,7 @@ traverse.cheap = function (node: t.Node, enter: (node: t.Node) => void) {
 
 traverse.node = function (
   node: t.Node,
-  opts: TraverseOptions,
+  opts: ExplodedTraverseOptions,
   scope?: Scope,
   state?: any,
   path?: NodePath,

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -24,6 +24,7 @@ export type TraverseOptions<S = t.Node> = {
   scope?: Scope;
   noScope?: boolean;
   denylist?: string[];
+  shouldSkip?: (node: NodePath) => boolean;
 } & Visitor<S>;
 
 function traverse<S>(

--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -3,20 +3,21 @@
 import { traverseNode } from "../traverse-node";
 import { SHOULD_SKIP, SHOULD_STOP } from "./index";
 import type TraversalContext from "../context";
+import type { VisitNodeKey } from "../types";
 import type NodePath from "./index";
 import type * as t from "@babel/types";
 
-export function call(this: NodePath, key: string): boolean {
+export function call(this: NodePath, key: VisitNodeKey): boolean {
   const opts = this.opts;
 
   this.debug(key);
 
   if (this.node) {
-    if (this._call(opts[key])) return true;
+    if (this._call(opts?.[key])) return true;
   }
 
   if (this.node) {
-    return this._call(opts[this.node.type] && opts[this.node.type][key]);
+    return this._call(opts?.[this.node.type]?.[key]);
   }
 
   return false;
@@ -55,7 +56,7 @@ export function _call(this: NodePath, fns?: Array<Function>): boolean {
 }
 
 export function isDenylisted(this: NodePath): boolean {
-  const denylist = this.opts.denylist ?? this.opts.blacklist;
+  const denylist = this.opts.denylist;
   return denylist && denylist.indexOf(this.node.type) > -1;
 }
 

--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -272,7 +272,7 @@ export function pushContext(this: NodePath, context: TraversalContext) {
 export function setup(
   this: NodePath,
   parentPath: NodePath | undefined,
-  container: t.Node,
+  container: t.Node | t.Node[],
   listKey: string,
   key: string | number,
 ) {

--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -3,21 +3,21 @@
 import { traverseNode } from "../traverse-node";
 import { SHOULD_SKIP, SHOULD_STOP } from "./index";
 import type TraversalContext from "../context";
-import type { VisitNodeKey } from "../types";
+import type { VisitPhase } from "../types";
 import type NodePath from "./index";
 import type * as t from "@babel/types";
 
-export function call(this: NodePath, key: VisitNodeKey): boolean {
+export function call(this: NodePath, key: VisitPhase): boolean {
   const opts = this.opts;
 
   this.debug(key);
 
   if (this.node) {
-    if (this._call(opts?.[key])) return true;
+    if (this._call(opts[key])) return true;
   }
 
   if (this.node) {
-    return this._call(opts?.[this.node.type]?.[key]);
+    return this._call(opts[this.node.type]?.[key]);
   }
 
   return false;
@@ -56,7 +56,8 @@ export function _call(this: NodePath, fns?: Array<Function>): boolean {
 }
 
 export function isDenylisted(this: NodePath): boolean {
-  const denylist = this.opts.denylist;
+  // @ts-expect-error TODO(Babel 8): Remove blacklist
+  const denylist = this.opts.denylist ?? this.opts.blacklist;
   return denylist && denylist.indexOf(this.node.type) > -1;
 }
 
@@ -169,7 +170,8 @@ export function setContext<S = unknown>(
   if (context) {
     this.context = context;
     this.state = context.state;
-    this.opts = context.opts;
+    // Discard the S type parameter from contect.opts
+    this.opts = context.opts as typeof this.opts;
   }
 
   this.setScope();

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -1,5 +1,6 @@
 import type { HubInterface } from "../hub";
 import type TraversalContext from "../context";
+import type { ExplodedTraverseOptions } from "..";
 import * as virtualTypes from "./lib/virtual-types";
 import buildDebug from "debug";
 import traverse from "../index";
@@ -51,7 +52,7 @@ class NodePath<T extends t.Node = t.Node> {
 
   contexts: Array<TraversalContext> = [];
   state: any = null;
-  opts: any = null;
+  opts: ExplodedTraverseOptions | null = null;
   // this.shouldSkip = false; this.shouldStop = false; this.removed = false;
   _traverseFlags: number = 0;
   skipKeys: Record<string, boolean> | null = null;

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -54,7 +54,7 @@ class NodePath<T extends t.Node = t.Node> {
   opts: any = null;
   // this.shouldSkip = false; this.shouldStop = false; this.removed = false;
   _traverseFlags: number = 0;
-  skipKeys: any = null;
+  skipKeys: Record<string, boolean> | null = null;
   parentPath: t.ParentMaps[T["type"]] extends null
     ? null
     : NodePath<t.ParentMaps[T["type"]]> | null = null;

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -280,9 +280,9 @@ export function updateSiblingKeys(
   if (!this.parent) return;
 
   const paths = pathCache.get(this.parent);
+
   for (const [, path] of paths) {
-    if (typeof path.key !== "number") continue;
-    if (path.key >= fromIndex) {
+    if (typeof path.key === "number" && path.key >= fromIndex) {
       path.key += incrementBy;
     }
   }

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -281,6 +281,7 @@ export function updateSiblingKeys(
 
   const paths = pathCache.get(this.parent);
   for (const [, path] of paths) {
+    if (typeof path.key !== "number") continue;
     if (path.key >= fromIndex) {
       path.key += incrementBy;
     }

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -54,6 +54,7 @@ import {
 import type * as t from "@babel/types";
 import { scope as scopeCache } from "../cache";
 import type { Visitor } from "../types";
+import { isExplodedVisitor } from "../visitors";
 
 type NodePart = string | number | boolean;
 // Recursively gathers the identifying names of a node.
@@ -1007,16 +1008,14 @@ export default class Scope {
     this.crawling = true;
     // traverse does not visit the root node, here we explicitly collect
     // root node binding info when the root is not a Program.
-    if (path.type !== "Program" && collectorVisitor._exploded) {
-      // @ts-expect-error when collectorVisitor is exploded, `enter` always exists
+    if (path.type !== "Program" && isExplodedVisitor(collectorVisitor)) {
       for (const visit of collectorVisitor.enter) {
-        visit(path, state);
+        visit.call(state, path, state);
       }
       const typeVisitors = collectorVisitor[path.type];
       if (typeVisitors) {
-        // @ts-expect-error when collectorVisitor is exploded, `enter` always exists
         for (const visit of typeVisitors.enter) {
-          visit(path, state);
+          visit.call(state, path, state);
         }
       }
     }

--- a/packages/babel-traverse/src/traverse-node.ts
+++ b/packages/babel-traverse/src/traverse-node.ts
@@ -17,9 +17,9 @@ import { VISITOR_KEYS } from "@babel/types";
 
  * @note This function does not visit the given `node`.
  */
-export function traverseNode(
+export function traverseNode<S = unknown>(
   node: t.Node,
-  opts: ExplodedTraverseOptions,
+  opts: ExplodedTraverseOptions<S>,
   scope?: Scope,
   state?: any,
   path?: NodePath,

--- a/packages/babel-traverse/src/traverse-node.ts
+++ b/packages/babel-traverse/src/traverse-node.ts
@@ -1,5 +1,5 @@
 import TraversalContext from "./context";
-import type { TraverseOptions } from "./index";
+import type { ExplodedTraverseOptions } from "./index";
 import type NodePath from "./path";
 import type Scope from "./scope";
 import type * as t from "@babel/types";
@@ -19,7 +19,7 @@ import { VISITOR_KEYS } from "@babel/types";
  */
 export function traverseNode(
   node: t.Node,
-  opts: TraverseOptions,
+  opts: ExplodedTraverseOptions,
   scope?: Scope,
   state?: any,
   path?: NodePath,

--- a/packages/babel-traverse/src/types.ts
+++ b/packages/babel-traverse/src/types.ts
@@ -2,29 +2,21 @@ import type * as t from "@babel/types";
 import type { NodePath } from "./index";
 import type { VirtualTypeAliases } from "./path/lib/virtual-types";
 
-export type VisitNodeKey = "enter" | "exit";
+export type VisitPhase = "enter" | "exit";
 
-export type VisitNodeObject<S, P extends t.Node> = {
-  [K in VisitNodeKey]?: VisitNodeFunction<S, P>;
+type VisitNodeObject<S, P extends t.Node> = {
+  [K in VisitPhase]?: VisitNodeFunction<S, P>;
 };
 
-export type ExplodedVisitNodeObject<S, P extends t.Node> = {
-  [K in VisitNodeKey]?: VisitNodeFunction<S, P>[];
+type ExplVisitNode<S, P extends t.Node> = {
+  [K in VisitPhase]?: VisitNodeFunction<S, P>[];
 };
 
-export type ExplodedVisitor<S = {}> = ExplodedVisitNodeObject<S, t.Node> & {
-  [Type in t.Node["type"]]?: ExplodedVisitNodeObject<
-    S,
-    Extract<t.Node, { type: Type }>
-  >;
-} & {
-  [K in keyof InternalVisitorFlags]?: InternalVisitorFlags[K];
-} & {
-  _exploded: true;
-  _verified: true;
-};
+export type ExplodedVisitor<S = unknown> = ExplVisitNode<S, t.Node> & {
+  [Type in t.Node["type"]]?: ExplVisitNode<S, Extract<t.Node, { type: Type }>>;
+} & { _exploded: true; _verified: true };
 
-export type Visitor<S = {}> =
+export type Visitor<S = unknown> =
   | (VisitNodeObject<S, t.Node> & {
       [Type in t.Node["type"]]?: VisitNode<S, Extract<t.Node, { type: Type }>>;
     } & {
@@ -32,20 +24,12 @@ export type Visitor<S = {}> =
     } & {
       [K in keyof VirtualTypeAliases]?: VisitNode<S, VirtualTypeAliases[K]>;
     } & {
-      [K in keyof InternalVisitorFlags]?: InternalVisitorFlags[K];
-    } & {
       // Babel supports `NodeTypesWithoutComment | NodeTypesWithoutComment | ... ` but it is
       // too complex for TS. So we type it as a general visitor only if the key contains `|`
       // this is good enough for non-visitor traverse options e.g. `noScope`
       [k: `${string}|${string}`]: VisitNode<S, t.Node>;
     })
   | ExplodedVisitor<S>;
-
-/** @internal */
-type InternalVisitorFlags = {
-  _exploded?: boolean;
-  _verified?: boolean;
-};
 
 export type VisitNode<S, P extends t.Node> =
   | VisitNodeFunction<S, P>

--- a/packages/babel-traverse/src/types.ts
+++ b/packages/babel-traverse/src/types.ts
@@ -2,20 +2,44 @@ import type * as t from "@babel/types";
 import type { NodePath } from "./index";
 import type { VirtualTypeAliases } from "./path/lib/virtual-types";
 
-export type Visitor<S = {}> = VisitNodeObject<S, t.Node> & {
-  [Type in t.Node["type"]]?: VisitNode<S, Extract<t.Node, { type: Type }>>;
-} & {
-  [K in keyof t.Aliases]?: VisitNode<S, t.Aliases[K]>;
-} & {
-  [K in keyof VirtualTypeAliases]?: VisitNode<S, VirtualTypeAliases[K]>;
+export type VisitNodeKey = "enter" | "exit";
+
+export type VisitNodeObject<S, P extends t.Node> = {
+  [K in VisitNodeKey]?: VisitNodeFunction<S, P>;
+};
+
+export type ExplodedVisitNodeObject<S, P extends t.Node> = {
+  [K in VisitNodeKey]?: VisitNodeFunction<S, P>[];
+};
+
+export type ExplodedVisitor<S = {}> = ExplodedVisitNodeObject<S, t.Node> & {
+  [Type in t.Node["type"]]?: ExplodedVisitNodeObject<
+    S,
+    Extract<t.Node, { type: Type }>
+  >;
 } & {
   [K in keyof InternalVisitorFlags]?: InternalVisitorFlags[K];
 } & {
-  // Babel supports `NodeTypesWithoutComment | NodeTypesWithoutComment | ... ` but it is
-  // too complex for TS. So we type it as a general visitor only if the key contains `|`
-  // this is good enough for non-visitor traverse options e.g. `noScope`
-  [k: `${string}|${string}`]: VisitNode<S, t.Node>;
+  _exploded: true;
+  _verified: true;
 };
+
+export type Visitor<S = {}> =
+  | (VisitNodeObject<S, t.Node> & {
+      [Type in t.Node["type"]]?: VisitNode<S, Extract<t.Node, { type: Type }>>;
+    } & {
+      [K in keyof t.Aliases]?: VisitNode<S, t.Aliases[K]>;
+    } & {
+      [K in keyof VirtualTypeAliases]?: VisitNode<S, VirtualTypeAliases[K]>;
+    } & {
+      [K in keyof InternalVisitorFlags]?: InternalVisitorFlags[K];
+    } & {
+      // Babel supports `NodeTypesWithoutComment | NodeTypesWithoutComment | ... ` but it is
+      // too complex for TS. So we type it as a general visitor only if the key contains `|`
+      // this is good enough for non-visitor traverse options e.g. `noScope`
+      [k: `${string}|${string}`]: VisitNode<S, t.Node>;
+    })
+  | ExplodedVisitor<S>;
 
 /** @internal */
 type InternalVisitorFlags = {
@@ -32,8 +56,3 @@ export type VisitNodeFunction<S, P extends t.Node> = (
   path: NodePath<P>,
   state: S,
 ) => void;
-
-export interface VisitNodeObject<S, P extends t.Node> {
-  enter?: VisitNodeFunction<S, P>;
-  exit?: VisitNodeFunction<S, P>;
-}

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -13,7 +13,10 @@ function isVirtualType(type: string): type is VIRTUAL_TYPES {
   return type in virtualTypes;
 }
 
-function isExplodedVisitor(visitor: Visitor): visitor is ExplodedVisitor {
+export function isExplodedVisitor(
+  visitor: Visitor,
+): visitor is ExplodedVisitor {
+  // @ts-expect-error _exploded is not defined on non-exploded Visitor
   return visitor?._exploded;
 }
 
@@ -33,8 +36,9 @@ function isExplodedVisitor(visitor: Visitor): visitor is ExplodedVisitor {
  * * `enter` and `exit` functions are wrapped in arrays, to ease merging of
  *   visitors
  */
-export function explode<S>(visitor: Visitor<S>): ExplodedVisitor {
+export function explode<S>(visitor: Visitor<S>): ExplodedVisitor<S> {
   if (isExplodedVisitor(visitor)) return visitor;
+  // @ts-expect-error `visitor` will be cast to ExplodedVisitor by this function
   visitor._exploded = true;
 
   // normalise pipes
@@ -147,6 +151,8 @@ export function explode<S>(visitor: Visitor<S>): ExplodedVisitor {
 }
 
 export function verify(visitor: Visitor) {
+  // @ts-expect-error _verified is not defined on non-verified Visitor.
+  // TODO: unify _verified and _exploded.
   if (visitor._verified) return;
 
   if (typeof visitor === "function") {
@@ -188,6 +194,8 @@ export function verify(visitor: Visitor) {
     }
   }
 
+  // @ts-expect-error _verified is not defined on non-verified Visitor.
+  // TODO: unify _verified and _exploded.
   visitor._verified = true;
 }
 


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | No
| License                  | MIT

* Narrows variables under `traverse.cache`
* Narrows the `skipKeys` property under `NodePath`
* Define an optional `shouldSkip` function as a traverse option
* Define exploded visitor objects separately from user-specified visitor objects
  * Node type callbacks are arrays
  * Used to narrow the `opts` property under `NodePath`

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15644"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

