### PR TITLE
Add opera mobile compat data

### DIFF
--- a/.yarn/patches/@babel-helper-compilation-targets-npm-7.22.5-5e6d9af186.patch
+++ b/.yarn/patches/@babel-helper-compilation-targets-npm-7.22.5-5e6d9af186.patch
@@ -1,0 +1,27 @@
+diff --git a/lib/options.js b/lib/options.js
+index 0ec76e1e3d2860aa800789d42d2ab1d6bd6e1c4d..71c949b356a266257c14d94a49a35d721cab7b55 100644
+--- a/lib/options.js
++++ b/lib/options.js
+@@ -17,7 +17,8 @@ const TargetNames = {
+   android: "android",
+   electron: "electron",
+   samsung: "samsung",
+-  rhino: "rhino"
++  rhino: "rhino",
++  opera_mobile: "opera_mobile"
+ };
+ exports.TargetNames = TargetNames;
+ 
+diff --git a/lib/targets.js b/lib/targets.js
+index 316e4cc1d78350e70c718bc24dbaa48048b708b6..6c4f68311441709f355cff282453c469f0f8b86e 100644
+--- a/lib/targets.js
++++ b/lib/targets.js
+@@ -20,7 +20,7 @@ const browserNameMap = {
+   ios_saf: "ios",
+   node: "node",
+   deno: "deno",
+-  op_mob: "opera",
++  op_mob: "opera_mobile",
+   opera: "opera",
+   safari: "safari",
+   samsung: "samsung"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,13 @@
     "@types/babel__traverse": "link:./nope",
     "@babel/parser/@babel/types": "workspace:*",
     "@babel/plugin-syntax-unicode-sets-regex/@babel/helper-create-regexp-features-plugin": "workspace:*",
-    "babel-plugin-polyfill-corejs2/@babel/compat-data": "workspace:*"
+    "babel-plugin-polyfill-corejs2/@babel/compat-data": "workspace:*",
+    "@babel/helper-compilation-targets@^7.17.7": "patch:@babel/helper-compilation-targets@npm%3A7.22.5#./.yarn/patches/@babel-helper-compilation-targets-npm-7.22.5-5e6d9af186.patch",
+    "@babel/helper-compilation-targets@^7.18.2": "patch:@babel/helper-compilation-targets@npm%3A7.22.5#./.yarn/patches/@babel-helper-compilation-targets-npm-7.22.5-5e6d9af186.patch",
+    "@babel/helper-compilation-targets@^7.21.5": "patch:@babel/helper-compilation-targets@npm%3A7.22.5#./.yarn/patches/@babel-helper-compilation-targets-npm-7.22.5-5e6d9af186.patch",
+    "@babel/helper-compilation-targets@^7.22.1": "patch:@babel/helper-compilation-targets@npm%3A7.22.5#./.yarn/patches/@babel-helper-compilation-targets-npm-7.22.5-5e6d9af186.patch",
+    "@babel/helper-compilation-targets@^7.18.9": "patch:@babel/helper-compilation-targets@npm%3A7.22.5#./.yarn/patches/@babel-helper-compilation-targets-npm-7.22.5-5e6d9af186.patch",
+    "@babel/helper-compilation-targets@^7.20.7": "patch:@babel/helper-compilation-targets@npm%3A7.22.5#./.yarn/patches/@babel-helper-compilation-targets-npm-7.22.5-5e6d9af186.patch"
   },
   "engines": {
     "yarn": ">=1.4.0"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "glob-watcher/chokidar": "npm:^3.4.0",
     "@types/babel__core": "link:./nope",
     "@types/babel__traverse": "link:./nope",
-    "@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets": "workspace:*",
     "@babel/parser/@babel/types": "workspace:*",
     "@babel/plugin-syntax-unicode-sets-regex/@babel/helper-create-regexp-features-plugin": "workspace:*",
     "babel-plugin-polyfill-corejs2/@babel/compat-data": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -88,13 +88,14 @@
     "benchmark"
   ],
   "resolutions": {
-    "browserslist": "npm:4.21.5",
+    "browserslist": "npm:4.21.9",
     "caniuse-lite": "npm:1.0.30001508",
     "core-js-compat": "npm:3.31.0",
     "electron-to-chromium": "npm:1.4.441",
     "glob-watcher/chokidar": "npm:^3.4.0",
     "@types/babel__core": "link:./nope",
     "@types/babel__traverse": "link:./nope",
+    "@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets": "workspace:*",
     "@babel/parser/@babel/types": "workspace:*",
     "@babel/plugin-syntax-unicode-sets-regex/@babel/helper-create-regexp-features-plugin": "workspace:*",
     "babel-plugin-polyfill-corejs2/@babel/compat-data": "workspace:*"

--- a/packages/babel-compat-data/data/corejs2-built-ins.json
+++ b/packages/babel-compat-data/data/corejs2-built-ins.json
@@ -10,6 +10,7 @@
     "ios": "9",
     "samsung": "5",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.31"
   },
   "es6.array.every": {
@@ -26,6 +27,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.array.fill": {
@@ -39,6 +41,7 @@
     "ios": "8",
     "samsung": "5",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.31"
   },
   "es6.array.filter": {
@@ -51,6 +54,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.array.find": {
@@ -64,6 +68,7 @@
     "ios": "8",
     "samsung": "5",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.31"
   },
   "es6.array.find-index": {
@@ -77,6 +82,7 @@
     "ios": "8",
     "samsung": "5",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.31"
   },
   "es7.array.flat-map": {
@@ -89,6 +95,7 @@
     "deno": "1",
     "ios": "12",
     "samsung": "10",
+    "opera_mobile": "48",
     "electron": "4.0"
   },
   "es6.array.for-each": {
@@ -105,6 +112,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.array.from": {
@@ -117,6 +125,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es7.array.includes": {
@@ -129,6 +138,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "34",
     "electron": "0.36"
   },
   "es6.array.index-of": {
@@ -145,6 +155,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.array.is-array": {
@@ -161,6 +172,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.array.iterator": {
@@ -174,6 +186,7 @@
     "ios": "9",
     "samsung": "9",
     "rhino": "1.7.13",
+    "opera_mobile": "47",
     "electron": "3.0"
   },
   "es6.array.last-index-of": {
@@ -190,6 +203,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.array.map": {
@@ -202,6 +216,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.array.of": {
@@ -215,6 +230,7 @@
     "ios": "9",
     "samsung": "5",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.31"
   },
   "es6.array.reduce": {
@@ -231,6 +247,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.array.reduce-right": {
@@ -247,6 +264,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.array.slice": {
@@ -259,6 +277,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.array.some": {
@@ -275,6 +294,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.array.sort": {
@@ -289,6 +309,7 @@
     "ios": "12",
     "samsung": "8",
     "rhino": "1.7.13",
+    "opera_mobile": "46",
     "electron": "3.0"
   },
   "es6.array.species": {
@@ -301,6 +322,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.date.now": {
@@ -317,6 +339,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.date.to-iso-string": {
@@ -333,6 +356,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.date.to-json": {
@@ -348,6 +372,7 @@
     "ios": "10",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "12.1",
     "electron": "0.20"
   },
   "es6.date.to-primitive": {
@@ -360,6 +385,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "34",
     "electron": "0.36"
   },
   "es6.date.to-string": {
@@ -376,6 +402,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.function.bind": {
@@ -392,6 +419,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "12",
     "electron": "0.20"
   },
   "es6.function.has-instance": {
@@ -404,6 +432,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.function.name": {
@@ -419,6 +448,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es6.map": {
@@ -431,6 +461,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.math.acosh": {
@@ -444,6 +475,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.asinh": {
@@ -457,6 +489,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.atanh": {
@@ -470,6 +503,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.cbrt": {
@@ -483,6 +517,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.clz32": {
@@ -496,6 +531,7 @@
     "ios": "9",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.cosh": {
@@ -509,6 +545,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.expm1": {
@@ -522,6 +559,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.fround": {
@@ -535,6 +573,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.hypot": {
@@ -548,6 +587,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.imul": {
@@ -562,6 +602,7 @@
     "ios": "7",
     "samsung": "2",
     "rhino": "1.7.13",
+    "opera_mobile": "18",
     "electron": "0.20"
   },
   "es6.math.log1p": {
@@ -575,6 +616,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.log10": {
@@ -588,6 +630,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.log2": {
@@ -601,6 +644,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.sign": {
@@ -614,6 +658,7 @@
     "ios": "9",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.sinh": {
@@ -627,6 +672,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.tanh": {
@@ -640,6 +686,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.math.trunc": {
@@ -653,6 +700,7 @@
     "ios": "8",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.number.constructor": {
@@ -666,6 +714,7 @@
     "ios": "9",
     "samsung": "3.4",
     "rhino": "1.7.13",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "es6.number.epsilon": {
@@ -679,6 +728,7 @@
     "ios": "9",
     "samsung": "2",
     "rhino": "1.7.14",
+    "opera_mobile": "21",
     "electron": "0.20"
   },
   "es6.number.is-finite": {
@@ -693,6 +743,7 @@
     "ios": "9",
     "samsung": "1.5",
     "rhino": "1.7.13",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.number.is-integer": {
@@ -706,6 +757,7 @@
     "ios": "9",
     "samsung": "2",
     "rhino": "1.7.13",
+    "opera_mobile": "21",
     "electron": "0.20"
   },
   "es6.number.is-nan": {
@@ -720,6 +772,7 @@
     "ios": "9",
     "samsung": "1.5",
     "rhino": "1.7.13",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.number.is-safe-integer": {
@@ -733,6 +786,7 @@
     "ios": "9",
     "samsung": "2",
     "rhino": "1.7.13",
+    "opera_mobile": "21",
     "electron": "0.20"
   },
   "es6.number.max-safe-integer": {
@@ -746,6 +800,7 @@
     "ios": "9",
     "samsung": "2",
     "rhino": "1.7.13",
+    "opera_mobile": "21",
     "electron": "0.20"
   },
   "es6.number.min-safe-integer": {
@@ -759,6 +814,7 @@
     "ios": "9",
     "samsung": "2",
     "rhino": "1.7.13",
+    "opera_mobile": "21",
     "electron": "0.20"
   },
   "es6.number.parse-float": {
@@ -772,6 +828,7 @@
     "ios": "9",
     "samsung": "2",
     "rhino": "1.7.14",
+    "opera_mobile": "21",
     "electron": "0.20"
   },
   "es6.number.parse-int": {
@@ -785,6 +842,7 @@
     "ios": "9",
     "samsung": "2",
     "rhino": "1.7.14",
+    "opera_mobile": "21",
     "electron": "0.20"
   },
   "es6.object.assign": {
@@ -797,6 +855,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.object.create": {
@@ -813,6 +872,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "12",
     "electron": "0.20"
   },
   "es7.object.define-getter": {
@@ -825,6 +885,7 @@
     "deno": "1",
     "ios": "9",
     "samsung": "8",
+    "opera_mobile": "46",
     "electron": "3.0"
   },
   "es7.object.define-setter": {
@@ -837,6 +898,7 @@
     "deno": "1",
     "ios": "9",
     "samsung": "8",
+    "opera_mobile": "46",
     "electron": "3.0"
   },
   "es6.object.define-property": {
@@ -853,6 +915,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "12",
     "electron": "0.20"
   },
   "es6.object.define-properties": {
@@ -869,6 +932,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "12",
     "electron": "0.20"
   },
   "es7.object.entries": {
@@ -882,6 +946,7 @@
     "ios": "10.3",
     "samsung": "6",
     "rhino": "1.7.14",
+    "opera_mobile": "41",
     "electron": "1.4"
   },
   "es6.object.freeze": {
@@ -895,6 +960,7 @@
     "ios": "9",
     "samsung": "4",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.30"
   },
   "es6.object.get-own-property-descriptor": {
@@ -908,6 +974,7 @@
     "ios": "9",
     "samsung": "4",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.30"
   },
   "es7.object.get-own-property-descriptors": {
@@ -920,6 +987,7 @@
     "deno": "1",
     "ios": "10.3",
     "samsung": "6",
+    "opera_mobile": "41",
     "electron": "1.4"
   },
   "es6.object.get-own-property-names": {
@@ -933,6 +1001,7 @@
     "ios": "9",
     "samsung": "3.4",
     "rhino": "1.7.13",
+    "opera_mobile": "27",
     "electron": "0.21"
   },
   "es6.object.get-prototype-of": {
@@ -946,6 +1015,7 @@
     "ios": "9",
     "samsung": "4",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.30"
   },
   "es7.object.lookup-getter": {
@@ -958,6 +1028,7 @@
     "deno": "1",
     "ios": "9",
     "samsung": "8",
+    "opera_mobile": "46",
     "electron": "3.0"
   },
   "es7.object.lookup-setter": {
@@ -970,6 +1041,7 @@
     "deno": "1",
     "ios": "9",
     "samsung": "8",
+    "opera_mobile": "46",
     "electron": "3.0"
   },
   "es6.object.prevent-extensions": {
@@ -983,6 +1055,7 @@
     "ios": "9",
     "samsung": "4",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.30"
   },
   "es6.object.to-string": {
@@ -995,6 +1068,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "7",
+    "opera_mobile": "43",
     "electron": "1.7"
   },
   "es6.object.is": {
@@ -1009,6 +1083,7 @@
     "ios": "9",
     "samsung": "1.5",
     "rhino": "1.7.13",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.object.is-frozen": {
@@ -1022,6 +1097,7 @@
     "ios": "9",
     "samsung": "4",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.30"
   },
   "es6.object.is-sealed": {
@@ -1035,6 +1111,7 @@
     "ios": "9",
     "samsung": "4",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.30"
   },
   "es6.object.is-extensible": {
@@ -1048,6 +1125,7 @@
     "ios": "9",
     "samsung": "4",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.30"
   },
   "es6.object.keys": {
@@ -1061,6 +1139,7 @@
     "ios": "9",
     "samsung": "3.4",
     "rhino": "1.7.13",
+    "opera_mobile": "27",
     "electron": "0.21"
   },
   "es6.object.seal": {
@@ -1074,6 +1153,7 @@
     "ios": "9",
     "samsung": "4",
     "rhino": "1.7.13",
+    "opera_mobile": "32",
     "electron": "0.30"
   },
   "es6.object.set-prototype-of": {
@@ -1088,6 +1168,7 @@
     "ios": "9",
     "samsung": "2",
     "rhino": "1.7.13",
+    "opera_mobile": "21",
     "electron": "0.20"
   },
   "es7.object.values": {
@@ -1101,6 +1182,7 @@
     "ios": "10.3",
     "samsung": "6",
     "rhino": "1.7.14",
+    "opera_mobile": "41",
     "electron": "1.4"
   },
   "es6.promise": {
@@ -1113,6 +1195,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es7.promise.finally": {
@@ -1125,6 +1208,7 @@
     "deno": "1",
     "ios": "11.3",
     "samsung": "8",
+    "opera_mobile": "46",
     "electron": "3.0"
   },
   "es6.reflect.apply": {
@@ -1137,6 +1221,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.construct": {
@@ -1149,6 +1234,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.define-property": {
@@ -1161,6 +1247,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.delete-property": {
@@ -1173,6 +1260,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.get": {
@@ -1185,6 +1273,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.get-own-property-descriptor": {
@@ -1197,6 +1286,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.get-prototype-of": {
@@ -1209,6 +1299,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.has": {
@@ -1221,6 +1312,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.is-extensible": {
@@ -1233,6 +1325,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.own-keys": {
@@ -1245,6 +1338,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.prevent-extensions": {
@@ -1257,6 +1351,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.set": {
@@ -1269,6 +1364,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.reflect.set-prototype-of": {
@@ -1281,6 +1377,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.regexp.constructor": {
@@ -1293,6 +1390,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "37",
     "electron": "1.1"
   },
   "es6.regexp.flags": {
@@ -1305,6 +1403,7 @@
     "deno": "1",
     "ios": "9",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "es6.regexp.match": {
@@ -1318,6 +1417,7 @@
     "ios": "10",
     "samsung": "5",
     "rhino": "1.7.13",
+    "opera_mobile": "37",
     "electron": "1.1"
   },
   "es6.regexp.replace": {
@@ -1330,6 +1430,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "37",
     "electron": "1.1"
   },
   "es6.regexp.split": {
@@ -1342,6 +1443,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "37",
     "electron": "1.1"
   },
   "es6.regexp.search": {
@@ -1355,6 +1457,7 @@
     "ios": "10",
     "samsung": "5",
     "rhino": "1.7.13",
+    "opera_mobile": "37",
     "electron": "1.1"
   },
   "es6.regexp.to-string": {
@@ -1367,6 +1470,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "37",
     "electron": "1.1"
   },
   "es6.set": {
@@ -1379,6 +1483,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.symbol": {
@@ -1391,6 +1496,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es7.symbol.async-iterator": {
@@ -1403,6 +1509,7 @@
     "deno": "1",
     "ios": "12",
     "samsung": "8",
+    "opera_mobile": "46",
     "electron": "3.0"
   },
   "es6.string.anchor": {
@@ -1418,6 +1525,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.big": {
@@ -1433,6 +1541,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.blink": {
@@ -1448,6 +1557,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.bold": {
@@ -1463,6 +1573,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.code-point-at": {
@@ -1476,6 +1587,7 @@
     "ios": "9",
     "samsung": "3.4",
     "rhino": "1.7.13",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "es6.string.ends-with": {
@@ -1489,6 +1601,7 @@
     "ios": "9",
     "samsung": "3.4",
     "rhino": "1.7.13",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "es6.string.fixed": {
@@ -1504,6 +1617,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.fontcolor": {
@@ -1519,6 +1633,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.fontsize": {
@@ -1534,6 +1649,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.from-code-point": {
@@ -1547,6 +1663,7 @@
     "ios": "9",
     "samsung": "3.4",
     "rhino": "1.7.13",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "es6.string.includes": {
@@ -1560,6 +1677,7 @@
     "ios": "9",
     "samsung": "3.4",
     "rhino": "1.7.13",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "es6.string.italics": {
@@ -1575,6 +1693,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.iterator": {
@@ -1588,6 +1707,7 @@
     "ios": "9",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "es6.string.link": {
@@ -1603,6 +1723,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es7.string.pad-start": {
@@ -1616,6 +1737,7 @@
     "ios": "10",
     "samsung": "7",
     "rhino": "1.7.13",
+    "opera_mobile": "43",
     "electron": "1.7"
   },
   "es7.string.pad-end": {
@@ -1629,6 +1751,7 @@
     "ios": "10",
     "samsung": "7",
     "rhino": "1.7.13",
+    "opera_mobile": "43",
     "electron": "1.7"
   },
   "es6.string.raw": {
@@ -1642,6 +1765,7 @@
     "ios": "9",
     "samsung": "3.4",
     "rhino": "1.7.14",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "es6.string.repeat": {
@@ -1655,6 +1779,7 @@
     "ios": "9",
     "samsung": "3.4",
     "rhino": "1.7.13",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "es6.string.small": {
@@ -1670,6 +1795,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.starts-with": {
@@ -1683,6 +1809,7 @@
     "ios": "9",
     "samsung": "3.4",
     "rhino": "1.7.13",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "es6.string.strike": {
@@ -1698,6 +1825,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.sub": {
@@ -1713,6 +1841,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.sup": {
@@ -1728,6 +1857,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.14",
+    "opera_mobile": "14",
     "electron": "0.20"
   },
   "es6.string.trim": {
@@ -1744,6 +1874,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "es7.string.trim-left": {
@@ -1757,6 +1888,7 @@
     "ios": "12",
     "samsung": "9",
     "rhino": "1.7.13",
+    "opera_mobile": "47",
     "electron": "3.0"
   },
   "es7.string.trim-right": {
@@ -1770,6 +1902,7 @@
     "ios": "12",
     "samsung": "9",
     "rhino": "1.7.13",
+    "opera_mobile": "47",
     "electron": "3.0"
   },
   "es6.typed.array-buffer": {
@@ -1782,6 +1915,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.typed.data-view": {
@@ -1798,6 +1932,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "12",
     "electron": "0.20"
   },
   "es6.typed.int8-array": {
@@ -1810,6 +1945,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.typed.uint8-array": {
@@ -1822,6 +1958,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.typed.uint8-clamped-array": {
@@ -1834,6 +1971,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.typed.int16-array": {
@@ -1846,6 +1984,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.typed.uint16-array": {
@@ -1858,6 +1997,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.typed.int32-array": {
@@ -1870,6 +2010,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.typed.uint32-array": {
@@ -1882,6 +2023,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.typed.float32-array": {
@@ -1894,6 +2036,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.typed.float64-array": {
@@ -1906,6 +2049,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.weak-map": {
@@ -1918,6 +2062,7 @@
     "deno": "1",
     "ios": "9",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "es6.weak-set": {
@@ -1930,6 +2075,7 @@
     "deno": "1",
     "ios": "9",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   }
 }

--- a/packages/babel-compat-data/data/native-modules.json
+++ b/packages/babel-compat-data/data/native-modules.json
@@ -7,7 +7,7 @@
     "and_ff": "60",
     "node": "13.2.0",
     "opera": "48",
-    "op_mob": "48",
+    "op_mob": "45",
     "safari": "10.1",
     "ios": "10.3",
     "samsung": "8.2",

--- a/packages/babel-compat-data/data/plugin-bugfixes.json
+++ b/packages/babel-compat-data/data/plugin-bugfixes.json
@@ -9,6 +9,7 @@
     "deno": "1",
     "ios": "11",
     "samsung": "6",
+    "opera_mobile": "42",
     "electron": "1.6"
   },
   "bugfix/transform-edge-default-parameters": {
@@ -21,6 +22,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "bugfix/transform-edge-function-name": {
@@ -33,6 +35,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "bugfix/transform-safari-block-shadowing": {
@@ -46,6 +49,7 @@
     "ie": "11",
     "ios": "11",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "bugfix/transform-safari-for-shadowing": {
@@ -60,6 +64,7 @@
     "ios": "11",
     "samsung": "5",
     "rhino": "1.7.13",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "bugfix/transform-safari-id-destructuring-collision-in-function-expression": {
@@ -70,6 +75,7 @@
     "node": "6",
     "deno": "1",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "bugfix/transform-tagged-template-caching": {
@@ -83,6 +89,7 @@
     "ios": "13",
     "samsung": "3.4",
     "rhino": "1.7.14",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "bugfix/transform-v8-spread-parameters-in-optional-chaining": {
@@ -95,6 +102,7 @@
     "deno": "1.9",
     "ios": "13.4",
     "samsung": "16",
+    "opera_mobile": "64",
     "electron": "13.0"
   },
   "transform-optional-chaining": {
@@ -107,6 +115,7 @@
     "deno": "1",
     "ios": "13.4",
     "samsung": "13",
+    "opera_mobile": "57",
     "electron": "8.0"
   },
   "proposal-optional-chaining": {
@@ -119,6 +128,7 @@
     "deno": "1",
     "ios": "13.4",
     "samsung": "13",
+    "opera_mobile": "57",
     "electron": "8.0"
   },
   "transform-parameters": {
@@ -131,6 +141,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "transform-async-to-generator": {
@@ -143,6 +154,7 @@
     "deno": "1",
     "ios": "10.3",
     "samsung": "6",
+    "opera_mobile": "42",
     "electron": "1.6"
   },
   "transform-template-literals": {
@@ -155,6 +167,7 @@
     "deno": "1",
     "ios": "9",
     "samsung": "3.4",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "transform-function-name": {
@@ -167,6 +180,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "transform-block-scoping": {
@@ -179,6 +193,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "37",
     "electron": "1.1"
   }
 }

--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -15,6 +15,7 @@
     "node": "16.11",
     "deno": "1.14",
     "samsung": "17",
+    "opera_mobile": "66",
     "electron": "15.0"
   },
   "proposal-class-static-block": {
@@ -25,6 +26,7 @@
     "node": "16.11",
     "deno": "1.14",
     "samsung": "17",
+    "opera_mobile": "66",
     "electron": "15.0"
   },
   "transform-private-property-in-object": {
@@ -37,6 +39,7 @@
     "deno": "1.9",
     "ios": "15",
     "samsung": "16",
+    "opera_mobile": "64",
     "electron": "13.0"
   },
   "proposal-private-property-in-object": {
@@ -49,6 +52,7 @@
     "deno": "1.9",
     "ios": "15",
     "samsung": "16",
+    "opera_mobile": "64",
     "electron": "13.0"
   },
   "transform-class-properties": {
@@ -61,6 +65,7 @@
     "deno": "1",
     "ios": "14.5",
     "samsung": "11",
+    "opera_mobile": "53",
     "electron": "6.0"
   },
   "proposal-class-properties": {
@@ -73,6 +78,7 @@
     "deno": "1",
     "ios": "14.5",
     "samsung": "11",
+    "opera_mobile": "53",
     "electron": "6.0"
   },
   "transform-private-methods": {
@@ -85,6 +91,7 @@
     "deno": "1",
     "ios": "15",
     "samsung": "14",
+    "opera_mobile": "60",
     "electron": "10.0"
   },
   "proposal-private-methods": {
@@ -97,6 +104,7 @@
     "deno": "1",
     "ios": "15",
     "samsung": "14",
+    "opera_mobile": "60",
     "electron": "10.0"
   },
   "transform-numeric-separator": {
@@ -110,6 +118,7 @@
     "ios": "13",
     "samsung": "11",
     "rhino": "1.7.14",
+    "opera_mobile": "54",
     "electron": "6.0"
   },
   "proposal-numeric-separator": {
@@ -123,6 +132,7 @@
     "ios": "13",
     "samsung": "11",
     "rhino": "1.7.14",
+    "opera_mobile": "54",
     "electron": "6.0"
   },
   "transform-logical-assignment-operators": {
@@ -135,6 +145,7 @@
     "deno": "1.2",
     "ios": "14",
     "samsung": "14",
+    "opera_mobile": "60",
     "electron": "10.0"
   },
   "proposal-logical-assignment-operators": {
@@ -147,6 +158,7 @@
     "deno": "1.2",
     "ios": "14",
     "samsung": "14",
+    "opera_mobile": "60",
     "electron": "10.0"
   },
   "transform-nullish-coalescing-operator": {
@@ -159,6 +171,7 @@
     "deno": "1",
     "ios": "13.4",
     "samsung": "13",
+    "opera_mobile": "57",
     "electron": "8.0"
   },
   "proposal-nullish-coalescing-operator": {
@@ -171,6 +184,7 @@
     "deno": "1",
     "ios": "13.4",
     "samsung": "13",
+    "opera_mobile": "57",
     "electron": "8.0"
   },
   "transform-optional-chaining": {
@@ -183,6 +197,7 @@
     "deno": "1.9",
     "ios": "13.4",
     "samsung": "16",
+    "opera_mobile": "64",
     "electron": "13.0"
   },
   "proposal-optional-chaining": {
@@ -195,6 +210,7 @@
     "deno": "1.9",
     "ios": "13.4",
     "samsung": "16",
+    "opera_mobile": "64",
     "electron": "13.0"
   },
   "transform-json-strings": {
@@ -208,6 +224,7 @@
     "ios": "12",
     "samsung": "9",
     "rhino": "1.7.14",
+    "opera_mobile": "47",
     "electron": "3.0"
   },
   "proposal-json-strings": {
@@ -221,6 +238,7 @@
     "ios": "12",
     "samsung": "9",
     "rhino": "1.7.14",
+    "opera_mobile": "47",
     "electron": "3.0"
   },
   "transform-optional-catch-binding": {
@@ -233,6 +251,7 @@
     "deno": "1",
     "ios": "11.3",
     "samsung": "9",
+    "opera_mobile": "47",
     "electron": "3.0"
   },
   "proposal-optional-catch-binding": {
@@ -245,6 +264,7 @@
     "deno": "1",
     "ios": "11.3",
     "samsung": "9",
+    "opera_mobile": "47",
     "electron": "3.0"
   },
   "transform-parameters": {
@@ -255,6 +275,7 @@
     "node": "6",
     "deno": "1",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "transform-async-generator-functions": {
@@ -267,6 +288,7 @@
     "deno": "1",
     "ios": "12",
     "samsung": "8",
+    "opera_mobile": "46",
     "electron": "3.0"
   },
   "proposal-async-generator-functions": {
@@ -279,6 +301,7 @@
     "deno": "1",
     "ios": "12",
     "samsung": "8",
+    "opera_mobile": "46",
     "electron": "3.0"
   },
   "transform-object-rest-spread": {
@@ -291,6 +314,7 @@
     "deno": "1",
     "ios": "11.3",
     "samsung": "8",
+    "opera_mobile": "44",
     "electron": "2.0"
   },
   "proposal-object-rest-spread": {
@@ -303,6 +327,7 @@
     "deno": "1",
     "ios": "11.3",
     "samsung": "8",
+    "opera_mobile": "44",
     "electron": "2.0"
   },
   "transform-dotall-regex": {
@@ -315,6 +340,7 @@
     "deno": "1",
     "ios": "11.3",
     "samsung": "8",
+    "opera_mobile": "46",
     "electron": "3.0"
   },
   "transform-unicode-property-regex": {
@@ -327,6 +353,7 @@
     "deno": "1",
     "ios": "11.3",
     "samsung": "9",
+    "opera_mobile": "47",
     "electron": "3.0"
   },
   "proposal-unicode-property-regex": {
@@ -339,6 +366,7 @@
     "deno": "1",
     "ios": "11.3",
     "samsung": "9",
+    "opera_mobile": "47",
     "electron": "3.0"
   },
   "transform-named-capturing-groups-regex": {
@@ -351,6 +379,7 @@
     "deno": "1",
     "ios": "11.3",
     "samsung": "9",
+    "opera_mobile": "47",
     "electron": "3.0"
   },
   "transform-async-to-generator": {
@@ -363,6 +392,7 @@
     "deno": "1",
     "ios": "11",
     "samsung": "6",
+    "opera_mobile": "42",
     "electron": "1.6"
   },
   "transform-exponentiation-operator": {
@@ -376,6 +406,7 @@
     "ios": "10.3",
     "samsung": "6",
     "rhino": "1.7.14",
+    "opera_mobile": "41",
     "electron": "1.3"
   },
   "transform-template-literals": {
@@ -388,6 +419,7 @@
     "deno": "1",
     "ios": "13",
     "samsung": "3.4",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "transform-literals": {
@@ -400,6 +432,7 @@
     "deno": "1",
     "ios": "9",
     "samsung": "4",
+    "opera_mobile": "32",
     "electron": "0.30"
   },
   "transform-function-name": {
@@ -412,6 +445,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "transform-arrow-functions": {
@@ -425,6 +459,7 @@
     "ios": "10",
     "samsung": "5",
     "rhino": "1.7.13",
+    "opera_mobile": "34",
     "electron": "0.36"
   },
   "transform-block-scoped-functions": {
@@ -438,6 +473,7 @@
     "ie": "11",
     "ios": "10",
     "samsung": "3.4",
+    "opera_mobile": "28",
     "electron": "0.21"
   },
   "transform-classes": {
@@ -450,6 +486,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "33",
     "electron": "0.36"
   },
   "transform-object-super": {
@@ -462,6 +499,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "33",
     "electron": "0.36"
   },
   "transform-shorthand-properties": {
@@ -475,6 +513,7 @@
     "ios": "9",
     "samsung": "4",
     "rhino": "1.7.14",
+    "opera_mobile": "30",
     "electron": "0.27"
   },
   "transform-duplicate-keys": {
@@ -487,6 +526,7 @@
     "deno": "1",
     "ios": "9",
     "samsung": "3.4",
+    "opera_mobile": "29",
     "electron": "0.25"
   },
   "transform-computed-properties": {
@@ -499,6 +539,7 @@
     "deno": "1",
     "ios": "8",
     "samsung": "4",
+    "opera_mobile": "32",
     "electron": "0.30"
   },
   "transform-for-of": {
@@ -511,6 +552,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "transform-sticky-regex": {
@@ -523,6 +565,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "36",
     "electron": "0.37"
   },
   "transform-unicode-escapes": {
@@ -535,6 +578,7 @@
     "deno": "1",
     "ios": "9",
     "samsung": "4",
+    "opera_mobile": "32",
     "electron": "0.30"
   },
   "transform-unicode-regex": {
@@ -547,6 +591,7 @@
     "deno": "1",
     "ios": "12",
     "samsung": "5",
+    "opera_mobile": "37",
     "electron": "1.1"
   },
   "transform-spread": {
@@ -559,6 +604,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "33",
     "electron": "0.36"
   },
   "transform-destructuring": {
@@ -571,6 +617,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "41",
     "electron": "1.2"
   },
   "transform-block-scoping": {
@@ -583,6 +630,7 @@
     "deno": "1",
     "ios": "11",
     "samsung": "5",
+    "opera_mobile": "37",
     "electron": "1.1"
   },
   "transform-typeof-symbol": {
@@ -596,6 +644,7 @@
     "ios": "9",
     "samsung": "3",
     "rhino": "1.7.13",
+    "opera_mobile": "25",
     "electron": "0.20"
   },
   "transform-new-target": {
@@ -608,6 +657,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "33",
     "electron": "0.36"
   },
   "transform-regenerator": {
@@ -620,6 +670,7 @@
     "deno": "1",
     "ios": "10",
     "samsung": "5",
+    "opera_mobile": "37",
     "electron": "1.1"
   },
   "transform-member-expression-literals": {
@@ -636,6 +687,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "12",
     "electron": "0.20"
   },
   "transform-property-literals": {
@@ -652,6 +704,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "12",
     "electron": "0.20"
   },
   "transform-reserved-words": {
@@ -668,6 +721,7 @@
     "phantom": "1.9",
     "samsung": "1",
     "rhino": "1.7.13",
+    "opera_mobile": "10.1",
     "electron": "0.20"
   },
   "transform-export-namespace-from": {
@@ -677,7 +731,7 @@
     "firefox": "80",
     "node": "13.2",
     "opera": "60",
-    "op_mob": "51",
+    "opera_mobile": "51",
     "safari": "14.1",
     "ios": "14.5",
     "samsung": "11.0",
@@ -691,7 +745,7 @@
     "firefox": "80",
     "node": "13.2",
     "opera": "60",
-    "op_mob": "51",
+    "opera_mobile": "51",
     "safari": "14.1",
     "ios": "14.5",
     "samsung": "11.0",

--- a/packages/babel-compat-data/scripts/build-modules-support.js
+++ b/packages/babel-compat-data/scripts/build-modules-support.js
@@ -22,7 +22,7 @@ const browserNameMaps = {
     safari_ios: "ios",
     nodejs: "node",
     webview_android: "android",
-    opera_android: "op_mob",
+    opera_android: "opera_mobile",
     samsunginternet_android: "samsung",
   },
 };
@@ -34,11 +34,6 @@ const browserSupportMap = {
 function browserVersion(browser, version_added) {
   if (browser === "samsunginternet_android" && version_added === "8.0") {
     return "8.2"; // samsung 8.0 is not defined in browserslist
-  }
-  // fixme: preset-env maps opera_android as opera, this is incorrect as they have different engine mappings
-  // see https://github.com/mdn/browser-compat-data/blob/master/browsers/opera_android.json
-  if (browser === "opera_android" && version_added === "45") {
-    return "48";
   }
   return version_added;
 }

--- a/packages/babel-compat-data/scripts/utils-build-data.js
+++ b/packages/babel-compat-data/scripts/utils-build-data.js
@@ -33,6 +33,7 @@ exports.environments = [
   "phantom",
   "samsung",
   "rhino",
+  "opera_mobile",
 ];
 
 const compatibilityTests = compatSources.flatMap(data =>

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -25,7 +25,7 @@
     "@babel/compat-data": "workspace:^",
     "@babel/helper-validator-option": "workspace:^",
     "@nicolo-ribaudo/semver-v6": "^6.3.3",
-    "browserslist": "^4.21.3",
+    "browserslist": "^4.21.9",
     "lru-cache": "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   },

--- a/packages/babel-helper-compilation-targets/src/index.ts
+++ b/packages/babel-helper-compilation-targets/src/index.ts
@@ -254,17 +254,20 @@ export default function getTargets(
 
     if (esmodules === "intersect") {
       for (const browser of Object.keys(queryBrowsers) as Target[]) {
-        const version = queryBrowsers[browser];
-        const esmSupportVersion =
-          // @ts-expect-error ie is not in ESM_SUPPORT
-          ESM_SUPPORT[browser];
+        if (browser !== "deno" && browser !== "ie") {
+          const esmSupportVersion =
+            ESM_SUPPORT[browser === "opera_mobile" ? "op_mob" : browser];
 
-        if (esmSupportVersion) {
-          queryBrowsers[browser] = getHighestUnreleased(
-            version,
-            semverify(esmSupportVersion),
-            browser,
-          );
+          if (esmSupportVersion) {
+            const version = queryBrowsers[browser];
+            queryBrowsers[browser] = getHighestUnreleased(
+              version,
+              semverify(esmSupportVersion),
+              browser,
+            );
+          } else {
+            delete queryBrowsers[browser];
+          }
         } else {
           delete queryBrowsers[browser];
         }

--- a/packages/babel-helper-compilation-targets/src/options.ts
+++ b/packages/babel-helper-compilation-targets/src/options.ts
@@ -12,4 +12,5 @@ export const TargetNames = {
   electron: "electron",
   samsung: "samsung",
   rhino: "rhino",
+  opera_mobile: "opera_mobile",
 };

--- a/packages/babel-helper-compilation-targets/src/targets.ts
+++ b/packages/babel-helper-compilation-targets/src/targets.ts
@@ -2,10 +2,8 @@ export const unreleasedLabels = {
   safari: "tp",
 } as const;
 
-import type { Target } from "./types";
-
 // Map from browserslist|@mdn/browser-compat-data browser names to @kangax/compat-table browser names
-export const browserNameMap: Record<string, Target> = {
+export const browserNameMap = {
   and_chr: "chrome",
   and_ff: "firefox",
   android: "android",

--- a/packages/babel-helper-compilation-targets/src/targets.ts
+++ b/packages/babel-helper-compilation-targets/src/targets.ts
@@ -17,7 +17,7 @@ export const browserNameMap: Record<string, Target> = {
   ios_saf: "ios",
   node: "node",
   deno: "deno",
-  op_mob: "opera",
+  op_mob: "opera_mobile",
   opera: "opera",
   safari: "safari",
   samsung: "samsung",

--- a/packages/babel-helper-compilation-targets/src/types.d.ts
+++ b/packages/babel-helper-compilation-targets/src/types.d.ts
@@ -11,7 +11,8 @@ export type Target =
   | "ios"
   | "android"
   | "electron"
-  | "samsung";
+  | "samsung"
+  | "opera_mobile";
 
 export type Targets = {
   [target in Target]?: string;

--- a/packages/babel-helper-compilation-targets/test/__snapshots__/targets-parser.spec.js.snap
+++ b/packages/babel-helper-compilation-targets/test/__snapshots__/targets-parser.spec.js.snap
@@ -37,6 +37,7 @@ Object {
   "ios": "10.3.0",
   "node": "13.2.0",
   "opera": "48.0.0",
+  "opera_mobile": "73.0.0",
   "safari": "10.1.0",
   "samsung": "8.2.0",
 }
@@ -52,6 +53,7 @@ Object {
   "ios": "10.3.0",
   "node": "13.2.0",
   "opera": "48.0.0",
+  "opera_mobile": "73.0.0",
   "safari": "10.1.0",
   "samsung": "8.2.0",
 }
@@ -66,6 +68,7 @@ Object {
   "ios": "10.3.0",
   "node": "13.2.0",
   "opera": "48.0.0",
+  "opera_mobile": "73.0.0",
   "safari": "10.1.0",
   "samsung": "8.2.0",
 }
@@ -80,6 +83,7 @@ Object {
   "ios": "10.3.0",
   "node": "13.2.0",
   "opera": "48.0.0",
+  "opera_mobile": "73.0.0",
   "safari": "10.1.0",
   "samsung": "8.2.0",
 }

--- a/packages/babel-preset-env/test/fixtures.js
+++ b/packages/babel-preset-env/test/fixtures.js
@@ -1,18 +1,3 @@
 import runner from "@babel/helper-plugin-test-runner";
-import { execSync } from "child_process";
 
-describe("preset-env", () => {
-  // todo: remove temporary resolution when @babel/helper-define-polyfill-provider bumps
-  // @babel/helper-compilation-targets to the latest version
-  beforeAll(() => {
-    execSync(
-      "yarn set resolution '@babel/helper-compilation-targets@npm:^7.17.7' 'workspace:*'",
-    );
-  });
-  afterAll(() => {
-    execSync(
-      "yarn set resolution '@babel/helper-compilation-targets@npm:^7.17.7' '7.22.5'",
-    );
-  });
-  runner(import.meta.url);
-});
+runner(import.meta.url);

--- a/packages/babel-preset-env/test/fixtures.js
+++ b/packages/babel-preset-env/test/fixtures.js
@@ -1,3 +1,18 @@
 import runner from "@babel/helper-plugin-test-runner";
+import { execSync } from "child_process";
 
-runner(import.meta.url);
+describe("preset-env", () => {
+  // todo: remove temporary resolution when @babel/helper-define-polyfill-provider bumps
+  // @babel/helper-compilation-targets to the latest version
+  beforeAll(() => {
+    execSync(
+      "yarn set resolution '@babel/helper-compilation-targets@npm:^7.17.7' 'workspace:*'",
+    );
+  });
+  afterAll(() => {
+    execSync(
+      "yarn set resolution '@babel/helper-compilation-targets@npm:^7.17.7' '7.22.5'",
+    );
+  });
+  runner(import.meta.url);
+});

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-babel-7/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-babel-7/stdout.txt
@@ -9,6 +9,7 @@ Using targets:
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }
@@ -16,7 +17,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, opera_mobile, safari, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes-babel-7/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes-babel-7/stdout.txt
@@ -9,6 +9,7 @@ Using targets:
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }
@@ -16,7 +17,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, opera_mobile, safari, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
@@ -9,6 +9,7 @@ Using targets:
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }
@@ -16,7 +17,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, opera_mobile, safari, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
@@ -9,6 +9,7 @@ Using targets:
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }
@@ -16,7 +17,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, opera_mobile, safari, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -9,6 +9,7 @@ Using targets:
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }
@@ -16,7 +17,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, opera_mobile, safari, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }
@@ -51,6 +52,7 @@ Using targets: {
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }
@@ -60,4 +62,4 @@ Using polyfills with `usage-global` method:
 [<CWD>/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/input.mjs]
 The corejs2 polyfill added the following polyfills:
   es6.array.iterator { "android":"61", "chrome":"61", "opera":"48", "samsung":"8.2" }
-  web.dom.iterable { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  web.dom.iterable { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "opera_mobile":"73", "safari":"10.1", "samsung":"8.2" }

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -9,6 +9,7 @@ Using targets:
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }
@@ -16,7 +17,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, opera_mobile, safari, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }
@@ -53,6 +54,7 @@ Using targets: {
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }
@@ -62,4 +64,4 @@ Using polyfills with `usage-global` method:
 [<CWD>/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/input.mjs]
 The corejs2 polyfill added the following polyfills:
   es6.array.iterator { "android":"61", "chrome":"61", "opera":"48", "samsung":"8.2" }
-  web.dom.iterable { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "safari":"10.1", "samsung":"8.2" }
+  web.dom.iterable { "android":"61", "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "node":"13.2", "opera":"48", "opera_mobile":"73", "safari":"10.1", "samsung":"8.2" }

--- a/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -9,6 +9,7 @@ Using targets:
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }
@@ -16,7 +17,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, opera_mobile, safari, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }
@@ -51,6 +52,7 @@ Using targets: {
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -9,6 +9,7 @@ Using targets:
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }
@@ -16,7 +17,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node, opera < 98, opera_mobile, safari, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios, node < 16.11, opera < 80, safari, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }
@@ -53,6 +54,7 @@ Using targets: {
   "ios": "10.3",
   "node": "13.2",
   "opera": "48",
+  "opera_mobile": "73",
   "safari": "10.1",
   "samsung": "8.2"
 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }
@@ -15,7 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, safari, samsung }
+  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile, safari, samsung }
   transform-class-static-block { ios, safari }
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }
@@ -15,7 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, safari, samsung }
+  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile, safari, samsung }
   transform-class-static-block { ios, safari }
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
   "firefox": "113",
   "ios": "16.4",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "16.4",
   "samsung": "20"
 }
@@ -15,7 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { firefox < 116, ios, safari, samsung }
+  transform-unicode-sets-regex { firefox < 116, ios, opera_mobile, safari, samsung }
   transform-class-static-block { ios, safari }
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }
@@ -15,7 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, safari, samsung }
+  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile, safari, samsung }
   transform-class-static-block { ios, safari }
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }
@@ -15,7 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, safari, samsung }
+  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile, safari, samsung }
   transform-class-static-block { ios, safari }
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -8,6 +8,7 @@ Using targets:
   "firefox": "113",
   "ios": "16.4",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "16.4",
   "samsung": "20"
 }
@@ -15,7 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { firefox < 116, ios, safari, samsung }
+  transform-unicode-sets-regex { firefox < 116, ios, opera_mobile, safari, samsung }
   transform-class-static-block { ios, safari }
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
@@ -71,6 +71,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
@@ -71,6 +71,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
@@ -71,6 +71,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
@@ -71,6 +71,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
@@ -70,6 +70,7 @@ Using targets: {
   "firefox": "102",
   "ios": "15.6",
   "opera": "98",
+  "opera_mobile": "73",
   "safari": "15.6",
   "samsung": "20"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -553,7 +553,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/helper-compilation-targets@npm:^7.18.2, @babel/helper-compilation-targets@npm:^7.18.9, @babel/helper-compilation-targets@npm:^7.20.7, @babel/helper-compilation-targets@npm:^7.21.5, @babel/helper-compilation-targets@npm:^7.22.1":
+"@babel/helper-compilation-targets@npm:^7.17.7, @babel/helper-compilation-targets@npm:^7.18.2, @babel/helper-compilation-targets@npm:^7.18.9, @babel/helper-compilation-targets@npm:^7.20.7, @babel/helper-compilation-targets@npm:^7.21.5, @babel/helper-compilation-targets@npm:^7.22.1":
   version: 7.22.5
   resolution: "@babel/helper-compilation-targets@npm:7.22.5"
   dependencies:
@@ -568,7 +568,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@workspace:*, @babel/helper-compilation-targets@workspace:^, @babel/helper-compilation-targets@workspace:packages/babel-helper-compilation-targets":
+"@babel/helper-compilation-targets@workspace:^, @babel/helper-compilation-targets@workspace:packages/babel-helper-compilation-targets":
   version: 0.0.0-use.local
   resolution: "@babel/helper-compilation-targets@workspace:packages/babel-helper-compilation-targets"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -553,7 +553,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/helper-compilation-targets@npm:^7.17.7, @babel/helper-compilation-targets@npm:^7.18.2, @babel/helper-compilation-targets@npm:^7.18.9, @babel/helper-compilation-targets@npm:^7.20.7, @babel/helper-compilation-targets@npm:^7.21.5, @babel/helper-compilation-targets@npm:^7.22.1":
+"@babel/helper-compilation-targets@npm:7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-compilation-targets@npm:7.22.5"
   dependencies:
@@ -565,6 +565,21 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: a479460615acffa0f4fd0a29b740eafb53a93694265207d23a6038ccd18d183a382cacca515e77b7c9b042c3ba80b0aca0da5f1f62215140e81660d2cf721b68
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@patch:@babel/helper-compilation-targets@npm%3A7.22.5#./.yarn/patches/@babel-helper-compilation-targets-npm-7.22.5-5e6d9af186.patch::locator=babel%40workspace%3A.":
+  version: 7.22.5
+  resolution: "@babel/helper-compilation-targets@patch:@babel/helper-compilation-targets@npm%3A7.22.5#./.yarn/patches/@babel-helper-compilation-targets-npm-7.22.5-5e6d9af186.patch::version=7.22.5&hash=88b490&locator=babel%40workspace%3A."
+  dependencies:
+    "@babel/compat-data": ^7.22.5
+    "@babel/helper-validator-option": ^7.22.5
+    browserslist: ^4.21.3
+    lru-cache: ^5.1.1
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 033b03d8e85949c234432b75b24bf3e979c0c3e60a19e98289157e328d0064cc7c01d96daa7e3c238070c2ad5f4de316a21c3ec37671be60aa26866821f61a07
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -553,7 +553,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/helper-compilation-targets@npm:^7.17.7, @babel/helper-compilation-targets@npm:^7.18.2, @babel/helper-compilation-targets@npm:^7.18.9, @babel/helper-compilation-targets@npm:^7.20.7, @babel/helper-compilation-targets@npm:^7.21.5, @babel/helper-compilation-targets@npm:^7.22.1":
+"@babel/helper-compilation-targets@npm:^7.18.2, @babel/helper-compilation-targets@npm:^7.18.9, @babel/helper-compilation-targets@npm:^7.20.7, @babel/helper-compilation-targets@npm:^7.21.5, @babel/helper-compilation-targets@npm:^7.22.1":
   version: 7.22.5
   resolution: "@babel/helper-compilation-targets@npm:7.22.5"
   dependencies:
@@ -568,7 +568,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@workspace:^, @babel/helper-compilation-targets@workspace:packages/babel-helper-compilation-targets":
+"@babel/helper-compilation-targets@workspace:*, @babel/helper-compilation-targets@workspace:^, @babel/helper-compilation-targets@workspace:packages/babel-helper-compilation-targets":
   version: 0.0.0-use.local
   resolution: "@babel/helper-compilation-targets@workspace:packages/babel-helper-compilation-targets"
   dependencies:
@@ -579,7 +579,7 @@ __metadata:
     "@nicolo-ribaudo/semver-v6": ^6.3.3
     "@types/lru-cache": ^5.1.1
     "@types/semver": ^5.5.0
-    browserslist: ^4.21.3
+    browserslist: ^4.21.9
     lru-cache: "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1"
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   peerDependencies:
@@ -6664,17 +6664,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:4.21.5":
-  version: 4.21.5
-  resolution: "browserslist@npm:4.21.5"
+"browserslist@npm:4.21.9":
+  version: 4.21.9
+  resolution: "browserslist@npm:4.21.9"
   dependencies:
-    caniuse-lite: ^1.0.30001449
-    electron-to-chromium: ^1.4.284
-    node-releases: ^2.0.8
-    update-browserslist-db: ^1.0.10
+    caniuse-lite: ^1.0.30001503
+    electron-to-chromium: ^1.4.431
+    node-releases: ^2.0.12
+    update-browserslist-db: ^1.0.11
   bin:
     browserslist: cli.js
-  checksum: 9755986b22e73a6a1497fd8797aedd88e04270be33ce66ed5d85a1c8a798292a65e222b0f251bafa1c2522261e237d73b08b58689d4920a607e5a53d56dc4706
+  checksum: 80d3820584e211484ad1b1a5cfdeca1dd00442f47be87e117e1dda34b628c87e18b81ae7986fa5977b3e6a03154f6d13cd763baa6b8bf5dd9dd19f4926603698
   languageName: node
   linkType: hard
 
@@ -12408,7 +12408,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.8":
+"node-releases@npm:^2.0.12":
   version: 2.0.12
   resolution: "node-releases@npm:2.0.12"
   checksum: b8c56db82c4642a0f443332b331a4396dae452a2ac5a65c8dbd93ef89ecb2fbb0da9d42ac5366d4764973febadca816cf7587dad492dce18d2a6b2af59cda260
@@ -15676,7 +15676,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.0.10":
+"update-browserslist-db@npm:^1.0.11":
   version: 1.0.11
   resolution: "update-browserslist-db@npm:1.0.11"
   dependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15711 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
<s>This PR contains commits from #15726, please review that one first.</s>

In https://github.com/browserslist/browserslist/pull/768, browserslist no longer returns `op_mob` version as if it were the one of Opera Desktop, it does return the correct opera mobile versions. However, `@babel/helper-compilation-targets` still maps `op_mob` as Opera. This significantly lowered the support matrix of queries like `last 2 versions` or `defaults` because although Opera Mobile 73 is modern, Opera Desktop 73 (Chrome 87) is 2 years old.

In this PR we maps `op_mob` as `opera_mobile` and add compat data for `opera_mobile`. While it is technically a new feature for `@babel/compat-data`, this PR fixes the regression that the `defaults` browserslist query is misintepreted by `@babel/preset-env` when using `browserslist@4.21.9`. Therefore I mark it as a bug fix.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15727"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

