### PR TITLE
Mark `assert` attributes with `extra.deprecatedAssertSyntax`

### DIFF
--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -3272,6 +3272,7 @@ export default abstract class StatementParser extends ExpressionParser {
             at: this.state.startLoc,
           });
         }
+        this.addExtra(node, "deprecatedAssertSyntax", true);
       } else {
         this.expectOnePlugin(["importAttributes", "importAssertions"]);
       }

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/_deprecated-syntax-not-enabled/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/_deprecated-syntax-not-enabled/output.json
@@ -23,6 +23,9 @@
           },
           "value": "foo"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/invalid-syntax-export-with-repeated-type/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/invalid-syntax-export-with-repeated-type/output.json
@@ -39,6 +39,9 @@
           "value": "foo.json"
         },
         "declaration": null,
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/invalid-syntax-with-repeated-type-string/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/invalid-syntax-with-repeated-type-string/output.json
@@ -34,6 +34,9 @@
           },
           "value": "foo.json"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/invalid-syntax-with-repeated-type/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/invalid-syntax-with-repeated-type/output.json
@@ -33,6 +33,9 @@
           },
           "value": "foo.json"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/string-literal/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/string-literal/output.json
@@ -30,6 +30,9 @@
           },
           "value": "foo.json"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",
@@ -80,6 +83,9 @@
           "value": "foo.json"
         },
         "declaration": null,
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/trailing-comma/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/trailing-comma/output.json
@@ -30,6 +30,9 @@
           },
           "value": "foo"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",
@@ -80,6 +83,9 @@
           "value": "foo"
         },
         "declaration": null,
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-empty-attribute/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-empty-attribute/output.json
@@ -44,6 +44,9 @@
           },
           "value": "foo"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": []
       },
       {
@@ -68,6 +71,9 @@
             "raw": "\"foo\""
           },
           "value": "foo"
+        },
+        "extra": {
+          "deprecatedAssertSyntax": true
         },
         "attributes": []
       },
@@ -100,6 +106,9 @@
           "value": "foo"
         },
         "declaration": null,
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": []
       },
       {
@@ -124,6 +133,9 @@
             "raw": "\"foo\""
           },
           "value": "foo"
+        },
+        "extra": {
+          "deprecatedAssertSyntax": true
         },
         "attributes": []
       }

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-string-attribute-key/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-string-attribute-key/output.json
@@ -20,6 +20,9 @@
           },
           "value": "foo"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-star-as-with-attributes/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-star-as-with-attributes/output.json
@@ -30,6 +30,9 @@
           },
           "value": "foo.json"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-star-with-attributes/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-star-with-attributes/output.json
@@ -19,6 +19,9 @@
           },
           "value": "foo.json"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-with-and-attributes-multiple-lines/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-with-and-attributes-multiple-lines/output.json
@@ -36,6 +36,9 @@
           "value": "foo"
         },
         "declaration": null,
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-with-attributes-and-value/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-with-attributes-and-value/output.json
@@ -40,6 +40,9 @@
           "value": "foo"
         },
         "declaration": null,
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-with-attributes/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-with-attributes/output.json
@@ -36,6 +36,9 @@
           "value": "foo.json"
         },
         "declaration": null,
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-with-no-type-attribute/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-with-no-type-attribute/output.json
@@ -36,6 +36,9 @@
           "value": "foo.json"
         },
         "declaration": null,
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-with-object-method-attribute/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-export-with-object-method-attribute/output.json
@@ -36,6 +36,9 @@
           "value": "foo.json"
         },
         "declaration": null,
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-with-attributes-and-value/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-with-attributes-and-value/output.json
@@ -20,6 +20,9 @@
           },
           "value": "x"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-with-attributes-multiple-lines/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-with-attributes-multiple-lines/output.json
@@ -20,6 +20,9 @@
           },
           "value": "x"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-with-attributes/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-with-attributes/output.json
@@ -30,6 +30,9 @@
           },
           "value": "foo.json"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-with-no-type-attribute/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-with-no-type-attribute/output.json
@@ -30,6 +30,9 @@
           },
           "value": "foo.json"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",

--- a/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-with-object-method-attribute/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/import-attributes-deprecatedAssertKeyword/valid-syntax-with-object-method-attribute/output.json
@@ -30,6 +30,9 @@
           },
           "value": "foo.json"
         },
+        "extra": {
+          "deprecatedAssertSyntax": true
+        },
         "attributes": [
           {
             "type": "ImportAttribute",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR marks import attributes parsed by the new parser plugin (thus with the new AST) with `extra.deprecatedAssertSyntax = true` when using the `assert` keyword, so that tools that care about which keyword is uses (e.g. prettier, or linters maybe) can get that info.

Needed for https://github.com/prettier/prettier/pull/14863#issuecomment-1566885716.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15667"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

