### PR TITLE
Make `.version` directly available in cjs proxy for ESM build

### DIFF
--- a/packages/babel-core/cjs-proxy.cjs
+++ b/packages/babel-core/cjs-proxy.cjs
@@ -8,6 +8,8 @@ Object.defineProperty(exports, "__ initialize @babel/core cjs proxy __", {
   },
 });
 
+exports.version = require("./package.json").version;
+
 const functionNames = [
   "createConfigItem",
   "loadPartialConfig",
@@ -17,7 +19,7 @@ const functionNames = [
   "transformFromAst",
   "parse",
 ];
-const propertyNames = ["types", "tokTypes", "traverse", "template", "version"];
+const propertyNames = ["types", "tokTypes", "traverse", "template"];
 
 for (const name of functionNames) {
   exports[name] = function (...args) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15804, closes https://github.com/babel/babel-loader/pull/999
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

It's not possible to easily inline it at build time because `cjs-proxy.cjs` is not compiled, but we can easily re-export it from `package.json`.