### PR TITLE
Simplify helper dependencies

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -111,10 +111,7 @@ gen_enforced_field(WorkspaceCwd, 'conditions', '{ "USE_ESM": [{ "type": "module"
   WorkspaceIdent \= '@babel/compat-data'.
 
 % Enforces that @babel/runtime-corejs2 must depend on core-js 2
-gen_enforced_dependency(WorkspaceCwd, 'core-js', '^2.6.12', DependencyType) :-
+gen_enforced_dependency(WorkspaceCwd, 'core-js', '^2.6.12', 'dependencies') :-
   % Get the workspace name
-  workspace_ident(WorkspaceCwd, WorkspaceIdent),
-  % Only consider 'dependencies'
-  (DependencyType = 'dependencies'),
   % The rule works for @babel/runtime-corejs2 only
-  (WorkspaceIdent = '@babel/runtime-corejs2').
+  workspace_ident(WorkspaceCwd, '@babel/runtime-corejs2').

--- a/constraints.pro
+++ b/constraints.pro
@@ -138,3 +138,8 @@ gen_enforced_dependency(WorkspaceCwd, '@babel/core', null, 'dependencies') :-
   workspace_ident(WorkspaceCwd, WorkspaceIdent),
   % Exclude some packages
   \+ member(WorkspaceIdent, ['@babel/eslint-shared-fixtures', '@babel/eslint-tests', '@babel/helper-transform-fixture-test-runner']).
+
+% Enforces that @babel/core should be in devDependencies if a package peer-depends on @babel/core and it does not list @babel/core in dependencies. Doing so will ensure that they are linked to an ESM @babel/core build in the e2e ESM tests.
+gen_enforced_dependency(WorkspaceCwd, '@babel/core', 'workspace:^', 'devDependencies') :-
+  workspace_has_dependency(WorkspaceCwd, '@babel/core', _, 'peerDependencies'),
+  \+ workspace_has_dependency(WorkspaceCwd, '@babel/core', _, 'dependencies').

--- a/constraints.pro
+++ b/constraints.pro
@@ -115,3 +115,26 @@ gen_enforced_dependency(WorkspaceCwd, 'core-js', '^2.6.12', 'dependencies') :-
   % Get the workspace name
   % The rule works for @babel/runtime-corejs2 only
   workspace_ident(WorkspaceCwd, '@babel/runtime-corejs2').
+
+% Enforces that @babel/helper-* must peer-depend on @babel/core if they depend on @babel/traverse
+gen_enforced_dependency(WorkspaceCwd, '@babel/core', '^7.0.0', 'peerDependencies') :-
+  % Get the workspace name
+  workspace_ident(WorkspaceCwd, WorkspaceIdent),
+  atom_concat('@babel/helper-', _, WorkspaceIdent),
+  workspace_has_dependency(WorkspaceCwd, DependencyIdent, _, 'dependencies'),
+  (DependencyIdent = '@babel/traverse').
+
+% Enforces that @babel/helper-* must not depend on @babel/traverse, @babel/template, @babel/types if they peer-depend on @babel/core
+gen_enforced_dependency(WorkspaceCwd, DependencyIdent, null, 'dependencies') :-
+  % Get the workspace name
+  workspace_ident(WorkspaceCwd, WorkspaceIdent),
+  atom_concat('@babel/helper-', _, WorkspaceIdent),
+  workspace_has_dependency(WorkspaceCwd, '@babel/core', _, 'peerDependencies'),
+  member(DependencyIdent, ['@babel/template', '@babel/traverse', '@babel/types']).
+
+% Enforces that @babel/core must not be in dependency for most packages
+gen_enforced_dependency(WorkspaceCwd, '@babel/core', null, 'dependencies') :-
+  % Get the workspace name
+  workspace_ident(WorkspaceCwd, WorkspaceIdent),
+  % Exclude some packages
+  \+ member(WorkspaceIdent, ['@babel/eslint-shared-fixtures', '@babel/eslint-tests', '@babel/helper-transform-fixture-test-runner']).

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -19,10 +19,13 @@
     "@babel/helper-module-imports": "workspace:^",
     "@babel/helper-simple-access": "workspace:^",
     "@babel/helper-split-export-declaration": "workspace:^",
-    "@babel/helper-validator-identifier": "workspace:^",
-    "@babel/template": "workspace:^",
-    "@babel/traverse": "workspace:^",
-    "@babel/types": "workspace:^"
+    "@babel/helper-validator-identifier": "workspace:^"
+  },
+  "devDependencies": {
+    "@babel/traverse": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -22,6 +22,7 @@
     "@babel/helper-validator-identifier": "workspace:^"
   },
   "devDependencies": {
+    "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/babel-helper-module-transforms/src/dynamic-import.ts
+++ b/packages/babel-helper-module-transforms/src/dynamic-import.ts
@@ -1,8 +1,7 @@
 // Heavily inspired by
 // https://github.com/airbnb/babel-plugin-dynamic-import-node/blob/master/src/utils.js
 
-import * as t from "@babel/types";
-import template from "@babel/template";
+import { types as t, template } from "@babel/core";
 
 if (!process.env.BABEL_8_BREAKING) {
   if (!USE_ESM) {

--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -1,21 +1,5 @@
 import assert from "assert";
-import {
-  booleanLiteral,
-  callExpression,
-  cloneNode,
-  directive,
-  directiveLiteral,
-  expressionStatement,
-  identifier,
-  isIdentifier,
-  memberExpression,
-  stringLiteral,
-  valueToNode,
-  variableDeclaration,
-  variableDeclarator,
-} from "@babel/types";
-import type * as t from "@babel/types";
-import template from "@babel/template";
+import { template, types as t } from "@babel/core";
 
 import { isModule } from "@babel/helper-module-imports";
 
@@ -34,6 +18,22 @@ import type {
   SourceModuleMetadata,
 } from "./normalize-and-load-metadata";
 import type { NodePath } from "@babel/traverse";
+
+const {
+  booleanLiteral,
+  callExpression,
+  cloneNode,
+  directive,
+  directiveLiteral,
+  expressionStatement,
+  identifier,
+  isIdentifier,
+  memberExpression,
+  stringLiteral,
+  valueToNode,
+  variableDeclaration,
+  variableDeclarator,
+} = t;
 
 export { buildDynamicImport } from "./dynamic-import";
 

--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
@@ -1,5 +1,11 @@
 import assert from "assert";
-import {
+import { template, types as t } from "@babel/core";
+import type { NodePath, Visitor, Scope } from "@babel/traverse";
+import simplifyAccess from "@babel/helper-simple-access";
+
+import type { ModuleMetadata } from "./normalize-and-load-metadata";
+
+const {
   assignmentExpression,
   callExpression,
   cloneNode,
@@ -16,13 +22,7 @@ import {
   stringLiteral,
   variableDeclaration,
   variableDeclarator,
-} from "@babel/types";
-import type * as t from "@babel/types";
-import template from "@babel/template";
-import type { NodePath, Visitor, Scope } from "@babel/traverse";
-import simplifyAccess from "@babel/helper-simple-access";
-
-import type { ModuleMetadata } from "./normalize-and-load-metadata";
+} = t;
 
 interface RewriteReferencesVisitorState {
   exported: Map<any, any>;

--- a/packages/babel-helper-module-transforms/src/rewrite-this.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-this.ts
@@ -1,6 +1,6 @@
 import environmentVisitor from "@babel/helper-environment-visitor";
-import traverse from "@babel/traverse";
-import { numericLiteral, unaryExpression } from "@babel/types";
+import { traverse, types as t } from "@babel/core";
+const { numericLiteral, unaryExpression } = t;
 
 import type { NodePath, Visitor } from "@babel/traverse";
 

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "@babel/helper-annotate-as-pure": "workspace:^",
     "@babel/helper-environment-visitor": "workspace:^",
-    "@babel/helper-wrap-function": "workspace:^",
-    "@babel/types": "workspace:^"
+    "@babel/helper-wrap-function": "workspace:^"
   },
   "devDependencies": {
     "@babel/core": "workspace:^",

--- a/packages/babel-helper-remap-async-to-generator/src/index.ts
+++ b/packages/babel-helper-remap-async-to-generator/src/index.ts
@@ -4,15 +4,14 @@ import type { NodePath } from "@babel/traverse";
 import wrapFunction from "@babel/helper-wrap-function";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 import environmentVisitor from "@babel/helper-environment-visitor";
-import { traverse } from "@babel/core";
-import {
+import { traverse, types as t } from "@babel/core";
+const {
   callExpression,
   cloneNode,
   isIdentifier,
   isThisExpression,
   yieldExpression,
-} from "@babel/types";
-import type * as t from "@babel/types";
+} = t;
 
 const awaitVisitor = traverse.visitors.merge<{ wrapAwait: t.Expression }>([
   {

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -16,10 +16,10 @@
   "dependencies": {
     "@babel/helper-environment-visitor": "workspace:^",
     "@babel/helper-member-expression-to-functions": "workspace:^",
-    "@babel/helper-optimise-call-expression": "workspace:^",
-    "@babel/template": "workspace:^",
-    "@babel/traverse": "workspace:^",
-    "@babel/types": "workspace:^"
+    "@babel/helper-optimise-call-expression": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -18,6 +18,9 @@
     "@babel/helper-member-expression-to-functions": "workspace:^",
     "@babel/helper-optimise-call-expression": "workspace:^"
   },
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  },
   "peerDependencies": {
     "@babel/core": "^7.0.0"
   },

--- a/packages/babel-helper-replace-supers/src/index.ts
+++ b/packages/babel-helper-replace-supers/src/index.ts
@@ -3,10 +3,9 @@ import environmentVisitor from "@babel/helper-environment-visitor";
 import memberExpressionToFunctions from "@babel/helper-member-expression-to-functions";
 import type { HandlerState } from "@babel/helper-member-expression-to-functions";
 import optimiseCall from "@babel/helper-optimise-call-expression";
-import template from "@babel/template";
-import traverse from "@babel/traverse";
+import { traverse, template, types as t } from "@babel/core";
 import type { NodePath, Scope } from "@babel/traverse";
-import {
+const {
   assignmentExpression,
   booleanLiteral,
   callExpression,
@@ -16,8 +15,7 @@ import {
   sequenceExpression,
   stringLiteral,
   thisExpression,
-} from "@babel/types";
-import type * as t from "@babel/types";
+} = t;
 
 if (!process.env.BABEL_8_BREAKING) {
   if (!USE_ESM) {

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -16,11 +16,13 @@
   "dependencies": {
     "@babel/helper-function-name": "workspace:^",
     "@babel/template": "workspace:^",
-    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"
+  },
+  "devDependencies": {
+    "@babel/traverse": "workspace:^"
   },
   "author": "The Babel Team (https://babel.dev/team)",
   "conditions": {

--- a/packages/babel-plugin-syntax-decimal/package.json
+++ b/packages/babel-plugin-syntax-decimal/package.json
@@ -45,5 +45,8 @@
       },
       {}
     ]
+  },
+  "devDependencies": {
+    "@babel/core": "workspace:^"
   }
 }

--- a/packages/babel-plugin-syntax-destructuring-private/package.json
+++ b/packages/babel-plugin-syntax-destructuring-private/package.json
@@ -48,5 +48,8 @@
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  }
 }

--- a/packages/babel-plugin-syntax-module-blocks/package.json
+++ b/packages/babel-plugin-syntax-module-blocks/package.json
@@ -45,5 +45,8 @@
       },
       {}
     ]
+  },
+  "devDependencies": {
+    "@babel/core": "workspace:^"
   }
 }

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -37,8 +37,6 @@
     "@babel/preset-env": "workspace:^",
     "@babel/runtime": "workspace:^",
     "@babel/runtime-corejs3": "workspace:^",
-    "@babel/template": "workspace:^",
-    "@babel/types": "workspace:^",
     "make-dir": "condition:BABEL_8_BREAKING ? : ^2.1.0"
   },
   "homepage": "https://babel.dev/docs/en/next/babel-plugin-transform-runtime",

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -2,9 +2,7 @@ import path from "path";
 import fs from "fs";
 import { createRequire } from "module";
 import * as helpers from "@babel/helpers";
