### PR TITLE
Enable `@typescript-eslint/no-redundant-type-constituents` rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -140,7 +140,6 @@ module.exports = [
           "@typescript-eslint/no-explicit-any": "off",
           "@typescript-eslint/no-misused-promises": "off",
           "@typescript-eslint/no-namespace": "off",
-          "@typescript-eslint/no-redundant-type-constituents": "off",
           "@typescript-eslint/no-this-alias": "off",
           "@typescript-eslint/no-unsafe-assignment": "off",
           "@typescript-eslint/no-unsafe-call": "off",

--- a/packages/babel-cli/src/babel-external-helpers.ts
+++ b/packages/babel-cli/src/babel-external-helpers.ts
@@ -1,10 +1,7 @@
 import commander from "commander";
 import { buildExternalHelpers } from "@babel/core";
 
-function collect(
-  value: string | any,
-  previousValue: Array<string>,
-): Array<string> {
+function collect(value: unknown, previousValue: Array<string>): Array<string> {
   // If the user passed the option with no value, like "babel-external-helpers --whitelist", do nothing.
   if (typeof value !== "string") return previousValue;
 

--- a/packages/babel-cli/src/babel/file.ts
+++ b/packages/babel-cli/src/babel/file.ts
@@ -9,6 +9,7 @@ import type { CmdOptions } from "./options";
 import * as watcher from "./watcher";
 
 import type {
+  EncodedSourceMap,
   SectionedSourceMap,
   SourceMapInput,
   TraceMap,
@@ -40,7 +41,7 @@ export default async function ({
 
       mapSections.push({
         offset: { line: offset, column: 0 },
-        map: result.map || {
+        map: (result.map as EncodedSourceMap) || {
           version: 3,
           names: [],
           sources: [],

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -359,7 +359,9 @@ export default function parseArgv(args: Array<string>): CmdOptions | null {
   };
 }
 
-function booleanify(val: any): boolean | any {
+function booleanify(val: "false" | 0 | ""): false;
+function booleanify(val: "true" | 1): true;
+function booleanify(val: any): any {
   if (val === undefined) return undefined;
 
   if (val === "true" || val == 1) {
@@ -373,10 +375,7 @@ function booleanify(val: any): boolean | any {
   return val;
 }
 
-function collect(
-  value: string | any,
-  previousValue: Array<string>,
-): Array<string> {
+function collect(value: unknown, previousValue: Array<string>): Array<string> {
   // If the user passed the option with no value, like "babel file.js --presets", do nothing.
   if (typeof value !== "string") return previousValue;
 

--- a/packages/babel-core/src/config/config-chain.ts
+++ b/packages/babel-core/src/config/config-chain.ts
@@ -18,6 +18,7 @@ import type { ReadonlyDeepArray } from "./helpers/deep-array";
 
 import { endHiddenCallStack } from "../errors/rewrite-stack-trace";
 import ConfigError from "../errors/config-error";
+import type { PluginAPI, PresetAPI } from "./helpers/config-api";
 
 const debug = buildDebug("babel:config:config-chain");
 
@@ -42,8 +43,8 @@ import type {
 } from "./config-descriptors";
 
 export type ConfigChain = {
-  plugins: Array<UnloadedDescriptor>;
-  presets: Array<UnloadedDescriptor>;
+  plugins: Array<UnloadedDescriptor<PluginAPI>>;
+  presets: Array<UnloadedDescriptor<PresetAPI>>;
   options: Array<ValidatedOptions>;
   files: Set<string>;
 };
@@ -760,12 +761,12 @@ function normalizeOptions(opts: ValidatedOptions): ValidatedOptions {
   return options;
 }
 
-function dedupDescriptors(
-  items: Array<UnloadedDescriptor>,
-): Array<UnloadedDescriptor> {
+function dedupDescriptors<API>(
+  items: Array<UnloadedDescriptor<API>>,
+): Array<UnloadedDescriptor<API>> {
   const map: Map<
     Function,
-    Map<string | void, { value: UnloadedDescriptor }>
+    Map<string | void, { value: UnloadedDescriptor<API> }>
   > = new Map();
 
   const descriptors = [];

--- a/packages/babel-core/src/config/index.ts
+++ b/packages/babel-core/src/config/index.ts
@@ -73,7 +73,7 @@ export const createConfigItemAsync = createConfigItemRunner.async;
 export function createConfigItem(
   target: PluginTarget,
   options: Parameters<typeof createConfigItemImpl>[1],
-  callback?: (err: Error, val: ConfigItem | null) => void,
+  callback?: (err: Error, val: ConfigItem<PluginAPI> | null) => void,
 ) {
   if (callback !== undefined) {
     createConfigItemRunner.errback(target, options, callback);

--- a/packages/babel-core/src/config/printer.ts
+++ b/packages/babel-core/src/config/printer.ts
@@ -68,10 +68,10 @@ const Formatter = {
   },
 };
 
-function descriptorToConfig(
-  d: UnloadedDescriptor,
-): string | {} | Array<unknown> {
-  let name = d.file?.request;
+function descriptorToConfig<API>(
+  d: UnloadedDescriptor<API>,
+): object | string | [string, unknown] | [string, unknown, string] {
+  let name: object | string = d.file?.request;
   if (name == null) {
     if (typeof d.value === "object") {
       name = d.value;

--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -28,6 +28,7 @@ import {
 } from "./option-assertions";
 import type { ValidatorSet, Validator, OptionPath } from "./option-assertions";
 import type { UnloadedDescriptor } from "../config-descriptors";
+import type { PluginAPI } from "../helpers/config-api";
 import type { ParserOptions } from "@babel/parser";
 import type { GeneratorOptions } from "@babel/generator";
 import ConfigError from "../../errors/config-error";
@@ -213,7 +214,7 @@ export type IgnoreList = ReadonlyArray<IgnoreItem>;
 export type PluginOptions = object | void | false;
 export type PluginTarget = string | object | Function;
 export type PluginItem =
-  | ConfigItem
+  | ConfigItem<PluginAPI>
   | Plugin
   | PluginTarget
   | [PluginTarget, PluginOptions]
@@ -460,8 +461,8 @@ function assertOverridesList(
   return arr as OverridesList;
 }
 
-export function checkNoUnwrappedItemOptionPairs(
-  items: Array<UnloadedDescriptor>,
+export function checkNoUnwrappedItemOptionPairs<API>(
+  items: Array<UnloadedDescriptor<API>>,
   index: number,
   type: "plugin" | "preset",
   e: Error,

--- a/packages/babel-core/src/config/validation/plugins.ts
+++ b/packages/babel-core/src/config/validation/plugins.ts
@@ -14,7 +14,7 @@ import type {
 import type { ParserOptions } from "@babel/parser";
 import type { Visitor } from "@babel/traverse";
 import type { ValidatedOptions } from "./options";
-import type { File, PluginPass } from "../../index";
+import type { File, PluginAPI, PluginPass } from "../../index";
 
 // Note: The casts here are just meant to be static assertions to make sure
 // that the assertion functions actually assert that the value's type matches
@@ -87,7 +87,11 @@ export type PluginObject<S extends PluginPass = PluginPass> = {
   ) => void;
   pre?: (this: S, file: File) => void;
   post?: (this: S, file: File) => void;
-  inherits?: Function;
+  inherits?: (
+    api: PluginAPI,
+    options: unknown,
+    dirname: string,
+  ) => PluginObject;
   visitor?: Visitor<S>;
   parserOverride?: Function;
   generatorOverride?: Function;

--- a/packages/babel-core/src/transformation/file/generate.ts
+++ b/packages/babel-core/src/transformation/file/generate.ts
@@ -1,6 +1,6 @@
 import type { PluginPasses } from "../../config";
 import convertSourceMap from "convert-source-map";
-type SourceMap = any;
+import type { GeneratorResult } from "@babel/generator";
 import generate from "@babel/generator";
 
 import type File from "./file";
@@ -11,7 +11,7 @@ export default function generateCode(
   file: File,
 ): {
   outputCode: string;
-  outputMap: SourceMap | null;
+  outputMap: GeneratorResult["map"] | null;
 } {
   const { opts, ast, code, inputMap } = file;
   const { generatorOpts } = opts;

--- a/packages/babel-core/src/transformation/index.ts
+++ b/packages/babel-core/src/transformation/index.ts
@@ -1,6 +1,7 @@
 import traverse from "@babel/traverse";
 import type * as t from "@babel/types";
-type SourceMap = any;
+import type { GeneratorResult } from "@babel/generator";
+
 import type { Handler } from "gensync";
 
 import type { ResolvedConfig, Plugin, PluginPasses } from "../config";
@@ -25,7 +26,7 @@ export type FileResult = {
   options: { [key: string]: any };
   ast: t.File | null;
   code: string | null;
-  map: SourceMap | null;
+  map: GeneratorResult["map"] | null;
   sourceType: "script" | "module";
   externalDependencies: Set<string>;
 };

--- a/packages/babel-core/src/transformation/plugin-pass.ts
+++ b/packages/babel-core/src/transformation/plugin-pass.ts
@@ -3,16 +3,16 @@ import type { NodeLocation } from "./file/file";
 
 export default class PluginPass<Options = {}> {
   _map: Map<unknown, unknown> = new Map();
-  declare key: string | undefined | null;
-  declare file: File;
-  declare opts: Partial<Options>;
+  key: string | undefined | null;
+  file: File;
+  opts: Partial<Options>;
 
   // The working directory that Babel's programmatic options are loaded
   // relative to.
-  declare cwd: string;
+  cwd: string;
 
   // The absolute path of the file being compiled.
-  declare filename: string | void;
+  filename: string | void;
 
   constructor(file: File, key?: string | null, options?: Options) {
     this.key = key;

--- a/packages/babel-core/src/transformation/plugin-pass.ts
+++ b/packages/babel-core/src/transformation/plugin-pass.ts
@@ -1,20 +1,20 @@
 import type File from "./file/file";
 import type { NodeLocation } from "./file/file";
 
-export default class PluginPass {
+export default class PluginPass<Options = {}> {
   _map: Map<unknown, unknown> = new Map();
-  key: string | undefined | null;
-  file: File;
-  opts: any;
+  declare key: string | undefined | null;
+  declare file: File;
+  declare opts: Partial<Options>;
 
   // The working directory that Babel's programmatic options are loaded
   // relative to.
-  cwd: string;
+  declare cwd: string;
 
   // The absolute path of the file being compiled.
-  filename: string | void;
+  declare filename: string | void;
 
-  constructor(file: File, key?: string | null, options?: any | null) {
+  constructor(file: File, key?: string | null, options?: Options) {
     this.key = key;
     this.file = file;
     this.opts = options || {};

--- a/packages/babel-generator/src/index.ts
+++ b/packages/babel-generator/src/index.ts
@@ -7,7 +7,11 @@ import type {
   RecordAndTuplePluginOptions,
   PipelineOperatorPluginOptions,
 } from "@babel/parser";
-import type { DecodedSourceMap, Mapping } from "@jridgewell/gen-mapping";
+import type {
+  EncodedSourceMap,
+  DecodedSourceMap,
+  Mapping,
+} from "@jridgewell/gen-mapping";
 
 /**
  * Babel's code generator, turns an ast into code, maintaining sourcemaps,
@@ -237,15 +241,7 @@ export interface GeneratorOptions {
 
 export interface GeneratorResult {
   code: string;
-  map: {
-    version: number;
-    sources: readonly string[];
-    names: readonly string[];
-    sourceRoot?: string;
-    sourcesContent?: readonly string[];
-    mappings: string;
-    file?: string;
-  } | null;
+  map: EncodedSourceMap | null;
   decodedMap: DecodedSourceMap | undefined;
   rawMappings: Mapping[] | undefined;
 }

--- a/packages/babel-helper-builder-react-jsx/src/index.ts
+++ b/packages/babel-helper-builder-react-jsx/src/index.ts
@@ -43,10 +43,12 @@ export interface Options {
   compat?: boolean;
   pure?: string;
   throwIfNamespace?: boolean;
+  useSpread?: boolean;
+  useBuiltIns?: boolean;
 }
 
 export default function (opts: Options) {
-  const visitor: Visitor<PluginPass> = {};
+  const visitor: Visitor<PluginPass<Options>> = {};
 
   visitor.JSXNamespacedName = function (path) {
     if (opts.throwIfNamespace) {
@@ -242,7 +244,7 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
 
   function buildOpeningElementAttributes(
     attribs: (t.JSXAttribute | t.JSXSpreadAttribute)[],
-    pass: PluginPass,
+    pass: PluginPass<Options>,
   ): t.Expression {
     let _props: (t.ObjectProperty | t.SpreadElement)[] = [];
     const objs: t.Expression[] = [];

--- a/packages/babel-preset-env/src/polyfills/regenerator.ts
+++ b/packages/babel-preset-env/src/polyfills/regenerator.ts
@@ -1,6 +1,7 @@
 import { getImportSource, getRequireSource } from "./utils";
 import type { Visitor } from "@babel/traverse";
 import type { PluginObject, PluginPass } from "@babel/core";
+import type { Options } from "../types";
 
 function isRegeneratorSource(source: string) {
   return (
@@ -13,7 +14,7 @@ type State = {
   regeneratorImportExcluded: boolean;
 };
 
-export default function (): PluginObject<State & PluginPass> {
+export default function (): PluginObject<State & PluginPass<Options>> {
   const visitor: Visitor<State & PluginPass> = {
     ImportDeclaration(path) {
       if (isRegeneratorSource(getImportSource(path))) {

--- a/packages/babel-standalone/src/index.ts
+++ b/packages/babel-standalone/src/index.ts
@@ -15,6 +15,8 @@ import {
   transformFromAstSync as babelTransformFromAstSync,
   transformSync as babelTransformSync,
   buildExternalHelpers as babelBuildExternalHelpers,
+  type PluginObject,
+  type PresetObject,
 } from "@babel/core";
 import { all } from "./generated/plugins";
 import preset2015 from "./preset-es2015";
@@ -168,7 +170,7 @@ export const buildExternalHelpers = babelBuildExternalHelpers;
 /**
  * Registers a named plugin for use with Babel.
  */
-export function registerPlugin(name: string, plugin: any | Function): void {
+export function registerPlugin(name: string, plugin: () => PluginObject): void {
   if (Object.prototype.hasOwnProperty.call(availablePlugins, name)) {
     console.warn(
       `A plugin named "${name}" is already registered, it will be overridden`,
@@ -181,7 +183,7 @@ export function registerPlugin(name: string, plugin: any | Function): void {
  * is the name of the plugin, and the value is the plugin itself.
  */
 export function registerPlugins(newPlugins: {
-  [x: string]: any | Function;
+  [x: string]: () => PluginObject;
 }): void {
   Object.keys(newPlugins).forEach(name =>
     registerPlugin(name, newPlugins[name]),
@@ -191,7 +193,7 @@ export function registerPlugins(newPlugins: {
 /**
  * Registers a named preset for use with Babel.
  */
-export function registerPreset(name: string, preset: any | Function): void {
+export function registerPreset(name: string, preset: () => PresetObject): void {
   if (Object.prototype.hasOwnProperty.call(availablePresets, name)) {
     if (name === "env") {
       console.warn(
@@ -212,7 +214,7 @@ export function registerPreset(name: string, preset: any | Function): void {
  * is the name of the preset, and the value is the preset itself.
  */
 export function registerPresets(newPresets: {
-  [x: string]: any | Function;
+  [x: string]: () => PresetObject;
 }): void {
   Object.keys(newPresets).forEach(name =>
     registerPreset(name, newPresets[name]),


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
<s>This PR is based on #15793, which also fixes some errors reported by the `no-redundant-type-constituents` rule. Please review that PR first.</s>

Summary of changes:
* Introduce an `API` type parameter to the `UnloadedDescriptor`. It also makes it easier to track preset descriptor vs. plugin descriptor, which ensures that we are not passing incorrect API set to the descriptor.
* Actually types the output source map, previously it is stubbed as `any`.
* Fixes other errors 

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15794"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

