### PR TITLE
Fix e2e-breaking react native failure

### DIFF
--- a/packages/babel-traverse/src/cache.ts
+++ b/packages/babel-traverse/src/cache.ts
@@ -17,3 +17,7 @@ export function clearPath() {
 export function clearScope() {
   scope = new WeakMap();
 }
+
+export function usePath(newPath: WeakMap<Node, Map<Node, NodePath>>) {
+  path = newPath;
+}

--- a/scripts/integration-tests/e2e-react-native.sh
+++ b/scripts/integration-tests/e2e-react-native.sh
@@ -39,6 +39,9 @@ if [ "$BABEL_8_BREAKING" = true ] ; then
   npx replace '(?=\[require\("@babel/plugin-syntax-flow")' '//' node_modules/metro-react-native-babel-preset/src/configs/main.js
   # https://github.com/facebook/metro/blob/2c16fa67/packages/metro-react-native-babel-preset/src/configs/main.js#L169
   npx replace '(?=plugins:.*?flow-strip-types)' 'exclude: [isTypeScriptSource, isTSXSource],' node_modules/metro-react-native-babel-preset/src/configs/main.js
+  # Use `usePath` API instead of reassigning named exports
+  # https://github.com/facebook/metro/blob/29bb5f2ad3319ba8f4764c3993aa85c15f59af23/packages/metro-source-map/src/generateFunctionMap.js#L182
+  npx replace '_traverse.default.cache.path = previousCache;' '_traverse.default.cache.usePath(previousCache);' node_modules/metro-source-map/src/generateFunctionMap.js
 fi
 
 # Build the project

--- a/scripts/integration-tests/e2e-react-native.sh
+++ b/scripts/integration-tests/e2e-react-native.sh
@@ -37,8 +37,9 @@ if [ "$BABEL_8_BREAKING" = true ] ; then
   # metro-react-native-babel-preset unconditionally enables the Flow plugin, even on TS files.
   # https://github.com/facebook/metro/blob/2c16fa67/packages/metro-react-native-babel-preset/src/configs/main.js#L25
   npx replace '(?=\[require\("@babel/plugin-syntax-flow")' '//' node_modules/metro-react-native-babel-preset/src/configs/main.js
+  npx replace '(?=\[require\("babel-plugin-transform-flow-enums")' '//' node_modules/metro-react-native-babel-preset/src/configs/main.js
   # https://github.com/facebook/metro/blob/2c16fa67/packages/metro-react-native-babel-preset/src/configs/main.js#L169
-  npx replace '(?=plugins:.*?flow-strip-types)' 'exclude: [isTypeScriptSource, isTSXSource],' node_modules/metro-react-native-babel-preset/src/configs/main.js
+  npx replace 'plugins: \[require\("@babel/plugin-transform-flow-strip-types"\)]' 'exclude: [isTypeScriptSource, isTSXSource],plugins: [require("@babel/plugin-transform-flow-strip-types"),require("babel-plugin-transform-flow-enums")]' node_modules/metro-react-native-babel-preset/src/configs/main.js
   # Use `usePath` API instead of reassigning named exports
   # https://github.com/facebook/metro/blob/29bb5f2ad3319ba8f4764c3993aa85c15f59af23/packages/metro-source-map/src/generateFunctionMap.js#L182
   npx replace '_traverse.default.cache.path = previousCache;' '_traverse.default.cache.usePath(previousCache);' node_modules/metro-source-map/src/generateFunctionMap.js


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes failing main branch: https://github.com/babel/babel/actions/runs/5351787059/jobs/9706068139
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In https://github.com/facebook/metro/pull/906, metro maintainers reset the NodePath path cache via reassignment:
```js
  const previousCache = traverse.cache.path;
  traverse.cache.clearPath();
  traverse(ast, { ... });
  traverse.cache.path = previousCache;
```
However, in our source the `path` is a named export and thus the reassignment should have failed. Currently `path` can be mutated because the published Babel 7 goes with cjs exports. In Babel 8 we bundle `@babel/traverse` by rollup, which emulates the ESM named exports behaviour, so the e2e breaking test is broken.

I am aware that currently we didn't offer means to reset the path cache to what it was before a sub-traversal. In this PR we introduced a `usePath` API so advanced users can reset it. This API should work for both Babel 7 and Babel 8.

We also exclude the flow enums transform for TS files as the it inherits the flow syntax plugin, which will collide with the TS syntax plugin.

/cc @robhogan as you know more about the use case than me.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15721"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

