### PR TITLE
fix: export `meta` from `eslint-parser/experimental-worker`

### DIFF
--- a/eslint/babel-eslint-parser/src/experimental-worker.cjs
+++ b/eslint/babel-eslint-parser/src/experimental-worker.cjs
@@ -13,6 +13,11 @@ const baseParse = require("./parse.cjs");
 const { WorkerClient } = require("./client.cjs");
 const client = new WorkerClient();
 
+exports.meta = {
+  name: "@babel/eslint-parser/experimental-worker",
+  version: PACKAGE_JSON.version,
+};
+
 exports.parseForESLint = function (code, options = {}) {
   const normalizedOptions = normalizeESLintConfig(options);
   const ast = baseParse(code, normalizedOptions, client);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `@babel/eslint-parser/experimental-worker` can not be used with flat ESLint config 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Pending integration tests with FlatESLint
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Currently ESLint will throw

```
ESLint: 8.44.0

Error: Could not serialize parser object (missing 'meta' object).
```
when the experimental worker is used with flat ESLint config. As a follow-up to https://github.com/babel/babel/pull/15465, in this PR we add `meta` info to the experimental worker.

In the future we should add integration tests with the `FlatESLint` class.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15747"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

