### PR TITLE
[babel 8] Bump eslint-parser/plugin eslint requirements

### DIFF
--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -27,7 +27,7 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "@babel/core": ">=7.11.0",
+    "@babel/core": "^7.11.0",
     "eslint": "^7.5.0 || ^8.0.0"
   },
   "dependencies": {
@@ -46,6 +46,10 @@
       {
         "engines": {
           "node": "^16.20.0 || ^18.16.0 || >=20.0.0"
+        },
+        "peerDependencies": {
+          "@babel/core": ">=7.11.0",
+          "eslint": "^8.9.0"
         }
       },
       {}

--- a/eslint/babel-eslint-plugin/package.json
+++ b/eslint/babel-eslint-plugin/package.json
@@ -33,8 +33,8 @@
   },
   "homepage": "https://babel.dev/",
   "peerDependencies": {
-    "@babel/eslint-parser": ">=7.11.0",
-    "eslint": ">=7.5.0"
+    "@babel/eslint-parser": "^7.11.0",
+    "eslint": "^7.5.0 || ^8.0.0"
   },
   "dependencies": {
     "eslint-rule-composer": "^0.3.0"
@@ -48,6 +48,10 @@
       {
         "engines": {
           "node": "^16.20.0 || ^18.16.0 || >=20.0.0"
+        },
+        "peerDependencies": {
+          "@babel/eslint-parser": "^7.11.0",
+          "eslint": "^8.9.0"
         }
       },
       {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14160,7 +14160,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"semver-BABEL_8_BREAKING-false@npm:semver@^6.3.1, semver@npm:^6.0.0, semver@npm:^6.1.0, semver@npm:^6.3.0, semver@npm:^6.3.1":
+"semver-BABEL_8_BREAKING-false@npm:semver@^6.3.1, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
@@ -14205,6 +14205,15 @@ fsevents@^1.2.7:
   bin:
     semver: ./bin/semver
   checksum: 57fd0acfd0bac382ee87cd52cd0aaa5af086a7dc8d60379dfe65fea491fb2489b6016400813930ecd61fd0952dae75c115287a1b16c234b1550887117744dfaf
+  languageName: node
+  linkType: hard
+
+"semver@npm:^6.0.0, semver@npm:^6.1.0, semver@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "semver@npm:6.3.0"
+  bin:
+    semver: ./bin/semver.js
+  checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14160,7 +14160,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"semver-BABEL_8_BREAKING-false@npm:semver@^6.3.1, semver@npm:^6.3.1":
+"semver-BABEL_8_BREAKING-false@npm:semver@^6.3.1, semver@npm:^6.0.0, semver@npm:^6.1.0, semver@npm:^6.3.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
@@ -14205,15 +14205,6 @@ fsevents@^1.2.7:
   bin:
     semver: ./bin/semver
   checksum: 57fd0acfd0bac382ee87cd52cd0aaa5af086a7dc8d60379dfe65fea491fb2489b6016400813930ecd61fd0952dae75c115287a1b16c234b1550887117744dfaf
-  languageName: node
-  linkType: hard
-
-"semver@npm:^6.0.0, semver@npm:^6.1.0, semver@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "semver@npm:6.3.0"
-  bin:
-    semver: ./bin/semver.js
-  checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -409,7 +409,7 @@ __metadata:
     eslint-visitor-keys: "condition:BABEL_8_BREAKING ? ^3.3.0 : ^2.1.0"
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.1"
   peerDependencies:
-    "@babel/core": ">=7.11.0"
+    "@babel/core": ^7.11.0
     eslint: ^7.5.0 || ^8.0.0
   languageName: unknown
   linkType: soft
@@ -441,8 +441,8 @@ __metadata:
     eslint: ^8.22.0
     eslint-rule-composer: ^0.3.0
   peerDependencies:
-    "@babel/eslint-parser": ">=7.11.0"
-    eslint: ">=7.5.0"
+    "@babel/eslint-parser": ^7.11.0
+    eslint: ^7.5.0 || ^8.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes https://github.com/babel/babel/issues/15563
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes, under `BABEL_8_BREAKING` flag
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we bumped the ESLint requirements of `@babel/eslint-parser` 8 and `@babel/eslint-plugin` 8, because Babel parser 8, when enabled with estree plugin, will not return the Babel style class features AST that an ESLint 7 plugin is expecting.

In this PR we also change the peerDependencies specification from `>=` to the _current_ equivalent `^` notations. It will not break any current users, but will serve as a guard when we need certain updates to support any major versions of `@babel/core` or `eslint`. We can always broaden the support matrix in the future.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15763"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

