### PR TITLE
Add `transformAstWithResolvedConfig` and `loadResolvedConfig`

### DIFF
--- a/packages/babel-core/src/config/index.ts
+++ b/packages/babel-core/src/config/index.ts
@@ -40,6 +40,13 @@ const loadOptionsRunner = gensync(function* (
   return config?.options ?? null;
 });
 
+const loadResolvedConfigRunner = gensync(function* (
+  opts: unknown,
+): Handler<ResolvedConfig | null> {
+  const config = yield* loadFullConfig(opts);
+  return config;
+});
+
 const createConfigItemRunner = gensync(createConfigItemImpl);
 
 const maybeErrback =
@@ -67,6 +74,9 @@ export const loadPartialConfigAsync = loadPartialConfigRunner.async;
 export const loadOptions = maybeErrback(loadOptionsRunner);
 export const loadOptionsSync = loadOptionsRunner.sync;
 export const loadOptionsAsync = loadOptionsRunner.async;
+
+export const loadResolvedConfigSync = loadResolvedConfigRunner.sync;
+export const loadResolvedConfigAsync = loadResolvedConfigRunner.async;
 
 export const createConfigItemSync = createConfigItemRunner.sync;
 export const createConfigItemAsync = createConfigItemRunner.async;

--- a/packages/babel-core/src/index.ts
+++ b/packages/babel-core/src/index.ts
@@ -27,6 +27,8 @@ export {
   loadPartialConfigAsync,
   loadOptions,
   loadOptionsAsync,
+  loadResolvedConfigSync,
+  loadResolvedConfigAsync,
 } from "./config";
 import { loadOptionsSync } from "./config";
 export { loadOptionsSync };
@@ -55,6 +57,8 @@ export {
   transformFromAst,
   transformFromAstSync,
   transformFromAstAsync,
+  transformFromAstWithResolvedConfigSync,
+  transformFromAstWithResolvedConfigAsync,
 } from "./transform-ast";
 export { parse, parseSync, parseAsync } from "./parse";
 

--- a/packages/babel-core/src/transform-ast.ts
+++ b/packages/babel-core/src/transform-ast.ts
@@ -82,3 +82,72 @@ export function transformFromAstAsync(
 ) {
   return beginHiddenCallStack(transformFromAstRunner.async)(...args);
 }
+
+type TransformFromAstWithResolvedConfig = {
+  (ast: AstRoot, code: string, callback: FileResultCallback): void;
+  (
+    ast: AstRoot,
+    code: string,
+    opts: ResolvedConfig | undefined | null,
+    callback: FileResultCallback,
+  ): void;
+};
+
+const transformFromAstWithResolvedConfigRunner = gensync(function* (
+  ast: AstRoot,
+  code: string,
+  config: ResolvedConfig | null,
+): Handler<FileResult | null> {
+  if (config === null) return null;
+
+  if (!ast) throw new Error("No AST given");
+
+  return yield* run(config, code, ast);
+});
+
+export const transformFromAstWithResolvedConfig: TransformFromAstWithResolvedConfig =
+  function transformFromAstWithResolvedConfig(
+    ast,
+    code,
+    optsOrCallback?: ResolvedConfig | null | undefined | FileResultCallback,
+    maybeCallback?: FileResultCallback,
+  ) {
+    let opts: ResolvedConfig | undefined | null;
+    let callback: FileResultCallback | undefined;
+    if (typeof optsOrCallback === "function") {
+      callback = optsOrCallback;
+      opts = undefined;
+    } else {
+      opts = optsOrCallback;
+      callback = maybeCallback;
+    }
+
+    if (callback === undefined) {
+      throw new Error(
+        "The 'transformFromAstWithResolvedConfig' function expects a callback. If you need to call it synchronously, please use 'transformFromAstWithResolvedConfigSync'.",
+      );
+    }
+
+    beginHiddenCallStack(transformFromAstWithResolvedConfigRunner.errback)(
+      ast,
+      code,
+      opts,
+      callback,
+    );
+  };
+
+export function transformFromAstWithResolvedConfigSync(
+  ...args: Parameters<typeof transformFromAstWithResolvedConfigRunner.sync>
+) {
+  return beginHiddenCallStack(transformFromAstWithResolvedConfigRunner.sync)(
+    ...args,
+  );
+}
+
+export function transformFromAstWithResolvedConfigAsync(
+  ...args: Parameters<typeof transformFromAstWithResolvedConfigRunner.async>
+) {
+  return beginHiddenCallStack(transformFromAstWithResolvedConfigRunner.async)(
+    ...args,
+  );
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Improve `make build-plugin-transform-runtime-dist` runtime
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This is an experimental PR. I would to hear about your opinions.

In this PR we introduce new core methods, both with sync and async variants:
- `loadResolvedConfig`: load the Babel config and resolve presets / plugins. It is very similar to the `loadOptions` API: The former returns the complete resolved config while the latter returns `.options` of the resolved config
- `transformAstWithResolvedConfig`: accepts a resolved config and runs the transform. It is very similar to the `transformAst` API: The latter accepts an user provided input options, which is then passed to `loadFullConfig` and converted to a resolved config.

We utilize these two methods to improve the runtime of `packages/babel-plugin-transform-runtime/scripts/build-dist.js`. The build script is essentially running Babel on hundreds of small files.

Here is a loose result:
**Before**
```sh
$ time node ./scripts/build-dist.js
node ./scripts/build-dist.js  5.12s user 0.28s system 155% cpu 3.474 total
```

**After**
```sh
$ time node ./scripts/build-dist.js
node ./scripts/build-dist.js  2.92s user 0.19s system 176% cpu 1.761 total
```
Note that the CPU time is halved.

I did a CPU profiling ([before.cpuprofile.gz](https://github.com/babel/babel/files/12149294/before.cpuprofile.gz)) for the main branch, here are two `buildHelper` sections:

<img width="632" alt="image" src="https://github.com/babel/babel/assets/3607926/0f39f66e-218b-4271-93dc-e4d921bf126d">

<img width="545" alt="image" src="https://github.com/babel/babel/assets/3607926/4f78cb5b-62f7-42ca-a67d-8bd5a442b162">

The `loadFullConfig` could take up to 60% of time spent on `buildHelper`, depending on the input code size. Although `loadFullConfig` has some caching abilities, we still have to execute the cached function to obtain a resolved config. So we cache the resolved config and reuse it for other babel helper transform tasks. After this PR, the `loadFullConfig` is gone so we the cpu runtime is cut by 50% ([after.cpuprofile.gz](https://github.com/babel/babel/files/12149428/after.cpuprofile.gz)).

## Caveat
Reusing resolved config is not generally safe, as 1) users should figure out the proper cache key and 2) we don't offer a method to update all `filename`-related options. It works for our task after a few modification to the inline plugins but it won't work generally for every project.

## Alternative API design
Instead of introducing new APIs, the current transform API can accept a `cacheKey` option for the resolved config caches, but users can not manipulate the resolved config like we did in this PR.