### PR TITLE
[babel 8] Use `chalk@4`

### DIFF
--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -17,7 +17,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/highlight": "workspace:^",
-    "chalk": "^2.4.2"
+    "chalk": "condition:BABEL_8_BREAKING ? ^4.1.2 : ^2.4.2"
   },
   "devDependencies": {
     "strip-ansi": "^4.0.0"

--- a/packages/babel-code-frame/src/index.ts
+++ b/packages/babel-code-frame/src/index.ts
@@ -1,10 +1,19 @@
 import highlight, { shouldHighlight } from "@babel/highlight";
-import chalk, { type Chalk } from "chalk";
+
+import _chalk from "chalk";
+const chalk = _chalk as unknown as typeof import("chalk-BABEL_8_BREAKING-true");
+type Chalk =
+  typeof import("chalk-BABEL_8_BREAKING-true").Instance extends new () => infer R
+    ? R
+    : never;
 
 let chalkWithForcedColor: Chalk = undefined;
 function getChalk(forceColor: boolean) {
   if (forceColor) {
-    chalkWithForcedColor ??= new chalk.constructor({ enabled: true, level: 1 });
+    chalkWithForcedColor ??= process.env.BABEL_8_BREAKING
+      ? new chalk.Instance({ level: 1 })
+      : // @ts-expect-error .Instance was .constructor in chalk 2
+        new chalk.constructor({ enabled: true, level: 1 });
     return chalkWithForcedColor;
   }
   return chalk;

--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -16,7 +16,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/helper-validator-identifier": "workspace:^",
-    "chalk": "^2.4.2",
+    "chalk": "condition:BABEL_8_BREAKING ? ^4.1.2 : ^2.4.2",
     "js-tokens": "condition:BABEL_8_BREAKING ? ^8.0.0 : ^4.0.0"
   },
   "devDependencies": {

--- a/packages/babel-highlight/src/index.ts
+++ b/packages/babel-highlight/src/index.ts
@@ -7,7 +7,13 @@ import {
   isStrictReservedWord,
   isKeyword,
 } from "@babel/helper-validator-identifier";
-import chalk, { type Chalk } from "chalk";
+
+import _chalk from "chalk";
+const chalk = _chalk as unknown as typeof import("chalk-BABEL_8_BREAKING-true");
+type Chalk =
+  typeof import("chalk-BABEL_8_BREAKING-true").Instance extends new () => infer R
+    ? R
+    : never;
 
 /**
  * Names that are always allowed as identifiers, but also appear as keywords
@@ -253,7 +259,10 @@ export function shouldHighlight(options: Options): boolean {
 let chalkWithForcedColor: Chalk = undefined;
 function getChalk(forceColor: boolean) {
   if (forceColor) {
-    chalkWithForcedColor ??= new chalk.constructor({ enabled: true, level: 1 });
+    chalkWithForcedColor ??= process.env.BABEL_8_BREAKING
+      ? new chalk.Instance({ level: 1 })
+      : // @ts-expect-error .Instance was .constructor in chalk 2
+        new chalk.constructor({ enabled: true, level: 1 });
     return chalkWithForcedColor;
   }
   return chalk;

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
   resolution: "@babel/code-frame@workspace:packages/babel-code-frame"
   dependencies:
     "@babel/highlight": "workspace:^"
-    chalk: ^2.4.2
+    chalk: "condition:BABEL_8_BREAKING ? ^4.1.2 : ^2.4.2"
     strip-ansi: ^4.0.0
   languageName: unknown
   linkType: soft
@@ -1073,7 +1073,7 @@ __metadata:
   resolution: "@babel/highlight@workspace:packages/babel-highlight"
   dependencies:
     "@babel/helper-validator-identifier": "workspace:^"
-    chalk: ^2.4.2
+    chalk: "condition:BABEL_8_BREAKING ? ^4.1.2 : ^2.4.2"
     js-tokens: "condition:BABEL_8_BREAKING ? ^8.0.0 : ^4.0.0"
     strip-ansi: ^4.0.0
   languageName: unknown
@@ -6940,6 +6940,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk-BABEL_8_BREAKING-false@npm:chalk@^2.4.2, chalk@npm:^2.0.0":
+  version: 2.4.2
+  resolution: "chalk@npm:2.4.2"
+  dependencies:
+    ansi-styles: ^3.2.1
+    escape-string-regexp: ^1.0.5
+    supports-color: ^5.3.0
+  checksum: ec3661d38fe77f681200f878edbd9448821924e0f93a9cefc0e26a33b145f1027a2084bf19967160d11e1f03bfe4eaffcabf5493b89098b2782c3fe0b03d80c2
+  languageName: node
+  linkType: hard
+
+"chalk-BABEL_8_BREAKING-true@npm:chalk@^4.1.2":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
+  languageName: node
+  linkType: hard
+
+"chalk@condition:BABEL_8_BREAKING ? ^4.1.2 : ^2.4.2":
+  version: 0.0.0-condition-fb503e
+  resolution: "chalk@condition:BABEL_8_BREAKING?^4.1.2:^2.4.2#fb503e"
+  dependencies:
+    chalk-BABEL_8_BREAKING-false: "npm:chalk@^2.4.2"
+    chalk-BABEL_8_BREAKING-true: "npm:chalk@^4.1.2"
+  checksum: 937a9201633153fa0e632bc166c6f87174d8dc08ab7a8008047373af6954f3ee7701b64d378bbff4f8aaa0995d4e2d771ad7b1e32962a8231bc727a928cb9248
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^1.1.3":
   version: 1.1.3
   resolution: "chalk@npm:1.1.3"
@@ -6950,17 +6981,6 @@ __metadata:
     strip-ansi: ^3.0.0
     supports-color: ^2.0.0
   checksum: 9d2ea6b98fc2b7878829eec223abcf404622db6c48396a9b9257f6d0ead2acf18231ae368d6a664a83f272b0679158da12e97b5229f794939e555cc574478acd
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^2.0.0, chalk@npm:^2.4.2":
-  version: 2.4.2
-  resolution: "chalk@npm:2.4.2"
-  dependencies:
-    ansi-styles: ^3.2.1
-    escape-string-regexp: ^1.0.5
-    supports-color: ^5.3.0
-  checksum: ec3661d38fe77f681200f878edbd9448821924e0f93a9cefc0e26a33b145f1027a2084bf19967160d11e1f03bfe4eaffcabf5493b89098b2782c3fe0b03d80c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

~~This PR includes all the commits from https://github.com/babel/babel/pull/15812. Please only review `[babel 8] Use chalk@4`.~~

We will eventually upgrade to chalk 5, which has the same interface of chalk 4 but uses ESM. 
I'm exploring Chalk 5 at https://github.com/babel/babel/pull/15792.

I was trying to run Babel in Deno, but chalk 2 doesn't work there because it relies on the [optional](https://tc39.es/ecma262/#sec-object.prototype.__proto__) `Object.prototype.__proto__` getter. This PR should make Babel (8) work there.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15814"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

