### PR TITLE
Disable workers for compiling on CircleCI

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -249,7 +249,12 @@ function getFiles(glob, { include, exclude }) {
 
 function createWorker(useWorker) {
   const numWorkers = Math.ceil(Math.max(cpus().length, 1) / 2) - 1;
-  if (numWorkers === 0 || !useWorker) {
+  if (
+    numWorkers === 0 ||
+    !useWorker ||
+    // For some reason, on CircleCI the workers hang indefinitely.
+    process.env.CIRCLECI
+  ) {
     return require("./babel-worker.cjs");
   }
   const worker = new JestWorker(require.resolve("./babel-worker.cjs"), {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

There has probably been a change related to workers in CircleCI recently, and now our build [hangs](https://app.circleci.com/pipelines/github/babel/babel/12399/workflows/325155e6-b290-4daf-b246-312b4729d424/jobs/54480). `os.cpus()` returns 36 (which seems surprisingly high), but even forcing it to be a lower number (4) doesn't solve the problem.

This PR completely disables the compilation worker on CircleCI.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15645"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

