### PR TITLE
[ts] Fix compiling extended exported nested namespace

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/namespace.ts
+++ b/packages/babel-plugin-transform-typescript/src/namespace.ts
@@ -23,16 +23,7 @@ export default function transpileNamespace(
 
   const name = path.node.id.name;
   const value = handleNested(path, t.cloneNode(path.node, true));
-  const bound = path.scope.hasOwnBinding(name);
-  if (path.parent.type === "ExportNamedDeclaration") {
-    if (!bound) {
-      path.parentPath.insertAfter(value);
-      path.replaceWith(getDeclaration(name));
-      path.scope.registerDeclaration(path.parentPath);
-    } else {
-      path.parentPath.replaceWith(value);
-    }
-  } else if (bound) {
+  if (path.scope.hasOwnBinding(name)) {
     path.replaceWith(value);
   } else {
     path.scope.registerDeclaration(

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-shorthand-export/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-shorthand-export/input.ts
@@ -1,0 +1,6 @@
+export namespace ui.a {
+  export const x = 1;
+}
+export namespace ui.b {
+  export const y = 2;
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-shorthand-export/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-shorthand-export/output.mjs
@@ -1,0 +1,13 @@
+export let ui;
+(function (_ui2) {
+  let a;
+  (function (_a) {
+    const x = _a.x = 1;
+  })(a || (a = _ui2.a || (_ui2.a = {})));
+})(ui || (ui = {}));
+(function (_ui) {
+  let b;
+  (function (_b) {
+    const y = _b.y = 2;
+  })(b || (b = _ui.b || (_ui.b = {})));
+})(ui || (ui = {}));


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15796
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`path.parentPath.replaceWith` always causes bugs, because the traversal continues in a detached tree.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15798"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

