### PR TITLE
Use `NodePath#hub` as part of the paths cache key

### DIFF
--- a/packages/babel-core/src/transformation/index.ts
+++ b/packages/babel-core/src/transformation/index.ts
@@ -117,7 +117,7 @@ function* transformFile(file: File, pluginPasses: PluginPasses): Handler<void> {
       passes,
       file.opts.wrapPluginVisitorMethod,
     );
-    traverse(file.ast, visitor, file.scope);
+    traverse(file.ast.program, visitor, file.scope, null, file.path, true);
 
     for (const [plugin, pass] of passPairs) {
       const fn = plugin.post;

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -28,6 +28,7 @@
     "globals": "condition:BABEL_8_BREAKING ? ^13.5.0 : ^11.1.0"
   },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/helper-plugin-test-runner": "workspace:^"
   },
   "engines": {

--- a/packages/babel-traverse/src/cache.ts
+++ b/packages/babel-traverse/src/cache.ts
@@ -3,10 +3,11 @@ import type NodePath from "./path";
 import type Scope from "./scope";
 import type { HubInterface } from "./hub";
 
-export let pathsCache: WeakMap<
+let pathsCache: WeakMap<
   HubInterface | typeof nullHub,
   WeakMap<Node, Map<Node, NodePath>>
 > = new WeakMap();
+export { pathsCache as path };
 export let scope: WeakMap<Node, Scope> = new WeakMap();
 
 export function clear() {

--- a/packages/babel-traverse/src/cache.ts
+++ b/packages/babel-traverse/src/cache.ts
@@ -1,8 +1,12 @@
 import type { Node } from "@babel/types";
 import type NodePath from "./path";
 import type Scope from "./scope";
+import type { HubInterface } from "./hub";
 
-export let path: WeakMap<Node, Map<Node, NodePath>> = new WeakMap();
+export let pathsCache: WeakMap<
+  HubInterface | typeof nullHub,
+  WeakMap<Node, Map<Node, NodePath>>
+> = new WeakMap();
 export let scope: WeakMap<Node, Scope> = new WeakMap();
 
 export function clear() {
@@ -11,9 +15,29 @@ export function clear() {
 }
 
 export function clearPath() {
-  path = new WeakMap();
+  pathsCache = new WeakMap();
 }
 
 export function clearScope() {
   scope = new WeakMap();
+}
+
+// NodePath#hub can be null, but it's not a valid weakmap key because it
+// cannot be collected by GC. Use an object, knowing tht it will not be
+// collected anyway. It's not a memory leak because pathsCache.get(nullHub)
+// is itself a weakmap, so its entries can still be collected.
+const nullHub = Object.freeze({} as const);
+
+export function getCachedPaths(hub: HubInterface | null, parent: Node) {
+  return pathsCache.get(hub ?? nullHub)?.get(parent);
+}
+
+export function getOrCreateCachedPaths(hub: HubInterface | null, parent: Node) {
+  let parents = pathsCache.get(hub ?? nullHub);
+  if (!parents) pathsCache.set(hub ?? nullHub, (parents = new WeakMap()));
+
+  let paths = parents.get(parent);
+  if (!paths) parents.set(parent, (paths = new Map()));
+
+  return paths;
 }

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -36,6 +36,7 @@ function traverse<S>(
   scope: Scope | undefined,
   state: S,
   parentPath?: NodePath,
+  visitSelf?: boolean,
 ): void;
 
 function traverse(
@@ -44,6 +45,7 @@ function traverse(
   scope?: Scope,
   state?: any,
   parentPath?: NodePath,
+  visitSelf?: boolean,
 ): void;
 
 function traverse<Options extends TraverseOptions>(
@@ -53,6 +55,7 @@ function traverse<Options extends TraverseOptions>(
   scope?: Scope,
   state?: any,
   parentPath?: NodePath,
+  visitSelf?: boolean,
 ) {
   if (!parent) return;
 
@@ -66,13 +69,25 @@ function traverse<Options extends TraverseOptions>(
     }
   }
 
+  if (!parentPath && visitSelf) {
+    throw new Error("visitSelf can only be used when providing a NodePath.");
+  }
+
   if (!VISITOR_KEYS[parent.type]) {
     return;
   }
 
   visitors.explode(opts as Visitor);
 
-  traverseNode(parent, opts as ExplodedVisitor, scope, state, parentPath);
+  traverseNode(
+    parent,
+    opts as ExplodedVisitor,
+    scope,
+    state,
+    parentPath,
+    /* skipKeys */ null,
+    visitSelf,
+  );
 }
 
 export default traverse;

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -115,8 +115,6 @@ traverse.node = function (
 
 traverse.clearNode = function (node: t.Node, opts?: RemovePropertiesOptions) {
   removeProperties(node, opts);
-
-  cache.path.delete(node);
 };
 
 traverse.removeProperties = function (

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -8,7 +8,7 @@ import type { Visitor } from "../types";
 import Scope from "../scope";
 import { validate } from "@babel/types";
 import * as t from "@babel/types";
-import { path as pathCache } from "../cache";
+import { getOrCreateCachedPaths } from "../cache";
 import generator from "@babel/generator";
 
 // NodePath is split across many files.
@@ -92,11 +92,7 @@ class NodePath<T extends t.Node = t.Node> {
       // @ts-expect-error key must present in container
       container[key];
 
-    let paths = pathCache.get(parent);
-    if (!paths) {
-      paths = new Map();
-      pathCache.set(parent, paths);
-    }
+    const paths = getOrCreateCachedPaths(hub, parent);
 
     let path = paths.get(targetNode);
     if (!path) {

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -1,6 +1,6 @@
 // This file contains methods that modify the path/node in some ways.
 
-import { path as pathCache } from "../cache";
+import { getCachedPaths } from "../cache";
 import PathHoister from "./lib/hoister";
 import NodePath from "./index";
 import {
@@ -279,7 +279,7 @@ export function updateSiblingKeys(
 ) {
   if (!this.parent) return;
 
-  const paths = pathCache.get(this.parent);
+  const paths = getCachedPaths(this.hub, this.parent) ?? ([] as never[]);
 
   for (const [, path] of paths) {
     if (typeof path.key === "number" && path.key >= fromIndex) {

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -279,7 +279,7 @@ export function updateSiblingKeys(
 ) {
   if (!this.parent) return;
 
-  const paths = getCachedPaths(this.hub, this.parent) ?? ([] as never[]);
+  const paths = getCachedPaths(this.hub, this.parent) || ([] as never[]);
 
   for (const [, path] of paths) {
     if (typeof path.key === "number" && path.key >= fromIndex) {

--- a/packages/babel-traverse/src/path/removal.ts
+++ b/packages/babel-traverse/src/path/removal.ts
@@ -1,7 +1,7 @@
 // This file contains methods responsible for removing a node.
 
 import { hooks } from "./lib/removal-hooks";
-import { path as pathCache } from "../cache";
+import { getCachedPaths } from "../cache";
 import type NodePath from "./index";
 import { REMOVED, SHOULD_SKIP } from "./index";
 
@@ -46,7 +46,9 @@ export function _remove(this: NodePath) {
 export function _markRemoved(this: NodePath) {
   // this.shouldSkip = true; this.removed = true;
   this._traverseFlags |= SHOULD_SKIP | REMOVED;
-  if (this.parent) pathCache.get(this.parent).delete(this.node);
+  if (this.parent) {
+    getCachedPaths(this.hub, this.parent).delete(this.node);
+  }
   this.node = null;
 }
 

--- a/packages/babel-traverse/src/path/replacement.ts
+++ b/packages/babel-traverse/src/path/replacement.ts
@@ -3,7 +3,7 @@
 import { codeFrameColumns } from "@babel/code-frame";
 import traverse from "../index";
 import NodePath from "./index";
-import { path as pathCache } from "../cache";
+import { getCachedPaths } from "../cache";
 import { parse } from "@babel/parser";
 import {
   FUNCTION_TYPES,
@@ -47,7 +47,7 @@ export function replaceWithMultiple(
   nodes = this._verifyNodeList(nodes);
   inheritLeadingComments(nodes[0], this.node);
   inheritTrailingComments(nodes[nodes.length - 1], this.node);
-  pathCache.get(this.parent)?.delete(this.node);
+  getCachedPaths(this.hub, this.parent)?.delete(this.node);
   this.node =
     // @ts-expect-error this.key must present in this.container
     this.container[this.key] = null;
@@ -210,7 +210,7 @@ export function _replaceWith(this: NodePath, node: t.Node) {
   }
 
   this.debug(`Replace with ${node?.type}`);
-  pathCache.get(this.parent)?.set(node, this).delete(this.node);
+  getCachedPaths(this.hub, this.parent)?.set(node, this).delete(this.node);
 
   this.node =
     // @ts-expect-error this.key must present in this.container

--- a/packages/babel-traverse/src/traverse-node.ts
+++ b/packages/babel-traverse/src/traverse-node.ts
@@ -24,13 +24,19 @@ export function traverseNode<S = unknown>(
   state?: any,
   path?: NodePath,
   skipKeys?: Record<string, boolean>,
+  visitSelf?: boolean,
 ): boolean {
   const keys = VISITOR_KEYS[node.type];
   if (!keys) return false;
 
   const context = new TraversalContext(scope, opts, state, path);
+  if (visitSelf) {
+    if (skipKeys?.[path.parentKey]) return false;
+    return context.visitQueue([path]);
+  }
+
   for (const key of keys) {
-    if (skipKeys && skipKeys[key]) continue;
+    if (skipKeys?.[key]) continue;
     if (context.visit(node, key)) {
       return true;
     }

--- a/packages/babel-traverse/test/hub.js
+++ b/packages/babel-traverse/test/hub.js
@@ -1,10 +1,46 @@
-import assert from "assert";
+import { transformSync } from "@babel/core";
 import { Hub } from "../lib/index.js";
 
 describe("hub", function () {
   it("default buildError should return TypeError", function () {
     const hub = new Hub();
     const msg = "test_msg";
-    assert.deepEqual(hub.buildError(null, msg), new TypeError(msg));
+    expect(hub.buildError(null, msg)).toEqual(new TypeError(msg));
+  });
+
+  it("should be preserved across nested traversals", function () {
+    let origHub;
+    let innerHub = {};
+    let exprHub;
+    function plugin({ types: t, traverse }) {
+      return {
+        visitor: {
+          Identifier(path) {
+            if (path.node.name !== "foo") return;
+            origHub = path.hub;
+
+            const mem = t.memberExpression(
+              t.identifier("property"),
+              t.identifier("access"),
+            );
+            traverse(mem, {
+              noScope: true,
+              Identifier(path) {
+                if (path.node.name === "property") innerHub = path.hub;
+              },
+            });
+            const [p2] = path.insertAfter(mem);
+
+            exprHub = p2.get("expression").hub;
+          },
+        },
+      };
+    }
+
+    transformSync("foo;", { configFile: false, plugins: [plugin] });
+
+    expect(origHub).toBeInstanceOf(Object);
+    expect(exprHub).toBe(origHub);
+    expect(innerHub).toBeUndefined();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3941,6 +3941,7 @@ __metadata:
   resolution: "@babel/traverse@workspace:packages/babel-traverse"
   dependencies:
     "@babel/code-frame": "workspace:^"
+    "@babel/core": "workspace:^"
     "@babel/generator": "workspace:^"
     "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-function-name": "workspace:^"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6437
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This fixes https://github.com/babel/babel/issues/6437, implementing option 2. I solved the problem of "we call `traverse` with no hub" by adding support for traversing a node visiting also the top-level node itself, so that we can directly traverse the `Program` NodePath that already has the hub.

We might want to, at some point, expose that top-level traversal as an official API, such as `NodePath#traverseSelf`, but I'm intentionally keeping it under the radar now (even if technically the new capability is accessible from the third-party code).

I don't know if this fixes or not #12570, because it looks like that issue has already been fixed on `main`?

cc @robhogan this fixes the underlying issue of https://github.com/facebook/metro/pull/906

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15725"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

