### PR TITLE
Fix importing symbol polyfill in `@babel/runtime-corejs2`

### DIFF
--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/helper-module-imports": "workspace:^",
     "@babel/helper-plugin-utils": "workspace:^",
-    "babel-plugin-polyfill-corejs2": "^0.4.1",
+    "babel-plugin-polyfill-corejs2": "^0.4.2",
     "babel-plugin-polyfill-corejs3": "^0.8.1",
     "babel-plugin-polyfill-regenerator": "^0.5.0",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/aliased-constructors/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/aliased-constructors/output.js
@@ -1,5 +1,5 @@
 var _Promise = require("@babel/runtime-corejs2/core-js/promise");
-var _Symbol = require("@babel/runtime-corejs2/core-js/symbol");
+var _Symbol = require("@babel/runtime-corejs2/core-js/symbol/index");
 var _Map = require("@babel/runtime-corejs2/core-js/map");
 obj.constructor === Object;
 obj.constructor === _Promise;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/full/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/full/output.mjs
@@ -1,6 +1,6 @@
 import _regeneratorRuntime from "@babel/runtime-corejs2/helpers/regeneratorRuntime";
 var _marked = /*#__PURE__*/_regeneratorRuntime().mark(giveWord);
-import _Symbol from "@babel/runtime-corejs2/core-js/symbol";
+import _Symbol from "@babel/runtime-corejs2/core-js/symbol/index";
 import foo, * as bar from "someModule";
 export const myWord = _Symbol("abc");
 export function giveWord() {

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -91,7 +91,7 @@
     "@babel/plugin-transform-unicode-sets-regex": "workspace:^",
     "@babel/preset-modules": "^0.1.5",
     "@babel/types": "workspace:^",
-    "babel-plugin-polyfill-corejs2": "^0.4.1",
+    "babel-plugin-polyfill-corejs2": "^0.4.2",
     "babel-plugin-polyfill-corejs3": "^0.8.1",
     "babel-plugin-polyfill-regenerator": "^0.5.0",
     "core-js-compat": "^3.30.2",

--- a/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
@@ -1,4 +1,4 @@
-import _Symbol from "core-js/library/fn/symbol.js";
+import _Symbol from "core-js/library/fn/symbol/index.js";
 import _Symbol$iterator from "core-js/library/fn/symbol/iterator.js";
 import _Array$from from "core-js/library/fn/array/from.js";
 export default function _iterableToArray(iter) {

--- a/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/iterableToArray.js
@@ -1,4 +1,4 @@
-var _Symbol = require("core-js/library/fn/symbol.js");
+var _Symbol = require("core-js/library/fn/symbol/index.js");
 var _Symbol$iterator = require("core-js/library/fn/symbol/iterator.js");
 var _Array$from = require("core-js/library/fn/array/from.js");
 function _iterableToArray(iter) {

--- a/packages/babel-runtime-corejs2/helpers/typeof.js
+++ b/packages/babel-runtime-corejs2/helpers/typeof.js
@@ -1,4 +1,4 @@
-var _Symbol = require("core-js/library/fn/symbol.js");
+var _Symbol = require("core-js/library/fn/symbol/index.js");
 var _Symbol$iterator = require("core-js/library/fn/symbol/iterator.js");
 function _typeof(obj) {
   "@babel/helpers - typeof";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,7 +3167,7 @@ __metadata:
     "@babel/runtime-corejs3": "workspace:^"
     "@babel/template": "workspace:^"
     "@babel/types": "workspace:^"
-    babel-plugin-polyfill-corejs2: ^0.4.1
+    babel-plugin-polyfill-corejs2: ^0.4.2
     babel-plugin-polyfill-corejs3: ^0.8.1
     babel-plugin-polyfill-regenerator: ^0.5.0
     make-dir: "condition:BABEL_8_BREAKING ? : ^2.1.0"
@@ -3581,7 +3581,7 @@ __metadata:
     "@babel/preset-modules": ^0.1.5
     "@babel/traverse": "workspace:^"
     "@babel/types": "workspace:^"
-    babel-plugin-polyfill-corejs2: ^0.4.1
+    babel-plugin-polyfill-corejs2: ^0.4.2
     babel-plugin-polyfill-corejs3: ^0.8.1
     babel-plugin-polyfill-regenerator: ^0.5.0
     core-js-compat: ^3.30.2
@@ -6096,16 +6096,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs2@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "babel-plugin-polyfill-corejs2@npm:0.4.1"
+"babel-plugin-polyfill-corejs2@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "babel-plugin-polyfill-corejs2@npm:0.4.2"
   dependencies:
     "@babel/compat-data": ^7.17.7
     "@babel/helper-define-polyfill-provider": ^0.4.0
     semver: ^6.1.1
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: f2b9bfec71914899b6e028441db565e1a2f2bc8208738c0fd7093e36fa6232cb803577751a745a0a30484928fcff65b3dad2c124bf9d956c3de19c26a1355a5e
+  checksum: 6a337c3ad16ebbf63e377ced3bb8be7db67c876ff51c26eea068bab73fc79dcf55a8c121ef45e220a0c7f08eaa975ac0556400987ce1ff48d76d8a46dd88c231
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/15659
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The actual fix is in https://github.com/babel/babel-polyfills/pull/162

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15660"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

