### PR TITLE
[babel 8] Reland "Use `NodePath#hub` as part of the paths cache key"

### DIFF
--- a/.github/workflows/e2e-tests-breaking.yml
+++ b/.github/workflows/e2e-tests-breaking.yml
@@ -50,7 +50,9 @@ jobs:
           # https://github.com/facebook/metro/blob/29bb5f2ad3319ba8f4764c3993aa85c15f59af23/packages/metro-source-map/src/generateFunctionMap.js#L182
           # react-native
           - prettier
-          - angular-cli
+          # disabled due to https://github.com/babel/babel/pull/15759, because
+          # angular pins the @babel/core dependency
+          # - angular-cli
     steps:
       - name: Get yarn1 cache directory path
         id: yarn1-cache-dir-path

--- a/packages/babel-core/src/transformation/file/file.ts
+++ b/packages/babel-core/src/transformation/file/file.ts
@@ -69,36 +69,6 @@ export default class File {
     this.ast = ast;
     this.inputMap = inputMap;
 
-    if (!IS_STANDALONE) {
-      if (!USE_ESM) {
-        if (!process.env.BABEL_8_BREAKING) {
-          // @ts-expect-error TS does not know about this property
-          if (traverse.cache.noHubInCacheKeyForBackwardCompat === undefined) {
-            try {
-              // For backward compatibility, `@babel/core` ignores `hub` when
-              // caching NodePath instances. Disable that backward
-              // compatibility hack when using new `@babel/core` versions.
-              // @ts-expect-error TS does not know about this property
-              traverse.cache.noHubInCacheKeyForBackwardCompat = false;
-
-              this.path = NodePath.get({
-                hub: this.hub,
-                parentPath: null,
-                parent: this.ast,
-                container: this.ast,
-                key: "program",
-              }).setContext() as NodePath<t.Program>;
-              this.scope = this.path.scope;
-            } finally {
-              // @ts-expect-error TS does not know about this property
-              traverse.cache.noHubInCacheKeyForBackwardCompat = undefined;
-            }
-            return;
-          }
-        }
-      }
-    }
-
     this.path = NodePath.get({
       hub: this.hub,
       parentPath: null,

--- a/packages/babel-core/src/transformation/file/file.ts
+++ b/packages/babel-core/src/transformation/file/file.ts
@@ -69,6 +69,36 @@ export default class File {
     this.ast = ast;
     this.inputMap = inputMap;
 
+    if (!IS_STANDALONE) {
+      if (!USE_ESM) {
+        if (!process.env.BABEL_8_BREAKING) {
+          // @ts-expect-error TS does not know about this property
+          if (traverse.cache.noHubInCacheKeyForBackwardCompat === undefined) {
+            try {
+              // For backward compatibility, `@babel/core` ignores `hub` when
+              // caching NodePath instances. Disable that backward
+              // compatibility hack when using new `@babel/core` versions.
+              // @ts-expect-error TS does not know about this property
+              traverse.cache.noHubInCacheKeyForBackwardCompat = false;
+
+              this.path = NodePath.get({
+                hub: this.hub,
+                parentPath: null,
+                parent: this.ast,
+                container: this.ast,
+                key: "program",
+              }).setContext() as NodePath<t.Program>;
+              this.scope = this.path.scope;
+            } finally {
+              // @ts-expect-error TS does not know about this property
+              traverse.cache.noHubInCacheKeyForBackwardCompat = undefined;
+            }
+            return;
+          }
+        }
+      }
+    }
+
     this.path = NodePath.get({
       hub: this.hub,
       parentPath: null,

--- a/packages/babel-core/src/transformation/index.ts
+++ b/packages/babel-core/src/transformation/index.ts
@@ -117,7 +117,7 @@ function* transformFile(file: File, pluginPasses: PluginPasses): Handler<void> {
       passes,
       file.opts.wrapPluginVisitorMethod,
     );
-    traverse(file.ast, visitor, file.scope);
+    traverse(file.ast.program, visitor, file.scope, null, file.path, true);
 
     for (const [plugin, pass] of passPairs) {
       const fn = plugin.post;

--- a/packages/babel-core/src/transformation/index.ts
+++ b/packages/babel-core/src/transformation/index.ts
@@ -117,7 +117,11 @@ function* transformFile(file: File, pluginPasses: PluginPasses): Handler<void> {
       passes,
       file.opts.wrapPluginVisitorMethod,
     );
-    traverse(file.ast.program, visitor, file.scope, null, file.path, true);
+    if (process.env.BABEL_8_BREAKING) {
+      traverse(file.ast.program, visitor, file.scope, null, file.path, true);
+    } else {
+      traverse(file.ast, visitor, file.scope);
+    }
 
     for (const [plugin, pass] of passPairs) {
       const fn = plugin.post;

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -28,6 +28,7 @@
     "globals": "condition:BABEL_8_BREAKING ? ^13.5.0 : ^11.1.0"
   },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/helper-plugin-test-runner": "workspace:^"
   },
   "engines": {

--- a/packages/babel-traverse/src/cache.ts
+++ b/packages/babel-traverse/src/cache.ts
@@ -1,8 +1,13 @@
 import type { Node } from "@babel/types";
 import type NodePath from "./path";
 import type Scope from "./scope";
+import type { HubInterface } from "./hub";
 
-export let path: WeakMap<Node, Map<Node, NodePath>> = new WeakMap();
+let pathsCache: WeakMap<
+  HubInterface | typeof nullHub,
+  WeakMap<Node, Map<Node, NodePath>>
+> = new WeakMap();
+export { pathsCache as path };
 export let scope: WeakMap<Node, Scope> = new WeakMap();
 
 export function clear() {
@@ -11,9 +16,29 @@ export function clear() {
 }
 
 export function clearPath() {
-  path = new WeakMap();
+  pathsCache = new WeakMap();
 }
 
 export function clearScope() {
   scope = new WeakMap();
+}
+
+// NodePath#hub can be null, but it's not a valid weakmap key because it
+// cannot be collected by GC. Use an object, knowing tht it will not be
+// collected anyway. It's not a memory leak because pathsCache.get(nullHub)
+// is itself a weakmap, so its entries can still be collected.
+const nullHub = Object.freeze({} as const);
+
+export function getCachedPaths(hub: HubInterface | null, parent: Node) {
+  return pathsCache.get(hub ?? nullHub)?.get(parent);
+}
+
+export function getOrCreateCachedPaths(hub: HubInterface | null, parent: Node) {
+  let parents = pathsCache.get(hub ?? nullHub);
+  if (!parents) pathsCache.set(hub ?? nullHub, (parents = new WeakMap()));
+
+  let paths = parents.get(parent);
+  if (!paths) parents.set(parent, (paths = new Map()));
+
+  return paths;
 }

--- a/packages/babel-traverse/src/cache.ts
+++ b/packages/babel-traverse/src/cache.ts
@@ -3,24 +3,6 @@ import type NodePath from "./path";
 import type Scope from "./scope";
 import type { HubInterface } from "./hub";
 
-if (!IS_STANDALONE) {
-  if (!USE_ESM) {
-    if (!process.env.BABEL_8_BREAKING) {
-      // `@babel/core` up to v7.22.5 relies on the (wrong) behavior
-      // of NodePaths not taking into account .hub for their cache
-      // key. To preserve backwards compatibility, we need to disable
-      // the caching behavior in some cases.
-      // The logic to detect _when_ we are being called by an old
-      // `@babel/core` version is rather ugly, and it's in the
-      // `traverse` function in ./index.ts and in the `static get`
-      // function in ./path/index.ts
-
-      // eslint-disable-next-line no-restricted-globals
-      exports.noHubInCacheKeyForBackwardCompat = undefined;
-    }
-  }
-}
-
 let pathsCache: WeakMap<
   HubInterface | typeof nullHub,
   WeakMap<Node, Map<Node, NodePath>>
@@ -48,25 +30,18 @@ export function clearScope() {
 const nullHub = Object.freeze({} as const);
 
 export function getCachedPaths(hub: HubInterface | null, parent: Node) {
-  if (!IS_STANDALONE) {
-    if (!USE_ESM) {
-      if (!process.env.BABEL_8_BREAKING) {
-        // eslint-disable-next-line no-restricted-globals
-        if (exports.noHubInCacheKeyForBackwardCompat) hub = null;
-      }
-    }
+  if (!process.env.BABEL_8_BREAKING) {
+    // Only use Hub as part of the cache key in Babel 8, because it is a
+    // breaking change (it causes incompatibilities with older `@babel/core`
+    // versions: see https://github.com/babel/babel/pull/15759)
+    hub = null;
   }
   return pathsCache.get(hub ?? nullHub)?.get(parent);
 }
 
 export function getOrCreateCachedPaths(hub: HubInterface | null, parent: Node) {
-  if (!IS_STANDALONE) {
-    if (!USE_ESM) {
-      if (!process.env.BABEL_8_BREAKING) {
-        // eslint-disable-next-line no-restricted-globals
-        if (exports.noHubInCacheKeyForBackwardCompat) hub = null;
-      }
-    }
+  if (!process.env.BABEL_8_BREAKING) {
+    hub = null;
   }
 
   let parents = pathsCache.get(hub ?? nullHub);

--- a/packages/babel-traverse/src/cache.ts
+++ b/packages/babel-traverse/src/cache.ts
@@ -3,6 +3,24 @@ import type NodePath from "./path";
 import type Scope from "./scope";
 import type { HubInterface } from "./hub";
 
+if (!IS_STANDALONE) {
+  if (!USE_ESM) {
+    if (!process.env.BABEL_8_BREAKING) {
+      // `@babel/core` up to v7.22.5 relies on the (wrong) behavior
+      // of NodePaths not taking into account .hub for their cache
+      // key. To preserve backwards compatibility, we need to disable
+      // the caching behavior in some cases.
+      // The logic to detect _when_ we are being called by an old
+      // `@babel/core` version is rather ugly, and it's in the
+      // `traverse` function in ./index.ts and in the `static get`
+      // function in ./path/index.ts
+
+      // eslint-disable-next-line no-restricted-globals
+      exports.noHubInCacheKeyForBackwardCompat = undefined;
+    }
+  }
+}
+
 let pathsCache: WeakMap<
   HubInterface | typeof nullHub,
   WeakMap<Node, Map<Node, NodePath>>
@@ -30,10 +48,27 @@ export function clearScope() {
 const nullHub = Object.freeze({} as const);
 
 export function getCachedPaths(hub: HubInterface | null, parent: Node) {
+  if (!IS_STANDALONE) {
+    if (!USE_ESM) {
+      if (!process.env.BABEL_8_BREAKING) {
+        // eslint-disable-next-line no-restricted-globals
+        if (exports.noHubInCacheKeyForBackwardCompat) hub = null;
+      }
+    }
+  }
   return pathsCache.get(hub ?? nullHub)?.get(parent);
 }
 
 export function getOrCreateCachedPaths(hub: HubInterface | null, parent: Node) {
+  if (!IS_STANDALONE) {
+    if (!USE_ESM) {
+      if (!process.env.BABEL_8_BREAKING) {
+        // eslint-disable-next-line no-restricted-globals
+        if (exports.noHubInCacheKeyForBackwardCompat) hub = null;
+      }
+    }
+  }
+
   let parents = pathsCache.get(hub ?? nullHub);
   if (!parents) pathsCache.set(hub ?? nullHub, (parents = new WeakMap()));
 

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -36,6 +36,7 @@ function traverse<S>(
   scope: Scope | undefined,
   state: S,
   parentPath?: NodePath,
+  visitSelf?: boolean,
 ): void;
 
 function traverse(
@@ -44,6 +45,7 @@ function traverse(
   scope?: Scope,
   state?: any,
   parentPath?: NodePath,
+  visitSelf?: boolean,
 ): void;
 
 function traverse<Options extends TraverseOptions>(
@@ -53,6 +55,7 @@ function traverse<Options extends TraverseOptions>(
   scope?: Scope,
   state?: any,
   parentPath?: NodePath,
+  visitSelf?: boolean,
 ) {
   if (!parent) return;
 
@@ -66,13 +69,25 @@ function traverse<Options extends TraverseOptions>(
     }
   }
 
+  if (!parentPath && visitSelf) {
+    throw new Error("visitSelf can only be used when providing a NodePath.");
+  }
+
   if (!VISITOR_KEYS[parent.type]) {
     return;
   }
 
   visitors.explode(opts as Visitor);
 
-  traverseNode(parent, opts as ExplodedVisitor, scope, state, parentPath);
+  traverseNode(
+    parent,
+    opts as ExplodedVisitor,
+    scope,
+    state,
+    parentPath,
+    /* skipKeys */ null,
+    visitSelf,
+  );
 }
 
 export default traverse;
@@ -100,8 +115,6 @@ traverse.node = function (
 
 traverse.clearNode = function (node: t.Node, opts?: RemovePropertiesOptions) {
   removeProperties(node, opts);
-
-  cache.path.delete(node);
 };
 
 traverse.removeProperties = function (

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -79,49 +79,6 @@ function traverse<Options extends TraverseOptions>(
 
   visitors.explode(opts as Visitor);
 
-  if (!IS_STANDALONE) {
-    if (!USE_ESM) {
-      if (!process.env.BABEL_8_BREAKING) {
-        // noHubInCacheKeyForBackwardCompat has three states (true, false, and
-        // undefined) instead of two so that we can run the magic checks only
-        // at the top-level of the traverse call stack, and not when recursing.
-        // new Error().stack is expensive, and no try/finally is better than
-        // using it in a very hot code path.
-        // See the .noHubInCacheKeyForBackwardCompat definition in ./cache.ts
-        // for why we need this.
-        // @ts-expect-error ts does not know about this property
-        if (cache.noHubInCacheKeyForBackwardCompat === undefined) {
-          const callerIsOldBabelCore =
-            arguments.length === 3 &&
-            !!new Error().stack
-              ?.split("\n", 3)[2]
-              ?.replace(/\\/g, "/")
-              .includes("@babel/core/lib/transformation/index.js");
-
-          // @ts-expect-error ts does not know about this property
-          // eslint-disable-next-line no-import-assign
-          cache.noHubInCacheKeyForBackwardCompat = callerIsOldBabelCore;
-          try {
-            traverseNode(
-              parent,
-              opts as ExplodedVisitor,
-              scope,
-              state,
-              parentPath,
-              /* skipKeys */ null,
-              visitSelf,
-            );
-          } finally {
-            // @ts-expect-error ts does not know about this property
-            // eslint-disable-next-line no-import-assign
-            cache.noHubInCacheKeyForBackwardCompat = undefined;
-          }
-          return;
-        }
-      }
-    }
-  }
-
   traverseNode(
     parent,
     opts as ExplodedVisitor,

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -8,7 +8,7 @@ import type { Visitor } from "../types";
 import Scope from "../scope";
 import { validate } from "@babel/types";
 import * as t from "@babel/types";
-import { getOrCreateCachedPaths } from "../cache";
+import * as cache from "../cache";
 import generator from "@babel/generator";
 
 // NodePath is split across many files.
@@ -92,7 +92,57 @@ class NodePath<T extends t.Node = t.Node> {
       // @ts-expect-error key must present in container
       container[key];
 
-    const paths = getOrCreateCachedPaths(hub, parent);
+    if (!IS_STANDALONE) {
+      if (!USE_ESM) {
+        if (!process.env.BABEL_8_BREAKING) {
+          // noHubInCacheKeyForBackwardCompat has three states (true, false,
+          // and undefined) instead of two so that we can run the magic checks
+          // only at the top-level of the traverse call stack, and not when
+          // recursing. new Error().stack is expensive, and we want to avoid it
+          // as much as possible in this very hot path. New @babel/core
+          // versions already set .noHubInCacheKeyForBackwardCompat to false.
+          // See the .noHubInCacheKeyForBackwardCompat definition in ./cache.ts
+          // for why we need this.
+          // @ts-expect-error ts does not know about this property
+          if (cache.noHubInCacheKeyForBackwardCompat === undefined) {
+            const callerIsOldBabelCore =
+              parentPath === null &&
+              key === "program" &&
+              !!new Error().stack
+                ?.split("\n", 3)[2]
+                ?.replace(/\\/g, "/")
+                .includes("@babel/core/lib/transformation/file/file.js");
+
+            // @ts-expect-error ts does not know about this property
+            // eslint-disable-next-line no-import-assign
+            cache.noHubInCacheKeyForBackwardCompat = callerIsOldBabelCore;
+
+            // Old @babel/core will call NodePath#setContext right after this
+            // NodePath.get call. We need to reset
+            // cache.noHubInCacheKeyForBackwardCompat _after_ that call is
+            // done, because .setContext internally calls .setScope which
+            // trigger a traverasal thus calling NodePath.get again.
+            // @ts-expect-error ts doesn't know about methods introduced
+            // by mixins at the end of the file here, because they are on
+            // the NodePath _interface_ and not class.
+            this.setContext = () => {
+              // @ts-expect-error same as above
+              this.setContext = NodePath_context.setContext;
+              try {
+                // @ts-expect-error same as above
+                return this.setContext();
+              } finally {
+                // @ts-expect-error ts does not know about this property
+                // eslint-disable-next-line no-import-assign
+                cache.noHubInCacheKeyForBackwardCompat = undefined;
+              }
+            };
+          }
+        }
+      }
+    }
+
+    const paths = cache.getOrCreateCachedPaths(hub, parent);
 
     let path = paths.get(targetNode);
     if (!path) {

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -8,7 +8,7 @@ import type { Visitor } from "../types";
 import Scope from "../scope";
 import { validate } from "@babel/types";
 import * as t from "@babel/types";
-import { path as pathCache } from "../cache";
+import { getOrCreateCachedPaths } from "../cache";
 import generator from "@babel/generator";
 
 // NodePath is split across many files.
@@ -92,11 +92,7 @@ class NodePath<T extends t.Node = t.Node> {
       // @ts-expect-error key must present in container
       container[key];
 
-    let paths = pathCache.get(parent);
-    if (!paths) {
-      paths = new Map();
-      pathCache.set(parent, paths);
-    }
+    const paths = getOrCreateCachedPaths(hub, parent);
 
     let path = paths.get(targetNode);
     if (!path) {

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -1,6 +1,6 @@
 // This file contains methods that modify the path/node in some ways.
 
-import { path as pathCache } from "../cache";
+import { getCachedPaths } from "../cache";
 import PathHoister from "./lib/hoister";
 import NodePath from "./index";
 import {
@@ -279,7 +279,7 @@ export function updateSiblingKeys(
 ) {
   if (!this.parent) return;
 
-  const paths = pathCache.get(this.parent);
+  const paths = getCachedPaths(this.hub, this.parent) || ([] as never[]);
 
   for (const [, path] of paths) {
     if (typeof path.key === "number" && path.key >= fromIndex) {

--- a/packages/babel-traverse/src/path/removal.ts
+++ b/packages/babel-traverse/src/path/removal.ts
@@ -1,7 +1,7 @@
 // This file contains methods responsible for removing a node.
 
 import { hooks } from "./lib/removal-hooks";
-import { path as pathCache } from "../cache";
+import { getCachedPaths } from "../cache";
 import type NodePath from "./index";
 import { REMOVED, SHOULD_SKIP } from "./index";
 
@@ -46,7 +46,9 @@ export function _remove(this: NodePath) {
 export function _markRemoved(this: NodePath) {
   // this.shouldSkip = true; this.removed = true;
   this._traverseFlags |= SHOULD_SKIP | REMOVED;
-  if (this.parent) pathCache.get(this.parent).delete(this.node);
+  if (this.parent) {
+    getCachedPaths(this.hub, this.parent).delete(this.node);
+  }
   this.node = null;
 }
 

--- a/packages/babel-traverse/src/path/replacement.ts
+++ b/packages/babel-traverse/src/path/replacement.ts
@@ -3,7 +3,7 @@
 import { codeFrameColumns } from "@babel/code-frame";
 import traverse from "../index";
 import NodePath from "./index";
-import { path as pathCache } from "../cache";
+import { getCachedPaths } from "../cache";
 import { parse } from "@babel/parser";
 import {
   FUNCTION_TYPES,
@@ -47,7 +47,7 @@ export function replaceWithMultiple(
   nodes = this._verifyNodeList(nodes);
   inheritLeadingComments(nodes[0], this.node);
   inheritTrailingComments(nodes[nodes.length - 1], this.node);
-  pathCache.get(this.parent)?.delete(this.node);
+  getCachedPaths(this.hub, this.parent)?.delete(this.node);
   this.node =
     // @ts-expect-error this.key must present in this.container
     this.container[this.key] = null;
@@ -210,7 +210,7 @@ export function _replaceWith(this: NodePath, node: t.Node) {
   }
 
   this.debug(`Replace with ${node?.type}`);
-  pathCache.get(this.parent)?.set(node, this).delete(this.node);
+  getCachedPaths(this.hub, this.parent)?.set(node, this).delete(this.node);
 
   this.node =
     // @ts-expect-error this.key must present in this.container

--- a/packages/babel-traverse/src/traverse-node.ts
+++ b/packages/babel-traverse/src/traverse-node.ts
@@ -24,13 +24,19 @@ export function traverseNode<S = unknown>(
   state?: any,
   path?: NodePath,
   skipKeys?: Record<string, boolean>,
+  visitSelf?: boolean,
 ): boolean {
   const keys = VISITOR_KEYS[node.type];
   if (!keys) return false;
 
   const context = new TraversalContext(scope, opts, state, path);
+  if (visitSelf) {
+    if (skipKeys?.[path.parentKey]) return false;
+    return context.visitQueue([path]);
+  }
+
   for (const key of keys) {
-    if (skipKeys && skipKeys[key]) continue;
+    if (skipKeys?.[key]) continue;
     if (context.visit(node, key)) {
       return true;
     }

--- a/packages/babel-traverse/test/hub.js
+++ b/packages/babel-traverse/test/hub.js
@@ -1,6 +1,8 @@
 import { transformSync } from "@babel/core";
 import { Hub } from "../lib/index.js";
 
+const itBabel8 = process.env.BABEL_8_BREAKING ? it : it.skip;
+
 describe("hub", function () {
   it("default buildError should return TypeError", function () {
     const hub = new Hub();
@@ -8,7 +10,7 @@ describe("hub", function () {
     expect(hub.buildError(null, msg)).toEqual(new TypeError(msg));
   });
 
-  it("should be preserved across nested traversals", function () {
+  itBabel8("should be preserved across nested traversals", function () {
     let origHub;
     let innerHub = {};
     let exprHub;

--- a/packages/babel-traverse/test/hub.js
+++ b/packages/babel-traverse/test/hub.js
@@ -1,10 +1,46 @@
-import assert from "assert";
+import { transformSync } from "@babel/core";
 import { Hub } from "../lib/index.js";
 
 describe("hub", function () {
   it("default buildError should return TypeError", function () {
     const hub = new Hub();
     const msg = "test_msg";
-    assert.deepEqual(hub.buildError(null, msg), new TypeError(msg));
+    expect(hub.buildError(null, msg)).toEqual(new TypeError(msg));
+  });
+
+  it("should be preserved across nested traversals", function () {
+    let origHub;
+    let innerHub = {};
+    let exprHub;
+    function plugin({ types: t, traverse }) {
+      return {
+        visitor: {
+          Identifier(path) {
+            if (path.node.name !== "foo") return;
+            origHub = path.hub;
+
+            const mem = t.memberExpression(
+              t.identifier("property"),
+              t.identifier("access"),
+            );
+            traverse(mem, {
+              noScope: true,
+              Identifier(path) {
+                if (path.node.name === "property") innerHub = path.hub;
+              },
+            });
+            const [p2] = path.insertAfter(mem);
+
+            exprHub = p2.get("expression").hub;
+          },
+        },
+      };
+    }
+
+    transformSync("foo;", { configFile: false, plugins: [plugin] });
+
+    expect(origHub).toBeInstanceOf(Object);
+    expect(exprHub).toBe(origHub);
+    expect(innerHub).toBeUndefined();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3951,6 +3951,7 @@ __metadata:
   resolution: "@babel/traverse@workspace:packages/babel-traverse"
   dependencies:
     "@babel/code-frame": "workspace:^"
+    "@babel/core": "workspace:^"
     "@babel/generator": "workspace:^"
     "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-function-name": "workspace:^"


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6437
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is just a revert of the revert of #15725, it's not fixed yet.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15759"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

