### PR TITLE
Fix handling of sync error in `@@asyncDispose`

### DIFF
--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -63,7 +63,7 @@ export default Object.freeze({
   ),
   dispose: helper(
     "7.22.0",
-    'function dispose_SuppressedError(suppressed,error){return"undefined"!=typeof SuppressedError?dispose_SuppressedError=SuppressedError:(dispose_SuppressedError=function(suppressed,error){this.suppressed=suppressed,this.error=error,this.stack=(new Error).stack},dispose_SuppressedError.prototype=Object.create(Error.prototype,{constructor:{value:dispose_SuppressedError,writable:!0,configurable:!0}})),new dispose_SuppressedError(suppressed,error)}export default function _dispose(stack,error,hasError){function next(){for(;stack.length>0;){var r=stack.pop();try{var p=r.d.call(r.v);if(r.a)return Promise.resolve(p).then(next,err)}catch(e){return err(e)}}if(hasError)throw error}function err(e){return error=hasError?new dispose_SuppressedError(e,error):e,hasError=!0,next()}return next()}',
+    'function dispose_SuppressedError(suppressed,error){return"undefined"!=typeof SuppressedError?dispose_SuppressedError=SuppressedError:(dispose_SuppressedError=function(suppressed,error){this.suppressed=suppressed,this.error=error,this.stack=(new Error).stack},dispose_SuppressedError.prototype=Object.create(Error.prototype,{constructor:{value:dispose_SuppressedError,writable:!0,configurable:!0}})),new dispose_SuppressedError(suppressed,error)}export default function _dispose(stack,error,hasError){function next(){for(;stack.length>0;)try{var r=stack.pop(),p=r.d.call(r.v);if(r.a)return Promise.resolve(p).then(next,err)}catch(e){return err(e)}if(hasError)throw error}function err(e){return error=hasError?new dispose_SuppressedError(e,error):e,hasError=!0,next()}return next()}',
   ),
   iterableToArrayLimit: helper(
     "7.0.0-beta.0",

--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -63,7 +63,7 @@ export default Object.freeze({
   ),
   dispose: helper(
     "7.22.0",
-    'function dispose_SuppressedError(suppressed,error){return"undefined"!=typeof SuppressedError?dispose_SuppressedError=SuppressedError:(dispose_SuppressedError=function(suppressed,error){this.suppressed=suppressed,this.error=error,this.stack=(new Error).stack},dispose_SuppressedError.prototype=Object.create(Error.prototype,{constructor:{value:dispose_SuppressedError,writable:!0,configurable:!0}})),new dispose_SuppressedError(suppressed,error)}export default function _dispose(stack,error,hasError){function next(){for(;stack.length>0;){var r=stack.pop();if(r.a)return Promise.resolve(r.d.call(r.v)).then(next,err);try{r.d.call(r.v)}catch(e){return err(e)}}if(hasError)throw error}function err(e){return error=hasError?new dispose_SuppressedError(e,error):e,hasError=!0,next()}return next()}',
+    'function dispose_SuppressedError(suppressed,error){return"undefined"!=typeof SuppressedError?dispose_SuppressedError=SuppressedError:(dispose_SuppressedError=function(suppressed,error){this.suppressed=suppressed,this.error=error,this.stack=(new Error).stack},dispose_SuppressedError.prototype=Object.create(Error.prototype,{constructor:{value:dispose_SuppressedError,writable:!0,configurable:!0}})),new dispose_SuppressedError(suppressed,error)}export default function _dispose(stack,error,hasError){function next(){for(;stack.length>0;){var r=stack.pop();try{var p=r.d.call(r.v);if(r.a)return Promise.resolve(p).then(next,err)}catch(e){return err(e)}}if(hasError)throw error}function err(e){return error=hasError?new dispose_SuppressedError(e,error):e,hasError=!0,next()}return next()}',
   ),
   iterableToArrayLimit: helper(
     "7.0.0-beta.0",

--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -63,7 +63,7 @@ export default Object.freeze({
   ),
   dispose: helper(
     "7.22.0",
-    'function dispose_SuppressedError(suppressed,error){return"undefined"!=typeof SuppressedError?dispose_SuppressedError=SuppressedError:(dispose_SuppressedError=function(suppressed,error){this.suppressed=suppressed,this.error=error,this.stack=(new Error).stack},dispose_SuppressedError.prototype=Object.create(Error.prototype,{constructor:{value:dispose_SuppressedError,writable:!0,configurable:!0}})),new dispose_SuppressedError(suppressed,error)}export default function _dispose(stack,error,hasError){function next(){if(0!==stack.length){var r=stack.pop();if(r.a)return Promise.resolve(r.d.call(r.v)).then(next,err);try{r.d.call(r.v)}catch(e){return err(e)}return next()}if(hasError)throw error}function err(e){return error=hasError?new dispose_SuppressedError(e,error):e,hasError=!0,next()}return next()}',
+    'function dispose_SuppressedError(suppressed,error){return"undefined"!=typeof SuppressedError?dispose_SuppressedError=SuppressedError:(dispose_SuppressedError=function(suppressed,error){this.suppressed=suppressed,this.error=error,this.stack=(new Error).stack},dispose_SuppressedError.prototype=Object.create(Error.prototype,{constructor:{value:dispose_SuppressedError,writable:!0,configurable:!0}})),new dispose_SuppressedError(suppressed,error)}export default function _dispose(stack,error,hasError){function next(){for(;stack.length>0;){var r=stack.pop();if(r.a)return Promise.resolve(r.d.call(r.v)).then(next,err);try{r.d.call(r.v)}catch(e){return err(e)}}if(hasError)throw error}function err(e){return error=hasError?new dispose_SuppressedError(e,error):e,hasError=!0,next()}return next()}',
   ),
   iterableToArrayLimit: helper(
     "7.0.0-beta.0",

--- a/packages/babel-helpers/src/helpers/dispose.js
+++ b/packages/babel-helpers/src/helpers/dispose.js
@@ -22,21 +22,18 @@ function dispose_SuppressedError(suppressed, error) {
 
 export default function _dispose(stack, error, hasError) {
   function next() {
-    if (stack.length === 0) {
-      if (hasError) throw error;
-      return;
+    while (stack.length > 0) {
+      var r = stack.pop();
+      if (r.a) {
+        return Promise.resolve(r.d.call(r.v)).then(next, err);
+      }
+      try {
+        r.d.call(r.v);
+      } catch (e) {
+        return err(e);
+      }
     }
-
-    var r = stack.pop();
-    if (r.a) {
-      return Promise.resolve(r.d.call(r.v)).then(next, err);
-    }
-    try {
-      r.d.call(r.v);
-    } catch (e) {
-      return err(e);
-    }
-    return next();
+    if (hasError) throw error;
   }
 
   function err(e) {

--- a/packages/babel-helpers/src/helpers/dispose.js
+++ b/packages/babel-helpers/src/helpers/dispose.js
@@ -24,11 +24,9 @@ export default function _dispose(stack, error, hasError) {
   function next() {
     while (stack.length > 0) {
       var r = stack.pop();
-      if (r.a) {
-        return Promise.resolve(r.d.call(r.v)).then(next, err);
-      }
       try {
-        r.d.call(r.v);
+        var p = r.d.call(r.v);
+        if (r.a) return Promise.resolve(p).then(next, err);
       } catch (e) {
         return err(e);
       }

--- a/packages/babel-helpers/src/helpers/dispose.js
+++ b/packages/babel-helpers/src/helpers/dispose.js
@@ -23,8 +23,8 @@ function dispose_SuppressedError(suppressed, error) {
 export default function _dispose(stack, error, hasError) {
   function next() {
     while (stack.length > 0) {
-      var r = stack.pop();
       try {
+        var r = stack.pop();
         var p = r.d.call(r.v);
         if (r.a) return Promise.resolve(p).then(next, err);
       } catch (e) {

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/async-dispose-throws-synchronously.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/async-dispose-throws-synchronously.js
@@ -2,18 +2,21 @@ return async function () {
   let disposed = false;
   let beforeEnd;
 
-  const err = {};
+  const err1 = {};
+  const err2 = {};
   let thrown;
 
   try {
     await using x = {
       [Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")]() {
-        throw err;
+        throw err1;
       }
     };
+    throw err2;
   } catch (e) {
     thrown = e;
   }
 
-  expect(thrown).toBe(err);
+  expect(thrown.suppressed).toBe(err1);
+  expect(thrown.error).toBe(err2);
 }();

--- a/packages/babel-runtime-corejs3/helpers/dispose.js
+++ b/packages/babel-runtime-corejs3/helpers/dispose.js
@@ -14,7 +14,7 @@ function dispose_SuppressedError(suppressed, error) {
 }
 function _dispose(stack, error, hasError) {
   function next() {
-    if (0 !== stack.length) {
+    for (; stack.length > 0;) {
       var r = stack.pop();
       if (r.a) return _Promise.resolve(r.d.call(r.v)).then(next, err);
       try {
@@ -22,7 +22,6 @@ function _dispose(stack, error, hasError) {
       } catch (e) {
         return err(e);
       }
-      return next();
     }
     if (hasError) throw error;
   }

--- a/packages/babel-runtime-corejs3/helpers/dispose.js
+++ b/packages/babel-runtime-corejs3/helpers/dispose.js
@@ -16,9 +16,9 @@ function _dispose(stack, error, hasError) {
   function next() {
     for (; stack.length > 0;) {
       var r = stack.pop();
-      if (r.a) return _Promise.resolve(r.d.call(r.v)).then(next, err);
       try {
-        r.d.call(r.v);
+        var p = r.d.call(r.v);
+        if (r.a) return _Promise.resolve(p).then(next, err);
       } catch (e) {
         return err(e);
       }

--- a/packages/babel-runtime-corejs3/helpers/dispose.js
+++ b/packages/babel-runtime-corejs3/helpers/dispose.js
@@ -14,14 +14,12 @@ function dispose_SuppressedError(suppressed, error) {
 }
 function _dispose(stack, error, hasError) {
   function next() {
-    for (; stack.length > 0;) {
-      var r = stack.pop();
-      try {
-        var p = r.d.call(r.v);
-        if (r.a) return _Promise.resolve(p).then(next, err);
-      } catch (e) {
-        return err(e);
-      }
+    for (; stack.length > 0;) try {
+      var r = stack.pop(),
+        p = r.d.call(r.v);
+      if (r.a) return _Promise.resolve(p).then(next, err);
+    } catch (e) {
+      return err(e);
     }
     if (hasError) throw error;
   }

--- a/packages/babel-runtime/helpers/dispose.js
+++ b/packages/babel-runtime/helpers/dispose.js
@@ -11,7 +11,7 @@ function dispose_SuppressedError(suppressed, error) {
 }
 function _dispose(stack, error, hasError) {
   function next() {
-    if (0 !== stack.length) {
+    for (; stack.length > 0;) {
       var r = stack.pop();
       if (r.a) return Promise.resolve(r.d.call(r.v)).then(next, err);
       try {
@@ -19,7 +19,6 @@ function _dispose(stack, error, hasError) {
       } catch (e) {
         return err(e);
       }
-      return next();
     }
     if (hasError) throw error;
   }

--- a/packages/babel-runtime/helpers/dispose.js
+++ b/packages/babel-runtime/helpers/dispose.js
@@ -11,14 +11,12 @@ function dispose_SuppressedError(suppressed, error) {
 }
 function _dispose(stack, error, hasError) {
   function next() {
-    for (; stack.length > 0;) {
-      var r = stack.pop();
-      try {
-        var p = r.d.call(r.v);
-        if (r.a) return Promise.resolve(p).then(next, err);
-      } catch (e) {
-        return err(e);
-      }
+    for (; stack.length > 0;) try {
+      var r = stack.pop(),
+        p = r.d.call(r.v);
+      if (r.a) return Promise.resolve(p).then(next, err);
+    } catch (e) {
+      return err(e);
     }
     if (hasError) throw error;
   }

--- a/packages/babel-runtime/helpers/dispose.js
+++ b/packages/babel-runtime/helpers/dispose.js
@@ -13,9 +13,9 @@ function _dispose(stack, error, hasError) {
   function next() {
     for (; stack.length > 0;) {
       var r = stack.pop();
-      if (r.a) return Promise.resolve(r.d.call(r.v)).then(next, err);
       try {
-        r.d.call(r.v);
+        var p = r.d.call(r.v);
+        if (r.a) return Promise.resolve(p).then(next, err);
       } catch (e) {
         return err(e);
       }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR copies two improvements to the `dispose` helper from TypeScript's implementation (https://github.com/microsoft/TypeScript/pull/54505):
- for synchronous disposals, we can avoid some recursion and use a loop instead. TS also avoids recursion in the `} catch {` case, at the expense of an extra closure passed to `.then`.
- our handling of synchronous errors in `@@asyncDispose` was wrong, because we didn't call it in the `try` block and thus its errors would always hide errors from the block.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15705"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

