### PR TITLE
Warn in `@babel/plugin-proposal-private-property-in-object` fallback

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -37,4 +37,10 @@ releaseTool:
 unsafeHttpWhitelist:
   - localhost
 
+packageExtensions:
+  jest-snapshot@*:
+    dependencies:
+      # It doesn't support Prettier 3 yet
+      prettier: "^2.0.0"
+
 yarnPath: .yarn/releases/yarn-3.6.0.cjs

--- a/jest.config.js
+++ b/jest.config.js
@@ -46,6 +46,7 @@ module.exports = {
     "/node_modules/",
     "/test/fixtures/",
     "/test/debug-fixtures/",
+    "/babel-preset-env/test/regressions/",
     "/babel-parser/test/expressions/",
     "/test/tmp/",
     "/test/__data__/",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "husky": "^7.0.4",
     "import-meta-resolve": "^3.0.0",
     "jest": "^29.5.0",
-    "jest-light-runner": "^0.4.1",
+    "jest-light-runner": "^0.5.0",
     "jest-worker": "^29.5.0",
     "lint-staged": "^13.0.3",
     "mergeiterator": "^1.4.4",

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -22,7 +22,7 @@
     "@babel/helper-validator-option": "workspace:^",
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "workspace:^",
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "workspace:^",
-    "@babel/plugin-proposal-private-property-in-object": "condition:BABEL_8_BREAKING ? : 7.21.0-placeholder-for-preset-env.1",
+    "@babel/plugin-proposal-private-property-in-object": "condition:BABEL_8_BREAKING ? : 7.21.0-placeholder-for-preset-env.2",
     "@babel/plugin-syntax-async-generators": "^7.8.4",
     "@babel/plugin-syntax-class-properties": "^7.12.13",
     "@babel/plugin-syntax-class-static-block": "^7.14.5",

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -22,7 +22,7 @@
     "@babel/helper-validator-option": "workspace:^",
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "workspace:^",
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "workspace:^",
-    "@babel/plugin-proposal-private-property-in-object": "^7.21.0",
+    "@babel/plugin-proposal-private-property-in-object": "condition:BABEL_8_BREAKING ? : 7.21.0-placeholder-for-preset-env.1",
     "@babel/plugin-syntax-async-generators": "^7.8.4",
     "@babel/plugin-syntax-class-properties": "^7.12.13",
     "@babel/plugin-syntax-class-static-block": "^7.14.5",

--- a/packages/babel-preset-env/test/regressions.js
+++ b/packages/babel-preset-env/test/regressions.js
@@ -5,6 +5,8 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 const itBabel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
+const itBabel7Node14plus =
+  process.env.BABEL_8_BREAKING || parseInt(process.version) < 14 ? it.skip : it;
 
 describe("regressions", () => {
   it("empty", () => {
@@ -62,7 +64,8 @@ describe("regressions", () => {
       consoleWarn.mockRestore();
     });
 
-    itBabel7(
+    // jest fake timers only work in the Jest version we are using for Node.js 14+
+    itBabel7Node14plus(
       "proposal-private-property-in-object should warn and fallback to transform-...",
       async () => {
         const out = babel.transformSync("class A { #a; x = #a in this }", {

--- a/packages/babel-preset-env/test/regressions.js
+++ b/packages/babel-preset-env/test/regressions.js
@@ -1,50 +1,90 @@
 import * as babel7_12 from "@babel/core-7.12";
+import * as babel from "@babel/core";
 import env from "../lib/index.js";
 import path from "path";
 import { fileURLToPath } from "url";
 
 const itBabel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
 
-describe("#12880", () => {
-  afterEach(() => {
-    jest.spyOn(process, "cwd").mockRestore();
-  });
-
+describe("regressions", () => {
   it("empty", () => {
     // TODO(Babel 8): Delete this file
   });
 
-  itBabel7(
-    "read the .browserslistrc file when using @babel/core < 7.13.0",
-    () => {
-      const root = path.join(
-        path.dirname(fileURLToPath(import.meta.url)),
-        "regressions",
-      );
+  describe("#12880", () => {
+    afterEach(() => {
+      jest.spyOn(process, "cwd").mockRestore();
+    });
 
-      // Unfortunatly, when loading the browserslist config through
-      // @babel/preset-env, it's resolved from process.cwd() and not
-      // from root. Mock it to isolate this test.
-      const spy = jest.spyOn(process, "cwd").mockReturnValue(root);
+    itBabel7(
+      "read the .browserslistrc file when using @babel/core < 7.13.0",
+      () => {
+        const root = path.join(
+          path.dirname(fileURLToPath(import.meta.url)),
+          "regressions",
+        );
 
-      try {
-        // The browserslistrc file contains "firefox 50".
-        // a ** b is supported starting from firefox 52;
-        // a => b is supported starting from firefox 45.
-        const out = babel7_12.transformSync("a ** b; a => b;", {
+        // Unfortunatly, when loading the browserslist config through
+        // @babel/preset-env, it's resolved from process.cwd() and not
+        // from root. Mock it to isolate this test.
+        const spy = jest.spyOn(process, "cwd").mockReturnValue(root);
+
+        try {
+          // The browserslistrc file contains "firefox 50".
+          // a ** b is supported starting from firefox 52;
+          // a => b is supported starting from firefox 45.
+          const out = babel7_12.transformSync("a ** b; a => b;", {
+            configFile: false,
+            presets: [[env, { modules: false }]],
+            filename: path.join(root, "input.js"),
+            root,
+          });
+
+          expect(out.code).toMatchInlineSnapshot(`
+                    "Math.pow(a, b);
+                    a => b;"
+                `);
+        } finally {
+          spy.mockRestore();
+        }
+      },
+    );
+  });
+
+  describe("create-reat-app missing dependency fallback", () => {
+    let consoleWarn;
+    beforeEach(() => {
+      jest.useFakeTimers();
+      consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+      consoleWarn.mockRestore();
+    });
+
+    itBabel7(
+      "proposal-private-property-in-object should warn and fallback to transform-...",
+      async () => {
+        const out = babel.transformSync("class A { #a; x = #a in this }", {
           configFile: false,
-          presets: [[env, { modules: false }]],
-          filename: path.join(root, "input.js"),
-          root,
+          presets: [
+            (await import("./regressions/babel-preset-react-app/index.js"))
+              .default,
+          ],
         });
 
+        jest.advanceTimersByTime(5000);
+        expect(consoleWarn).toHaveBeenCalled();
+
         expect(out.code).toMatchInlineSnapshot(`
-        "Math.pow(a, b);
-        a => b;"
+        "function _checkInRHS(value) { if (Object(value) !== value) throw TypeError(\\"right-hand side of 'in' should be an object, got \\" + (null !== value ? typeof value : \\"null\\")); return value; }
+        var _aBrandCheck = /*#__PURE__*/new WeakSet();
+        class A {
+          #a = void _aBrandCheck.add(this);
+          x = _aBrandCheck.has(_checkInRHS(this));
+        }"
       `);
-      } finally {
-        spy.mockRestore();
-      }
-    },
-  );
+      },
+    );
+  });
 });

--- a/packages/babel-preset-env/test/regressions.js
+++ b/packages/babel-preset-env/test/regressions.js
@@ -3,7 +3,9 @@ import * as babel from "@babel/core";
 import env from "../lib/index.js";
 import path from "path";
 import { fileURLToPath } from "url";
-import { USE_ESM } from "$repo-utils";
+import { USE_ESM, commonJS } from "$repo-utils";
+
+const { require } = commonJS(import.meta.url);
 
 const itBabel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
 const itBabel7Node14plusCjs =
@@ -56,7 +58,7 @@ describe("regressions", () => {
   // jest fake timers only work in the Jest version we are using for Node.js 14+
   itBabel7Node14plusCjs(
     "proposal-private-property-in-object should warn and fallback to transform-...",
-    async () => {
+    () => {
       jest.useFakeTimers();
       const consoleWarn = jest
         .spyOn(console, "warn")
@@ -65,8 +67,7 @@ describe("regressions", () => {
         const out = babel.transformSync("class A { #a; x = #a in this }", {
           configFile: false,
           presets: [
-            (await import("./regressions/babel-preset-react-app/index.js"))
-              .default,
+            require("./regressions/babel-preset-react-app/index.js").default,
           ],
         });
 

--- a/packages/babel-preset-env/test/regressions.js
+++ b/packages/babel-preset-env/test/regressions.js
@@ -3,10 +3,13 @@ import * as babel from "@babel/core";
 import env from "../lib/index.js";
 import path from "path";
 import { fileURLToPath } from "url";
+import { USE_ESM } from "$repo-utils";
 
 const itBabel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
-const itBabel7Node14plus =
-  process.env.BABEL_8_BREAKING || parseInt(process.version) < 14 ? it.skip : it;
+const describeBabel7Node14plusCjs =
+  process.env.BABEL_8_BREAKING || parseInt(process.version) < 14 || USE_ESM
+    ? describe.skip
+    : describe;
 
 describe("regressions", () => {
   it("empty", () => {
@@ -53,21 +56,21 @@ describe("regressions", () => {
     );
   });
 
-  describe("create-reat-app missing dependency fallback", () => {
-    let consoleWarn;
-    beforeEach(() => {
-      jest.useFakeTimers();
-      consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
-    });
-    afterEach(() => {
-      jest.useRealTimers();
-      consoleWarn.mockRestore();
-    });
+  describeBabel7Node14plusCjs(
+    "create-reat-app missing dependency fallback",
+    () => {
+      let consoleWarn;
+      beforeEach(() => {
+        jest.useFakeTimers();
+        consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
+      });
+      afterEach(() => {
+        jest.useRealTimers();
+        consoleWarn.mockRestore();
+      });
 
-    // jest fake timers only work in the Jest version we are using for Node.js 14+
-    itBabel7Node14plus(
-      "proposal-private-property-in-object should warn and fallback to transform-...",
-      async () => {
+      // jest fake timers only work in the Jest version we are using for Node.js 14+
+      it("proposal-private-property-in-object should warn and fallback to transform-...", async () => {
         const out = babel.transformSync("class A { #a; x = #a in this }", {
           configFile: false,
           presets: [
@@ -87,7 +90,7 @@ describe("regressions", () => {
           x = _aBrandCheck.has(_checkInRHS(this));
         }"
       `);
-      },
-    );
-  });
+      });
+    },
+  );
 });

--- a/packages/babel-preset-env/test/regressions.js
+++ b/packages/babel-preset-env/test/regressions.js
@@ -7,7 +7,9 @@ import { USE_ESM } from "$repo-utils";
 
 const itBabel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
 const itBabel7Node14plusCjs =
-  process.env.BABEL_8_BREAKING || parseInt(process.version) < 14 || USE_ESM
+  process.env.BABEL_8_BREAKING ||
+  parseInt(process.versions.node) < 14 ||
+  USE_ESM
     ? it.skip
     : it;
 

--- a/packages/babel-preset-env/test/regressions.js
+++ b/packages/babel-preset-env/test/regressions.js
@@ -66,9 +66,7 @@ describe("regressions", () => {
       try {
         const out = babel.transformSync("class A { #a; x = #a in this }", {
           configFile: false,
-          presets: [
-            require("./regressions/babel-preset-react-app/index.js").default,
-          ],
+          presets: [require("./regressions/babel-preset-react-app/index.js")],
         });
 
         jest.advanceTimersByTime(5000);

--- a/packages/babel-preset-env/test/regressions.js
+++ b/packages/babel-preset-env/test/regressions.js
@@ -6,71 +6,60 @@ import { fileURLToPath } from "url";
 import { USE_ESM } from "$repo-utils";
 
 const itBabel7 = process.env.BABEL_8_BREAKING ? it.skip : it;
-const describeBabel7Node14plusCjs =
+const itBabel7Node14plusCjs =
   process.env.BABEL_8_BREAKING || parseInt(process.version) < 14 || USE_ESM
-    ? describe.skip
-    : describe;
+    ? it.skip
+    : it;
 
 describe("regressions", () => {
   it("empty", () => {
     // TODO(Babel 8): Delete this file
   });
 
-  describe("#12880", () => {
-    afterEach(() => {
-      jest.spyOn(process, "cwd").mockRestore();
-    });
+  itBabel7(
+    "#12880 - read the .browserslistrc file when using @babel/core < 7.13.0",
+    () => {
+      const root = path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "regressions",
+      );
 
-    itBabel7(
-      "read the .browserslistrc file when using @babel/core < 7.13.0",
-      () => {
-        const root = path.join(
-          path.dirname(fileURLToPath(import.meta.url)),
-          "regressions",
-        );
+      // Unfortunatly, when loading the browserslist config through
+      // @babel/preset-env, it's resolved from process.cwd() and not
+      // from root. Mock it to isolate this test.
+      const spy = jest.spyOn(process, "cwd").mockReturnValue(root);
 
-        // Unfortunatly, when loading the browserslist config through
-        // @babel/preset-env, it's resolved from process.cwd() and not
-        // from root. Mock it to isolate this test.
-        const spy = jest.spyOn(process, "cwd").mockReturnValue(root);
+      try {
+        // The browserslistrc file contains "firefox 50".
+        // a ** b is supported starting from firefox 52;
+        // a => b is supported starting from firefox 45.
+        const out = babel7_12.transformSync("a ** b; a => b;", {
+          configFile: false,
+          presets: [[env, { modules: false }]],
+          filename: path.join(root, "input.js"),
+          root,
+        });
 
-        try {
-          // The browserslistrc file contains "firefox 50".
-          // a ** b is supported starting from firefox 52;
-          // a => b is supported starting from firefox 45.
-          const out = babel7_12.transformSync("a ** b; a => b;", {
-            configFile: false,
-            presets: [[env, { modules: false }]],
-            filename: path.join(root, "input.js"),
-            root,
-          });
-
-          expect(out.code).toMatchInlineSnapshot(`
+        expect(out.code).toMatchInlineSnapshot(`
                     "Math.pow(a, b);
                     a => b;"
                 `);
-        } finally {
-          spy.mockRestore();
-        }
-      },
-    );
-  });
+      } finally {
+        spy.mockRestore();
+      }
+    },
+  );
 
-  describeBabel7Node14plusCjs(
-    "create-reat-app missing dependency fallback",
-    () => {
-      let consoleWarn;
-      beforeEach(() => {
-        jest.useFakeTimers();
-        consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
-      });
-      afterEach(() => {
-        jest.useRealTimers();
-        consoleWarn.mockRestore();
-      });
-
-      // jest fake timers only work in the Jest version we are using for Node.js 14+
-      it("proposal-private-property-in-object should warn and fallback to transform-...", async () => {
+  // create-reat-app missing dependency fallback
+  // jest fake timers only work in the Jest version we are using for Node.js 14+
+  itBabel7Node14plusCjs(
+    "proposal-private-property-in-object should warn and fallback to transform-...",
+    async () => {
+      jest.useFakeTimers();
+      const consoleWarn = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      try {
         const out = babel.transformSync("class A { #a; x = #a in this }", {
           configFile: false,
           presets: [
@@ -90,7 +79,10 @@ describe("regressions", () => {
           x = _aBrandCheck.has(_checkInRHS(this));
         }"
       `);
-      });
+      } finally {
+        jest.useRealTimers();
+        consoleWarn.mockRestore();
+      }
     },
   );
 });

--- a/packages/babel-preset-env/test/regressions/babel-preset-react-app/index.js
+++ b/packages/babel-preset-env/test/regressions/babel-preset-react-app/index.js
@@ -1,0 +1,7 @@
+/* eslint-disable no-restricted-globals */
+
+module.exports = function () {
+  return {
+    plugins: [require("@babel/plugin-proposal-private-property-in-object")],
+  };
+};

--- a/packages/babel-preset-env/test/regressions/babel-preset-react-app/package.json
+++ b/packages/babel-preset-env/test/regressions/babel-preset-react-app/package.json
@@ -1,0 +1,1 @@
+{ "type": "commonjs" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,21 +1387,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/plugin-proposal-private-property-in-object-BABEL_8_BREAKING-false@npm:@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.1":
-  version: 7.21.0-placeholder-for-preset-env.1
-  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.0-placeholder-for-preset-env.1"
+"@babel/plugin-proposal-private-property-in-object-BABEL_8_BREAKING-false@npm:@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2":
+  version: 7.21.0-placeholder-for-preset-env.2
+  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.0-placeholder-for-preset-env.2"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 34ee9fee925efe5271ea7652dc65c0218210f2313e64f69d516a31fbdd4757e0ab58140283f8702a5920e82ffed438541a83badec8bcc2101feadb58b29d8014
+  checksum: d97745d098b835d55033ff3a7fb2b895b9c5295b08a5759e4f20df325aa385a3e0bc9bd5ad8f2ec554a44d4e6525acfc257b8c5848a1345cb40f26a30e277e91
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-private-property-in-object@condition:BABEL_8_BREAKING ? : 7.21.0-placeholder-for-preset-env.1":
-  version: 0.0.0-condition-c1180e
-  resolution: "@babel/plugin-proposal-private-property-in-object@condition:BABEL_8_BREAKING?:7.21.0-placeholder-for-preset-env.1#c1180e"
+"@babel/plugin-proposal-private-property-in-object@condition:BABEL_8_BREAKING ? : 7.21.0-placeholder-for-preset-env.2":
+  version: 0.0.0-condition-87b572
+  resolution: "@babel/plugin-proposal-private-property-in-object@condition:BABEL_8_BREAKING?:7.21.0-placeholder-for-preset-env.2#87b572"
   dependencies:
-    "@babel/plugin-proposal-private-property-in-object-BABEL_8_BREAKING-false": "npm:@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.1"
-  checksum: db920fe1b3349424e856d9b02d96bb4aa2d5608b224edb28c8942b42bddd2d281ecc207ce65978e0b71f70244980110a69405c57576278c19e9fbd1bc698cf28
+    "@babel/plugin-proposal-private-property-in-object-BABEL_8_BREAKING-false": "npm:@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2"
+  checksum: 3eb1935da93425f15865962e434f3574cf05510f4ed72be4e3ffa6242ea1e75efc98a906fa90e178debc915cae8dc5f03691b780ab2f5fc27d7911bfcdfa1b26
   languageName: node
   linkType: hard
 
@@ -3559,7 +3559,7 @@ __metadata:
     "@babel/helper-validator-option": "workspace:^"
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "workspace:^"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "workspace:^"
-    "@babel/plugin-proposal-private-property-in-object": "condition:BABEL_8_BREAKING ? : 7.21.0-placeholder-for-preset-env.1"
+    "@babel/plugin-proposal-private-property-in-object": "condition:BABEL_8_BREAKING ? : 7.21.0-placeholder-for-preset-env.2"
     "@babel/plugin-syntax-async-generators": ^7.8.4
     "@babel/plugin-syntax-class-properties": ^7.12.13
     "@babel/plugin-syntax-class-static-block": ^7.14.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,6 +1387,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@babel/plugin-proposal-private-property-in-object-BABEL_8_BREAKING-false@npm:@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.1":
+  version: 7.21.0-placeholder-for-preset-env.1
+  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.0-placeholder-for-preset-env.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 34ee9fee925efe5271ea7652dc65c0218210f2313e64f69d516a31fbdd4757e0ab58140283f8702a5920e82ffed438541a83badec8bcc2101feadb58b29d8014
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-private-property-in-object@condition:BABEL_8_BREAKING ? : 7.21.0-placeholder-for-preset-env.1":
+  version: 0.0.0-condition-c1180e
+  resolution: "@babel/plugin-proposal-private-property-in-object@condition:BABEL_8_BREAKING?:7.21.0-placeholder-for-preset-env.1#c1180e"
+  dependencies:
+    "@babel/plugin-proposal-private-property-in-object-BABEL_8_BREAKING-false": "npm:@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.1"
+  checksum: db920fe1b3349424e856d9b02d96bb4aa2d5608b224edb28c8942b42bddd2d281ecc207ce65978e0b71f70244980110a69405c57576278c19e9fbd1bc698cf28
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-private-property-in-object@npm:^7.21.0":
   version: 7.21.0
   resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.0"
@@ -3541,7 +3559,7 @@ __metadata:
     "@babel/helper-validator-option": "workspace:^"
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "workspace:^"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "workspace:^"
-    "@babel/plugin-proposal-private-property-in-object": ^7.21.0
+    "@babel/plugin-proposal-private-property-in-object": "condition:BABEL_8_BREAKING ? : 7.21.0-placeholder-for-preset-env.1"
     "@babel/plugin-syntax-async-generators": ^7.8.4
     "@babel/plugin-syntax-class-properties": ^7.12.13
     "@babel/plugin-syntax-class-static-block": ^7.14.5
@@ -4163,7 +4181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:^29.5.0":
+"@jest/fake-timers@npm:^29.2.2, @jest/fake-timers@npm:^29.5.0":
   version: 29.5.0
   resolution: "@jest/fake-timers@npm:29.5.0"
   dependencies:
@@ -6269,7 +6287,7 @@ __metadata:
     husky: ^7.0.4
     import-meta-resolve: ^3.0.0
     jest: ^29.5.0
-    jest-light-runner: ^0.4.1
+    jest-light-runner: ^0.5.0
     jest-worker: ^29.5.0
     lint-staged: ^13.0.3
     mergeiterator: ^1.4.4
@@ -10861,11 +10879,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jest-light-runner@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "jest-light-runner@npm:0.4.1"
+"jest-light-runner@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "jest-light-runner@npm:0.5.0"
   dependencies:
     "@jest/expect": ^29.0.1
+    "@jest/fake-timers": ^29.2.2
     jest-circus: ^29.0.1
     jest-each: ^29.0.1
     jest-mock: ^29.0.1
@@ -10874,7 +10893,7 @@ fsevents@^1.2.7:
     supports-color: ^9.2.1
   peerDependencies:
     jest: ^27.5.0 || ^28.0.0 || ^29.0.0
-  checksum: e1a3019e9d3cd03627f85e2a7cfd10f89c6b34e88f6fbd8496575fe995cad1e333a7aed476137612cbd2f2de0474c4bc6c5191a28c4db8b231c9ea957d09d07b
+  checksum: 9a572e175ccadaaa67073ea6e3caf02c20e937f4e6a1dc7c4f8ccafcbed47b475375694f1f87e980da85af79d120830ff133f73831f294439f3125f9eb5f93a7
   languageName: node
   linkType: hard
 
@@ -13206,6 +13225,15 @@ fsevents@^1.2.7:
   bin:
     prettier: bin/prettier.cjs
   checksum: a5e326653997c38dcc20c1b908f90089b0e7fd7613eec67c2ec298c7637f5a26b4ca7486ed6830d9b49160467d5442769f3b5b61cbce1850122cccecf1ce73a8
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^2.0.0":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8"
+  bin:
+    prettier: bin-prettier.js
+  checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is a better workaround for the create-react-app that replaces https://github.com/babel/babel/pull/15658. It warns when the fallback is triggered, explaining users how to fix the problem.

This is the code of the fallback package:
```js
maybeWarn: try {
  var stackTraceLimit = Error.stackTraceLimit;
  Error.stackTraceLimit = Infinity;
  var stack = new Error().stack;
  Error.stackTraceLimit = stackTraceLimit;
  if (!stack.includes("babel-preset-react-app")) break maybeWarn;

  // Try this as a fallback, in case it's available in node_modules
  module.exports = require("@babel/plugin-transform-private-property-in-object");

  setTimeout(console.warn, 2500, `\
\x1B[0;33mOne of your dependencies, babel-preset-react-app, is importing the
"@babel/plugin-proposal-private-property-in-object" package without
declaring it in its dependencies. This is currently working because
"@babel/plugin-proposal-private-property-in-object" is already in your
node_modules folder for unrelated reasons, but it \x1B[1mmay break at any time\x1B[0;33m.

babel-preset-react-app is part of the create-react-app project, \x1B[1mwhich
is not maintianed anymore\x1B[0;33m. It is thus unlikely that this bug will
ever be fixed. Add "@babel/plugin-proposal-private-property-in-object" to
your devDependencies to work around this error. This will make this message
go away.\x1B[0m
  `);

  return;
} catch (e) {}

throw new Error(`\
--- PLACEHOLDER PACKAGE ---
This @babel/plugi-proposal-private-property-in-object version is not meant to
be imported. Something is importing
@babel/plugi-proposal-private-property-in-object without declaring it in its
dependencies (or devDependencies) in the package.json file.
Add "@babel/plugin-proposal-private-property-in-object" to your devDependencies
to work around this error. This will make this message go away.
`);
```

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15687"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