-import { transformFromAstSync, File } from "@babel/core";
-import template from "@babel/template";
-import * as t from "@babel/types";
+import { transformFromAstSync, File, template, types as t } from "@babel/core";
 import { fileURLToPath } from "url";
 
 import transformRuntime from "../lib/index.js";

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,6 +797,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-module-transforms@workspace:packages/babel-helper-module-transforms"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-module-imports": "workspace:^"
     "@babel/helper-simple-access": "workspace:^"
@@ -894,6 +895,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-replace-supers@workspace:packages/babel-helper-replace-supers"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-member-expression-to-functions": "workspace:^"
     "@babel/helper-optimise-call-expression": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1541,6 +1541,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/plugin-syntax-decimal@workspace:packages/babel-plugin-syntax-decimal"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -1562,6 +1563,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/plugin-syntax-destructuring-private@workspace:packages/babel-plugin-syntax-destructuring-private"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -1770,6 +1772,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/plugin-syntax-module-blocks@workspace:packages/babel-plugin-syntax-module-blocks"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3192,8 +3192,6 @@ __metadata:
     "@babel/preset-env": "workspace:^"
     "@babel/runtime": "workspace:^"
     "@babel/runtime-corejs3": "workspace:^"
-    "@babel/template": "workspace:^"
-    "@babel/types": "workspace:^"
     babel-plugin-polyfill-corejs2: ^0.4.4
     babel-plugin-polyfill-corejs3: ^0.8.2
     babel-plugin-polyfill-regenerator: ^0.5.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -802,9 +802,9 @@ __metadata:
     "@babel/helper-simple-access": "workspace:^"
     "@babel/helper-split-export-declaration": "workspace:^"
     "@babel/helper-validator-identifier": "workspace:^"
