### PR TITLE
Disable react-native e2e-breaking tests

### DIFF
--- a/.github/workflows/e2e-tests-breaking.yml
+++ b/.github/workflows/e2e-tests-breaking.yml
@@ -46,7 +46,9 @@ jobs:
           - create-react-app
           - vue-cli
           - jest
-          - react-native
+          # todo: Enable this test when metro-source-map does not reassign NodePath cache
+          # https://github.com/facebook/metro/blob/29bb5f2ad3319ba8f4764c3993aa85c15f59af23/packages/metro-source-map/src/generateFunctionMap.js#L182
+          # react-native
           - prettier
     steps:
       - name: Get yarn1 cache directory path


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Disables current broken e2e-breaking tests, closes #15721 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This is an alternative PR to #15721. The test is disabled temporarily. We can reenable the test when the NodePath cache issue is fixed.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15729"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

