### PR TITLE
Use forked `semver@6` with backported security fixes

### DIFF
--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -32,9 +32,10 @@
   },
   "dependencies": {
     "@nicolo-ribaudo/eslint-scope-5-internals": "condition:BABEL_8_BREAKING ? : 5.1.1-v1",
+    "@nicolo-ribaudo/semver-v6": "condition:BABEL_8_BREAKING ? : ^6.3.3",
     "eslint-scope": "condition:BABEL_8_BREAKING ? ^7.1.1 : ",
     "eslint-visitor-keys": "condition:BABEL_8_BREAKING ? ^3.3.0 : ^2.1.0",
-    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   },
   "devDependencies": {
     "@babel/core": "workspace:^",

--- a/eslint/babel-eslint-parser/src/parse.cjs
+++ b/eslint/babel-eslint-parser/src/parse.cjs
@@ -1,6 +1,8 @@
 "use strict";
 
-const semver = require("semver");
+const semver = process.env.BABEL_8_BREAKING
+  ? require("semver")
+  : require("@nicolo-ribaudo/semver-v6");
 const convert = require("./convert/index.cjs");
 
 const babelParser = require(require.resolve("@babel/parser", {

--- a/lib/semver.d.ts
+++ b/lib/semver.d.ts
@@ -1,0 +1,4 @@
+declare module "@nicolo-ribaudo/semver-v6" {
+  export { default } from "semver";
+  export * from "semver";
+}

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -42,10 +42,10 @@
   "devDependencies": {
     "@babel/core": "workspace:^",
     "@babel/helper-fixtures": "workspace:^",
+    "@nicolo-ribaudo/semver-v6": "^6.3.3",
     "@types/fs-readdir-recursive": "^1.1.0",
     "@types/glob": "^7.2.0",
-    "rimraf": "^3.0.0",
-    "semver": "^6.3.0"
+    "rimraf": "^3.0.0"
   },
   "bin": {
     "babel": "./bin/babel.js",

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -1,7 +1,7 @@
 import readdir from "fs-readdir-recursive";
 import * as helper from "@babel/helper-fixtures";
 import rimraf from "rimraf";
-import semver from "semver";
+import semver from "@nicolo-ribaudo/semver-v6";
 import child from "child_process";
 import path from "path";
 import fs from "fs";

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -56,11 +56,12 @@
     "@babel/template": "workspace:^",
     "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^",
+    "@nicolo-ribaudo/semver-v6": "^6.3.3",
     "convert-source-map": "^1.7.0",
     "debug": "^4.1.0",
     "gensync": "^1.0.0-beta.2",
     "json5": "^2.2.2",
-    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   },
   "devDependencies": {
     "@babel/helper-transform-fixture-test-runner": "workspace:^",

--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -1,9 +1,12 @@
+/// <reference path="../../../../../lib/semver.d.ts" />
+
 import { isAsync, waitFor } from "../../gensync-utils/async";
 import type { Handler } from "gensync";
 import path from "path";
 import { pathToFileURL } from "url";
 import { createRequire } from "module";
-import semver from "semver";
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 
 import { endHiddenCallStack } from "../../errors/rewrite-stack-trace";
 import ConfigError from "../../errors/config-error";

--- a/packages/babel-core/src/config/helpers/config-api.ts
+++ b/packages/babel-core/src/config/helpers/config-api.ts
@@ -1,4 +1,5 @@
-import semver from "semver";
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 import type { Targets } from "@babel/helper-compilation-targets";
 
 import { version as coreVersion } from "../../";

--- a/packages/babel-core/src/transformation/file/file.ts
+++ b/packages/babel-core/src/transformation/file/file.ts
@@ -6,7 +6,8 @@ import traverse from "@babel/traverse";
 import { cloneNode, interpreterDirective } from "@babel/types";
 import type * as t from "@babel/types";
 import { getModuleName } from "@babel/helper-module-transforms";
-import semver from "semver";
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 
 import type { NormalizedFile } from "../normalize-file";
 

--- a/packages/babel-core/test/config-ts.js
+++ b/packages/babel-core/test/config-ts.js
@@ -1,6 +1,6 @@
 import { loadPartialConfigSync } from "../lib/index.js";
 import path from "path";
-import semver from "semver";
+import semver from "@nicolo-ribaudo/semver-v6";
 import { USE_ESM, commonJS } from "$repo-utils";
 
 const { __dirname, require } = commonJS(import.meta.url);

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -24,9 +24,10 @@
   "dependencies": {
     "@babel/compat-data": "workspace:^",
     "@babel/helper-validator-option": "workspace:^",
+    "@nicolo-ribaudo/semver-v6": "^6.3.3",
     "browserslist": "^4.21.3",
     "lru-cache": "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1",
-    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0"

--- a/packages/babel-helper-compilation-targets/src/debug.ts
+++ b/packages/babel-helper-compilation-targets/src/debug.ts
@@ -1,4 +1,7 @@
-import semver from "semver";
+/// <reference path="../../../lib/semver.d.ts" />
+
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 import { prettifyVersion } from "./pretty";
 import {
   semverify,

--- a/packages/babel-helper-compilation-targets/src/filter-items.ts
+++ b/packages/babel-helper-compilation-targets/src/filter-items.ts
@@ -1,4 +1,5 @@
-import semver from "semver";
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 
 import pluginsCompatData from "@babel/compat-data/plugins";
 

--- a/packages/babel-helper-compilation-targets/src/pretty.ts
+++ b/packages/babel-helper-compilation-targets/src/pretty.ts
@@ -1,4 +1,5 @@
-import semver from "semver";
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 import { unreleasedLabels } from "./targets";
 import type { Targets, Target } from "./types";
 

--- a/packages/babel-helper-compilation-targets/src/utils.ts
+++ b/packages/babel-helper-compilation-targets/src/utils.ts
@@ -1,4 +1,5 @@
-import semver from "semver";
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 import { OptionValidator } from "@babel/helper-validator-option";
 import { unreleasedLabels } from "./targets";
 import type { Target, Targets } from "./types";

--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -26,7 +26,8 @@
     "@babel/helper-replace-supers": "workspace:^",
     "@babel/helper-skip-transparent-expression-wrappers": "workspace:^",
     "@babel/helper-split-export-declaration": "workspace:^",
-    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    "@nicolo-ribaudo/semver-v6": "^6.3.3",
+    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0"

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -1,10 +1,13 @@
+/// <reference path="../../../lib/semver.d.ts" />
+
 import { types as t } from "@babel/core";
 import type { PluginAPI, PluginObject } from "@babel/core";
 import type { NodePath } from "@babel/traverse";
 import nameFunction from "@babel/helper-function-name";
 import splitExportDeclaration from "@babel/helper-split-export-declaration";
 
-import semver from "semver";
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 
 import {
   buildPrivateNamesNodes,

--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -19,8 +19,9 @@
   ],
   "dependencies": {
     "@babel/helper-annotate-as-pure": "workspace:^",
+    "@nicolo-ribaudo/semver-v6": "^6.3.3",
     "regexpu-core": "^5.3.1",
-    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0"

--- a/packages/babel-helper-create-regexp-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-regexp-features-plugin/src/index.ts
@@ -1,9 +1,12 @@
+/// <reference path="../../../lib/semver.d.ts" />
+
 import rewritePattern from "regexpu-core";
 import type { NodePath } from "@babel/traverse";
 import { types as t, type PluginObject } from "@babel/core";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 
-import semver from "semver";
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 
 import {
   featuresKey,

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -15,7 +15,8 @@
   "homepage": "https://babel.dev/docs/en/next/babel-helper-fixtures",
   "main": "./lib/index.js",
   "dependencies": {
-    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    "@nicolo-ribaudo/semver-v6": "^6.3.3",
+    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   },
   "devDependencies": {
     "@types/semver": "^7.3.4"

--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -1,4 +1,7 @@
-import semver from "semver";
+/// <reference path="../../../lib/semver.d.ts" />
+
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -22,10 +22,11 @@
   "dependencies": {
     "@babel/helper-module-imports": "workspace:^",
     "@babel/helper-plugin-utils": "workspace:^",
+    "@nicolo-ribaudo/semver-v6": "^6.3.3",
     "babel-plugin-polyfill-corejs2": "^0.4.3",
     "babel-plugin-polyfill-corejs3": "^0.8.1",
     "babel-plugin-polyfill-regenerator": "^0.5.0",
-    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-plugin-transform-runtime/src/helpers.ts
+++ b/packages/babel-plugin-transform-runtime/src/helpers.ts
@@ -1,4 +1,7 @@
-import semver from "semver";
+/// <reference path="../../../lib/semver.d.ts" />
+
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 
 export function hasMinVersion(
   minVersion: string,

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -91,11 +91,12 @@
     "@babel/plugin-transform-unicode-sets-regex": "workspace:^",
     "@babel/preset-modules": "^0.1.5",
     "@babel/types": "workspace:^",
+    "@nicolo-ribaudo/semver-v6": "^6.3.3",
     "babel-plugin-polyfill-corejs2": "^0.4.3",
     "babel-plugin-polyfill-corejs3": "^0.8.1",
     "babel-plugin-polyfill-regenerator": "^0.5.0",
     "core-js-compat": "^3.31.0",
-    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-preset-env/src/filter-items.ts
+++ b/packages/babel-preset-env/src/filter-items.ts
@@ -1,4 +1,7 @@
-import semver from "semver";
+/// <reference path="../../../lib/semver.d.ts" />
+
+// TODO(Babel 8): Use "semver" directly
+import semver from "@nicolo-ribaudo/semver-v6";
 import { minVersions } from "./available-plugins";
 
 const has = Function.call.bind(Object.hasOwnProperty);

--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -1,4 +1,5 @@
-import semver, { type SemVer } from "semver";
+// TODO(Babel 8): Use "semver" directly
+import semver, { type SemVer } from "@nicolo-ribaudo/semver-v6";
 import { logPlugin } from "./debug";
 import getOptionSpecificExcludesFor from "./get-option-specific-excludes";
 import {

--- a/packages/babel-preset-env/src/normalize-options.ts
+++ b/packages/babel-preset-env/src/normalize-options.ts
@@ -1,4 +1,5 @@
-import semver, { type SemVer } from "semver";
+// TODO(Babel 8): Use "semver" directly
+import semver, { type SemVer } from "@nicolo-ribaudo/semver-v6";
 import corejs2Polyfills from "@babel/compat-data/corejs2-built-ins";
 // @ts-expect-error Fixme: TS can not infer types from ../data/core-js-compat.js
 // but we can't import core-js-compat/data.json because JSON imports do

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,6 +228,7 @@ __metadata:
     "@babel/helper-fixtures": "workspace:^"
     "@jridgewell/trace-mapping": ^0.3.17
     "@nicolo-ribaudo/chokidar-2": "condition:BABEL_8_BREAKING ? : 2.1.8-no-fsevents.3"
+    "@nicolo-ribaudo/semver-v6": ^6.3.3
     "@types/fs-readdir-recursive": ^1.1.0
     "@types/glob": ^7.2.0
     chokidar: ^3.4.0
@@ -237,7 +238,6 @@ __metadata:
     glob: ^7.2.0
     make-dir: "condition:BABEL_8_BREAKING ? : ^2.1.0"
     rimraf: ^3.0.0
-    semver: ^6.3.0
     slash: "condition:BABEL_8_BREAKING ? ^3.0.0 : ^2.0.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -364,6 +364,7 @@ __metadata:
     "@babel/traverse": "workspace:^"
     "@babel/types": "workspace:^"
     "@jridgewell/trace-mapping": ^0.3.17
+    "@nicolo-ribaudo/semver-v6": ^6.3.3
     "@types/convert-source-map": ^1.5.1
     "@types/debug": ^4.1.0
     "@types/gensync": ^1.0.0
@@ -374,7 +375,7 @@ __metadata:
     gensync: ^1.0.0-beta.2
     json5: ^2.2.2
     rimraf: ^3.0.0
-    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : "
     ts-node: ^10.9.1
   languageName: unknown
   linkType: soft
@@ -393,11 +394,12 @@ __metadata:
   dependencies:
     "@babel/core": "workspace:^"
     "@nicolo-ribaudo/eslint-scope-5-internals": "condition:BABEL_8_BREAKING ? : 5.1.1-v1"
+    "@nicolo-ribaudo/semver-v6": "condition:BABEL_8_BREAKING ? : ^6.3.3"
     dedent: ^0.7.0
     eslint: ^8.22.0
     eslint-scope: "condition:BABEL_8_BREAKING ? ^7.1.1 : "
     eslint-visitor-keys: "condition:BABEL_8_BREAKING ? ^3.3.0 : ^2.1.0"
-    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   peerDependencies:
     "@babel/core": ">=7.11.0"
     eslint: ^7.5.0 || ^8.0.0
@@ -574,11 +576,12 @@ __metadata:
     "@babel/core": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-validator-option": "workspace:^"
+    "@nicolo-ribaudo/semver-v6": ^6.3.3
     "@types/lru-cache": ^5.1.1
     "@types/semver": ^5.5.0
     browserslist: ^4.21.3
     lru-cache: "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1"
-    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   peerDependencies:
     "@babel/core": ^7.0.0
   languageName: unknown
@@ -619,7 +622,8 @@ __metadata:
     "@babel/helper-split-export-declaration": "workspace:^"
     "@babel/plugin-syntax-class-static-block": ^7.14.5
     "@babel/preset-env": "workspace:^"
-    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    "@nicolo-ribaudo/semver-v6": ^6.3.3
+    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   peerDependencies:
     "@babel/core": ^7.0.0
   languageName: unknown
@@ -645,8 +649,9 @@ __metadata:
     "@babel/core": "workspace:^"
     "@babel/helper-annotate-as-pure": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
+    "@nicolo-ribaudo/semver-v6": ^6.3.3
     regexpu-core: ^5.3.1
-    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   peerDependencies:
     "@babel/core": ^7.0.0
   languageName: unknown
@@ -688,8 +693,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-fixtures@workspace:packages/babel-helper-fixtures"
   dependencies:
+    "@nicolo-ribaudo/semver-v6": ^6.3.3
     "@types/semver": ^7.3.4
-    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   languageName: unknown
   linkType: soft
 
@@ -3186,11 +3192,12 @@ __metadata:
     "@babel/runtime-corejs3": "workspace:^"
     "@babel/template": "workspace:^"
     "@babel/types": "workspace:^"
+    "@nicolo-ribaudo/semver-v6": ^6.3.3
     babel-plugin-polyfill-corejs2: ^0.4.3
     babel-plugin-polyfill-corejs3: ^0.8.1
     babel-plugin-polyfill-regenerator: ^0.5.0
     make-dir: "condition:BABEL_8_BREAKING ? : ^2.1.0"
-    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown
@@ -3630,11 +3637,12 @@ __metadata:
     "@babel/preset-modules": ^0.1.5
     "@babel/traverse": "workspace:^"
     "@babel/types": "workspace:^"
+    "@nicolo-ribaudo/semver-v6": ^6.3.3
     babel-plugin-polyfill-corejs2: ^0.4.3
     babel-plugin-polyfill-corejs3: ^0.8.1
     babel-plugin-polyfill-regenerator: ^0.5.0
     core-js-compat: ^3.31.0
-    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0"
+    semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : "
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown
@@ -4443,6 +4451,24 @@ __metadata:
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals-BABEL_8_BREAKING-false": "npm:@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1"
   checksum: 35c6c2d0fe2e6ff24708b60835fe4f53e8bcdc0dcda98f81ce04849d27e51f6039b213e08d8440d8ee14aa5b8d94654314b1a2ba4d64bb09bd16feb01db74631
+  languageName: node
+  linkType: hard
+
+"@nicolo-ribaudo/semver-v6-BABEL_8_BREAKING-false@npm:@nicolo-ribaudo/semver-v6@^6.3.3, @nicolo-ribaudo/semver-v6@npm:^6.3.3":
+  version: 6.3.3
+  resolution: "@nicolo-ribaudo/semver-v6@npm:6.3.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 8290855b1591477d2298364541fda64fafd4acc110b387067a71c9b05f4105c0a4ac079857ae9cd107c42ee884e8724a406b5116f069575e02d7ab87a35a5272
+  languageName: node
+  linkType: hard
+
+"@nicolo-ribaudo/semver-v6@condition:BABEL_8_BREAKING ? : ^6.3.3":
+  version: 0.0.0-condition-95613c
+  resolution: "@nicolo-ribaudo/semver-v6@condition:BABEL_8_BREAKING?:^6.3.3#95613c"
+  dependencies:
+    "@nicolo-ribaudo/semver-v6-BABEL_8_BREAKING-false": "npm:@nicolo-ribaudo/semver-v6@^6.3.3"
+  checksum: c3d51e01a6abcc86bfc9d5ef99ec12b455bef66f45b27c2b7c9806c25d9e48bca7a7c3394155f224405d5d40b68eaa9780c3f1046aeec1f16478e6133d1f07b0
   languageName: node
   linkType: hard
 
@@ -14062,15 +14088,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"semver-BABEL_8_BREAKING-false@npm:semver@^6.3.0, semver@npm:^6.0.0, semver@npm:^6.1.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "semver@npm:6.3.0"
-  bin:
-    semver: ./bin/semver.js
-  checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
-  languageName: node
-  linkType: hard
-
 "semver-BABEL_8_BREAKING-true@npm:semver@^7.3.4":
   version: 7.3.4
   resolution: "semver@npm:7.3.4"
@@ -14091,13 +14108,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"semver@condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.0":
-  version: 0.0.0-condition-4d8c2f
-  resolution: "semver@condition:BABEL_8_BREAKING?^7.3.4:^6.3.0#4d8c2f"
+"semver@condition:BABEL_8_BREAKING ? ^7.3.4 : ":
+  version: 0.0.0-condition-414f33
+  resolution: "semver@condition:BABEL_8_BREAKING?^7.3.4:#414f33"
   dependencies:
-    semver-BABEL_8_BREAKING-false: "npm:semver@^6.3.0"
     semver-BABEL_8_BREAKING-true: "npm:semver@^7.3.4"
-  checksum: 7d234c05a75393edc945e70d0c67df4b61beb3ffe7eaa3c3ebd9b93627e5ff98afb009e52f82d6de4a1d425287c5f7f3c98631514bf1524d1a1c07cb511fb1b1
+  checksum: 41eeaa7c35f21b3c66a8d9d77ccd1db5d96e907cf3a340ada2e141b767c70ba71ed88c033f9965ff17ff1b77616d1b80dbb6701779734d6eb719eb4f6d3e9793
   languageName: node
   linkType: hard
 
@@ -14107,6 +14123,15 @@ fsevents@^1.2.7:
   bin:
     semver: ./bin/semver
   checksum: 57fd0acfd0bac382ee87cd52cd0aaa5af086a7dc8d60379dfe65fea491fb2489b6016400813930ecd61fd0952dae75c115287a1b16c234b1550887117744dfaf
+  languageName: node
+  linkType: hard
+
+"semver@npm:^6.0.0, semver@npm:^6.1.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "semver@npm:6.3.0"
+  bin:
+    semver: ./bin/semver.js
+  checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15720
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I forked semver to backport https://github.com/npm/node-semver/pull/564 to v6. The fork is at https://github.com/nicolo-ribaudo/semver-v6 (lmk if you need write access at any point).

Our `conditions` system does not support having two different package names for the two options, and we cannot have `if` statements around static imports, so for now v8 also uses the forked package.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15742"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

