### PR TITLE
Redundant  valueToNode property with NaN and Infinity values

### DIFF
--- a/packages/babel-types/src/converters/valueToNode.ts
+++ b/packages/babel-types/src/converters/valueToNode.ts
@@ -82,16 +82,13 @@ function valueToNode(value: unknown): t.Expression {
     if (Number.isFinite(value)) {
       result = numericLiteral(Math.abs(value));
     } else {
-      let numerator;
       if (Number.isNaN(value)) {
         // NaN
-        numerator = numericLiteral(0);
+        result = identifier("NaN");
       } else {
         // Infinity / -Infinity
-        numerator = numericLiteral(1);
+        result = identifier("Infinity");
       }
-
-      result = binaryExpression("/", numerator, numericLiteral(0));
     }
 
     if (value < 0 || Object.is(value, -0)) {

--- a/packages/babel-types/src/converters/valueToNode.ts
+++ b/packages/babel-types/src/converters/valueToNode.ts
@@ -10,7 +10,6 @@ import {
   objectProperty,
   objectExpression,
   unaryExpression,
-  binaryExpression,
 } from "../builders/generated";
 import type * as t from "..";
 

--- a/packages/babel-types/test/converters.js
+++ b/packages/babel-types/test/converters.js
@@ -32,21 +32,12 @@ describe("converters", function () {
       expect(t.valueToNode(-0)).toEqual(
         t.unaryExpression("-", t.numericLiteral(0)),
       );
-      expect(t.valueToNode(NaN)).toEqual(
-        t.binaryExpression("/", t.numericLiteral(0), t.numericLiteral(0)),
-      );
-      expect(t.valueToNode(-NaN)).toEqual(
-        t.binaryExpression("/", t.numericLiteral(0), t.numericLiteral(0)),
-      );
+      expect(t.valueToNode(NaN)).toEqual(t.identifier("NaN"));
+      expect(t.valueToNode(-NaN)).toEqual(t.identifier("NaN"));
 
-      expect(t.valueToNode(Infinity)).toEqual(
-        t.binaryExpression("/", t.numericLiteral(1), t.numericLiteral(0)),
-      );
+      expect(t.valueToNode(Infinity)).toEqual(t.identifier("Infinity"));
       expect(t.valueToNode(-Infinity)).toEqual(
-        t.unaryExpression(
-          "-",
-          t.binaryExpression("/", t.numericLiteral(1), t.numericLiteral(0)),
-        ),
+        t.unaryExpression("-", t.identifier("Infinity")),
       );
     });
     it("string", function () {


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

I'm working on automating javascript deobfuscation via ast, specifically in evaluating costant binary expressions.
I'd like to replace constant binary expressions with the results of  the binary expressions with the right node type.
I found `path.evaluate()` property which, if values are constant, return the result of the expression.
Problems comes when I pass the value calculated with `path.evaluate()` in `valueToNode` property.
For example with the following code:
```js
// types is updated version on my local computer
const types = require("../babel/packages/babel-types/lib");
const oldTypes = require("@babel/types");

types.valueToNode(0/0); // { type: 'Identifier', name: 'NaN' }
oldTypes.valueToNode(0/0); // { type: 'BinaryExpression', operator: '/', left: { type: 'NumericLiteral', value: 0 }, right: { type: 'NumericLiteral', value: 0 } }

types.valueToNode(1/0); // { type: 'Identifier', name: 'Infinity' }
oldTypes.valueToNode(1/0); // { type: 'BinaryExpression', operator: '/', left: { type: 'NumericLiteral', value: 1 }, right: { type: 'NumericLiteral', value: 0 } }
```
Another example is:
```js
// types is updated version on my local computer
const types = require("../babel/packages/babel-types/lib");
const oldTypes = require("@babel/types");

types.valueToNode(NaN); // { type: 'Identifier', name: 'NaN' }
oldTypes.valueToNode(NaN); // { type: 'BinaryExpression', operator: '/', left: { type: 'NumericLiteral', value: 0 }, right: { type: 'NumericLiteral', value: 0 } }

types.valueToNode(Infinity); // { type: 'Identifier', name: 'Infinity' }
oldTypes.valueToNode(Infinity); // { type: 'BinaryExpression', operator: '/', left: { type: 'NumericLiteral', value: 1 }, right: { type: 'NumericLiteral', value: 0 } }
```
These two types of binary expressions don't produce an exact result, but a binary expression.
For my purpose these types should generate a literal node.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15779"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

