### PR TITLE
Fix using `syntax-unicode-sets-regex` in standalone

### DIFF
--- a/packages/babel-preset-env/src/available-plugins.ts
+++ b/packages/babel-preset-env/src/available-plugins.ts
@@ -110,6 +110,13 @@ export default {
   // syntax enabled by default, we can safely skip enabling it.
   "syntax-unicode-sets-regex": USE_ESM
     ? null
+    : // We cannot use the require call when bundling, because this is an ESM file.
+    // Babel standalone uses a modern parser, so just include a known noop plugin.
+    // Use `bind` so that it's not detected as a duplicate plugin when using it
+    // together with the TLA
+    IS_STANDALONE
+    ? // @ts-expect-error syntaxTopLevelAwait is a function when bundled
+      () => syntaxTopLevelAwait.bind()
     : // eslint-disable-next-line no-restricted-globals
       () => require("@babel/plugin-syntax-unicode-sets-regex"),
   "transform-arrow-functions": () => transformArrowFunctions,

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -261,12 +261,26 @@ describe("@babel/standalone", () => {
     it("#14425 - numeric separators should be parsed correctly", () => {
       expect(() => Babel.transform("1_1", {})).not.toThrow();
     });
-    it("#15674 - syntax-unicode-sets-regex can be used", () => {
-      expect(() =>
-        Babel.transform("/[\\p{L}]/u", {
-          plugins: ["syntax-unicode-sets-regex"],
-        }),
-      ).not.toThrow();
+    it("#15674 - supports unicode sets regex", () => {
+      expect(
+        Babel.transform("/[\\w--[b]]/v", {
+          plugins: ["transform-unicode-sets-regex"],
+        }).code,
+      ).toMatchInlineSnapshot(`"/[0-9A-Z_ac-z]/u;"`);
+
+      expect(
+        Babel.transform("/[\\w--[b]]/v", {
+          targets: { chrome: 90 },
+          presets: [["env", { modules: false }]],
+        }).code,
+      ).toMatchInlineSnapshot(`"/[0-9A-Z_ac-z]/u;"`);
+
+      expect(
+        Babel.transform("/[\\w--[b]]/v", {
+          targets: { chrome: 113 },
+          presets: [["env", { modules: false }]],
+        }).code,
+      ).toMatchInlineSnapshot(`"/[\\\\w--[b]]/v;"`);
     });
   });
 });

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -261,5 +261,12 @@ describe("@babel/standalone", () => {
     it("#14425 - numeric separators should be parsed correctly", () => {
       expect(() => Babel.transform("1_1", {})).not.toThrow();
     });
+    it("#15674 - syntax-unicode-sets-regex can be used", () => {
+      expect(() =>
+        Babel.transform("/[\\p{L}]/u", {
+          plugins: ["syntax-unicode-sets-regex"],
+        }),
+      ).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15674
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The standalone bundle contained a `require` call, because our Rollup setup doesn't intercept `require()` calls in ESM files.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15675"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

