### PR TITLE
[babel 8] Remove `getChalk` function

### DIFF
--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -16,7 +16,8 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "@babel/highlight": "workspace:^"
+    "@babel/highlight": "workspace:^",
+    "chalk": "^2.4.2"
   },
   "devDependencies": {
     "strip-ansi": "^4.0.0"

--- a/packages/babel-code-frame/src/index.ts
+++ b/packages/babel-code-frame/src/index.ts
@@ -1,6 +1,14 @@
-import highlight, { shouldHighlight, getChalk } from "@babel/highlight";
+import highlight, { shouldHighlight } from "@babel/highlight";
+import chalk, { type Chalk } from "chalk";
 
-type Chalk = ReturnType<typeof getChalk>;
+let chalkWithForcedColor: Chalk = undefined;
+function getChalk(forceColor: boolean) {
+  if (forceColor) {
+    chalkWithForcedColor ??= new chalk.constructor({ enabled: true, level: 1 });
+    return chalkWithForcedColor;
+  }
+  return chalk;
+}
 
 let deprecationWarningShown = false;
 
@@ -137,7 +145,7 @@ export function codeFrameColumns(
 ): string {
   const highlighted =
     (opts.highlightCode || opts.forceColor) && shouldHighlight(opts);
-  const chalk = getChalk(opts);
+  const chalk = getChalk(opts.forceColor);
   const defs = getDefs(chalk);
   const maybeHighlight = (chalkFn: Chalk, string: string) => {
     return highlighted ? chalkFn(string) : string;

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -5,18 +5,11 @@ const codeFrame = _codeFrame.default || _codeFrame;
 
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
-
-const babelHightlightChalkPath = require.resolve("chalk", {
+const babelHighlightChalk = require(require.resolve("chalk", {
   paths: [require.resolve("@babel/highlight")],
-});
+}));
 
 describe("@babel/code-frame", function () {
-  let babelHighlightChalk;
-
-  beforeAll(async function () {
-    ({ default: babelHighlightChalk } = await import(babelHightlightChalkPath));
-  });
-
   function stubColorSupport(supported) {
     let originalChalkEnabled;
     let originalChalkLevel;

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -1,30 +1,25 @@
 import stripAnsi from "strip-ansi";
-import { getChalk } from "@babel/highlight";
+import chalk from "chalk";
 import _codeFrame, { codeFrameColumns } from "../lib/index.js";
 const codeFrame = _codeFrame.default || _codeFrame;
-
-const chalk = getChalk({});
 
 describe("@babel/code-frame", function () {
   function stubColorSupport(supported) {
     let originalChalkLevel;
     let originalChalkSupportsColor;
-    let originalChalkEnabled;
     beforeEach(function () {
       originalChalkSupportsColor = chalk.supportsColor;
       originalChalkLevel = chalk.level;
-      originalChalkEnabled = chalk.enabled;
       chalk.supportsColor = supported ? { level: 1 } : false;
       chalk.level = supported ? 1 : 0;
-      chalk.enabled = supported;
     });
 
     afterEach(function () {
       chalk.supportsColor = originalChalkSupportsColor;
       chalk.level = originalChalkLevel;
-      chalk.enabled = originalChalkEnabled;
     });
   }
+
   test("basic usage", function () {
     const rawLines = ["class Foo {", "  constructor()", "};"].join("\n");
     expect(codeFrame(rawLines, 2, 16)).toEqual(

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -3,20 +3,50 @@ import chalk from "chalk";
 import _codeFrame, { codeFrameColumns } from "../lib/index.js";
 const codeFrame = _codeFrame.default || _codeFrame;
 
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+
+const babelHightlightChalkPath = require.resolve("chalk", {
+  paths: [require.resolve("@babel/highlight")],
+});
+
 describe("@babel/code-frame", function () {
+  let babelHighlightChalk;
+
+  beforeAll(async function () {
+    ({ default: babelHighlightChalk } = await import(babelHightlightChalkPath));
+  });
+
   function stubColorSupport(supported) {
+    let originalChalkEnabled;
     let originalChalkLevel;
     let originalChalkSupportsColor;
-    beforeEach(function () {
+    let originalHighlightChalkEnabled;
+    let originalHighlightChalkLevel;
+    let originalHighlightChalkSupportsColor;
+
+    beforeEach(async function () {
       originalChalkSupportsColor = chalk.supportsColor;
       originalChalkLevel = chalk.level;
-      chalk.supportsColor = supported ? { level: 1 } : false;
-      chalk.level = supported ? 1 : 0;
+      originalChalkEnabled = chalk.enabled;
+      originalHighlightChalkSupportsColor = babelHighlightChalk.supportsColor;
+      originalHighlightChalkLevel = babelHighlightChalk.level;
+      originalHighlightChalkEnabled = babelHighlightChalk.enabled;
+
+      babelHighlightChalk.supportsColor = chalk.supportsColor = supported
+        ? { level: 1 }
+        : false;
+      babelHighlightChalk.level = chalk.level = supported ? 1 : 0;
+      babelHighlightChalk.enabled = chalk.enabled = true;
     });
 
     afterEach(function () {
       chalk.supportsColor = originalChalkSupportsColor;
       chalk.level = originalChalkLevel;
+      chalk.enabled = originalChalkEnabled;
+      babelHighlightChalk.supportsColor = originalHighlightChalkSupportsColor;
+      babelHighlightChalk.level = originalHighlightChalkLevel;
+      babelHighlightChalk.enabled = originalChalkEnabled;
     });
   }
 

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -18,7 +18,7 @@ describe("@babel/code-frame", function () {
     let originalHighlightChalkLevel;
     let originalHighlightChalkSupportsColor;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       originalChalkSupportsColor = chalk.supportsColor;
       originalChalkLevel = chalk.level;
       originalChalkEnabled = chalk.enabled;
@@ -30,7 +30,7 @@ describe("@babel/code-frame", function () {
         ? { level: 1 }
         : false;
       babelHighlightChalk.level = chalk.level = supported ? 1 : 0;
-      babelHighlightChalk.enabled = chalk.enabled = true;
+      babelHighlightChalk.enabled = chalk.enabled = supported;
     });
 
     afterEach(function () {

--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -20,7 +20,6 @@
     "js-tokens": "condition:BABEL_8_BREAKING ? ^8.0.0 : ^4.0.0"
   },
   "devDependencies": {
-    "@types/chalk": "^2.0.0",
     "strip-ansi": "^4.0.0"
   },
   "engines": {

--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -16,7 +16,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/helper-validator-identifier": "workspace:^",
-    "chalk": "^2.0.0",
+    "chalk": "^2.4.2",
     "js-tokens": "condition:BABEL_8_BREAKING ? ^8.0.0 : ^4.0.0"
   },
   "devDependencies": {

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -6,22 +6,10 @@ import chalk from "chalk";
 import _highlight, { shouldHighlight } from "../lib/index.js";
 const highlight = _highlight.default || _highlight;
 
-import { createRequire } from "module";
-const require = createRequire(import.meta.url);
-
-const babelHightlightChalkPath = require.resolve("chalk", {
-  paths: [require.resolve("@babel/highlight")],
-});
-
 const describeBabel7NoESM =
   process.env.BABEL_8_BREAKING || USE_ESM ? describe.skip : describe;
 
 describe("@babel/highlight", function () {
-  let babelHighlightChalk;
-  beforeAll(async function () {
-    ({ default: babelHighlightChalk } = await import(babelHightlightChalkPath));
-  });
-
   function stubColorSupport(supported) {
     let originalChalkEnabled;
     let originalChalkLevel;

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -96,7 +96,10 @@ describe("@babel/highlight", function () {
   });
 
   describeBabel7NoESM("getChalk", function () {
-    const { getChalk } = require("../lib/index.js");
+	let getChalk;
+	beforeAll(() => {
+      ({ getChalk } = require("../lib/index.js"));
+    });
 
     describe("when colors are supported", function () {
       stubColorSupport(true);

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -6,23 +6,41 @@ import chalk from "chalk";
 import _highlight, { shouldHighlight } from "../lib/index.js";
 const highlight = _highlight.default || _highlight;
 
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+
+const babelHightlightChalkPath = require.resolve("chalk", {
+  paths: [require.resolve("@babel/highlight")],
+});
+
 const describeBabel7NoESM =
   process.env.BABEL_8_BREAKING || USE_ESM ? describe.skip : describe;
 
 describe("@babel/highlight", function () {
+  let babelHighlightChalk;
+  beforeAll(async function () {
+    ({ default: babelHighlightChalk } = await import(babelHightlightChalkPath));
+  });
+
   function stubColorSupport(supported) {
+    let originalChalkEnabled;
     let originalChalkLevel;
     let originalChalkSupportsColor;
-    beforeEach(function () {
+
+    beforeEach(async function () {
       originalChalkSupportsColor = chalk.supportsColor;
       originalChalkLevel = chalk.level;
+      originalChalkEnabled = chalk.enabled;
+
       chalk.supportsColor = supported ? { level: 1 } : false;
       chalk.level = supported ? 1 : 0;
+      chalk.enabled = true;
     });
 
     afterEach(function () {
       chalk.supportsColor = originalChalkSupportsColor;
       chalk.level = originalChalkLevel;
+      chalk.enabled = originalChalkEnabled;
     });
   }
 

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -93,22 +93,19 @@ describe("@babel/highlight", function () {
   });
 
   describeBabel7NoESM("getChalk", function () {
-    let getChalk;
-    beforeAll(() => {
-      ({ getChalk } = require("../lib/index.js"));
-    });
-
     describe("when colors are supported", function () {
       stubColorSupport(true);
 
       describe("when forceColor is not passed", function () {
         it("returns a Chalk instance", function () {
+          const { getChalk } = require("../lib/index.js");
           expect(getChalk({}).constructor).toBe(chalk.constructor);
         });
       });
 
       describe("when forceColor is passed", function () {
         it("returns a Chalk instance", function () {
+          const { getChalk } = require("../lib/index.js");
           expect(getChalk({ forceColor: true }).constructor).toBe(
             chalk.constructor,
           );
@@ -121,12 +118,14 @@ describe("@babel/highlight", function () {
 
       describe("when forceColor is not passed", function () {
         it("returns a Chalk instance", function () {
+          const { getChalk } = require("../lib/index.js");
           expect(getChalk({}).constructor).toBe(chalk.constructor);
         });
       });
 
       describe("when forceColor is passed", function () {
         it("returns a Chalk instance", function () {
+          const { getChalk } = require("../lib/index.js");
           expect(getChalk({ forceColor: true }).constructor).toBe(
             chalk.constructor,
           );

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -4,6 +4,7 @@ import stripAnsi from "strip-ansi";
 import chalk from "chalk";
 
 import { createRequire } from "module";
+const require = createRequire(import.meta.url);
 
 import _highlight, { shouldHighlight } from "../lib/index.js";
 const highlight = _highlight.default || _highlight;

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -3,6 +3,8 @@ import { USE_ESM } from "$repo-utils";
 import stripAnsi from "strip-ansi";
 import chalk from "chalk";
 
+import { createRequire } from "module";
+
 import _highlight, { shouldHighlight } from "../lib/index.js";
 const highlight = _highlight.default || _highlight;
 
@@ -93,6 +95,8 @@ describe("@babel/highlight", function () {
   });
 
   describeBabel7NoESM("getChalk", function () {
+    const { getChalk } = require("../lib/index.js");
+
     describe("when colors are supported", function () {
       stubColorSupport(true);
 

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -14,18 +14,17 @@ const describeBabel7NoESM =
 
 describe("@babel/highlight", function () {
   function stubColorSupport(supported) {
-    let originalChalkEnabled;
     let originalChalkLevel;
     let originalChalkSupportsColor;
+    let originalChalkEnabled;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       originalChalkSupportsColor = chalk.supportsColor;
       originalChalkLevel = chalk.level;
       originalChalkEnabled = chalk.enabled;
-
       chalk.supportsColor = supported ? { level: 1 } : false;
       chalk.level = supported ? 1 : 0;
-      chalk.enabled = true;
+      chalk.enabled = supported;
     });
 
     afterEach(function () {
@@ -106,14 +105,12 @@ describe("@babel/highlight", function () {
 
       describe("when forceColor is not passed", function () {
         it("returns a Chalk instance", function () {
-          const { getChalk } = require("../lib/index.js");
           expect(getChalk({}).constructor).toBe(chalk.constructor);
         });
       });
 
       describe("when forceColor is passed", function () {
         it("returns a Chalk instance", function () {
-          const { getChalk } = require("../lib/index.js");
           expect(getChalk({ forceColor: true }).constructor).toBe(
             chalk.constructor,
           );
@@ -126,14 +123,12 @@ describe("@babel/highlight", function () {
 
       describe("when forceColor is not passed", function () {
         it("returns a Chalk instance", function () {
-          const { getChalk } = require("../lib/index.js");
           expect(getChalk({}).constructor).toBe(chalk.constructor);
         });
       });
 
       describe("when forceColor is passed", function () {
         it("returns a Chalk instance", function () {
-          const { getChalk } = require("../lib/index.js");
           expect(getChalk({ forceColor: true }).constructor).toBe(
             chalk.constructor,
           );

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -94,8 +94,8 @@ describe("@babel/highlight", function () {
 
   describeBabel7NoESM("getChalk", function () {
     let getChalk;
-    beforeAll(async () => {
-      ({ getChalk } = await import("../lib/index.js"));
+    beforeAll(() => {
+      ({ getChalk } = require("../lib/index.js"));
     });
 
     describe("when colors are supported", function () {

--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -1,28 +1,28 @@
-import stripAnsi from "strip-ansi";
+import { USE_ESM } from "$repo-utils";
 
-import _highlight, { shouldHighlight, getChalk } from "../lib/index.js";
+import stripAnsi from "strip-ansi";
+import chalk from "chalk";
+
+import _highlight, { shouldHighlight } from "../lib/index.js";
 const highlight = _highlight.default || _highlight;
 
-const chalk = getChalk({});
+const describeBabel7NoESM =
+  process.env.BABEL_8_BREAKING || USE_ESM ? describe.skip : describe;
 
 describe("@babel/highlight", function () {
   function stubColorSupport(supported) {
     let originalChalkLevel;
     let originalChalkSupportsColor;
-    let originalChalkEnabled;
     beforeEach(function () {
       originalChalkSupportsColor = chalk.supportsColor;
       originalChalkLevel = chalk.level;
-      originalChalkEnabled = chalk.enabled;
       chalk.supportsColor = supported ? { level: 1 } : false;
       chalk.level = supported ? 1 : 0;
-      chalk.enabled = supported;
     });
 
     afterEach(function () {
       chalk.supportsColor = originalChalkSupportsColor;
       chalk.level = originalChalkLevel;
-      chalk.enabled = originalChalkEnabled;
     });
   }
 
@@ -86,7 +86,12 @@ describe("@babel/highlight", function () {
     });
   });
 
-  describe("getChalk", function () {
+  describeBabel7NoESM("getChalk", function () {
+    let getChalk;
+    beforeAll(async () => {
+      ({ getChalk } = await import("../lib/index.js"));
+    });
+
     describe("when colors are supported", function () {
       stubColorSupport(true);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,7 +1076,6 @@ __metadata:
   resolution: "@babel/highlight@workspace:packages/babel-highlight"
   dependencies:
     "@babel/helper-validator-identifier": "workspace:^"
-    "@types/chalk": ^2.0.0
     chalk: ^2.4.2
     js-tokens: "condition:BABEL_8_BREAKING ? ^8.0.0 : ^4.0.0"
     strip-ansi: ^4.0.0
@@ -4687,15 +4686,6 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@types/chalk@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "@types/chalk@npm:2.2.0"
-  dependencies:
-    chalk: "*"
-  checksum: 846437590d0bf0026d8c2f454e5d91a486becfabde61c0441025e791a0fed75304e143717bc4d025569394dcce5a32f2c53d97253d0c735ac1abae63f1b25c3e
-  languageName: node
-  linkType: hard
-
 "@types/charcodes@npm:^0.2.0":
   version: 0.2.0
   resolution: "@types/charcodes@npm:0.2.0"
@@ -6949,13 +6939,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:*, chalk@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "chalk@npm:5.0.0"
-  checksum: 6eba7c518b9aa5fe882ae6d14a1ffa58c418d72a3faa7f72af56641f1bbef51b645fca1d6e05d42357b7d3c846cd504c0b7b64d12309cdd07867e3b4411e0d01
-  languageName: node
-  linkType: hard
-
 "chalk@npm:^1.1.3":
   version: 1.1.3
   resolution: "chalk@npm:1.1.3"
@@ -6987,6 +6970,13 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: 5561c7b4c063badee3e16d04bce50bd033e1be1bf4c6948639275683ffa7a1993c44639b43c22b1c505f0f813a24b1889037eb182546b48946f9fe7cdd0e7d13
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "chalk@npm:5.0.0"
+  checksum: 6eba7c518b9aa5fe882ae6d14a1ffa58c418d72a3faa7f72af56641f1bbef51b645fca1d6e05d42357b7d3c846cd504c0b7b64d12309cdd07867e3b4411e0d01
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,6 +282,7 @@ __metadata:
   resolution: "@babel/code-frame@workspace:packages/babel-code-frame"
   dependencies:
     "@babel/highlight": "workspace:^"
+    chalk: ^2.4.2
     strip-ansi: ^4.0.0
   languageName: unknown
   linkType: soft
@@ -1076,7 +1077,7 @@ __metadata:
   dependencies:
     "@babel/helper-validator-identifier": "workspace:^"
     "@types/chalk": ^2.0.0
-    chalk: ^2.0.0
+    chalk: ^2.4.2
     js-tokens: "condition:BABEL_8_BREAKING ? ^8.0.0 : ^4.0.0"
     strip-ansi: ^4.0.0
   languageName: unknown
@@ -6968,7 +6969,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.0.0":
+"chalk@npm:^2.0.0, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

There is no good reason for us to have chalk exposed as part of our public API, and it's making the upgrade to v4/5 incredibly complex.


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15812"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