-    "@babel/template": "workspace:^"
     "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -871,7 +871,6 @@ __metadata:
     "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-wrap-function": "workspace:^"
     "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0
   languageName: unknown
@@ -898,9 +897,8 @@ __metadata:
     "@babel/helper-environment-visitor": "workspace:^"
     "@babel/helper-member-expression-to-functions": "workspace:^"
     "@babel/helper-optimise-call-expression": "workspace:^"
-    "@babel/template": "workspace:^"
-    "@babel/traverse": "workspace:^"
-    "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15765
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we simplify the helper dependencies by replacing imports from `@babel/types`, `@babel/template` and `@babel/traverse` to a peer dependent `@babel/core`. It probably also fixes #15765 but we will need confirmation once the proposed changes are published.

Possible story on #15765:

Given node_modules layouts as followed. Here dotted link means the start point has declared dependency on the end point, and solid link means the start point has a folder named the end point.

```mermaid
graph TD;
    A[node_modules]-->B["@babel/traverse@7.16"];
    A-->C["@babel/types@7.16"];
    A-->F["@babel/core@7.16"];
    F -.-> C
    F -.-> B
    A-->ECH["ember-composable-helpers@5"]
    ECH-.->D
    ECH-.-> F
    A-->D["ember-cli-babel@7"];
    D-.-> F
    D-.-> I
    D-->E[node_modules];
    E-->G["@babel/traverse@7.22.8"];
    E-->H["@babel/types@7.22"];
    E-->I["@babel/preset-env@7.22"]
    I -.-> BTC
    E-->BTC["@babel/plugin-transform-classes@7.22"]
    BTC-.->BRS
    E-->BRS["@babel/helper-replace-supers@7.22"]
    BRS-.-> G
    G -.-> H
```

The `helper-replace-supers` calls `traverse.visitors.merge` from `@babel/traverse` to merge the environment visitor with a visitor hooking on the `Scopeable` alias .

https://github.com/babel/babel/blob/30ff3acde21371850a8fd52f885a88e0a5567516/packages/babel-helper-replace-supers/src/index.ts#L80-L93

After #15702 is merged in `@babel/traverse@7.22.8`, `visitors.merge` will explode the alias into node types. Here `Scopeable` is expanded to `ClassAccessorProperty` and other AST nodes according to the latest `@babel/types` definition. At this time the visitor is not executed.

Now when the visitor is eventually invoked by `ember-cli-babel`, the root `@babel/traverse` is backed by an older version of `@babel/types`, which does not recognize `ClassAccessorProperty` and therefore an error is thrown.

So in this PR we replace all traverse usage with peer dependencies of `@babel/core`. It should at least alleviate the situation of duplicated libraries.

For end users, the best solution is still to deduplicate `@babel/types` instances in node_modules: It is more memory efficient and less prone to compatibility issues like this.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15771"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>