### PR TITLE
Remove `@babel/core` peerDep from `helper-compilation-targets`

### DIFF
--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -28,11 +28,7 @@
     "lru-cache": "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.1"
   },
-  "peerDependencies": {
-    "@babel/core": "^7.0.0"
-  },
   "devDependencies": {
-    "@babel/core": "workspace:^",
     "@babel/helper-plugin-test-runner": "workspace:^",
     "@types/lru-cache": "^5.1.1",
     "@types/semver": "^5.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -582,7 +582,6 @@ __metadata:
   resolution: "@babel/helper-compilation-targets@workspace:packages/babel-helper-compilation-targets"
   dependencies:
     "@babel/compat-data": "workspace:^"
-    "@babel/core": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-validator-option": "workspace:^"
     "@types/lru-cache": ^5.1.1
@@ -590,8 +589,6 @@ __metadata:
     browserslist: ^4.21.9
     lru-cache: "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1"
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This package and all its dependencies do not use `@babel/core` (neither directly via imports, or indirectly like plugins do). As such, there is no need to specify `@babel/core` in its `devDependencies` and `peerDependencies`.

This gets rid of one of the remaining warnings mentioned in #15810, since `@babel/helper-define-polyfill-provider` has a dependency on this package.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15811"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

