### PR TITLE
[babel 8] Only support `legacy` and `2023-05` decorators

### DIFF
--- a/packages/babel-plugin-proposal-decorators/src/transformer-2023-05.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-2023-05.ts
@@ -1120,7 +1120,7 @@ function createLocalsAssignment(
     elementDecorations,
     classDecorations,
   ];
-  // TODO(Babel 8): Only keep the else branch
+
   if (!process.env.BABEL_8_BREAKING) {
     if (
       version === "2021-12" ||

--- a/packages/babel-plugin-proposal-decorators/src/transformer-2023-05.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-2023-05.ts
@@ -1121,73 +1121,81 @@ function createLocalsAssignment(
     classDecorations,
   ];
   // TODO(Babel 8): Only keep the else branch
-  if (
-    version === "2021-12" ||
-    (version === "2022-03" && !state.availableHelper("applyDecs2203R"))
-  ) {
-    lhs = t.arrayPattern([...elementLocals, ...classLocals]);
-    rhs = t.callExpression(
-      state.addHelper(version === "2021-12" ? "applyDecs" : "applyDecs2203"),
-      args,
-    );
-  } else {
-    // TODO(Babel 8): Only keep the if branch
-    if (version === "2023-05") {
-      if (maybePrivateBranName || classDecorationsFlag.value !== 0) {
-        args.push(classDecorationsFlag);
-      }
-      if (maybePrivateBranName) {
-        args.push(
-          template.expression.ast`
-            _ => ${t.cloneNode(maybePrivateBranName)} in _
-          ` as t.ArrowFunctionExpression,
-        );
-      }
-      rhs = t.callExpression(state.addHelper("applyDecs2305"), args);
-    } else if (version === "2023-01") {
-      if (maybePrivateBranName) {
-        args.push(
-          template.expression.ast`
-            _ => ${t.cloneNode(maybePrivateBranName)} in _
-          ` as t.ArrowFunctionExpression,
-        );
-      }
-      rhs = t.callExpression(state.addHelper("applyDecs2301"), args);
-    } else {
-      rhs = t.callExpression(state.addHelper("applyDecs2203R"), args);
-    }
-    // optimize `{ c: [classLocals] } = applyapplyDecs2203R(...)` to
-    // `[classLocals] = applyapplyDecs2203R(...).c`
-    if (elementLocals.length > 0) {
-      if (classLocals.length > 0) {
-        lhs = t.objectPattern([
-          t.objectProperty(t.identifier("e"), t.arrayPattern(elementLocals)),
-          t.objectProperty(t.identifier("c"), t.arrayPattern(classLocals)),
-        ]);
-      } else {
-        lhs = t.arrayPattern(elementLocals);
-        rhs = t.memberExpression(rhs, t.identifier("e"), false, false);
-      }
-    } else {
-      // invariant: classLocals.length > 0
-      lhs = t.arrayPattern(classLocals);
-      rhs = t.memberExpression(rhs, t.identifier("c"), false, false);
+  if (!process.env.BABEL_8_BREAKING) {
+    if (
+      version === "2021-12" ||
+      (version === "2022-03" && !state.availableHelper("applyDecs2203R"))
+    ) {
+      const lhs = t.arrayPattern([...elementLocals, ...classLocals]);
+      const rhs = t.callExpression(
+        state.addHelper(version === "2021-12" ? "applyDecs" : "applyDecs2203"),
+        args,
+      );
+      return t.assignmentExpression("=", lhs, rhs);
     }
   }
+
+  if (process.env.BABEL_8_BREAKING || version === "2023-05") {
+    if (maybePrivateBranName || classDecorationsFlag.value !== 0) {
+      args.push(classDecorationsFlag);
+    }
+    if (maybePrivateBranName) {
+      args.push(
+        template.expression.ast`
+            _ => ${t.cloneNode(maybePrivateBranName)} in _
+          ` as t.ArrowFunctionExpression,
+      );
+    }
+    rhs = t.callExpression(state.addHelper("applyDecs2305"), args);
+  } else if (version === "2023-01") {
+    if (maybePrivateBranName) {
+      args.push(
+        template.expression.ast`
+            _ => ${t.cloneNode(maybePrivateBranName)} in _
+          ` as t.ArrowFunctionExpression,
+      );
+    }
+    rhs = t.callExpression(state.addHelper("applyDecs2301"), args);
+  } else {
+    rhs = t.callExpression(state.addHelper("applyDecs2203R"), args);
+  }
+  // optimize `{ c: [classLocals] } = applyapplyDecs2203R(...)` to
+  // `[classLocals] = applyapplyDecs2203R(...).c`
+  if (elementLocals.length > 0) {
+    if (classLocals.length > 0) {
+      lhs = t.objectPattern([
+        t.objectProperty(t.identifier("e"), t.arrayPattern(elementLocals)),
+        t.objectProperty(t.identifier("c"), t.arrayPattern(classLocals)),
+      ]);
+    } else {
+      lhs = t.arrayPattern(elementLocals);
+      rhs = t.memberExpression(rhs, t.identifier("e"), false, false);
+    }
+  } else {
+    // invariant: classLocals.length > 0
+    lhs = t.arrayPattern(classLocals);
+    rhs = t.memberExpression(rhs, t.identifier("c"), false, false);
+  }
+
   return t.assignmentExpression("=", lhs, rhs);
 }
 
 export default function (
   { assertVersion, assumption }: PluginAPI,
   { loose }: Options,
+  // TODO(Babel 8): Only keep 2023-05
   version: "2023-05" | "2023-01" | "2022-03" | "2021-12",
 ): PluginObject {
-  if (version === "2023-05" || version === "2023-01") {
+  if (process.env.BABEL_8_BREAKING) {
     assertVersion("^7.21.0");
-  } else if (version === "2021-12") {
-    assertVersion("^7.16.0");
   } else {
-    assertVersion("^7.19.0");
+    if (version === "2023-05" || version === "2023-01") {
+      assertVersion("^7.21.0");
+    } else if (version === "2021-12") {
+      assertVersion("^7.16.0");
+    } else {
+      assertVersion("^7.19.0");
+    }
   }
 
   const VISITED = new WeakSet<NodePath>();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]],
   "assumptions": {
     "constantSuper": true

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-metadata--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-metadata--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-ordering--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-ordering--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-ordering/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-ordering/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]],
   "minNodeVersion": "16.11.0"
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-runtime-errors--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-runtime-errors--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2021-12" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2021-12" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2022-03" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]],
   "assumptions": {
     "constantSuper": true

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2022-03" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2022-03" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2022-03" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2022-03" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2022-03" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2022-03" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2022-03" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-ordering--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-ordering--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2022-03" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-ordering/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-ordering/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]],
   "minNodeVersion": "16.11.0"
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-runtime-errors--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-runtime-errors--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2022-03" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2022-03" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2022-03" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2023-01" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]],
   "assumptions": {
     "constantSuper": true

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2023-01" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2023-01" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2023-01" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2023-01" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2023-01" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2023-01" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2023-01" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-ordering--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-ordering--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2023-01" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-ordering/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-ordering/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]],
   "minNodeVersion": "16.11.0"
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-runtime-errors--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-runtime-errors--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2023-01" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [
     ["proposal-decorators", { "version": "2023-01" }],
     "transform-class-properties",

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/options.json
@@ -1,3 +1,4 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["proposal-decorators", { "version": "2023-01" }]]
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/class-decorator/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/class-decorator/options.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     ["proposal-pipeline-operator", { "proposal": "hack", "topicToken": "@@" }],
-    ["proposal-decorators", { "version": "2021-12" }],
+    ["proposal-decorators", { "version": "2023-05" }],
     "transform-class-static-block",
     "transform-class-properties"
   ]

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/class-decorator/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/class-decorator/output.js
@@ -7,6 +7,6 @@ const result = ((_class = class {
   constructor() {
     this.value = expectedValue;
   }
-}, [_decorated_class, _initClass] = babelHelpers.applyDecs(_class, [], [decorator]), _initClass()), _decorated_class);
+}, [_decorated_class, _initClass] = babelHelpers.applyDecs2305(_class, [], [decorator]).c, _initClass()), _decorated_class);
 expect(result.decoratorValue).toBe(expectedValue);
 expect(new result().value).toBe(expectedValue);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/class-decorator/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/class-decorator/options.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     ["proposal-pipeline-operator", { "proposal": "hack", "topicToken": "^^" }],
