### PR TITLE
Use more optional chaining

### DIFF
--- a/packages/babel-core/src/config/config-chain.ts
+++ b/packages/babel-core/src/config/config-chain.ts
@@ -395,9 +395,7 @@ function* loadFileChain(
   baseLogger: ConfigPrinter,
 ) {
   const chain = yield* loadFileChainWalker(input, context, files, baseLogger);
-  if (chain) {
-    chain.files.add(input.filepath);
-  }
+  chain?.files.add(input.filepath);
 
   return chain;
 }

--- a/packages/babel-core/src/config/full.ts
+++ b/packages/babel-core/src/config/full.ts
@@ -440,11 +440,9 @@ const validatePreset = (
   if (!context.filename) {
     const { options } = preset;
     validateIfOptionNeedsFilename(options, descriptor);
-    if (options.overrides) {
-      options.overrides.forEach(overrideOptions =>
-        validateIfOptionNeedsFilename(overrideOptions, descriptor),
-      );
-    }
+    options.overrides?.forEach(overrideOptions =>
+      validateIfOptionNeedsFilename(overrideOptions, descriptor),
+    );
   }
 };
 

--- a/packages/babel-core/src/config/validation/option-assertions.ts
+++ b/packages/babel-core/src/config/validation/option-assertions.ts
@@ -245,9 +245,7 @@ export function assertIgnoreList(
   value: unknown[] | undefined,
 ): IgnoreList | void {
   const arr = assertArray(loc, value);
-  if (arr) {
-    arr.forEach((item, i) => assertIgnoreItem(access(loc, i), item));
-  }
+  arr?.forEach((item, i) => assertIgnoreItem(access(loc, i), item));
   // @ts-expect-error todo(flow->ts)
   return arr;
 }

--- a/packages/babel-helper-compilation-targets/src/filter-items.ts
+++ b/packages/babel-helper-compilation-targets/src/filter-items.ts
@@ -97,13 +97,8 @@ export default function filterItems(
     }
   }
 
-  if (defaultIncludes) {
-    defaultIncludes.forEach(item => !excludes.has(item) && result.add(item));
-  }
-
-  if (defaultExcludes) {
-    defaultExcludes.forEach(item => !includes.has(item) && result.delete(item));
-  }
+  defaultIncludes?.forEach(item => !excludes.has(item) && result.add(item));
+  defaultExcludes?.forEach(item => !includes.has(item) && result.delete(item));
 
   return result;
 }

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -1429,9 +1429,7 @@ export default abstract class StatementParser extends ExpressionParser {
       body.push(stmt);
     }
 
-    if (afterBlockParse) {
-      afterBlockParse.call(this, hasStrictModeDirective);
-    }
+    afterBlockParse?.call(this, hasStrictModeDirective);
 
     if (!oldStrict) {
       this.setStrict(false);

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -790,8 +790,7 @@ export default class Scope {
   registerConstantViolation(path: NodePath) {
     const ids = path.getBindingIdentifiers();
     for (const name of Object.keys(ids)) {
-      const binding = this.getBinding(name);
-      if (binding) binding.reassign(path);
+      this.getBinding(name)?.reassign(path);
     }
   }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I was analyzing our code bases for cases where `a?.b = c` would be useful, and I found a few places where we can use optional chaining.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15703"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

