### PR TITLE
Test Jest patch for our e2e breaking tests

### DIFF
--- a/scripts/integration-tests/e2e-jest.sh
+++ b/scripts/integration-tests/e2e-jest.sh
@@ -15,7 +15,7 @@ source utils/cleanup.sh
 set -x
 
 # Clone jest
-git clone --depth=1 https://github.com/jestjs/jest /tmp/jest
+git clone --depth=1 -b tweak-test https://github.com/SimenB/jest /tmp/jest
 cd /tmp/jest || exit
 
 # Update @babel/* dependencies


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

For some reason, since https://github.com/babel/babel/pull/15736 our Jest e2e breaking tests are failing with the following error:

```
Summary of all failing tests
 FAIL  packages/jest-circus/src/__tests__/baseTest.test.ts (7.17 s)
  ● simple test

    ENOENT: no such file or directory, unlink '/tmp/cc58abc84d0c01815c8b5a78d1e4bf22'

      at unlinkSync (packages/jest-circus/src/__mocks__/testUtils.ts:83:6)

  ● function descriptors

    ENOENT: no such file or directory, unlink '/tmp/0b3d1b744b3ba18630ef86d427cd7904'

      at unlinkSync (packages/jest-circus/src/__mocks__/testUtils.ts:83:6)

  ● failures

    Command failed with exit code 1: node /tmp/11d28d3fe24bf6f25135cdc204adb12c
    node:internal/modules/cjs/loader:1080
      throw err;
      ^

    Error: Cannot find module '/tmp/11d28d3fe24bf6f25135cdc204adb12c'

      at node:internal/main/run_main_module:23:47 {
        code: 'MODULE_NOT_FOUND',
        requireStack: []
      }
      Node.js v18.16.1
```

https://github.com/jestjs/jest/pull/14296 _should_ make the error go away, but it may (hopefully) uncover the underlying cause.

cc @SimenB

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15744"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

