### PR TITLE
Fix transform of `delete a?.b` in function params

### DIFF
--- a/packages/babel-plugin-transform-optional-chaining/src/transform.ts
+++ b/packages/babel-plugin-transform-optional-chaining/src/transform.ts
@@ -68,7 +68,9 @@ export function transformOptionalChain(
   // Replace `function (a, x = a.b?.c) {}` to `function (a, x = (() => a.b?.c)() ){}`
   // so the temporary variable can be injected in correct scope
   if (scope.path.isPattern() && needsMemoize(path)) {
-    path.replaceWith(template.ast`(() => ${path.node})()` as t.Statement);
+    replacementPath.replaceWith(
+      template.expression.ast`(() => ${replacementPath.node})()`,
+    );
     // The injected optional chain will be queued and eventually transformed when visited
     return;
   }

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/delete-in-function-params/input.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/delete-in-function-params/input.js
@@ -1,0 +1,1 @@
+function f(x = delete a()?.b) {}

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/delete-in-function-params/output.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/delete-in-function-params/output.js
@@ -1,0 +1,4 @@
+function f(x = (() => {
+  var _a;
+  return (_a = a()) === null || _a === void 0 ? true : delete _a.b;
+})()) {}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15738
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Please review commit-by-commit.

The first one splits the existing transform logic in two parts, without causing any observable change:
1. how to, in general, traverse and transform an optional chain (moved to the `transformOptionalChain` function)
2. how the output should change depending on whether the optional chain is in a "read" context or in a "delete context". This will make it incredibly easy to implement `a?.b = c` in the future, which [I'm presenting](https://docs.google.com/presentation/d/1KL9MRyxprgXDEsxT8Ddrdro074L3fQm88zXHsWL-Dwk) at the next TC39 meeting

The second commit actually fixes the bug, that I found while working on `a?.b = c` because `function f(x = a?.b = c) {}` was also broken.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15739"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

