### PR TITLE
Pass through nonce to the transformed script element

### DIFF
--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -115,8 +115,7 @@
     "@babel/preset-react": "workspace:^",
     "@babel/preset-typescript": "workspace:^",
     "acorn": "^8.7.0",
-    "jsdom": "^22.1.0",
-    "semver": "^6.3.0"
+    "jsdom": "^22.1.0"
   },
   "keywords": [
     "babel",

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -114,7 +114,9 @@
     "@babel/preset-flow": "workspace:^",
     "@babel/preset-react": "workspace:^",
     "@babel/preset-typescript": "workspace:^",
-    "acorn": "^8.7.0"
+    "acorn": "^8.7.0",
+    "jsdom": "^22.1.0",
+    "semver": "^6.3.0"
   },
   "keywords": [
     "babel",

--- a/packages/babel-standalone/test/transform-script-tags.test.js
+++ b/packages/babel-standalone/test/transform-script-tags.test.js
@@ -1,0 +1,57 @@
+import fs from "fs";
+import semver from "semver";
+
+const nodeGte16 = semver.gte(process.version, "16.0.0");
+
+(nodeGte16 ? describe : describe.skip)("transformScriptTags", () => {
+  let standaloneSource;
+  let JSDOM;
+  beforeAll(async () => {
+    standaloneSource = fs.readFileSync(
+      new URL("../babel.js", import.meta.url),
+      "utf8",
+    );
+    JSDOM = (await import("jsdom")).JSDOM;
+  });
+  it("should transform script element with type 'text/babel'", () => {
+    const dom = new JSDOM(
+      `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel">globalThis ?? window</script></head>`,
+      { runScripts: "dangerously" },
+    );
+    return new Promise((resolve, reject) => {
+      dom.window.addEventListener("DOMContentLoaded", () => {
+        try {
+          const transformedScriptElement =
+            dom.window.document.head.children.item(2);
+          expect(transformedScriptElement.getAttribute("type")).toBeNull();
+          expect(transformedScriptElement.innerHTML).toContain(
+            "globalThis !== null && globalThis !== void 0 ? globalThis : window",
+          );
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+  });
+  it("should pass through the nonce attribute to the transformed script element", () => {
+    const nonceAttribute = "nonce_example";
+
+    const dom = new JSDOM(
+      `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel" nonce="${nonceAttribute}">globalThis ?? window</script></head>`,
+      { runScripts: "dangerously" },
+    );
+    return new Promise((resolve, reject) => {
+      dom.window.addEventListener("DOMContentLoaded", () => {
+        try {
+          const transformedScriptElement =
+            dom.window.document.head.children.item(2);
+          expect(transformedScriptElement.nonce).toBe(nonceAttribute);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+  });
+});

--- a/packages/babel-standalone/test/transform-script-tags.test.js
+++ b/packages/babel-standalone/test/transform-script-tags.test.js
@@ -3,8 +3,6 @@ import { createRequire } from "module";
 import { itGte } from "$repo-utils";
 const require = createRequire(import.meta.url);
 
-const nodeGte16 = itGte("16.0.0");
-
 describe("transformScriptTags", () => {
   let standaloneSource;
   let JSDOM;
@@ -15,28 +13,31 @@ describe("transformScriptTags", () => {
     );
     JSDOM = require("jsdom").JSDOM;
   });
-  nodeGte16("should transform script element with type 'text/babel'", () => {
-    const dom = new JSDOM(
-      `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel">globalThis ?? window</script></head>`,
-      { runScripts: "dangerously" },
-    );
-    return new Promise((resolve, reject) => {
-      dom.window.addEventListener("DOMContentLoaded", () => {
-        try {
-          const transformedScriptElement =
-            dom.window.document.head.children.item(2);
-          expect(transformedScriptElement.getAttribute("type")).toBeNull();
-          expect(transformedScriptElement.innerHTML).toContain(
-            "globalThis !== null && globalThis !== void 0 ? globalThis : window",
-          );
-          resolve();
-        } catch (err) {
-          reject(err);
-        }
+  itGte("16.0.0")(
+    "should transform script element with type 'text/babel'",
+    () => {
+      const dom = new JSDOM(
+        `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel">globalThis ?? window</script></head>`,
+        { runScripts: "dangerously" },
+      );
+      return new Promise((resolve, reject) => {
+        dom.window.addEventListener("DOMContentLoaded", () => {
+          try {
+            const transformedScriptElement =
+              dom.window.document.head.children.item(2);
+            expect(transformedScriptElement.getAttribute("type")).toBeNull();
+            expect(transformedScriptElement.innerHTML).toContain(
+              "globalThis !== null && globalThis !== void 0 ? globalThis : window",
+            );
+            resolve();
+          } catch (err) {
+            reject(err);
+          }
+        });
       });
-    });
-  });
-  nodeGte16(
+    },
+  );
+  itGte("16.0.0")(
     "should pass through the nonce attribute to the transformed script element",
     () => {
       const nonceAttribute = "nonce_example";

--- a/packages/babel-standalone/test/transform-script-tags.test.js
+++ b/packages/babel-standalone/test/transform-script-tags.test.js
@@ -1,5 +1,7 @@
 import fs from "fs";
+import { createRequire } from "module";
 import semver from "semver";
+const require = createRequire(import.meta.url);
 
 const nodeGte16 = semver.gte(process.version, "16.0.0");
 
@@ -11,7 +13,7 @@ const nodeGte16 = semver.gte(process.version, "16.0.0");
       new URL("../babel.js", import.meta.url),
       "utf8",
     );
-    JSDOM = (await import("jsdom")).JSDOM;
+    JSDOM = require("jsdom").JSDOM;
   });
   it("should transform script element with type 'text/babel'", () => {
     const dom = new JSDOM(

--- a/packages/babel-standalone/test/transform-script-tags.test.js
+++ b/packages/babel-standalone/test/transform-script-tags.test.js
@@ -1,11 +1,11 @@
 import fs from "fs";
 import { createRequire } from "module";
-import semver from "semver";
+import { itGte } from "$repo-utils";
 const require = createRequire(import.meta.url);
 
-const nodeGte16 = semver.gte(process.version, "16.0.0");
+const nodeGte16 = itGte("16.0.0");
 
-(nodeGte16 ? describe : describe.skip)("transformScriptTags", () => {
+describe("transformScriptTags", () => {
   let standaloneSource;
   let JSDOM;
   beforeAll(async () => {
@@ -15,7 +15,7 @@ const nodeGte16 = semver.gte(process.version, "16.0.0");
     );
     JSDOM = require("jsdom").JSDOM;
   });
-  it("should transform script element with type 'text/babel'", () => {
+  nodeGte16("should transform script element with type 'text/babel'", () => {
     const dom = new JSDOM(
       `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel">globalThis ?? window</script></head>`,
       { runScripts: "dangerously" },
@@ -36,24 +36,27 @@ const nodeGte16 = semver.gte(process.version, "16.0.0");
       });
     });
   });
-  it("should pass through the nonce attribute to the transformed script element", () => {
-    const nonceAttribute = "nonce_example";
+  nodeGte16(
+    "should pass through the nonce attribute to the transformed script element",
+    () => {
+      const nonceAttribute = "nonce_example";
 
-    const dom = new JSDOM(
-      `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel" nonce="${nonceAttribute}">globalThis ?? window</script></head>`,
-      { runScripts: "dangerously" },
-    );
-    return new Promise((resolve, reject) => {
-      dom.window.addEventListener("DOMContentLoaded", () => {
-        try {
-          const transformedScriptElement =
-            dom.window.document.head.children.item(2);
-          expect(transformedScriptElement.nonce).toBe(nonceAttribute);
-          resolve();
-        } catch (err) {
-          reject(err);
-        }
+      const dom = new JSDOM(
+        `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel" nonce="${nonceAttribute}">globalThis ?? window</script></head>`,
+        { runScripts: "dangerously" },
+      );
+      return new Promise((resolve, reject) => {
+        dom.window.addEventListener("DOMContentLoaded", () => {
+          try {
+            const transformedScriptElement =
+              dom.window.document.head.children.item(2);
+            expect(transformedScriptElement.nonce).toBe(nonceAttribute);
+            resolve();
+          } catch (err) {
+            reject(err);
+          }
+        });
       });
-    });
-  });
+    },
+  );
 });

--- a/packages/babel-standalone/test/transform-script-tags.test.js
+++ b/packages/babel-standalone/test/transform-script-tags.test.js
@@ -1,9 +1,9 @@
 import fs from "fs";
 import { createRequire } from "module";
-import { itGte } from "$repo-utils";
+import { describeGte } from "$repo-utils";
 const require = createRequire(import.meta.url);
 
-describe("transformScriptTags", () => {
+describeGte("16.0.0")("transformScriptTags", () => {
   let standaloneSource;
   let JSDOM;
   beforeAll(async () => {
@@ -13,51 +13,45 @@ describe("transformScriptTags", () => {
     );
     JSDOM = require("jsdom").JSDOM;
   });
-  itGte("16.0.0")(
-    "should transform script element with type 'text/babel'",
-    () => {
-      const dom = new JSDOM(
-        `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel">globalThis ?? window</script></head>`,
-        { runScripts: "dangerously" },
-      );
-      return new Promise((resolve, reject) => {
-        dom.window.addEventListener("DOMContentLoaded", () => {
-          try {
-            const transformedScriptElement =
-              dom.window.document.head.children.item(2);
-            expect(transformedScriptElement.getAttribute("type")).toBeNull();
-            expect(transformedScriptElement.innerHTML).toContain(
-              "globalThis !== null && globalThis !== void 0 ? globalThis : window",
-            );
-            resolve();
-          } catch (err) {
-            reject(err);
-          }
-        });
+  it("should transform script element with type 'text/babel'", () => {
+    const dom = new JSDOM(
+      `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel">globalThis ?? window</script></head>`,
+      { runScripts: "dangerously" },
+    );
+    return new Promise((resolve, reject) => {
+      dom.window.addEventListener("DOMContentLoaded", () => {
+        try {
+          const transformedScriptElement =
+            dom.window.document.head.children.item(2);
+          expect(transformedScriptElement.getAttribute("type")).toBeNull();
+          expect(transformedScriptElement.innerHTML).toContain(
+            "globalThis !== null && globalThis !== void 0 ? globalThis : window",
+          );
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
       });
-    },
-  );
-  itGte("16.0.0")(
-    "should pass through the nonce attribute to the transformed script element",
-    () => {
-      const nonceAttribute = "nonce_example";
+    });
+  });
+  it("should pass through the nonce attribute to the transformed script element", () => {
+    const nonceAttribute = "nonce_example";
 
-      const dom = new JSDOM(
-        `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel" nonce="${nonceAttribute}">globalThis ?? window</script></head>`,
-        { runScripts: "dangerously" },
-      );
-      return new Promise((resolve, reject) => {
-        dom.window.addEventListener("DOMContentLoaded", () => {
-          try {
-            const transformedScriptElement =
-              dom.window.document.head.children.item(2);
-            expect(transformedScriptElement.nonce).toBe(nonceAttribute);
-            resolve();
-          } catch (err) {
-            reject(err);
-          }
-        });
+    const dom = new JSDOM(
+      `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel" nonce="${nonceAttribute}">globalThis ?? window</script></head>`,
+      { runScripts: "dangerously" },
+    );
+    return new Promise((resolve, reject) => {
+      dom.window.addEventListener("DOMContentLoaded", () => {
+        try {
+          const transformedScriptElement =
+            dom.window.document.head.children.item(2);
+          expect(transformedScriptElement.nonce).toBe(nonceAttribute);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
       });
-    },
-  );
+    });
+  });
 });

--- a/scripts/repo-utils/index.cjs
+++ b/scripts/repo-utils/index.cjs
@@ -44,6 +44,9 @@ if (typeof jest !== "undefined") {
   exports.describeESM = USE_ESM ? describe : dummy;
   exports.describeBabel7 = process.env.BABEL_8_BREAKING ? dummy : describe;
   exports.describeBabel8 = process.env.BABEL_8_BREAKING ? describe : dummy;
+  exports.describeGte = function (version) {
+    return semver.gte(process.version, version) ? describe : describe.skip;
+  };
 }
 
 exports.commonJS = function (metaUrl) {

--- a/scripts/repo-utils/index.d.ts
+++ b/scripts/repo-utils/index.d.ts
@@ -17,3 +17,4 @@ export const itBabel7NoESM: jest.It;
 export const itDummy: jest.It;
 export const describeBabel7: jest.Describe;
 export const describeBabel8: jest.Describe;
+export function describeGte(version: string): jest.Describe;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,7 +4229,6 @@ __metadata:
     "@babel/preset-typescript": "workspace:^"
     acorn: ^8.7.0
     jsdom: ^22.1.0
-    semver: ^6.3.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4228,6 +4228,8 @@ __metadata:
     "@babel/preset-react": "workspace:^"
     "@babel/preset-typescript": "workspace:^"
     acorn: ^8.7.0
+    jsdom: ^22.1.0
+    semver: ^6.3.0
   languageName: unknown
   linkType: soft
 
@@ -5060,6 +5062,13 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^3.0.0
   checksum: 586c76e1dd90d03b0c4e754f2011325b38ac6055878c81c52434c900f36d9d245438c96ef69e08e28d9fbecf2335fb347b67850962d8b6e539dd7359d8c62802
+  languageName: node
+  linkType: hard
+
+"@tootallnate/once@npm:2":
+  version: 2.0.0
+  resolution: "@tootallnate/once@npm:2.0.0"
+  checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
   languageName: node
   linkType: hard
 
@@ -5902,6 +5911,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abab@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "abab@npm:2.0.6"
+  checksum: 6ffc1af4ff315066c62600123990d87551ceb0aafa01e6539da77b0f5987ac7019466780bf480f1787576d4385e3690c81ccc37cfda12819bf510b8ab47e5a3e
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:1":
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
@@ -6003,6 +6019,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 538ba38af0cc9e5ef983aee196c4b8b4d87c0c94532334fa7e065b2c8a1f85863467bb774231aae91613fcda5e68740c15d97b1967ae3394d20faddddd8af61d
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:6":
+  version: 6.0.2
+  resolution: "agent-base@npm:6.0.2"
+  dependencies:
+    debug: 4
+  checksum: f52b6872cc96fd5f622071b71ef200e01c7c4c454ee68bc9accca90c98cfb39f2810e3e9aa330435835eedc8c23f4f8a15267f67c6e245d2b33757575bdac49d
   languageName: node
   linkType: hard
 
@@ -7715,7 +7740,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.6, combined-stream@npm:~1.0.6":
+"combined-stream@npm:^1.0.6, combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.6":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
   dependencies:
@@ -7980,6 +8005,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cssstyle@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "cssstyle@npm:3.0.0"
+  dependencies:
+    rrweb-cssom: ^0.6.0
+  checksum: 31f694dfed9998ed93570fe539610837b878193dd8487c33cb12db8004333c53c2a3904166288bbec68388c72fb01014d46d3243ddfb02fe845989d852c06f27
+  languageName: node
+  linkType: hard
+
 "cyclist@npm:^1.0.1":
   version: 1.0.2
   resolution: "cyclist@npm:1.0.2"
@@ -8013,7 +8047,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4.3.4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
+"data-urls@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "data-urls@npm:4.0.0"
+  dependencies:
+    abab: ^2.0.6
+    whatwg-mimetype: ^3.0.0
+    whatwg-url: ^12.0.0
+  checksum: 006e869b5bf079647949a3e9b1dd69d84b2d5d26e6b01c265485699bc96e83817d4b5aae758b2910a4c58c0601913f3a0034121c1ca2da268e9a244c57515b15
+  languageName: node
+  linkType: hard
+
+"debug@npm:4, debug@npm:4.3.4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -8047,6 +8092,13 @@ __metadata:
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:^10.4.3":
+  version: 10.4.3
+  resolution: "decimal.js@npm:10.4.3"
+  checksum: 796404dcfa9d1dbfdc48870229d57f788b48c21c603c3f6554a1c17c10195fc1024de338b0cf9e1efe0c7c167eeb18f04548979bcc5fdfabebb7cc0ae3287bae
   languageName: node
   linkType: hard
 
@@ -8304,6 +8356,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"domexception@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "domexception@npm:4.0.0"
+  dependencies:
+    webidl-conversions: ^7.0.0
+  checksum: ddbc1268edf33a8ba02ccc596735ede80375ee0cf124b30d2f05df5b464ba78ef4f49889b6391df4a04954e63d42d5631c7fcf8b1c4f12bc531252977a5f13d5
+  languageName: node
+  linkType: hard
+
 "duplexer2@npm:^0.1.2, duplexer2@npm:~0.1.0, duplexer2@npm:~0.1.2":
   version: 0.1.4
   resolution: "duplexer2@npm:0.1.4"
@@ -8441,6 +8502,13 @@ __metadata:
     graceful-fs: ^4.2.4
     tapable: ^2.2.0
   checksum: fbd8cdc9263be71cc737aa8a7d6c57b43d6aa38f6cc75dde6fcd3598a130cc465f979d2f4d01bb3bf475acb43817749c79f8eef9be048683602ca91ab52e4f11
+  languageName: node
+  linkType: hard
+
+"entities@npm:^4.4.0":
+  version: 4.5.0
+  resolution: "entities@npm:4.5.0"
+  checksum: 853f8ebd5b425d350bffa97dd6958143179a5938352ccae092c62d1267c4e392a039be1bae7d51b6e4ffad25f51f9617531fedf5237f15df302ccfb452cbf2d7
   languageName: node
   linkType: hard
 
@@ -9563,6 +9631,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
+  languageName: node
+  linkType: hard
+
 "form-data@npm:~2.3.2":
   version: 2.3.3
   resolution: "form-data@npm:2.3.3"
@@ -10317,6 +10396,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-encoding-sniffer@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "html-encoding-sniffer@npm:3.0.0"
+  dependencies:
+    whatwg-encoding: ^2.0.0
+  checksum: 8d806aa00487e279e5ccb573366a951a9f68f65c90298eac9c3a2b440a7ffe46615aff2995a2f61c6746c639234e6179a97e18ca5ccbbf93d3725ef2099a4502
+  languageName: node
+  linkType: hard
+
 "html-escaper@npm:^2.0.0":
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
@@ -10328,6 +10416,17 @@ __metadata:
   version: 1.1.1
   resolution: "htmlescape@npm:1.1.1"
   checksum: c59a915ae6ae076b5720243c8c594fd8c76e927d511ed5f205e4d586f47d521478d7148dc7fbe3d4a0cfc30abcc2dd215b30255903c09ed04eb38bca44367c5d
+  languageName: node
+  linkType: hard
+
+"http-proxy-agent@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "http-proxy-agent@npm:5.0.0"
+  dependencies:
+    "@tootallnate/once": 2
+    agent-base: 6
+    debug: 4
+  checksum: e2ee1ff1656a131953839b2a19cd1f3a52d97c25ba87bd2559af6ae87114abf60971e498021f9b73f9fd78aea8876d1fb0d4656aac8a03c6caa9fc175f22b786
   languageName: node
   linkType: hard
 
@@ -10346,6 +10445,16 @@ __metadata:
   version: 1.0.0
   resolution: "https-browserify@npm:1.0.0"
   checksum: 09b35353e42069fde2435760d13f8a3fb7dd9105e358270e2e225b8a94f811b461edd17cb57594e5f36ec1218f121c160ddceeec6e8be2d55e01dcbbbed8cbae
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "https-proxy-agent@npm:5.0.1"
+  dependencies:
+    agent-base: 6
+    debug: 4
+  checksum: 571fccdf38184f05943e12d37d6ce38197becdd69e58d03f43637f7fa1269cf303a7d228aa27e5b27bbd3af8f09fd938e1c91dcfefff2df7ba77c20ed8dfc765
   languageName: node
   linkType: hard
 
@@ -10369,6 +10478,15 @@ __metadata:
   bin:
     husky: lib/bin.js
   checksum: 837bc7e4413e58c1f2946d38fb050f5d7324c6f16b0fd66411ffce5703b294bd21429e8ba58711cd331951ee86ed529c5be4f76805959ff668a337dbfa82a1b0
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:0.6.3":
+  version: 0.6.3
+  resolution: "iconv-lite@npm:0.6.3"
+  dependencies:
+    safer-buffer: ">= 2.1.2 < 3.0.0"
+  checksum: 3f60d47a5c8fc3313317edfd29a00a692cc87a19cac0159e2ce711d0ebc9019064108323b5e493625e25594f11c6236647d8e256fbe7a58f4a3b33b89e6d30bf
   languageName: node
   linkType: hard
 
@@ -10883,6 +11001,13 @@ __metadata:
   version: 5.0.0
   resolution: "is-plain-object@npm:5.0.0"
   checksum: e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
+  languageName: node
+  linkType: hard
+
+"is-potential-custom-element-name@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-potential-custom-element-name@npm:1.0.1"
+  checksum: ced7bbbb6433a5b684af581872afe0e1767e2d1146b2207ca0068a648fb5cab9d898495d1ac0583524faaf24ca98176a7d9876363097c2d14fee6dd324f3a1ab
   languageName: node
   linkType: hard
 
@@ -11672,6 +11797,42 @@ __metadata:
   version: 0.1.1
   resolution: "jsbn@npm:0.1.1"
   checksum: e5ff29c1b8d965017ef3f9c219dacd6e40ad355c664e277d31246c90545a02e6047018c16c60a00f36d561b3647215c41894f5d869ada6908a2e0ce4200c88f2
+  languageName: node
+  linkType: hard
+
+"jsdom@npm:^22.1.0":
+  version: 22.1.0
+  resolution: "jsdom@npm:22.1.0"
+  dependencies:
+    abab: ^2.0.6
+    cssstyle: ^3.0.0
+    data-urls: ^4.0.0
+    decimal.js: ^10.4.3
+    domexception: ^4.0.0
+    form-data: ^4.0.0
+    html-encoding-sniffer: ^3.0.0
+    http-proxy-agent: ^5.0.0
+    https-proxy-agent: ^5.0.1
+    is-potential-custom-element-name: ^1.0.1
+    nwsapi: ^2.2.4
+    parse5: ^7.1.2
+    rrweb-cssom: ^0.6.0
+    saxes: ^6.0.0
+    symbol-tree: ^3.2.4
+    tough-cookie: ^4.1.2
+    w3c-xmlserializer: ^4.0.0
+    webidl-conversions: ^7.0.0
+    whatwg-encoding: ^2.0.0
+    whatwg-mimetype: ^3.0.0
+    whatwg-url: ^12.0.1
+    ws: ^8.13.0
+    xml-name-validator: ^4.0.0
+  peerDependencies:
+    canvas: ^2.5.0
+  peerDependenciesMeta:
+    canvas:
+      optional: true
+  checksum: d955ab83a6dad3e6af444098d30647c719bbb4cf97de053aa5751c03c8d6f3283d8c4d7fc2774c181f1d432fb0250e7332bc159e6b466424f4e337d73adcbf30
   languageName: node
   linkType: hard
 
@@ -12957,6 +13118,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nwsapi@npm:^2.2.4":
+  version: 2.2.5
+  resolution: "nwsapi@npm:2.2.5"
+  checksum: 3acfe387214e2a9a03960662ad600ecb41fc24385c9de91262a881608407f02d14686e5df3e6e87af0cf7b173ed2a6a202a569ab7bef376ec1841cd9b6cbf0a6
+  languageName: node
+  linkType: hard
+
 "oauth-sign@npm:~0.9.0":
   version: 0.9.0
   resolution: "oauth-sign@npm:0.9.0"
@@ -13375,6 +13543,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "parse5@npm:7.1.2"
+  dependencies:
+    entities: ^4.4.0
+  checksum: 59465dd05eb4c5ec87b76173d1c596e152a10e290b7abcda1aecf0f33be49646ea74840c69af975d7887543ea45564801736356c568d6b5e71792fd0f4055713
+  languageName: node
+  linkType: hard
+
 "pascalcase@npm:^0.1.1":
   version: 0.1.1
   resolution: "pascalcase@npm:0.1.1"
@@ -13763,10 +13940,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"psl@npm:^1.1.28":
-  version: 1.8.0
-  resolution: "psl@npm:1.8.0"
-  checksum: 6150048ed2da3f919478bee8a82f3828303bc0fc730fb015a48f83c9977682c7b28c60ab01425a72d82a2891a1681627aa530a991d50c086b48a3be27744bde7
+"psl@npm:^1.1.28, psl@npm:^1.1.33":
+  version: 1.9.0
+  resolution: "psl@npm:1.9.0"
+  checksum: 20c4277f640c93d393130673f392618e9a8044c6c7bf61c53917a0fddb4952790f5f362c6c730a9c32b124813e173733f9895add8d26f566ed0ea0654b2e711d
   languageName: node
   linkType: hard
 
@@ -13822,10 +13999,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0, punycode@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "punycode@npm:2.1.1"
-  checksum: 823bf443c6dd14f669984dea25757b37993f67e8d94698996064035edd43bed8a5a17a9f12e439c2b35df1078c6bec05a6c86e336209eb1061e8025c481168e8
+"punycode@npm:^2.1.0, punycode@npm:^2.1.1, punycode@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "punycode@npm:2.3.0"
+  checksum: 39f760e09a2a3bbfe8f5287cf733ecdad69d6af2fe6f97ca95f24b8921858b91e9ea3c9eeec6e08cede96181b3bb33f95c6ffd8c77e63986508aa2e8159fa200
   languageName: node
   linkType: hard
 
@@ -13856,6 +14033,13 @@ __metadata:
   version: 0.2.1
   resolution: "querystring-es3@npm:0.2.1"
   checksum: 691e8d6b8b157e7cd49ae8e83fcf86de39ab3ba948c25abaa94fba84c0986c641aa2f597770848c64abce290ed17a39c9df6df737dfa7e87c3b63acc7d225d61
+  languageName: node
+  linkType: hard
+
+"querystringify@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "querystringify@npm:2.2.0"
+  checksum: 5641ea231bad7ef6d64d9998faca95611ed4b11c2591a8cae741e178a974f6a8e0ebde008475259abe1621cb15e692404e6b6626e927f7b849d5c09392604b15
   languageName: node
   linkType: hard
 
@@ -14194,6 +14378,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"requires-port@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "requires-port@npm:1.0.0"
+  checksum: eee0e303adffb69be55d1a214e415cf42b7441ae858c76dfc5353148644f6fd6e698926fc4643f510d5c126d12a705e7c8ed7e38061113bdf37547ab356797ff
+  languageName: node
+  linkType: hard
+
 "resolve-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "resolve-cwd@npm:3.0.0"
@@ -14419,6 +14610,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rrweb-cssom@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "rrweb-cssom@npm:0.6.0"
+  checksum: 182312f6e4f41d18230ccc34f14263bc8e8a6b9d30ee3ec0d2d8e643c6f27964cd7a8d638d4a00e988d93e8dc55369f4ab5a473ccfeff7a8bab95b36d2b5499c
+  languageName: node
+  linkType: hard
+
 "run-applescript@npm:^5.0.0":
   version: 5.0.0
   resolution: "run-applescript@npm:5.0.0"
@@ -14490,10 +14688,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:^2.0.2, safer-buffer@npm:^2.1.0, safer-buffer@npm:~2.1.0":
+"safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.0.2, safer-buffer@npm:^2.1.0, safer-buffer@npm:~2.1.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
+  languageName: node
+  linkType: hard
+
+"saxes@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "saxes@npm:6.0.0"
+  dependencies:
+    xmlchars: ^2.2.0
+  checksum: d3fa3e2aaf6c65ed52ee993aff1891fc47d5e47d515164b5449cbf5da2cbdc396137e55590472e64c5c436c14ae64a8a03c29b9e7389fc6f14035cf4e982ef3b
   languageName: node
   linkType: hard
 
@@ -15366,6 +15573,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"symbol-tree@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "symbol-tree@npm:3.2.4"
+  checksum: 6e8fc7e1486b8b54bea91199d9535bb72f10842e40c79e882fc94fb7b14b89866adf2fd79efa5ebb5b658bc07fb459ccce5ac0e99ef3d72f474e74aaf284029d
+  languageName: node
+  linkType: hard
+
 "synckit@npm:^0.8.5":
   version: 0.8.5
   resolution: "synckit@npm:0.8.5"
@@ -15681,6 +15895,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tough-cookie@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "tough-cookie@npm:4.1.2"
+  dependencies:
+    psl: ^1.1.33
+    punycode: ^2.1.1
+    universalify: ^0.2.0
+    url-parse: ^1.5.3
+  checksum: a7359e9a3e875121a84d6ba40cc184dec5784af84f67f3a56d1d2ae39b87c0e004e6ba7c7331f9622a7d2c88609032473488b28fe9f59a1fec115674589de39a
+  languageName: node
+  linkType: hard
+
 "tough-cookie@npm:~2.5.0":
   version: 2.5.0
   resolution: "tough-cookie@npm:2.5.0"
@@ -15688,6 +15914,15 @@ __metadata:
     psl: ^1.1.28
     punycode: ^2.1.1
   checksum: 16a8cd090224dd176eee23837cbe7573ca0fa297d7e468ab5e1c02d49a4e9a97bb05fef11320605eac516f91d54c57838a25864e8680e27b069a5231d8264977
+  languageName: node
+  linkType: hard
+
+"tr46@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "tr46@npm:4.1.1"
+  dependencies:
+    punycode: ^2.3.0
+  checksum: aeeb821ac2cd792e63ec84888b4fd6598ac6ed75d861579e21a5cf9d4ee78b2c6b94e7d45036f2ca2088bc85b9b46560ad23c4482979421063b24137349dbd96
   languageName: node
   linkType: hard
 
@@ -16085,6 +16320,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"universalify@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "universalify@npm:0.2.0"
+  checksum: e86134cb12919d177c2353196a4cc09981524ee87abf621f7bc8d249dbbbebaec5e7d1314b96061497981350df786e4c5128dbf442eba104d6e765bc260678b5
+  languageName: node
+  linkType: hard
+
 "unset-value@npm:^1.0.0":
   version: 1.0.0
   resolution: "unset-value@npm:1.0.0"
@@ -16136,6 +16378,16 @@ __metadata:
   version: 0.1.0
   resolution: "urix@npm:0.1.0"
   checksum: 4c076ecfbf3411e888547fe844e52378ab5ada2d2f27625139011eada79925e77f7fbf0e4016d45e6a9e9adb6b7e64981bd49b22700c7c401c5fc15f423303b3
+  languageName: node
+  linkType: hard
+
+"url-parse@npm:^1.5.3":
+  version: 1.5.10
+  resolution: "url-parse@npm:1.5.10"
+  dependencies:
+    querystringify: ^2.1.1
+    requires-port: ^1.0.0
+  checksum: fbdba6b1d83336aca2216bbdc38ba658d9cfb8fc7f665eb8b17852de638ff7d1a162c198a8e4ed66001ddbf6c9888d41e4798912c62b4fd777a31657989f7bdf
   languageName: node
   linkType: hard
 
@@ -16332,6 +16584,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"w3c-xmlserializer@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "w3c-xmlserializer@npm:4.0.0"
+  dependencies:
+    xml-name-validator: ^4.0.0
+  checksum: eba070e78deb408ae8defa4d36b429f084b2b47a4741c4a9be3f27a0a3d1845e277e3072b04391a138f7e43776842627d1334e448ff13ff90ad9fb1214ee7091
+  languageName: node
+  linkType: hard
+
 "walker@npm:^1.0.8":
   version: 1.0.8
   resolution: "walker@npm:1.0.8"
@@ -16374,6 +16635,13 @@ __metadata:
     glob-to-regexp: ^0.4.1
     graceful-fs: ^4.1.2
   checksum: 23d4bc58634dbe13b86093e01c6a68d8096028b664ab7139d58f0c37d962d549a940e98f2f201cecdabd6f9c340338dc73ef8bf094a2249ef582f35183d1a131
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "webidl-conversions@npm:7.0.0"
+  checksum: f05588567a2a76428515333eff87200fae6c83c3948a7482ebb109562971e77ef6dc49749afa58abb993391227c5697b3ecca52018793e0cb4620a48f10bd21b
   languageName: node
   linkType: hard
 
@@ -16544,6 +16812,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"whatwg-encoding@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "whatwg-encoding@npm:2.0.0"
+  dependencies:
+    iconv-lite: 0.6.3
+  checksum: 7087810c410aa9b689cbd6af8773341a53cdc1f3aae2a882c163bd5522ec8ca4cdfc269aef417a5792f411807d5d77d50df4c24e3abb00bb60192858a40cc675
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "whatwg-mimetype@npm:3.0.0"
+  checksum: ce08bbb36b6aaf64f3a84da89707e3e6a31e5ab1c1a2379fd68df79ba712a4ab090904f0b50e6693b0dafc8e6343a6157e40bf18fdffd26e513cf95ee2a59824
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^12.0.0, whatwg-url@npm:^12.0.1":
+  version: 12.0.1
+  resolution: "whatwg-url@npm:12.0.1"
+  dependencies:
+    tr46: ^4.1.1
+    webidl-conversions: ^7.0.0
+  checksum: 8698993b763c1e7eda5ed16c31dab24bca6489626aca7caf8b5a2b64684dda6578194786f10ec42ceb1c175feea16d0a915096e6419e08d154ce551c43176972
+  languageName: node
+  linkType: hard
+
 "which-boxed-primitive@npm:^1.0.2":
   version: 1.0.2
   resolution: "which-boxed-primitive@npm:1.0.2"
@@ -16692,6 +16986,35 @@ __metadata:
     imurmurhash: ^0.1.4
     signal-exit: ^3.0.7
   checksum: 5da60bd4eeeb935eec97ead3df6e28e5917a6bd317478e4a85a5285e8480b8ed96032bbcc6ecd07b236142a24f3ca871c924ec4a6575e623ec1b11bf8c1c253c
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.13.0":
+  version: 8.13.0
+  resolution: "ws@npm:8.13.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 53e991bbf928faf5dc6efac9b8eb9ab6497c69feeb94f963d648b7a3530a720b19ec2e0ec037344257e05a4f35bd9ad04d9de6f289615ffb133282031b18c61c
+  languageName: node
+  linkType: hard
+
+"xml-name-validator@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "xml-name-validator@npm:4.0.0"
+  checksum: af100b79c29804f05fa35aa3683e29a321db9b9685d5e5febda3fa1e40f13f85abc40f45a6b2bf7bee33f68a1dc5e8eaef4cec100a304a9db565e6061d4cb5ad
+  languageName: node
+  linkType: hard
+
+"xmlchars@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "xmlchars@npm:2.2.0"
+  checksum: 8c70ac94070ccca03f47a81fcce3b271bd1f37a591bf5424e787ae313fcb9c212f5f6786e1fa82076a2c632c0141552babcd85698c437506dfa6ae2d58723062
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Resolves #15668 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we pass through the `nonce` attribute to the script element holding the source transformed by `@babel/standalone`.

I am trying to draft a jsdom test for the new behaviour. Another approach would be the headless browser, which is slower and prone to flaky results.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15671"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

