### PR TITLE
Minor class transform cleanups

### DIFF
--- a/packages/babel-plugin-transform-classes/src/transformClass.ts
+++ b/packages/babel-plugin-transform-classes/src/transformClass.ts
@@ -163,17 +163,13 @@ export default function transformClass(
   }
 
   /**
-   * Creates a class constructor or bail out if there is none
+   * Creates a class constructor or bail out if there is one
    */
   function maybeCreateConstructor() {
-    let hasConstructor = false;
-    const paths = classState.path.get("body.body");
-    for (const path of paths) {
-      // @ts-expect-error: StaticBlock does not have `kind` property
-      hasConstructor = path.equals("kind", "constructor");
-      if (hasConstructor) break;
+    const classBodyPath = classState.path.get("body");
+    for (const path of classBodyPath.get("body")) {
+      if (path.isClassMethod({ kind: "constructor" })) return;
     }
-    if (hasConstructor) return;
 
     let params: t.FunctionExpression["params"], body;
 
@@ -190,12 +186,10 @@ export default function transformClass(
       body = t.blockStatement([]);
     }
 
-    classState.path
-      .get("body")
-      .unshiftContainer(
-        "body",
-        t.classMethod("constructor", t.identifier("constructor"), params, body),
-      );
+    classBodyPath.unshiftContainer(
+      "body",
+      t.classMethod("constructor", t.identifier("constructor"), params, body),
+    );
   }
 
   function buildBody() {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Two minor cleanups about class / class properties transform:
- The first one get rid of a `@ts-expect-error` comment.
- The second one generally improves the `thisContextVisitor` performance as now we don't have to access the parent node for every `ThisExpression` node.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15700"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

