### PR TITLE
Fix typo: decarations -> declarations

### DIFF
--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -91,7 +91,7 @@ export default Object.freeze({
   ),
   using: helper(
     "7.22.0",
-    'export default function _using(stack,value,isAwait){if(null==value)return value;if("object"!=typeof value)throw new TypeError("using decarations can only be used with objects, null, or undefined.");if(isAwait)var dispose=value[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==dispose&&(dispose=value[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof dispose)throw new TypeError("Property [Symbol.dispose] is not a function.");return stack.push({v:value,d:dispose,a:isAwait}),value}',
+    'export default function _using(stack,value,isAwait){if(null==value)return value;if("object"!=typeof value)throw new TypeError("using declarations can only be used with objects, null, or undefined.");if(isAwait)var dispose=value[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==dispose&&(dispose=value[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof dispose)throw new TypeError("Property [Symbol.dispose] is not a function.");return stack.push({v:value,d:dispose,a:isAwait}),value}',
   ),
   wrapRegExp: helper(
     "7.19.0",

--- a/packages/babel-helpers/src/helpers/using.js
+++ b/packages/babel-helpers/src/helpers/using.js
@@ -4,7 +4,7 @@ export default function _using(stack, value, isAwait) {
   if (value === null || value === void 0) return value;
   if (typeof value !== "object") {
     throw new TypeError(
-      "using decarations can only be used with objects, null, or undefined."
+      "using declarations can only be used with objects, null, or undefined."
     );
   }
   // core-js-pure uses Symbol.for for polyfilling well-known symbols


### PR DESCRIPTION
I just noticed this typo in an error message for @babel/plugin-proposal-explicit-resource-management.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15710"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

