### PR TITLE
Inject tmp vars in the params list of IIFEs when possible

### DIFF
--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/completion-do-expression/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/completion-do-expression/output.js
@@ -4,8 +4,7 @@ var _x = {
   writable: true,
   value: void 0
 };
-(() => {
-  var _m, _m2;
+((_m, _m2) => {
   var x;
   result = (_m = C, _m2 = babelHelpers.classStaticPrivateFieldSpecGet(_m, C, _x), x = _m2 === void 0 ? 2 : _m2, _m);
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-and-keys/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-and-keys/output.js
@@ -12,8 +12,7 @@ var _y = {
 babelHelpers.defineProperty(C, "a", "a");
 babelHelpers.defineProperty(C, "b", "b");
 babelHelpers.defineProperty(C, "c", "c");
-(() => {
-  var _C;
+(_C => {
   let x, y, z;
   x = babelHelpers.classStaticPrivateFieldSpecGet(C, C, _x), (_C = C, ({
     y

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-and-private-keys/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-and-private-keys/output.js
@@ -11,8 +11,7 @@ var _y = {
 babelHelpers.defineProperty(C, "a", "a");
 babelHelpers.defineProperty(C, "b", "b");
 babelHelpers.defineProperty(C, "c", "c");
-(() => {
-  var _C;
+(_C => {
   let x, y, z;
   x = babelHelpers.classStaticPrivateFieldSpecGet(C, C, _x), y = babelHelpers.classStaticPrivateFieldSpecGet(C, C, _y), (_C = C, ({} = _C), z = Object.assign({}, (babelHelpers.objectDestructuringEmpty(_C), _C)), _C);
   result = {

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-under-private/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-under-private/output.js
@@ -8,8 +8,7 @@ var _x = {
   writable: true,
   value: C
 };
-(() => {
-  var _babelHelpers$classSt;
+(_babelHelpers$classSt => {
   var x, y, z;
   ({
     x

--- a/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/while-if/output.js
+++ b/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/while-if/output.js
@@ -1,6 +1,5 @@
 let p;
-let a = function () {
-  var _ret;
+let a = function (_ret) {
   while (p = p.parentPath) {
     if (a) {
       _ret = 'a';

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/indirect-eval/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/indirect-eval/output.js
@@ -1,7 +1,6 @@
-(function () {
+(function (_functionReturn) {
   'use strict';
 
-  var _functionReturn;
   var result = (_functionReturn = '(function() { return this; })()', (0, eval)(_functionReturn));
   expect(result).not.toBeUndefined();
 })();

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/indirect-eval/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/indirect-eval/output.js
@@ -1,7 +1,6 @@
-(function () {
+(function (_functionReturn) {
   'use strict';
 
-  var _functionReturn;
   var result = (_functionReturn = '(function() { return this; })()', (0, eval)(_functionReturn));
   expect(result).not.toBeUndefined();
 })();

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/smart/pipe-body-with-eval-tacit-call/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/smart/pipe-body-with-eval-tacit-call/output.js
@@ -1,7 +1,6 @@
-(function () {
+(function (_functionReturn) {
   'use strict';
 
-  var _functionReturn;
   var result = (_functionReturn = '(function() { return this; })()', (0, eval)(_functionReturn));
   expect(result).not.toBeUndefined();
 })();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-in-function-param-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-in-function-param-with-transform/output.js
@@ -23,28 +23,16 @@ class Foo {
     function f(o, r = (() => o === null || o === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(o.Foo, _m)[_m]())()) {
       return r;
     }
-    function g(o, r = (() => {
-      var _ref;
-      return (_ref = (() => o === null || o === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(babelHelpers.classPrivateFieldLooseBase(o.Foo, _self)[_self].getSelf(), _m)[_m])()) == null ? void 0 : _ref();
-    })()) {
+    function g(o, r = (_ref => (_ref = (() => o === null || o === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(babelHelpers.classPrivateFieldLooseBase(o.Foo, _self)[_self].getSelf(), _m)[_m])()) == null ? void 0 : _ref())()) {
       return r;
     }
-    function h(fnDeep, r = (() => {
-      var _fnDeep$very$o$Foo, _fnDeep$very$o;
-      return (_fnDeep$very$o$Foo = fnDeep == null ? void 0 : (_fnDeep$very$o = fnDeep().very.o) == null ? void 0 : _fnDeep$very$o.Foo) === null || _fnDeep$very$o$Foo === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_fnDeep$very$o$Foo, _m)[_m]();
-    })()) {
+    function h(fnDeep, r = ((_fnDeep$very$o$Foo, _fnDeep$very$o) => (_fnDeep$very$o$Foo = fnDeep == null ? void 0 : (_fnDeep$very$o = fnDeep().very.o) == null ? void 0 : _fnDeep$very$o.Foo) === null || _fnDeep$very$o$Foo === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_fnDeep$very$o$Foo, _m)[_m]())()) {
       return r;
     }
-    function i(fn, r = (() => {
-      var _getSelf, _ref2;
-      return (_getSelf = (_ref2 = (() => fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self])()) == null ? void 0 : _ref2.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf.self, _m)[_m]();
-    })()) {
+    function i(fn, r = ((_getSelf, _ref2) => (_getSelf = (_ref2 = (() => fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self])()) == null ? void 0 : _ref2.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf.self, _m)[_m]())()) {
       return r;
     }
-    function j(fn, r = (() => {
-      var _babelHelpers$classPr, _babelHelpers$classPr2;
-      return (_babelHelpers$classPr = (_babelHelpers$classPr2 = babelHelpers.classPrivateFieldLooseBase(babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self].getSelf().self, _m))[_m]) == null ? void 0 : _babelHelpers$classPr.call(_babelHelpers$classPr2);
-    })()) {
+    function j(fn, r = ((_babelHelpers$classPr, _babelHelpers$classPr2) => (_babelHelpers$classPr = (_babelHelpers$classPr2 = babelHelpers.classPrivateFieldLooseBase(babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self].getSelf().self, _m))[_m]) == null ? void 0 : _babelHelpers$classPr.call(_babelHelpers$classPr2))()) {
       return r;
     }
     f(o);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-in-function-param/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-in-function-param/output.js
@@ -26,16 +26,10 @@ class Foo {
     function g(o, r = (() => o === null || o === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(babelHelpers.classPrivateFieldLooseBase(o.Foo, _self)[_self].getSelf(), _m)[_m])()?.()) {
       return r;
     }
-    function h(fnDeep, r = (() => {
-      var _fnDeep$very$o$Foo;
-      return (_fnDeep$very$o$Foo = fnDeep?.().very.o?.Foo) === null || _fnDeep$very$o$Foo === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_fnDeep$very$o$Foo, _m)[_m]();
-    })()) {
+    function h(fnDeep, r = (_fnDeep$very$o$Foo => (_fnDeep$very$o$Foo = fnDeep?.().very.o?.Foo) === null || _fnDeep$very$o$Foo === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_fnDeep$very$o$Foo, _m)[_m]())()) {
       return r;
     }
-    function i(fn, r = (() => {
-      var _getSelf;
-      return (_getSelf = (() => fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self])()?.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf.self, _m)[_m]();
-    })()) {
+    function i(fn, r = (_getSelf => (_getSelf = (() => fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self])()?.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf.self, _m)[_m]())()) {
       return r;
     }
     function j(fn, r = (() => babelHelpers.classPrivateFieldLooseBase(babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self].getSelf().self, _m)[_m]?.())()) {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-in-function-param-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-in-function-param-with-transform/output.js
@@ -17,34 +17,19 @@ class Foo {
     function fnDeep() {
       return deep;
     }
-    function f(o, r = (() => {
-      var _o$Foo;
-      return o === null || o === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_o$Foo = o.Foo, Foo, _m).call(_o$Foo);
-    })()) {
+    function f(o, r = (_o$Foo => o === null || o === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_o$Foo = o.Foo, Foo, _m).call(_o$Foo))()) {
       return r;
     }
-    function g(o, r = (() => {
-      var _ref;
-      return (_ref = (() => o === null || o === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(babelHelpers.classStaticPrivateFieldSpecGet(o.Foo, Foo, _self).getSelf(), Foo, _m))()) === null || _ref === void 0 ? void 0 : _ref();
-    })()) {
+    function g(o, r = (_ref => (_ref = (() => o === null || o === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(babelHelpers.classStaticPrivateFieldSpecGet(o.Foo, Foo, _self).getSelf(), Foo, _m))()) === null || _ref === void 0 ? void 0 : _ref())()) {
       return r;
     }
-    function h(fnDeep, r = (() => {
-      var _fnDeep$very$o$Foo, _fnDeep$very$o;
-      return (_fnDeep$very$o$Foo = fnDeep === null || fnDeep === void 0 ? void 0 : (_fnDeep$very$o = fnDeep().very.o) === null || _fnDeep$very$o === void 0 ? void 0 : _fnDeep$very$o.Foo) === null || _fnDeep$very$o$Foo === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_fnDeep$very$o$Foo, Foo, _m).call(_fnDeep$very$o$Foo);
-    })()) {
+    function h(fnDeep, r = ((_fnDeep$very$o$Foo, _fnDeep$very$o) => (_fnDeep$very$o$Foo = fnDeep === null || fnDeep === void 0 ? void 0 : (_fnDeep$very$o = fnDeep().very.o) === null || _fnDeep$very$o === void 0 ? void 0 : _fnDeep$very$o.Foo) === null || _fnDeep$very$o$Foo === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_fnDeep$very$o$Foo, Foo, _m).call(_fnDeep$very$o$Foo))()) {
       return r;
     }
-    function i(fn, r = (() => {
-      var _getSelf, _getSelf$self, _ref2;
-      return (_getSelf = (_ref2 = (() => fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self))()) === null || _ref2 === void 0 ? void 0 : _ref2.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf$self = _getSelf.self, Foo, _m).call(_getSelf$self);
-    })()) {
+    function i(fn, r = ((_getSelf, _getSelf$self, _ref2) => (_getSelf = (_ref2 = (() => fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self))()) === null || _ref2 === void 0 ? void 0 : _ref2.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf$self = _getSelf.self, Foo, _m).call(_getSelf$self))()) {
       return r;
     }
-    function j(fn, r = (() => {
-      var _babelHelpers$classSt, _babelHelpers$classSt2;
-      return (_babelHelpers$classSt2 = babelHelpers.classStaticPrivateFieldSpecGet(_babelHelpers$classSt = babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self).getSelf().self, Foo, _m)) === null || _babelHelpers$classSt2 === void 0 ? void 0 : _babelHelpers$classSt2.call(_babelHelpers$classSt);
-    })()) {
+    function j(fn, r = ((_babelHelpers$classSt, _babelHelpers$classSt2) => (_babelHelpers$classSt2 = babelHelpers.classStaticPrivateFieldSpecGet(_babelHelpers$classSt = babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self).getSelf().self, Foo, _m)) === null || _babelHelpers$classSt2 === void 0 ? void 0 : _babelHelpers$classSt2.call(_babelHelpers$classSt))()) {
       return r;
     }
     f(o);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-in-function-param/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-in-function-param/output.js
@@ -17,31 +17,19 @@ class Foo {
     function fnDeep() {
       return deep;
     }
-    function f(o, r = (() => {
-      var _o$Foo;
-      return o === null || o === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_o$Foo = o.Foo, Foo, _m).call(_o$Foo);
-    })()) {
+    function f(o, r = (_o$Foo => o === null || o === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_o$Foo = o.Foo, Foo, _m).call(_o$Foo))()) {
       return r;
     }
     function g(o, r = (() => o === null || o === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(babelHelpers.classStaticPrivateFieldSpecGet(o.Foo, Foo, _self).getSelf(), Foo, _m))()?.()) {
       return r;
     }
-    function h(fnDeep, r = (() => {
-      var _fnDeep$very$o$Foo;
-      return (_fnDeep$very$o$Foo = fnDeep?.().very.o?.Foo) === null || _fnDeep$very$o$Foo === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_fnDeep$very$o$Foo, Foo, _m).call(_fnDeep$very$o$Foo);
-    })()) {
+    function h(fnDeep, r = (_fnDeep$very$o$Foo => (_fnDeep$very$o$Foo = fnDeep?.().very.o?.Foo) === null || _fnDeep$very$o$Foo === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_fnDeep$very$o$Foo, Foo, _m).call(_fnDeep$very$o$Foo))()) {
       return r;
     }
-    function i(fn, r = (() => {
-      var _getSelf, _getSelf$self;
-      return (_getSelf = (() => fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self))()?.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf$self = _getSelf.self, Foo, _m).call(_getSelf$self);
-    })()) {
+    function i(fn, r = ((_getSelf, _getSelf$self) => (_getSelf = (() => fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self))()?.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf$self = _getSelf.self, Foo, _m).call(_getSelf$self))()) {
       return r;
     }
-    function j(fn, r = (() => {
-      var _babelHelpers$classSt;
-      return babelHelpers.classStaticPrivateFieldSpecGet(_babelHelpers$classSt = babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self).getSelf().self, Foo, _m)?.call(_babelHelpers$classSt);
-    })()) {
+    function j(fn, r = (_babelHelpers$classSt => babelHelpers.classStaticPrivateFieldSpecGet(_babelHelpers$classSt = babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self).getSelf().self, Foo, _m)?.call(_babelHelpers$classSt))()) {
       return r;
     }
     f(o);

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-default-param/output.js
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/assumption-noDocumentAll/transform-in-default-param/output.js
@@ -1,5 +1,2 @@
-function foo(foo, qux = (() => {
-  var _foo$bar;
-  return (_foo$bar = foo.bar) != null ? _foo$bar : "qux";
-})()) {}
+function foo(foo, qux = (_foo$bar => (_foo$bar = foo.bar) != null ? _foo$bar : "qux")()) {}
 function bar(bar, qux = bar != null ? bar : "qux") {}

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-in-default-param/output.js
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-in-default-param/output.js
@@ -1,5 +1,2 @@
-function foo(foo, qux = (() => {
-  var _foo$bar;
-  return (_foo$bar = foo.bar) !== null && _foo$bar !== void 0 ? _foo$bar : "qux";
-})()) {}
+function foo(foo, qux = (_foo$bar => (_foo$bar = foo.bar) !== null && _foo$bar !== void 0 ? _foo$bar : "qux")()) {}
 function bar(bar, qux = bar !== null && bar !== void 0 ? bar : "qux") {}

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/assumption-noDocumentAll/in-function-params/output.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/assumption-noDocumentAll/in-function-params/output.js
@@ -1,26 +1,14 @@
-function f(a = (() => {
-  var _x;
-  return (_x = x) == null ? void 0 : _x.y;
-})()) {}
+function f(a = (_x => (_x = x) == null ? void 0 : _x.y)()) {}
 function g({
   a,
   b = a == null ? void 0 : a.c
 }) {}
 function h(a, {
-  b = (() => {
-    var _a$b, _a$b$c;
-    return (_a$b = a.b) == null ? void 0 : (_a$b$c = _a$b.c) == null ? void 0 : _a$b$c.d.e;
-  })()
+  b = ((_a$b, _a$b$c) => (_a$b = a.b) == null ? void 0 : (_a$b$c = _a$b.c) == null ? void 0 : _a$b$c.d.e)()
 }) {}
 function i(a, {
-  b = (() => {
-    var _a$b2, _a$b2$c;
-    return (_a$b2 = a.b) == null ? void 0 : (_a$b2$c = _a$b2.c) == null ? void 0 : _a$b2$c.d;
-  })().e
+  b = ((_a$b2, _a$b2$c) => (_a$b2 = a.b) == null ? void 0 : (_a$b2$c = _a$b2.c) == null ? void 0 : _a$b2$c.d)().e
 }) {}
 function j(a, {
-  b = (() => {
-    var _a$b3;
-    return a == null ? void 0 : (_a$b3 = a.b) == null ? void 0 : _a$b3.c().d.e;
-  })()
+  b = (_a$b3 => a == null ? void 0 : (_a$b3 = a.b) == null ? void 0 : _a$b3.c().d.e)()
 }) {}

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/in-function-params-loose/output.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/in-function-params-loose/output.js
@@ -1,26 +1,14 @@
-function f(a = (() => {
-  var _x;
-  return (_x = x) == null ? void 0 : _x.y;
-})()) {}
+function f(a = (_x => (_x = x) == null ? void 0 : _x.y)()) {}
 function g({
   a,
   b = a == null ? void 0 : a.c
 }) {}
 function h(a, {
-  b = (() => {
-    var _a$b, _a$b$c;
-    return (_a$b = a.b) == null ? void 0 : (_a$b$c = _a$b.c) == null ? void 0 : _a$b$c.d.e;
-  })()
+  b = ((_a$b, _a$b$c) => (_a$b = a.b) == null ? void 0 : (_a$b$c = _a$b.c) == null ? void 0 : _a$b$c.d.e)()
 }) {}
 function i(a, {
-  b = (() => {
-    var _a$b2, _a$b2$c;
-    return (_a$b2 = a.b) == null ? void 0 : (_a$b2$c = _a$b2.c) == null ? void 0 : _a$b2$c.d;
-  })().e
+  b = ((_a$b2, _a$b2$c) => (_a$b2 = a.b) == null ? void 0 : (_a$b2$c = _a$b2.c) == null ? void 0 : _a$b2$c.d)().e
 }) {}
 function j(a, {
-  b = (() => {
-    var _a$b3;
-    return a == null ? void 0 : (_a$b3 = a.b) == null ? void 0 : _a$b3.c().d.e;
-  })()
+  b = (_a$b3 => a == null ? void 0 : (_a$b3 = a.b) == null ? void 0 : _a$b3.c().d.e)()
 }) {}

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/in-function-params/output.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/in-function-params/output.js
@@ -1,26 +1,14 @@
-function f(a = (() => {
-  var _x;
-  return (_x = x) === null || _x === void 0 ? void 0 : _x.y;
-})()) {}
+function f(a = (_x => (_x = x) === null || _x === void 0 ? void 0 : _x.y)()) {}
 function g({
   a,
   b = a === null || a === void 0 ? void 0 : a.c
 }) {}
 function h(a, {
-  b = (() => {
-    var _a$b, _a$b$c;
-    return (_a$b = a.b) === null || _a$b === void 0 ? void 0 : (_a$b$c = _a$b.c) === null || _a$b$c === void 0 ? void 0 : _a$b$c.d.e;
-  })()
+  b = ((_a$b, _a$b$c) => (_a$b = a.b) === null || _a$b === void 0 ? void 0 : (_a$b$c = _a$b.c) === null || _a$b$c === void 0 ? void 0 : _a$b$c.d.e)()
 }) {}
 function i(a, {
-  b = (() => {
-    var _a$b2, _a$b2$c;
-    return (_a$b2 = a.b) === null || _a$b2 === void 0 ? void 0 : (_a$b2$c = _a$b2.c) === null || _a$b2$c === void 0 ? void 0 : _a$b2$c.d;
-  })().e
+  b = ((_a$b2, _a$b2$c) => (_a$b2 = a.b) === null || _a$b2 === void 0 ? void 0 : (_a$b2$c = _a$b2.c) === null || _a$b2$c === void 0 ? void 0 : _a$b2$c.d)().e
 }) {}
 function j(a, {
-  b = (() => {
-    var _a$b3;
-    return a === null || a === void 0 ? void 0 : (_a$b3 = a.b) === null || _a$b3 === void 0 ? void 0 : _a$b3.c().d.e;
-  })()
+  b = (_a$b3 => a === null || a === void 0 ? void 0 : (_a$b3 = a.b) === null || _a$b3 === void 0 ? void 0 : _a$b3.c().d.e)()
 }) {}

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/to-native-fields/class-expression-in-default-param/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/to-native-fields/class-expression-in-default-param/output.js
@@ -1,9 +1,6 @@
-(x = (() => {
-  var _fooBrandCheck;
-  return _fooBrandCheck = /*#__PURE__*/new WeakSet(), class {
-    #foo = void _fooBrandCheck.add(this);
-    test(other) {
-      return _fooBrandCheck.has(babelHelpers.checkInRHS(other));
-    }
-  };
-})()) => {};
+(x = (_fooBrandCheck => (_fooBrandCheck = /*#__PURE__*/new WeakSet(), class {
+  #foo = void _fooBrandCheck.add(this);
+  test(other) {
+    return _fooBrandCheck.has(babelHelpers.checkInRHS(other));
+  }
+}))()) => {};

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -51,7 +51,7 @@ import {
   isPrivateName,
   isExportDeclaration,
 } from "@babel/types";
-import type * as t from "@babel/types";
+import * as t from "@babel/types";
 import { scope as scopeCache } from "../cache";
 import type { Visitor } from "../types";
 import { isExplodedVisitor } from "../visitors";
@@ -1069,6 +1069,31 @@ export default class Scope {
       path = (this.getFunctionParent() || this.getProgramParent()).path;
     }
 
+    const { init, unique, kind = "var", id } = opts;
+
+    // When injecting a non-const non-initialized binding inside
+    // an IIFE, if the number of call arguments is less than or
+    // equal to the number of function parameters, we can safely
+    // inject the binding into the parameter list.
+    if (
+      !init &&
+      !unique &&
+      kind !== "const" &&
+      path.isFunction() &&
+      // @ts-expect-error ArrowFunctionExpression never has a name
+      !path.node.name &&
+      t.isCallExpression(path.parent, { callee: path.node }) &&
+      path.parent.arguments.length <= path.node.params.length &&
+      t.isIdentifier(id)
+    ) {
+      path.pushContainer("params", id);
+      path.scope.registerBinding(
+        "param",
+        path.get("params")[path.node.params.length - 1],
+      );
+      return;
+    }
+
     if (path.isLoop() || path.isCatchClause() || path.isFunction()) {
       // @ts-expect-error TS can not infer NodePath<Loop> | NodePath<CatchClause> as NodePath<Loop | CatchClause>
       path.ensureBlock();
@@ -1076,8 +1101,6 @@ export default class Scope {
       path = path.get("body");
     }
 
-    const unique = opts.unique;
-    const kind = opts.kind || "var";
     const blockHoist = opts._blockHoist == null ? 2 : opts._blockHoist;
 
     const dataKey = `declaration:${kind}:${blockHoist}`;
@@ -1095,7 +1118,7 @@ export default class Scope {
       if (!unique) path.setData(dataKey, declarPath);
     }
 
-    const declarator = variableDeclarator(opts.id, opts.init);
+    const declarator = variableDeclarator(id, init);
     const len = declarPath.node.declarations.push(declarator);
     path.scope.registerBinding(kind, declarPath.get("declarations")[len - 1]);
   }

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -1078,7 +1078,7 @@ export default class Scope {
     if (
       !init &&
       !unique &&
-      kind !== "const" &&
+      (kind === "var" || kind === "let") &&
       path.isFunction() &&
       // @ts-expect-error ArrowFunctionExpression never has a name
       !path.node.name &&


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When injecting a non-const non-initialized binding inside an IIFE, if the number of call arguments is less than or equal to the number of function parameters, we can safely inject the binding into the parameter list.

I copied this possible optimization from how ESBuild compiles optional chaining in function parameters :)
https://esbuild.github.io/try/#dAAwLjE4LjExAC0tdGFyZ2V0PWVzMjAxOQBmdW5jdGlvbiBmKHggPSBhKCk/LmIpIHt9


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15741"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

