### PR TITLE
Materialize conditional dependencies when bundling

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -26,6 +26,7 @@ import { resolve as importMetaResolve } from "import-meta-resolve";
 
 import rollupBabelSource from "./scripts/rollup-plugin-babel-source.js";
 import rollupStandaloneInternals from "./scripts/rollup-plugin-standalone-internals.js";
+import rollupDependencyCondition from "./scripts/rollup-plugin-dependency-condition.js";
 import formatCode from "./scripts/utils/formatCode.js";
 import { log } from "./scripts/utils/logger.cjs";
 import { USE_ESM, commonJS } from "$repo-utils";
@@ -386,6 +387,7 @@ function buildRollup(packages, buildStandalone) {
           plugins: [
             buildStandalone && rollupStandaloneInternals(),
             rollupBabelSource(),
+            process.env.STRIP_BABEL_8_FLAG && rollupDependencyCondition(),
             rollupReplace({
               preventAssignment: true,
               values: {

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -387,7 +387,8 @@ function buildRollup(packages, buildStandalone) {
           plugins: [
             buildStandalone && rollupStandaloneInternals(),
             rollupBabelSource(),
-            process.env.STRIP_BABEL_8_FLAG && rollupDependencyCondition(),
+            process.env.STRIP_BABEL_8_FLAG &&
+              rollupDependencyCondition(bool(process.env.BABEL_8_BREAKING)),
             rollupReplace({
               preventAssignment: true,
               values: {

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -388,7 +388,7 @@ function buildRollup(packages, buildStandalone) {
             buildStandalone && rollupStandaloneInternals(),
             rollupBabelSource(),
             process.env.STRIP_BABEL_8_FLAG &&
-              rollupDependencyCondition(bool(process.env.BABEL_8_BREAKING)),
+              rollupDependencyCondition(!!bool(process.env.BABEL_8_BREAKING)),
             rollupReplace({
               preventAssignment: true,
               values: {

--- a/scripts/rollup-plugin-dependency-condition.js
+++ b/scripts/rollup-plugin-dependency-condition.js
@@ -1,17 +1,13 @@
-import { createRequire } from "module";
-
-const require = createRequire(import.meta.url);
-
 export default function (value) {
+  const re = value
+    ? /^(.*?-BABEL_8_BREAKING)-false$/
+    : /^(.*?-BABEL_8_BREAKING)-true$/;
   return {
     name: "dependency-condition",
-    resolveId(specifier, referrer) {
-      const re = /^(.*?-BABEL_8_BREAKING)-(?:true|false)$/;
-      const match = specifier.match(re);
+    resolveId(source, importer, options) {
+      const match = source.match(re);
       if (!match) return null;
-      return require.resolve(`${match[1]}-${!!value}`, {
-        paths: [referrer],
-      });
+      return this.resolve(`${match[1]}-${value}`, importer, options);
     },
   };
 }

--- a/scripts/rollup-plugin-dependency-condition.js
+++ b/scripts/rollup-plugin-dependency-condition.js
@@ -2,14 +2,14 @@ import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
 
-export default function () {
+export default function (value) {
   return {
     name: "dependency-condition",
     resolveId(specifier, referrer) {
       const re = /^(.*?-BABEL_8_BREAKING)-(?:true|false)$/;
       const match = specifier.match(re);
       if (!match) return null;
-      return require.resolve(`${match[1]}-${!!process.env.BABEL_8_BREAKING}`, {
+      return require.resolve(`${match[1]}-${value}`, {
         paths: [referrer],
       });
     },

--- a/scripts/rollup-plugin-dependency-condition.js
+++ b/scripts/rollup-plugin-dependency-condition.js
@@ -9,7 +9,7 @@ export default function (value) {
       const re = /^(.*?-BABEL_8_BREAKING)-(?:true|false)$/;
       const match = specifier.match(re);
       if (!match) return null;
-      return require.resolve(`${match[1]}-${value}`, {
+      return require.resolve(`${match[1]}-${!!value}`, {
         paths: [referrer],
       });
     },

--- a/scripts/rollup-plugin-dependency-condition.js
+++ b/scripts/rollup-plugin-dependency-condition.js
@@ -1,0 +1,17 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+export default function () {
+  return {
+    name: "dependency-condition",
+    resolveId(specifier, referrer) {
+      const re = /^(.*?-BABEL_8_BREAKING)-(?:true|false)$/;
+      const match = specifier.match(re);
+      if (!match) return null;
+      return require.resolve(`${match[1]}-${!!process.env.BABEL_8_BREAKING}`, {
+        paths: [referrer],
+      });
+    },
+  };
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

If you search for `BABEL_8_BREAKINGTrue` in https://unpkg.com/browse/@babel/standalone@7.22.9/babel.js, you'll see that it includes multiple Babel 8 dependencies even if it should not.

This PR fixes that, by resolving both `...-BABEL_8_BREAKING-true` and `...-BABEL_8_BREAKING-false` dependencies to the same one when `STRIP_BABEL_8_BREAKING` is enabled.

I don't really know how to write a CI test for this change, but I notice it in https://github.com/babel/babel/pull/15792 because Chalk 5 cannot be even _loaded_ in Node.js 6 (even when bundled) because it uses `Object.entries` in the top-level evaluation. Once that PR is merged, if we regress on this one CI will start failing.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15842"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