-    ["proposal-decorators", { "version": "2021-12" }],
+    ["proposal-decorators", { "version": "2023-05" }],
     "transform-class-static-block",
     "transform-class-properties"
   ]

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/class-decorator/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/class-decorator/output.js
@@ -7,6 +7,6 @@ const result = ((_class = class {
   constructor() {
     this.value = expectedValue;
   }
-}, [_decorated_class, _initClass] = babelHelpers.applyDecs(_class, [], [decorator]), _initClass()), _decorated_class);
+}, [_decorated_class, _initClass] = babelHelpers.applyDecs2305(_class, [], [decorator]).c, _initClass()), _decorated_class);
 expect(result.decoratorValue).toBe(expectedValue);
 expect(new result().value).toBe(expectedValue);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/options.json
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    ["proposal-decorators", { "version": "2021-12" }],
+    ["proposal-decorators", { "version": "2023-05" }],
     "transform-class-static-block",
     "transform-class-properties",
     "transform-classes"

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
@@ -16,7 +16,7 @@ let Outer = /*#__PURE__*/function (_Hello) {
       babelHelpers.classCallCheck(this, Inner);
       babelHelpers.defineProperty(this, "hello", _init_hello(this));
     });
-    [_init_hello] = babelHelpers.applyDecs(Inner, [[_dec, 0, "hello"]], []);
+    [_init_hello] = babelHelpers.applyDecs2305(Inner, [[_dec, 0, "hello"]], []).e;
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
   return babelHelpers.createClass(Outer);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
@@ -25,7 +25,7 @@ let Outer = /*#__PURE__*/function (_Hello) {
       babelHelpers.classCallCheck(this, Inner);
       babelHelpers.defineProperty(this, "hello", _init_hello(this));
     });
-    [_init_hello] = babelHelpers.applyDecs(Inner, [[_dec, 0, "hello"]], []);
+    [_init_hello] = babelHelpers.applyDecs2305(Inner, [[_dec, 0, "hello"]], []).e;
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
   return babelHelpers.createClass(Outer);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Follow up to https://github.com/babel/babel/pull/15576. I suggest reviewing with [whitespace diff disabled](https://github.com/babel/babel/pull/15676/files?w=1).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15676"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

