### PR TITLE
[babel 8] Numeric literals must be finite and non-negative

### DIFF
--- a/packages/babel-plugin-transform-typescript/test/fixtures/regression/15768/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/regression/15768/input.ts
@@ -1,11 +1,21 @@
 const v = 42;
 const v2 = Infinity;
-var Infinity = 1; // Known inconsistencies
-enum StateEnum {
-	okay = 0,
-	neg = -Infinity,
-	pos = Infinity,
-	nan = NaN,
-	ext = v,
-  ext2 = v2,
+const v3 = NaN;
+
+{
+	let Infinity = 1;
+	let NaN = 2;
+
+	enum StateEnum {
+		okay = 0,
+		neg = -Infinity,
+		pos = Infinity,
+		nan = NaN,
+		negReal = -1 / 0,
+		posReal = 1 / 0,
+		nanReal = 0 / 0,
+		ext = v,
+		ext2 = v2,
+		ext3 = v3,
+	}
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/regression/15768/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/regression/15768/output.js
@@ -1,12 +1,20 @@
 const v = 42;
 const v2 = Infinity;
-var Infinity = 1; // Known inconsistencies
-var StateEnum = /*#__PURE__*/function (StateEnum) {
-  StateEnum[StateEnum["okay"] = 0] = "okay";
-  StateEnum[StateEnum["neg"] = -Infinity] = "neg";
-  StateEnum[StateEnum["pos"] = Infinity] = "pos";
-  StateEnum[StateEnum["nan"] = NaN] = "nan";
-  StateEnum[StateEnum["ext"] = 42] = "ext";
-  StateEnum[StateEnum["ext2"] = 1] = "ext2";
-  return StateEnum;
-}(StateEnum || {});
+const v3 = NaN;
+{
+  let Infinity = 1;
+  let NaN = 2;
+  let StateEnum = /*#__PURE__*/function (StateEnum) {
+    StateEnum[StateEnum["okay"] = 0] = "okay";
+    StateEnum[StateEnum["neg"] = -Infinity] = "neg";
+    StateEnum[StateEnum["pos"] = Infinity] = "pos";
+    StateEnum[StateEnum["nan"] = NaN] = "nan";
+    StateEnum[StateEnum["negReal"] = -Infinity] = "negReal";
+    StateEnum[StateEnum["posReal"] = Infinity] = "posReal";
+    StateEnum[StateEnum["nanReal"] = NaN] = "nanReal";
+    StateEnum[StateEnum["ext"] = 42] = "ext";
+    StateEnum[StateEnum["ext2"] = Infinity] = "ext2";
+    StateEnum[StateEnum["ext3"] = NaN] = "ext3";
+    return StateEnum;
+  }({});
+}

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -611,7 +611,30 @@ defineType("NumericLiteral", {
   deprecatedAlias: "NumberLiteral",
   fields: {
     value: {
-      validate: assertValueType("number"),
+      validate: chain(
+        assertValueType("number"),
+        Object.assign(
+          function (node, key, val) {
+            if (1 / val < 0 || !Number.isFinite(val)) {
+              const error = new Error(
+                "NumericLiterals must be non-negative finite numbers. " +
+                  `You can use t.valueToNode(${val}) instead.`,
+              );
+              if (process.env.BABEL_8_BREAKING) {
+                // TODO(@nicolo-ribaudo) Fix regenerator to not pass negative
+                // numbers here.
+                if (!new Error().stack.includes("regenerator")) {
+                  throw error;
+                }
+              } else {
+                // TODO: Enable this warning once regenerator is fixed.
+                // console.warn(error);
+              }
+            }
+          } satisfies Validator,
+          { type: "number" },
+        ),
+      ),
     },
   },
   aliases: ["Expression", "Pureish", "Literal", "Immutable"],

--- a/packages/babel-types/test/builders/core.js
+++ b/packages/babel-types/test/builders/core.js
@@ -1,0 +1,13 @@
+import * as t from "../../lib/index.js";
+
+const itBabel8 = process.env.BABEL_8_BREAKING ? it : it.skip;
+
+describe("builders", function () {
+  itBabel8("t.numericLiteral expexts a non-negative finite value", () => {
+    expect(() => t.numericLiteral(-1)).toThrow();
+    expect(() => t.numericLiteral(-0)).toThrow();
+    expect(() => t.numericLiteral(-Infinity)).toThrow();
+    expect(() => t.numericLiteral(Infinity)).toThrow();
+    expect(() => t.numericLiteral(NaN)).toThrow();
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes #15801
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I wanted to start warning in Babel 7, but we first need to fix regenerator to not pass negative numbers to `t.numericLiteral`.