### PR TITLE
fix: Generating source maps with unexpected paths

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,12 @@
 "use strict";
 
 if (typeof it === "function") {
-  throw new Error("Monorepo root's babel.config.js loaded by a test.");
+  const err = {};
+  Error.captureStackTrace(err);
+  // jest-snapshot
+  if (!err.stack.includes("at addSnapshotData")) {
+    throw new Error("Monorepo root's babel.config.js loaded by a test.");
+  }
 }
 
 const pathUtils = require("path");

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -972,6 +972,50 @@ describe("generation", function () {
       ]
     `);
   });
+
+  it("should normalize sources", () => {
+    const ast = parseExpression("a(\n)");
+
+    expect(
+      generate(ast, {
+        sourceMaps: true,
+        sourceFileName: "input.js",
+        sourceRoot: __dirname,
+        inputSourceMap: {
+          version: 3,
+          names: [],
+          sources: [
+            path.join(__dirname, "input.js"),
+            path.join(__dirname, "input2.js"),
+          ],
+
+          // [ generatedCodeColumn, sourceIndex, sourceCodeLine, sourceCodeColumn, nameIndex ]
+          mappings: encode([
+            [0, 0, 1, 0],
+            [0, 1, 1, 0],
+          ]),
+        },
+      }).map,
+    ).toMatchInlineSnapshot(`
+      Object {
+        "file": undefined,
+        "mappings": "AAAAA,CAAA",
+        "names": Array [
+          "a",
+        ],
+        "sourceRoot": undefined,
+        "sources": Array [
+          "F:/babel/packages/babel-generator/test/input.js",
+          "F:/babel/packages/babel-generator/test/input2.js",
+        ],
+        "sourcesContent": Array [
+          undefined,
+          undefined,
+        ],
+        "version": 3,
+      }
+    `);
+  });
 });
 
 describe("programmatic generation", function () {

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -331,7 +331,7 @@ describe("@babel/register", function () {
       ]);
       const sourceMap = JSON.parse(output);
       expect(sourceMap.map.sourceRoot + sourceMap.map.sources[0]).toBe(
-        require.resolve("./fixtures/source-map/foo/bar"),
+        require.resolve("./fixtures/source-map/foo/bar").replace(/\\/g, "/"),
       );
     });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15784 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This isn't actually a windows-specific regression, it's just that downstream only throws exceptions in windows.
![image](https://github.com/babel/babel/assets/30521560/15417cb3-8db9-4176-94b6-34e2911e36b9)

The source of the problem is that the new output is 
```
{
	sourceRoot: "dir/",
	sources: ["dir/a.js"]
}
```
