### PR TITLE
Refactor Binding properties and cache Binding instances

### DIFF
--- a/packages/babel-traverse/src/cache.ts
+++ b/packages/babel-traverse/src/cache.ts
@@ -1,13 +1,16 @@
 import type { Node } from "@babel/types";
 import type NodePath from "./path";
 import type Scope from "./scope";
+import type { Binding } from "./scope";
 
 export let path: WeakMap<Node, Map<Node, NodePath>> = new WeakMap();
 export let scope: WeakMap<Node, Scope> = new WeakMap();
+export let binding: WeakMap<Node, Map<Node, Binding>> = new WeakMap();
 
 export function clear() {
   clearPath();
   clearScope();
+  clearBinding();
 }
 
 export function clearPath() {
@@ -16,4 +19,8 @@ export function clearPath() {
 
 export function clearScope() {
   scope = new WeakMap();
+}
+
+export function clearBinding() {
+  binding = new WeakMap();
 }

--- a/packages/babel-traverse/src/scope/binding.ts
+++ b/packages/babel-traverse/src/scope/binding.ts
@@ -66,11 +66,17 @@ export default class Binding {
   }
 
   constantViolations: Array<NodePath> = [];
-  constant: boolean = true;
+  get constant(): boolean {
+    return this.constantViolations.length === 0;
+  }
 
   referencePaths: Array<NodePath> = [];
-  referenced: boolean = false;
-  references: number = 0;
+  get references(): number {
+    return this.referencePaths.length;
+  }
+  get referenced(): boolean {
+    return this.references !== 0;
+  }
 
   declare hasDeoptedValue: boolean;
   declare hasValue: boolean;
@@ -98,7 +104,6 @@ export default class Binding {
    */
 
   reassign(path: NodePath) {
-    this.constant = false;
     if (this.constantViolations.indexOf(path) !== -1) {
       return;
     }
@@ -113,8 +118,6 @@ export default class Binding {
     if (this.referencePaths.indexOf(path) !== -1) {
       return;
     }
-    this.referenced = true;
-    this.references++;
     this.referencePaths.push(path);
   }
 
@@ -122,9 +125,12 @@ export default class Binding {
    * Decrement the amount of references to this binding.
    */
 
-  dereference() {
-    this.references--;
-    this.referenced = !!this.references;
+  dereference(path: NodePath) {
+    const index = this.referencePaths.indexOf(path);
+    if (index === -1) {
+      return;
+    }
+    this.referencePaths.splice(index, 1);
   }
 }
 

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -52,7 +52,7 @@ import {
   isExportDeclaration,
 } from "@babel/types";
 import type * as t from "@babel/types";
-import { scope as scopeCache } from "../cache";
+import { scope as scopeCache, binding as bindingCache } from "../cache";
 import type { Visitor } from "../types";
 import { isExplodedVisitor } from "../visitors";
 
@@ -1308,12 +1308,15 @@ export default class Scope {
   }
 
   removeOwnBinding(name: string) {
+    const binding = this.bindings[name];
+    bindingCache.get(binding?.path.node)?.delete(binding?.identifier);
     delete this.bindings[name];
   }
 
   removeBinding(name: string) {
     // clear literal binding
-    this.getBinding(name)?.scope.removeOwnBinding(name);
+    const binding = this.getBinding(name);
+    binding?.scope.removeOwnBinding(name);
 
     // clear uids with this name - https://github.com/babel/babel/issues/2101
     let scope: Scope = this;

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -107,8 +107,10 @@ describe("traverse", function () {
   it("clearCache", function () {
     const paths = [];
     const scopes = [];
+    const bindings = [];
     traverse(ast, {
       enter(path) {
+        bindings.push(...Object.values(path.scope.bindings));
         scopes.push(path.scope);
         paths.push(path);
         path.stop();
@@ -119,8 +121,10 @@ describe("traverse", function () {
 
     const paths2 = [];
     const scopes2 = [];
+    const bindings2 = [];
     traverse(ast, {
       enter(path) {
+        bindings2.push(...Object.values(path.scope.bindings));
         scopes2.push(path.scope);
         paths2.push(path);
         path.stop();
@@ -128,6 +132,7 @@ describe("traverse", function () {
     });
 
     scopes2.forEach(function (_, i) {
+      expect(bindings[i]).not.toBe(bindings2[i]);
       expect(scopes[i]).not.toBe(scopes2[i]);
       expect(paths[i]).not.toBe(paths2[i]);
     });
@@ -176,6 +181,31 @@ describe("traverse", function () {
 
     scopes2.forEach(function (p, i) {
       expect(p).not.toBe(scopes[i]);
+    });
+  });
+
+  it("clearBinding", function () {
+    const bindings = [];
+    traverse(ast, {
+      enter(path) {
+        bindings.push(...Object.values(path.scope.bindings));
+        path.stop();
+      },
+    });
+
+    traverse.cache.clearBinding();
+
+    const bindings2 = [];
+    traverse(ast, {
+      enter(path) {
+        path.scope.crawl(); // force binding registering
+        bindings2.push(...Object.values(path.scope.bindings));
+        path.stop();
+      },
+    });
+
+    bindings2.forEach(function (p, i) {
+      expect(p).not.toBe(bindings[i]);
     });
   });
 


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes(?)
| Major: Breaking Change?  | Yes
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  | No
| License                  | MIT

Allows object references to Bindings to be maintained across `Scope.crawl()`s.