### PR TITLE
perf: Improve `@babel/types` builders

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -790,10 +790,21 @@ const standaloneBundle = [
   },
 ];
 
-gulp.task("generate-type-helpers", () => {
+gulp.task("generate-type-helpers", async () => {
   log("Generating @babel/types and @babel/traverse dynamic functions");
 
-  return Promise.all([
+  if (!process.env.IS_PUBLISH) {
+    const { default: astOrderData } = await import(
+      "./packages/babel-types/scripts/ast-order-data.js"
+    );
+    const data = astOrderData();
+    fs.writeFileSync(
+      "./packages/babel-types/ast-order-data.json",
+      JSON.stringify(data, null, 2)
+    );
+  }
+
+  await Promise.all([
     generateTypeHelpers("asserts"),
     generateTypeHelpers("builders"),
     generateTypeHelpers("builders", "uppercase.js"),

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -703,6 +703,8 @@ function* libBundlesIterator() {
       "babel-helper-builder-react-jsx",
       // exit-loader.cjs
       "babel-helper-transform-fixture-test-runner",
+      // imported "@babel/plugin-transform-react-jsx/lib/development", this will accidentally bundle everything
+      "babel-plugin-transform-react-jsx-development",
     ].map(n => `packages/${n}`)
   );
   for (const src of packagesIterator(noBundle)) {

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -450,6 +450,14 @@ function buildRollup(packages, buildStandalone) {
               preferBuiltins: !buildStandalone,
             }),
             rollupJson(),
+            !buildStandalone &&
+              rollupReplace({
+                preventAssignment: true,
+                delimiters: ["", ""],
+                values: {
+                  "../../../ast-order-data.json": "../ast-order-data.json",
+                },
+              }),
             src === "packages/babel-parser" &&
               getBabelOutputPlugin({
                 configFile: false,
@@ -800,7 +808,7 @@ gulp.task("generate-type-helpers", async () => {
     const data = astOrderData();
     fs.writeFileSync(
       "./packages/babel-types/ast-order-data.json",
-      JSON.stringify(data, null, 2)
+      await formatCode(JSON.stringify(data), "1.json")
     );
   }
 

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -793,7 +793,7 @@ const standaloneBundle = [
 gulp.task("generate-type-helpers", async () => {
   log("Generating @babel/types and @babel/traverse dynamic functions");
 
-  if (!process.env.IS_PUBLISH) {
+  if (!process.env.STRIP_BABEL_8_FLAG) {
     const { default: astOrderData } = await import(
       "./packages/babel-types/scripts/ast-order-data.js"
     );

--- a/packages/babel-types/ast-order-data.json
+++ b/packages/babel-types/ast-order-data.json
@@ -1,0 +1,580 @@
+[
+  ["ArrayExpression", ["elements"]],
+  ["AssignmentExpression", ["operator", "left", "right"]],
+  ["BinaryExpression", ["operator", "left", "right"]],
+  ["InterpreterDirective", ["value"]],
+  ["Directive", ["value"]],
+  ["DirectiveLiteral", ["value"]],
+  ["BlockStatement", ["directives", "body"]],
+  ["BreakStatement", ["label"]],
+  [
+    "CallExpression",
+    ["callee", "arguments", "optional", "typeArguments", "typeParameters"]
+  ],
+  ["CatchClause", ["param", "body"]],
+  ["ConditionalExpression", ["test", "consequent", "alternate"]],
+  ["ContinueStatement", ["label"]],
+  ["DebuggerStatement", []],
+  ["DoWhileStatement", ["test", "body"]],
+  ["EmptyStatement", []],
+  ["ExpressionStatement", ["expression"]],
+  ["File", ["program", "comments", "tokens"]],
+  ["ForInStatement", ["left", "right", "body"]],
+  ["ForStatement", ["init", "test", "update", "body"]],
+  [
+    "FunctionDeclaration",
+    [
+      "params",
+      "generator",
+      "async",
+      "declare",
+      "id",
+      "returnType",
+      "typeParameters",
+      "body",
+      "predicate"
+    ]
+  ],
+  [
+    "FunctionExpression",
+    [
+      "params",
+      "generator",
+      "async",
+      "returnType",
+      "typeParameters",
+      "id",
+      "body",
+      "predicate"
+    ]
+  ],
+  ["Identifier", ["typeAnnotation", "optional", "decorators", "name"]],
+  ["IfStatement", ["test", "consequent", "alternate"]],
+  ["LabeledStatement", ["label", "body"]],
+  ["StringLiteral", ["value"]],
+  ["NumericLiteral", ["value"]],
+  ["NullLiteral", []],
+  ["BooleanLiteral", ["value"]],
+  ["RegExpLiteral", ["pattern", "flags"]],
+  ["LogicalExpression", ["operator", "left", "right"]],
+  ["MemberExpression", ["object", "property", "computed", "optional"]],
+  [
+    "NewExpression",
+    ["callee", "arguments", "optional", "typeArguments", "typeParameters"]
+  ],
+  ["Program", ["sourceType", "interpreter", "directives", "body"]],
+  ["ObjectExpression", ["properties"]],
+  [
+    "ObjectMethod",
+    [
+      "params",
+      "generator",
+      "async",
+      "returnType",
+      "typeParameters",
+      "kind",
+      "computed",
+      "key",
+      "decorators",
+      "body"
+    ]
+  ],
+  ["ObjectProperty", ["computed", "key", "value", "shorthand", "decorators"]],
+  ["RestElement", ["typeAnnotation", "optional", "decorators", "argument"]],
+  ["ReturnStatement", ["argument"]],
+  ["SequenceExpression", ["expressions"]],
+  ["ParenthesizedExpression", ["expression"]],
+  ["SwitchCase", ["test", "consequent"]],
+  ["SwitchStatement", ["discriminant", "cases"]],
+  ["ThisExpression", []],
+  ["ThrowStatement", ["argument"]],
+  ["TryStatement", ["block", "handler", "finalizer"]],
+  ["UnaryExpression", ["prefix", "argument", "operator"]],
+  ["UpdateExpression", ["prefix", "argument", "operator"]],
+  ["VariableDeclaration", ["declare", "kind", "declarations"]],
+  ["VariableDeclarator", ["id", "definite", "init"]],
+  ["WhileStatement", ["test", "body"]],
+  ["WithStatement", ["object", "body"]],
+  [
+    "AssignmentPattern",
+    ["typeAnnotation", "optional", "decorators", "left", "right"]
+  ],
+  ["ArrayPattern", ["typeAnnotation", "optional", "decorators", "elements"]],
+  [
+    "ArrowFunctionExpression",
+    [
+      "params",
+      "generator",
+      "async",
+      "returnType",
+      "typeParameters",
+      "expression",
+      "body",
+      "predicate"
+    ]
+  ],
+  ["ClassBody", ["body"]],
+  [
+    "ClassExpression",
+    [
+      "id",
+      "typeParameters",
+      "body",
+      "superClass",
+      "superTypeParameters",
+      "implements",
+      "decorators",
+      "mixins"
+    ]
+  ],
+  [
+    "ClassDeclaration",
+    [
+      "id",
+      "typeParameters",
+      "body",
+      "superClass",
+      "superTypeParameters",
+      "implements",
+      "decorators",
+      "mixins",
+      "declare",
+      "abstract"
+    ]
+  ],
+  [
+    "ExportAllDeclaration",
+    ["source", "exportKind", "attributes", "assertions"]
+  ],
+  ["ExportDefaultDeclaration", ["declaration", "exportKind"]],
+  [
+    "ExportNamedDeclaration",
+    [
+      "declaration",
+      "attributes",
+      "assertions",
+      "specifiers",
+      "source",
+      "exportKind"
+    ]
+  ],
+  ["ExportSpecifier", ["local", "exported", "exportKind"]],
+  ["ForOfStatement", ["left", "right", "body", "await"]],
+  [
+    "ImportDeclaration",
+    [
+      "attributes",
+      "assertions",
+      "module",
+      "phase",
+      "specifiers",
+      "source",
+      "importKind"
+    ]
+  ],
+  ["ImportDefaultSpecifier", ["local"]],
+  ["ImportNamespaceSpecifier", ["local"]],
+  ["ImportSpecifier", ["local", "imported", "importKind"]],
+  ["ImportExpression", ["phase", "source", "options"]],
+  ["MetaProperty", ["meta", "property"]],
+  [
+    "ClassMethod",
+    [
+      "params",
+      "generator",
+      "async",
+      "abstract",
+      "accessibility",
+      "static",
+      "override",
+      "computed",
+      "optional",
+      "key",
+      "kind",
+      "access",
+      "decorators",
+      "returnType",
+      "typeParameters",
+      "body"
+    ]
+  ],
+  ["ObjectPattern", ["typeAnnotation", "optional", "decorators", "properties"]],
+  ["SpreadElement", ["argument"]],
+  ["Super", []],
+  ["TaggedTemplateExpression", ["tag", "quasi", "typeParameters"]],
+  ["TemplateElement", ["value", "tail"]],
+  ["TemplateLiteral", ["quasis", "expressions"]],
+  ["YieldExpression", ["delegate", "argument"]],
+  ["AwaitExpression", ["argument"]],
+  ["Import", []],
+  ["BigIntLiteral", ["value"]],
+  ["ExportNamespaceSpecifier", ["exported"]],
+  ["OptionalMemberExpression", ["object", "property", "computed", "optional"]],
+  [
+    "OptionalCallExpression",
+    ["callee", "arguments", "optional", "typeArguments", "typeParameters"]
+  ],
+  [
+    "ClassProperty",
+    [
+      "abstract",
+      "accessibility",
+      "static",
+      "override",
+      "computed",
+      "optional",
+      "key",
+      "value",
+      "definite",
+      "typeAnnotation",
+      "decorators",
+      "readonly",
+      "declare",
+      "variance"
+    ]
+  ],
+  [
+    "ClassAccessorProperty",
+    [
+      "abstract",
+      "accessibility",
+      "static",
+      "override",
+      "computed",
+      "optional",
+      "key",
+      "value",
+      "definite",
+      "typeAnnotation",
+      "decorators",
+      "readonly",
+      "declare",
+      "variance"
+    ]
+  ],
+  [
+    "ClassPrivateProperty",
+    [
+      "key",
+      "value",
+      "typeAnnotation",
+      "decorators",
+      "static",
+      "readonly",
+      "definite",
+      "variance"
+    ]
+  ],
+  [
+    "ClassPrivateMethod",
+    [
+      "params",
+      "generator",
+      "async",
+      "abstract",
+      "accessibility",
+      "static",
+      "override",
+      "computed",
+      "optional",
+      "key",
+      "kind",
+      "access",
+      "decorators",
+      "returnType",
+      "typeParameters",
+      "body"
+    ]
+  ],
+  ["PrivateName", ["id"]],
+  ["StaticBlock", ["body"]],
+  ["AnyTypeAnnotation", []],
+  ["ArrayTypeAnnotation", ["elementType"]],
+  ["BooleanTypeAnnotation", []],
+  ["BooleanLiteralTypeAnnotation", ["value"]],
+  ["NullLiteralTypeAnnotation", []],
+  ["ClassImplements", ["id", "typeParameters"]],
+  [
+    "DeclareClass",
+    ["id", "typeParameters", "extends", "mixins", "implements", "body"]
+  ],
+  ["DeclareFunction", ["id", "predicate"]],
+  ["DeclareInterface", ["id", "typeParameters", "extends", "body"]],
+  ["DeclareModule", ["id", "body", "kind"]],
+  ["DeclareModuleExports", ["typeAnnotation"]],
+  ["DeclareTypeAlias", ["id", "typeParameters", "right"]],
+  ["DeclareOpaqueType", ["id", "typeParameters", "supertype", "impltype"]],
+  ["DeclareVariable", ["id"]],
+  [
+    "DeclareExportDeclaration",
+    ["declaration", "specifiers", "source", "default"]
+  ],
+  ["DeclareExportAllDeclaration", ["source", "exportKind"]],
+  ["DeclaredPredicate", ["value"]],
+  ["ExistsTypeAnnotation", []],
+  [
+    "FunctionTypeAnnotation",
+    ["typeParameters", "params", "rest", "this", "returnType"]
+  ],
+  ["FunctionTypeParam", ["name", "typeAnnotation", "optional"]],
+  ["GenericTypeAnnotation", ["id", "typeParameters"]],
+  ["InferredPredicate", []],
+  ["InterfaceExtends", ["id", "typeParameters"]],
+  ["InterfaceDeclaration", ["id", "typeParameters", "extends", "body"]],
+  ["InterfaceTypeAnnotation", ["extends", "body"]],
+  ["IntersectionTypeAnnotation", ["types"]],
+  ["MixedTypeAnnotation", []],
+  ["EmptyTypeAnnotation", []],
+  ["NullableTypeAnnotation", ["typeAnnotation"]],
+  ["NumberLiteralTypeAnnotation", ["value"]],
+  ["NumberTypeAnnotation", []],
+  [
+    "ObjectTypeAnnotation",
+    [
+      "properties",
+      "indexers",
+      "callProperties",
+      "internalSlots",
+      "exact",
+      "inexact"
+    ]
+  ],
+  ["ObjectTypeInternalSlot", ["id", "value", "optional", "static", "method"]],
+  ["ObjectTypeCallProperty", ["value", "static"]],
+  ["ObjectTypeIndexer", ["id", "key", "value", "static", "variance"]],
+  [
+    "ObjectTypeProperty",
+    [
+      "key",
+      "value",
+      "kind",
+      "static",
+      "proto",
+      "optional",
+      "variance",
+      "method"
+    ]
+  ],
+  ["ObjectTypeSpreadProperty", ["argument"]],
+  ["OpaqueType", ["id", "typeParameters", "supertype", "impltype"]],
+  ["QualifiedTypeIdentifier", ["id", "qualification"]],
+  ["StringLiteralTypeAnnotation", ["value"]],
+  ["StringTypeAnnotation", []],
+  ["SymbolTypeAnnotation", []],
+  ["ThisTypeAnnotation", []],
+  ["TupleTypeAnnotation", ["types"]],
+  ["TypeofTypeAnnotation", ["argument"]],
+  ["TypeAlias", ["id", "typeParameters", "right"]],
+  ["TypeAnnotation", ["typeAnnotation"]],
+  ["TypeCastExpression", ["expression", "typeAnnotation"]],
+  ["TypeParameter", ["name", "bound", "default", "variance"]],
+  ["TypeParameterDeclaration", ["params"]],
+  ["TypeParameterInstantiation", ["params"]],
+  ["UnionTypeAnnotation", ["types"]],
+  ["Variance", ["kind"]],
+  ["VoidTypeAnnotation", []],
+  ["EnumDeclaration", ["id", "body"]],
+  ["EnumBooleanBody", ["explicitType", "members", "hasUnknownMembers"]],
+  ["EnumNumberBody", ["explicitType", "members", "hasUnknownMembers"]],
+  ["EnumStringBody", ["explicitType", "members", "hasUnknownMembers"]],
+  ["EnumSymbolBody", ["members", "hasUnknownMembers"]],
+  ["EnumBooleanMember", ["id", "init"]],
+  ["EnumNumberMember", ["id", "init"]],
+  ["EnumStringMember", ["id", "init"]],
+  ["EnumDefaultedMember", ["id"]],
+  ["IndexedAccessType", ["objectType", "indexType"]],
+  ["OptionalIndexedAccessType", ["objectType", "indexType", "optional"]],
+  ["JSXAttribute", ["name", "value"]],
+  ["JSXClosingElement", ["name"]],
+  [
+    "JSXElement",
+    ["openingElement", "closingElement", "children", "selfClosing"]
+  ],
+  ["JSXEmptyExpression", []],
+  ["JSXExpressionContainer", ["expression"]],
+  ["JSXSpreadChild", ["expression"]],
+  ["JSXIdentifier", ["name"]],
+  ["JSXMemberExpression", ["object", "property"]],
+  ["JSXNamespacedName", ["namespace", "name"]],
+  [
+    "JSXOpeningElement",
+    ["name", "selfClosing", "attributes", "typeParameters"]
+  ],
+  ["JSXSpreadAttribute", ["argument"]],
+  ["JSXText", ["value"]],
+  ["JSXFragment", ["openingFragment", "closingFragment", "children"]],
+  ["JSXOpeningFragment", []],
+  ["JSXClosingFragment", []],
+  ["Noop", []],
+  ["Placeholder", ["name", "expectedNode"]],
+  ["V8IntrinsicIdentifier", ["name"]],
+  ["ArgumentPlaceholder", []],
+  ["BindExpression", ["object", "callee"]],
+  ["ImportAttribute", ["key", "value"]],
+  ["Decorator", ["expression"]],
+  ["DoExpression", ["body", "async"]],
+  ["ExportDefaultSpecifier", ["exported"]],
+  ["RecordExpression", ["properties"]],
+  ["TupleExpression", ["elements"]],
+  ["DecimalLiteral", ["value"]],
+  ["ModuleExpression", ["body"]],
+  ["TopicReference", []],
+  ["PipelineTopicExpression", ["expression"]],
+  ["PipelineBareFunction", ["callee"]],
+  ["PipelinePrimaryTopicReference", []],
+  [
+    "TSParameterProperty",
+    ["accessibility", "readonly", "parameter", "override", "decorators"]
+  ],
+  [
+    "TSDeclareFunction",
+    [
+      "params",
+      "generator",
+      "async",
+      "declare",
+      "id",
+      "returnType",
+      "typeParameters"
+    ]
+  ],
+  [
+    "TSDeclareMethod",
+    [
+      "params",
+      "generator",
+      "async",
+      "abstract",
+      "accessibility",
+      "static",
+      "override",
+      "computed",
+      "optional",
+      "key",
+      "kind",
+      "access",
+      "decorators",
+      "returnType",
+      "typeParameters"
+    ]
+  ],
+  ["TSQualifiedName", ["left", "right"]],
+  [
+    "TSCallSignatureDeclaration",
+    ["typeParameters", "parameters", "typeAnnotation", "params", "returnType"]
+  ],
+  [
+    "TSConstructSignatureDeclaration",
+    ["typeParameters", "parameters", "typeAnnotation", "params", "returnType"]
+  ],
+  [
+    "TSPropertySignature",
+    ["key", "computed", "optional", "readonly", "typeAnnotation", "kind"]
+  ],
+  [
+    "TSMethodSignature",
+    [
+      "typeParameters",
+      "parameters",
+      "typeAnnotation",
+      "key",
+      "computed",
+      "optional",
+      "kind",
+      "params",
+      "returnType"
+    ]
+  ],
+  ["TSIndexSignature", ["readonly", "static", "parameters", "typeAnnotation"]],
+  ["TSAnyKeyword", []],
+  ["TSBooleanKeyword", []],
+  ["TSBigIntKeyword", []],
+  ["TSIntrinsicKeyword", []],
+  ["TSNeverKeyword", []],
+  ["TSNullKeyword", []],
+  ["TSNumberKeyword", []],
+  ["TSObjectKeyword", []],
+  ["TSStringKeyword", []],
+  ["TSSymbolKeyword", []],
+  ["TSUndefinedKeyword", []],
+  ["TSUnknownKeyword", []],
+  ["TSVoidKeyword", []],
+  ["TSThisType", []],
+  [
+    "TSFunctionType",
+    ["typeParameters", "parameters", "typeAnnotation", "params", "returnType"]
+  ],
+  [
+    "TSConstructorType",
+    [
+      "typeParameters",
+      "parameters",
+      "typeAnnotation",
+      "abstract",
+      "params",
+      "returnType"
+    ]
+  ],
+  ["TSTypeReference", ["typeName", "typeParameters"]],
+  ["TSTypePredicate", ["parameterName", "typeAnnotation", "asserts"]],
+  ["TSTypeQuery", ["exprName", "typeParameters"]],
+  ["TSTypeLiteral", ["members"]],
+  ["TSArrayType", ["elementType"]],
+  ["TSTupleType", ["elementTypes"]],
+  ["TSOptionalType", ["typeAnnotation"]],
+  ["TSRestType", ["typeAnnotation"]],
+  ["TSNamedTupleMember", ["label", "optional", "elementType"]],
+  ["TSUnionType", ["types"]],
+  ["TSIntersectionType", ["types"]],
+  ["TSConditionalType", ["checkType", "extendsType", "trueType", "falseType"]],
+  ["TSInferType", ["typeParameter"]],
+  ["TSParenthesizedType", ["typeAnnotation"]],
+  ["TSTypeOperator", ["operator", "typeAnnotation"]],
+  ["TSIndexedAccessType", ["objectType", "indexType"]],
+  [
+    "TSMappedType",
+    [
+      "typeParameter",
+      "readonly",
+      "optional",
+      "typeAnnotation",
+      "nameType",
+      "key",
+      "constraint"
+    ]
+  ],
+  ["TSLiteralType", ["literal"]],
+  ["TSExpressionWithTypeArguments", ["expression", "typeParameters"]],
+  [
+    "TSInterfaceDeclaration",
+    ["declare", "id", "typeParameters", "extends", "body"]
+  ],
+  ["TSInterfaceBody", ["body"]],
+  [
+    "TSTypeAliasDeclaration",
+    ["declare", "id", "typeParameters", "typeAnnotation"]
+  ],
+  ["TSInstantiationExpression", ["expression", "typeParameters"]],
+  ["TSAsExpression", ["expression", "typeAnnotation"]],
+  ["TSSatisfiesExpression", ["expression", "typeAnnotation"]],
+  ["TSTypeAssertion", ["typeAnnotation", "expression"]],
+  ["TSEnumDeclaration", ["declare", "const", "id", "members", "initializer"]],
+  ["TSEnumMember", ["id", "initializer"]],
+  ["TSModuleDeclaration", ["declare", "global", "id", "body"]],
+  ["TSModuleBlock", ["body"]],
+  ["TSImportType", ["argument", "qualifier", "typeParameters", "options"]],
+  [
+    "TSImportEqualsDeclaration",
+    ["isExport", "id", "moduleReference", "importKind"]
+  ],
+  ["TSExternalModuleReference", ["expression"]],
+  ["TSNonNullExpression", ["expression"]],
+  ["TSExportAssignment", ["expression"]],
+  ["TSNamespaceExportDeclaration", ["id"]],
+  ["TSTypeAnnotation", ["typeAnnotation"]],
+  ["TSTypeParameterInstantiation", ["params"]],
+  ["TSTypeParameterDeclaration", ["params"]],
+  ["TSTypeParameter", ["name", "in", "out", "const", "constraint", "default"]],
+  ["TSClassImplements", ["expression", "typeParameters"]],
+  ["TSInterfaceHeritage", ["expression", "typeParameters"]]
+]

--- a/packages/babel-types/scripts/ast-order-data.js
+++ b/packages/babel-types/scripts/ast-order-data.js
@@ -1,0 +1,51 @@
+import { execFileSync } from "child_process";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { commonJS } from "$repo-utils";
+import assert from "assert";
+
+const { __dirname } = commonJS(import.meta.url);
+
+function newTypesFields(babel8) {
+  const result = execFileSync(
+    process.execPath,
+    [
+      "-e",
+      `import("../lib/index.js").then(t => {console.log(JSON.stringify(t.NODE_FIELDS))})`,
+    ],
+    {
+      encoding: "utf8",
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        BABEL_8_BREAKING: babel8 ? "true" : "",
+      },
+    }
+  );
+
+  return JSON.parse(result);
+}
+
+export default function () {
+  const fieldsBabel7 = newTypesFields();
+  const fieldsBabel8 = newTypesFields(true);
+
+  assert.ok(fieldsBabel7["DecimalLiteral"]);
+  assert.ok(!fieldsBabel8["DecimalLiteral"]);
+
+  const nodeFieldMap = new Map();
+
+  for (const [type, fields] of Object.entries(fieldsBabel7).concat(
+    Object.entries(fieldsBabel8)
+  )) {
+    const set = nodeFieldMap.get(type) || new Set();
+    nodeFieldMap.set(type, set);
+
+    Object.keys(fields).forEach(field => {
+      set.add(field);
+    });
+  }
+
+  return Array.from(nodeFieldMap).map(([type, fields]) => {
+    return [type, Array.from(fields)];
+  });
+}

--- a/packages/babel-types/scripts/generators/builders.js
+++ b/packages/babel-types/scripts/generators/builders.js
@@ -114,6 +114,10 @@ for (const [type, fields] of astOrderData as [string, []][]) {
 
 `;
 
+  if (process.env.IS_BABEL_OLD_E2E) {
+    output = output.replace(`with { type: "json" }`, "");
+  }
+
   const reservedNames = new Set(["super", "import"]);
   Object.keys(BUILDER_KEYS).forEach(type => {
     const defArgs = generateBuilderArgs(type);

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -5,32 +5,15 @@
 import * as _validate from "../../validators/validate.ts";
 import type * as t from "../../index.ts";
 import deprecationWarning from "../../utils/deprecationWarning.ts";
-import {
-  BUILDER_KEYS,
-  NODE_FIELDS,
-  type FieldOptions,
-} from "../../definitions/utils.ts";
+import { NODE_FIELDS, type FieldOptions } from "../../definitions/utils.ts";
+import astOrderData from "../../../ast-order-data.json" with { type: "json" };
 
 const { validateInternal: validate } = _validate;
 
 const _data: FieldOptions[][] = [];
-Object.keys(BUILDER_KEYS).forEach(type => {
-  const fields = NODE_FIELDS[type];
-
-  _data.push(
-    sortFieldNames(Object.keys(fields), type).map(field => fields[field]),
-  );
-});
-
-function sortFieldNames(fields: string[], type: string) {
-  return fields.sort((fieldA, fieldB) => {
-    const indexA = BUILDER_KEYS[type].indexOf(fieldA);
-    const indexB = BUILDER_KEYS[type].indexOf(fieldB);
-    if (indexA === indexB) return fieldA < fieldB ? -1 : 1;
-    if (indexA === -1) return 1;
-    if (indexB === -1) return -1;
-    return indexA - indexB;
-  });
+for (const [type, fields] of astOrderData as [string, []][]) {
+  const fieldOptions = NODE_FIELDS[type];
+  _data.push(fieldOptions ? fields.map(field => fieldOptions[field]) : null);
 }
 
 export function arrayExpression(
@@ -131,8 +114,8 @@ export function blockStatement(
     body,
     directives,
   };
-  validate(_data[6][0], node, "body", body, true);
-  validate(_data[6][1], node, "directives", directives, true);
+  validate(_data[6][1], node, "body", body, true);
+  validate(_data[6][0], node, "directives", directives, true);
   return node;
 }
 export function breakStatement(
@@ -301,11 +284,11 @@ export function functionDeclaration(
     generator,
     async,
   };
-  validate(_data[19][0], node, "id", id, true);
-  validate(_data[19][1], node, "params", params, true);
-  validate(_data[19][2], node, "body", body, true);
-  validate(_data[19][3], node, "generator", generator);
-  validate(_data[19][4], node, "async", async);
+  validate(_data[19][4], node, "id", id, true);
+  validate(_data[19][0], node, "params", params, true);
+  validate(_data[19][7], node, "body", body, true);
+  validate(_data[19][1], node, "generator", generator);
+  validate(_data[19][2], node, "async", async);
   return node;
 }
 export function functionExpression(
@@ -323,11 +306,11 @@ export function functionExpression(
     generator,
     async,
   };
-  validate(_data[20][0], node, "id", id, true);
-  validate(_data[20][1], node, "params", params, true);
-  validate(_data[20][2], node, "body", body, true);
-  validate(_data[20][3], node, "generator", generator);
-  validate(_data[20][4], node, "async", async);
+  validate(_data[20][5], node, "id", id, true);
+  validate(_data[20][0], node, "params", params, true);
+  validate(_data[20][6], node, "body", body, true);
+  validate(_data[20][1], node, "generator", generator);
+  validate(_data[20][2], node, "async", async);
   return node;
 }
 export function identifier(name: string): t.Identifier {
@@ -335,7 +318,7 @@ export function identifier(name: string): t.Identifier {
     type: "Identifier",
     name,
   };
-  validate(_data[21][0], node, "name", name);
+  validate(_data[21][3], node, "name", name);
   return node;
 }
 export function ifStatement(
@@ -470,10 +453,10 @@ export function program(
     sourceType,
     interpreter,
   };
-  validate(_data[32][0], node, "body", body, true);
-  validate(_data[32][1], node, "directives", directives, true);
-  validate(_data[32][2], node, "sourceType", sourceType);
-  validate(_data[32][3], node, "interpreter", interpreter, true);
+  validate(_data[32][3], node, "body", body, true);
+  validate(_data[32][2], node, "directives", directives, true);
+  validate(_data[32][0], node, "sourceType", sourceType);
+  validate(_data[32][1], node, "interpreter", interpreter, true);
   return node;
 }
 export function objectExpression(
@@ -510,13 +493,13 @@ export function objectMethod(
     generator,
     async,
   };
-  validate(_data[34][0], node, "kind", kind);
-  validate(_data[34][1], node, "key", key, true);
-  validate(_data[34][2], node, "params", params, true);
-  validate(_data[34][3], node, "body", body, true);
-  validate(_data[34][4], node, "computed", computed);
-  validate(_data[34][5], node, "generator", generator);
-  validate(_data[34][6], node, "async", async);
+  validate(_data[34][5], node, "kind", kind);
+  validate(_data[34][7], node, "key", key, true);
+  validate(_data[34][0], node, "params", params, true);
+  validate(_data[34][9], node, "body", body, true);
+  validate(_data[34][6], node, "computed", computed);
+  validate(_data[34][1], node, "generator", generator);
+  validate(_data[34][2], node, "async", async);
   return node;
 }
 export function objectProperty(
@@ -541,9 +524,9 @@ export function objectProperty(
     shorthand,
     decorators,
   };
-  validate(_data[35][0], node, "key", key, true);
-  validate(_data[35][1], node, "value", value, true);
-  validate(_data[35][2], node, "computed", computed);
+  validate(_data[35][1], node, "key", key, true);
+  validate(_data[35][2], node, "value", value, true);
+  validate(_data[35][0], node, "computed", computed);
   validate(_data[35][3], node, "shorthand", shorthand);
   validate(_data[35][4], node, "decorators", decorators, true);
   return node;
@@ -553,7 +536,7 @@ export function restElement(argument: t.LVal): t.RestElement {
     type: "RestElement",
     argument,
   };
-  validate(_data[36][0], node, "argument", argument, true);
+  validate(_data[36][3], node, "argument", argument, true);
   return node;
 }
 export function returnStatement(
@@ -652,9 +635,9 @@ export function unaryExpression(
     argument,
     prefix,
   };
-  validate(_data[45][0], node, "operator", operator);
+  validate(_data[45][2], node, "operator", operator);
   validate(_data[45][1], node, "argument", argument, true);
-  validate(_data[45][2], node, "prefix", prefix);
+  validate(_data[45][0], node, "prefix", prefix);
   return node;
 }
 export function updateExpression(
@@ -668,9 +651,9 @@ export function updateExpression(
     argument,
     prefix,
   };
-  validate(_data[46][0], node, "operator", operator);
+  validate(_data[46][2], node, "operator", operator);
   validate(_data[46][1], node, "argument", argument, true);
-  validate(_data[46][2], node, "prefix", prefix);
+  validate(_data[46][0], node, "prefix", prefix);
   return node;
 }
 export function variableDeclaration(
@@ -682,8 +665,8 @@ export function variableDeclaration(
     kind,
     declarations,
   };
-  validate(_data[47][0], node, "kind", kind);
-  validate(_data[47][1], node, "declarations", declarations, true);
+  validate(_data[47][1], node, "kind", kind);
+  validate(_data[47][2], node, "declarations", declarations, true);
   return node;
 }
 export function variableDeclarator(
@@ -696,7 +679,7 @@ export function variableDeclarator(
     init,
   };
   validate(_data[48][0], node, "id", id, true);
-  validate(_data[48][1], node, "init", init, true);
+  validate(_data[48][2], node, "init", init, true);
   return node;
 }
 export function whileStatement(
@@ -742,8 +725,8 @@ export function assignmentPattern(
     left,
     right,
   };
-  validate(_data[51][0], node, "left", left, true);
-  validate(_data[51][1], node, "right", right, true);
+  validate(_data[51][3], node, "left", left, true);
+  validate(_data[51][4], node, "right", right, true);
   return node;
 }
 export function arrayPattern(
@@ -753,7 +736,7 @@ export function arrayPattern(
     type: "ArrayPattern",
     elements,
   };
-  validate(_data[52][0], node, "elements", elements, true);
+  validate(_data[52][3], node, "elements", elements, true);
   return node;
 }
 export function arrowFunctionExpression(
@@ -769,7 +752,7 @@ export function arrowFunctionExpression(
     expression: null,
   };
   validate(_data[53][0], node, "params", params, true);
-  validate(_data[53][1], node, "body", body, true);
+  validate(_data[53][6], node, "body", body, true);
   validate(_data[53][2], node, "async", async);
   return node;
 }
@@ -806,9 +789,9 @@ export function classExpression(
     decorators,
   };
   validate(_data[55][0], node, "id", id, true);
-  validate(_data[55][1], node, "superClass", superClass, true);
+  validate(_data[55][3], node, "superClass", superClass, true);
   validate(_data[55][2], node, "body", body, true);
-  validate(_data[55][3], node, "decorators", decorators, true);
+  validate(_data[55][6], node, "decorators", decorators, true);
   return node;
 }
 export function classDeclaration(
@@ -825,9 +808,9 @@ export function classDeclaration(
     decorators,
   };
   validate(_data[56][0], node, "id", id, true);
-  validate(_data[56][1], node, "superClass", superClass, true);
+  validate(_data[56][3], node, "superClass", superClass, true);
   validate(_data[56][2], node, "body", body, true);
-  validate(_data[56][3], node, "decorators", decorators, true);
+  validate(_data[56][6], node, "decorators", decorators, true);
   return node;
 }
 export function exportAllDeclaration(
@@ -868,8 +851,8 @@ export function exportNamedDeclaration(
     source,
   };
   validate(_data[59][0], node, "declaration", declaration, true);
-  validate(_data[59][1], node, "specifiers", specifiers, true);
-  validate(_data[59][2], node, "source", source, true);
+  validate(_data[59][3], node, "specifiers", specifiers, true);
+  validate(_data[59][4], node, "source", source, true);
   return node;
 }
 export function exportSpecifier(
@@ -915,8 +898,8 @@ export function importDeclaration(
     specifiers,
     source,
   };
-  validate(_data[62][0], node, "specifiers", specifiers, true);
-  validate(_data[62][1], node, "source", source, true);
+  validate(_data[62][4], node, "specifiers", specifiers, true);
+  validate(_data[62][5], node, "source", source, true);
   return node;
 }
 export function importDefaultSpecifier(
@@ -961,8 +944,8 @@ export function importExpression(
     source,
     options,
   };
-  validate(_data[66][0], node, "source", source, true);
-  validate(_data[66][1], node, "options", options, true);
+  validate(_data[66][1], node, "source", source, true);
+  validate(_data[66][2], node, "options", options, true);
   return node;
 }
 export function metaProperty(
@@ -1006,14 +989,14 @@ export function classMethod(
     generator,
     async,
   };
-  validate(_data[68][0], node, "kind", kind);
-  validate(_data[68][1], node, "key", key, true);
-  validate(_data[68][2], node, "params", params, true);
-  validate(_data[68][3], node, "body", body, true);
-  validate(_data[68][4], node, "computed", computed);
+  validate(_data[68][10], node, "kind", kind);
+  validate(_data[68][9], node, "key", key, true);
+  validate(_data[68][0], node, "params", params, true);
+  validate(_data[68][15], node, "body", body, true);
+  validate(_data[68][7], node, "computed", computed);
   validate(_data[68][5], node, "static", _static);
-  validate(_data[68][6], node, "generator", generator);
-  validate(_data[68][7], node, "async", async);
+  validate(_data[68][1], node, "generator", generator);
+  validate(_data[68][2], node, "async", async);
   return node;
 }
 export function objectPattern(
@@ -1023,7 +1006,7 @@ export function objectPattern(
     type: "ObjectPattern",
     properties,
   };
-  validate(_data[69][0], node, "properties", properties, true);
+  validate(_data[69][3], node, "properties", properties, true);
   return node;
 }
 export function spreadElement(argument: t.Expression): t.SpreadElement {
@@ -1088,8 +1071,8 @@ export function yieldExpression(
     argument,
     delegate,
   };
-  validate(_data[75][0], node, "argument", argument, true);
-  validate(_data[75][1], node, "delegate", delegate);
+  validate(_data[75][1], node, "argument", argument, true);
+  validate(_data[75][0], node, "delegate", delegate);
   return node;
 }
 export function awaitExpression(argument: t.Expression): t.AwaitExpression {
@@ -1181,12 +1164,12 @@ export function classProperty(
     computed,
     static: _static,
   };
-  validate(_data[82][0], node, "key", key, true);
-  validate(_data[82][1], node, "value", value, true);
-  validate(_data[82][2], node, "typeAnnotation", typeAnnotation, true);
-  validate(_data[82][3], node, "decorators", decorators, true);
+  validate(_data[82][6], node, "key", key, true);
+  validate(_data[82][7], node, "value", value, true);
+  validate(_data[82][9], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[82][10], node, "decorators", decorators, true);
   validate(_data[82][4], node, "computed", computed);
-  validate(_data[82][5], node, "static", _static);
+  validate(_data[82][2], node, "static", _static);
   return node;
 }
 export function classAccessorProperty(
@@ -1212,12 +1195,12 @@ export function classAccessorProperty(
     computed,
     static: _static,
   };
-  validate(_data[83][0], node, "key", key, true);
-  validate(_data[83][1], node, "value", value, true);
-  validate(_data[83][2], node, "typeAnnotation", typeAnnotation, true);
-  validate(_data[83][3], node, "decorators", decorators, true);
+  validate(_data[83][6], node, "key", key, true);
+  validate(_data[83][7], node, "value", value, true);
+  validate(_data[83][9], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[83][10], node, "decorators", decorators, true);
   validate(_data[83][4], node, "computed", computed);
-  validate(_data[83][5], node, "static", _static);
+  validate(_data[83][2], node, "static", _static);
   return node;
 }
 export function classPrivateProperty(
@@ -1235,8 +1218,8 @@ export function classPrivateProperty(
   };
   validate(_data[84][0], node, "key", key, true);
   validate(_data[84][1], node, "value", value, true);
-  validate(_data[84][2], node, "decorators", decorators, true);
-  validate(_data[84][3], node, "static", _static);
+  validate(_data[84][3], node, "decorators", decorators, true);
+  validate(_data[84][4], node, "static", _static);
   return node;
 }
 export function classPrivateMethod(
@@ -1256,11 +1239,11 @@ export function classPrivateMethod(
     body,
     static: _static,
   };
-  validate(_data[85][0], node, "kind", kind);
-  validate(_data[85][1], node, "key", key, true);
-  validate(_data[85][2], node, "params", params, true);
-  validate(_data[85][3], node, "body", body, true);
-  validate(_data[85][4], node, "static", _static);
+  validate(_data[85][10], node, "kind", kind);
+  validate(_data[85][9], node, "key", key, true);
+  validate(_data[85][0], node, "params", params, true);
+  validate(_data[85][15], node, "body", body, true);
+  validate(_data[85][5], node, "static", _static);
   return node;
 }
 export function privateName(id: t.Identifier): t.PrivateName {
@@ -1343,7 +1326,7 @@ export function declareClass(
   validate(_data[94][0], node, "id", id, true);
   validate(_data[94][1], node, "typeParameters", typeParameters, true);
   validate(_data[94][2], node, "extends", _extends, true);
-  validate(_data[94][3], node, "body", body, true);
+  validate(_data[94][5], node, "body", body, true);
   return node;
 }
 export function declareFunction(id: t.Identifier): t.DeclareFunction {
@@ -1496,7 +1479,7 @@ export function functionTypeAnnotation(
   validate(_data[106][0], node, "typeParameters", typeParameters, true);
   validate(_data[106][1], node, "params", params, true);
   validate(_data[106][2], node, "rest", rest, true);
-  validate(_data[106][3], node, "returnType", returnType, true);
+  validate(_data[106][4], node, "returnType", returnType, true);
   return node;
 }
 export function functionTypeParam(
@@ -1692,7 +1675,7 @@ export function objectTypeIndexer(
   validate(_data[122][0], node, "id", id, true);
   validate(_data[122][1], node, "key", key, true);
   validate(_data[122][2], node, "value", value, true);
-  validate(_data[122][3], node, "variance", variance, true);
+  validate(_data[122][4], node, "variance", variance, true);
   return node;
 }
 export function objectTypeProperty(
@@ -1713,7 +1696,7 @@ export function objectTypeProperty(
   };
   validate(_data[123][0], node, "key", key, true);
   validate(_data[123][1], node, "value", value, true);
-  validate(_data[123][2], node, "variance", variance, true);
+  validate(_data[123][6], node, "variance", variance, true);
   return node;
 }
 export function objectTypeSpreadProperty(
@@ -1852,9 +1835,9 @@ export function typeParameter(
     variance,
     name: null,
   };
-  validate(_data[136][0], node, "bound", bound, true);
-  validate(_data[136][1], node, "default", _default, true);
-  validate(_data[136][2], node, "variance", variance, true);
+  validate(_data[136][1], node, "bound", bound, true);
+  validate(_data[136][2], node, "default", _default, true);
+  validate(_data[136][3], node, "variance", variance, true);
   return node;
 }
 export function typeParameterDeclaration(
@@ -1926,7 +1909,7 @@ export function enumBooleanBody(
     explicitType: null,
     hasUnknownMembers: null,
   };
-  validate(_data[143][0], node, "members", members, true);
+  validate(_data[143][1], node, "members", members, true);
   return node;
 }
 export function enumNumberBody(
@@ -1938,7 +1921,7 @@ export function enumNumberBody(
     explicitType: null,
     hasUnknownMembers: null,
   };
-  validate(_data[144][0], node, "members", members, true);
+  validate(_data[144][1], node, "members", members, true);
   return node;
 }
 export function enumStringBody(
@@ -1950,7 +1933,7 @@ export function enumStringBody(
     explicitType: null,
     hasUnknownMembers: null,
   };
-  validate(_data[145][0], node, "members", members, true);
+  validate(_data[145][1], node, "members", members, true);
   return node;
 }
 export function enumSymbolBody(
@@ -2165,8 +2148,8 @@ export function jsxOpeningElement(
     selfClosing,
   };
   validate(_data[162][0], node, "name", name, true);
-  validate(_data[162][1], node, "attributes", attributes, true);
-  validate(_data[162][2], node, "selfClosing", selfClosing);
+  validate(_data[162][2], node, "attributes", attributes, true);
+  validate(_data[162][1], node, "selfClosing", selfClosing);
   return node;
 }
 export { jsxOpeningElement as jSXOpeningElement };
@@ -2247,8 +2230,8 @@ export function placeholder(
     expectedNode,
     name,
   };
-  validate(_data[169][0], node, "expectedNode", expectedNode);
-  validate(_data[169][1], node, "name", name, true);
+  validate(_data[169][1], node, "expectedNode", expectedNode);
+  validate(_data[169][0], node, "name", name, true);
   return node;
 }
 export function v8IntrinsicIdentifier(name: string): t.V8IntrinsicIdentifier {
@@ -2394,7 +2377,7 @@ export function tsParameterProperty(
     type: "TSParameterProperty",
     parameter,
   };
-  validate(_data[185][0], node, "parameter", parameter, true);
+  validate(_data[185][2], node, "parameter", parameter, true);
   return node;
 }
 export { tsParameterProperty as tSParameterProperty };
@@ -2415,10 +2398,10 @@ export function tsDeclareFunction(
     params,
     returnType,
   };
-  validate(_data[186][0], node, "id", id, true);
-  validate(_data[186][1], node, "typeParameters", typeParameters, true);
-  validate(_data[186][2], node, "params", params, true);
-  validate(_data[186][3], node, "returnType", returnType, true);
+  validate(_data[186][4], node, "id", id, true);
+  validate(_data[186][6], node, "typeParameters", typeParameters, true);
+  validate(_data[186][0], node, "params", params, true);
+  validate(_data[186][5], node, "returnType", returnType, true);
   return node;
 }
 export { tsDeclareFunction as tSDeclareFunction };
@@ -2448,11 +2431,11 @@ export function tsDeclareMethod(
     params,
     returnType,
   };
-  validate(_data[187][0], node, "decorators", decorators, true);
-  validate(_data[187][1], node, "key", key, true);
-  validate(_data[187][2], node, "typeParameters", typeParameters, true);
-  validate(_data[187][3], node, "params", params, true);
-  validate(_data[187][4], node, "returnType", returnType, true);
+  validate(_data[187][12], node, "decorators", decorators, true);
+  validate(_data[187][9], node, "key", key, true);
+  validate(_data[187][14], node, "typeParameters", typeParameters, true);
+  validate(_data[187][0], node, "params", params, true);
+  validate(_data[187][13], node, "returnType", returnType, true);
   return node;
 }
 export { tsDeclareMethod as tSDeclareMethod };
@@ -2519,7 +2502,7 @@ export function tsPropertySignature(
     kind: null,
   };
   validate(_data[191][0], node, "key", key, true);
-  validate(_data[191][1], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[191][4], node, "typeAnnotation", typeAnnotation, true);
   return node;
 }
 export { tsPropertySignature as tSPropertySignature };
@@ -2539,10 +2522,10 @@ export function tsMethodSignature(
     typeAnnotation,
     kind: null,
   };
-  validate(_data[192][0], node, "key", key, true);
-  validate(_data[192][1], node, "typeParameters", typeParameters, true);
-  validate(_data[192][2], node, "parameters", parameters, true);
-  validate(_data[192][3], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[192][3], node, "key", key, true);
+  validate(_data[192][0], node, "typeParameters", typeParameters, true);
+  validate(_data[192][1], node, "parameters", parameters, true);
+  validate(_data[192][2], node, "typeAnnotation", typeAnnotation, true);
   return node;
 }
 export { tsMethodSignature as tSMethodSignature };
@@ -2555,8 +2538,8 @@ export function tsIndexSignature(
     parameters,
     typeAnnotation,
   };
-  validate(_data[193][0], node, "parameters", parameters, true);
-  validate(_data[193][1], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[193][2], node, "parameters", parameters, true);
+  validate(_data[193][3], node, "typeAnnotation", typeAnnotation, true);
   return node;
 }
 export { tsIndexSignature as tSIndexSignature };
@@ -2788,8 +2771,8 @@ export function tsNamedTupleMember(
     optional,
   };
   validate(_data[218][0], node, "label", label, true);
-  validate(_data[218][1], node, "elementType", elementType, true);
-  validate(_data[218][2], node, "optional", optional);
+  validate(_data[218][2], node, "elementType", elementType, true);
+  validate(_data[218][1], node, "optional", optional);
   return node;
 }
 export { tsNamedTupleMember as tSNamedTupleMember };
@@ -2859,7 +2842,7 @@ export function tsTypeOperator(typeAnnotation: t.TSType): t.TSTypeOperator {
     typeAnnotation,
     operator: null,
   };
-  validate(_data[224][0], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[224][1], node, "typeAnnotation", typeAnnotation, true);
   return node;
 }
 export { tsTypeOperator as tSTypeOperator };
@@ -2889,8 +2872,8 @@ export function tsMappedType(
     nameType,
   };
   validate(_data[226][0], node, "typeParameter", typeParameter, true);
-  validate(_data[226][1], node, "typeAnnotation", typeAnnotation, true);
-  validate(_data[226][2], node, "nameType", nameType, true);
+  validate(_data[226][3], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[226][4], node, "nameType", nameType, true);
   return node;
 }
 export { tsMappedType as tSMappedType };
@@ -2938,10 +2921,10 @@ export function tsInterfaceDeclaration(
     extends: _extends,
     body,
   };
-  validate(_data[229][0], node, "id", id, true);
-  validate(_data[229][1], node, "typeParameters", typeParameters, true);
-  validate(_data[229][2], node, "extends", _extends, true);
-  validate(_data[229][3], node, "body", body, true);
+  validate(_data[229][1], node, "id", id, true);
+  validate(_data[229][2], node, "typeParameters", typeParameters, true);
+  validate(_data[229][3], node, "extends", _extends, true);
+  validate(_data[229][4], node, "body", body, true);
   return node;
 }
 export { tsInterfaceDeclaration as tSInterfaceDeclaration };
@@ -2967,9 +2950,9 @@ export function tsTypeAliasDeclaration(
     typeParameters,
     typeAnnotation,
   };
-  validate(_data[231][0], node, "id", id, true);
-  validate(_data[231][1], node, "typeParameters", typeParameters, true);
-  validate(_data[231][2], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[231][1], node, "id", id, true);
+  validate(_data[231][2], node, "typeParameters", typeParameters, true);
+  validate(_data[231][3], node, "typeAnnotation", typeAnnotation, true);
   return node;
 }
 export { tsTypeAliasDeclaration as tSTypeAliasDeclaration };
@@ -3038,8 +3021,8 @@ export function tsEnumDeclaration(
     id,
     members,
   };
-  validate(_data[236][0], node, "id", id, true);
-  validate(_data[236][1], node, "members", members, true);
+  validate(_data[236][2], node, "id", id, true);
+  validate(_data[236][3], node, "members", members, true);
   return node;
 }
 export { tsEnumDeclaration as tSEnumDeclaration };
@@ -3066,8 +3049,8 @@ export function tsModuleDeclaration(
     id,
     body,
   };
-  validate(_data[238][0], node, "id", id, true);
-  validate(_data[238][1], node, "body", body, true);
+  validate(_data[238][2], node, "id", id, true);
+  validate(_data[238][3], node, "body", body, true);
   return node;
 }
 export { tsModuleDeclaration as tSModuleDeclaration };
@@ -3107,8 +3090,8 @@ export function tsImportEqualsDeclaration(
     moduleReference,
     isExport: null,
   };
-  validate(_data[241][0], node, "id", id, true);
-  validate(_data[241][1], node, "moduleReference", moduleReference, true);
+  validate(_data[241][1], node, "id", id, true);
+  validate(_data[241][2], node, "moduleReference", moduleReference, true);
   return node;
 }
 export { tsImportEqualsDeclaration as tSImportEqualsDeclaration };
@@ -3198,9 +3181,9 @@ export function tsTypeParameter(
     default: _default,
     name,
   };
-  validate(_data[249][0], node, "constraint", constraint, true);
-  validate(_data[249][1], node, "default", _default, true);
-  validate(_data[249][2], node, "name", name);
+  validate(_data[249][4], node, "constraint", constraint, true);
+  validate(_data[249][5], node, "default", _default, true);
+  validate(_data[249][0], node, "name", name);
   return node;
 }
 export { tsTypeParameter as tSTypeParameter };

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -2,28 +2,62 @@
  * This file is auto-generated! Do not modify it directly.
  * To re-generate run 'make build'
  */
-import validateNode from "../validateNode.ts";
+import * as _validate from "../../validators/validate.ts";
 import type * as t from "../../index.ts";
 import deprecationWarning from "../../utils/deprecationWarning.ts";
+import {
+  BUILDER_KEYS,
+  NODE_FIELDS,
+  type FieldOptions,
+} from "../../definitions/utils.ts";
+
+const { validateInternal: validate } = _validate;
+
+const _data: FieldOptions[][] = [];
+Object.keys(BUILDER_KEYS).forEach(type => {
+  const fields = NODE_FIELDS[type];
+
+  _data.push(
+    sortFieldNames(Object.keys(fields), type).map(field => fields[field]),
+  );
+});
+
+function sortFieldNames(fields: string[], type: string) {
+  return fields.sort((fieldA, fieldB) => {
+    const indexA = BUILDER_KEYS[type].indexOf(fieldA);
+    const indexB = BUILDER_KEYS[type].indexOf(fieldB);
+    if (indexA === indexB) return fieldA < fieldB ? -1 : 1;
+    if (indexA === -1) return 1;
+    if (indexB === -1) return -1;
+    return indexA - indexB;
+  });
+}
+
 export function arrayExpression(
   elements: Array<null | t.Expression | t.SpreadElement> = [],
 ): t.ArrayExpression {
-  return validateNode<t.ArrayExpression>({
+  const node: t.ArrayExpression = {
     type: "ArrayExpression",
     elements,
-  });
+  };
+  validate(_data[0][0], node, "elements", elements, true);
+  return node;
 }
 export function assignmentExpression(
   operator: string,
   left: t.LVal | t.OptionalMemberExpression,
   right: t.Expression,
 ): t.AssignmentExpression {
-  return validateNode<t.AssignmentExpression>({
+  const node: t.AssignmentExpression = {
     type: "AssignmentExpression",
     operator,
     left,
     right,
-  });
+  };
+  validate(_data[1][0], node, "operator", operator);
+  validate(_data[1][1], node, "left", left, true);
+  validate(_data[1][2], node, "right", right, true);
+  return node;
 }
 export function binaryExpression(
   operator:
@@ -53,58 +87,76 @@ export function binaryExpression(
   left: t.Expression | t.PrivateName,
   right: t.Expression,
 ): t.BinaryExpression {
-  return validateNode<t.BinaryExpression>({
+  const node: t.BinaryExpression = {
     type: "BinaryExpression",
     operator,
     left,
     right,
-  });
+  };
+  validate(_data[2][0], node, "operator", operator);
+  validate(_data[2][1], node, "left", left, true);
+  validate(_data[2][2], node, "right", right, true);
+  return node;
 }
 export function interpreterDirective(value: string): t.InterpreterDirective {
-  return validateNode<t.InterpreterDirective>({
+  const node: t.InterpreterDirective = {
     type: "InterpreterDirective",
     value,
-  });
+  };
+  validate(_data[3][0], node, "value", value);
+  return node;
 }
 export function directive(value: t.DirectiveLiteral): t.Directive {
-  return validateNode<t.Directive>({
+  const node: t.Directive = {
     type: "Directive",
     value,
-  });
+  };
+  validate(_data[4][0], node, "value", value, true);
+  return node;
 }
 export function directiveLiteral(value: string): t.DirectiveLiteral {
-  return validateNode<t.DirectiveLiteral>({
+  const node: t.DirectiveLiteral = {
     type: "DirectiveLiteral",
     value,
-  });
+  };
+  validate(_data[5][0], node, "value", value);
+  return node;
 }
 export function blockStatement(
   body: Array<t.Statement>,
   directives: Array<t.Directive> = [],
 ): t.BlockStatement {
-  return validateNode<t.BlockStatement>({
+  const node: t.BlockStatement = {
     type: "BlockStatement",
     body,
     directives,
-  });
+  };
+  validate(_data[6][0], node, "body", body, true);
+  validate(_data[6][1], node, "directives", directives, true);
+  return node;
 }
 export function breakStatement(
   label: t.Identifier | null = null,
 ): t.BreakStatement {
-  return validateNode<t.BreakStatement>({
+  const node: t.BreakStatement = {
     type: "BreakStatement",
     label,
-  });
+  };
+  validate(_data[7][0], node, "label", label, true);
+  return node;
 }
 export function callExpression(
   callee: t.Expression | t.Super | t.V8IntrinsicIdentifier,
   _arguments: Array<t.Expression | t.SpreadElement | t.ArgumentPlaceholder>,
 ): t.CallExpression {
-  return validateNode<t.CallExpression>({
+  const node: t.CallExpression = {
     type: "CallExpression",
     callee,
     arguments: _arguments,
-  });
+  };
+  validate(_data[8][0], node, "callee", callee, true);
+  validate(_data[8][1], node, "arguments", _arguments, true);
+  return node;
 }
 export function catchClause(
   param:
@@ -115,31 +167,40 @@ export function catchClause(
     | undefined = null,
   body: t.BlockStatement,
 ): t.CatchClause {
-  return validateNode<t.CatchClause>({
+  const node: t.CatchClause = {
     type: "CatchClause",
     param,
     body,
-  });
+  };
+  validate(_data[9][0], node, "param", param, true);
+  validate(_data[9][1], node, "body", body, true);
+  return node;
 }
 export function conditionalExpression(
   test: t.Expression,
   consequent: t.Expression,
   alternate: t.Expression,
 ): t.ConditionalExpression {
-  return validateNode<t.ConditionalExpression>({
+  const node: t.ConditionalExpression = {
     type: "ConditionalExpression",
     test,
     consequent,
     alternate,
-  });
+  };
+  validate(_data[10][0], node, "test", test, true);
+  validate(_data[10][1], node, "consequent", consequent, true);
+  validate(_data[10][2], node, "alternate", alternate, true);
+  return node;
 }
 export function continueStatement(
   label: t.Identifier | null = null,
 ): t.ContinueStatement {
-  return validateNode<t.ContinueStatement>({
+  const node: t.ContinueStatement = {
     type: "ContinueStatement",
     label,
-  });
+  };
+  validate(_data[11][0], node, "label", label, true);
+  return node;
 }
 export function debuggerStatement(): t.DebuggerStatement {
   return {
@@ -150,11 +211,14 @@ export function doWhileStatement(
   test: t.Expression,
   body: t.Statement,
 ): t.DoWhileStatement {
-  return validateNode<t.DoWhileStatement>({
+  const node: t.DoWhileStatement = {
     type: "DoWhileStatement",
     test,
     body,
-  });
+  };
+  validate(_data[13][0], node, "test", test, true);
+  validate(_data[13][1], node, "body", body, true);
+  return node;
 }
 export function emptyStatement(): t.EmptyStatement {
   return {
@@ -164,34 +228,44 @@ export function emptyStatement(): t.EmptyStatement {
 export function expressionStatement(
   expression: t.Expression,
 ): t.ExpressionStatement {
-  return validateNode<t.ExpressionStatement>({
+  const node: t.ExpressionStatement = {
     type: "ExpressionStatement",
     expression,
-  });
+  };
+  validate(_data[15][0], node, "expression", expression, true);
+  return node;
 }
 export function file(
   program: t.Program,
   comments: Array<t.CommentBlock | t.CommentLine> | null = null,
   tokens: Array<any> | null = null,
 ): t.File {
-  return validateNode<t.File>({
+  const node: t.File = {
     type: "File",
     program,
     comments,
     tokens,
-  });
+  };
+  validate(_data[16][0], node, "program", program, true);
+  validate(_data[16][1], node, "comments", comments, true);
+  validate(_data[16][2], node, "tokens", tokens);
+  return node;
 }
 export function forInStatement(
   left: t.VariableDeclaration | t.LVal,
   right: t.Expression,
   body: t.Statement,
 ): t.ForInStatement {
-  return validateNode<t.ForInStatement>({
+  const node: t.ForInStatement = {
     type: "ForInStatement",
     left,
     right,
     body,
-  });
+  };
+  validate(_data[17][0], node, "left", left, true);
+  validate(_data[17][1], node, "right", right, true);
+  validate(_data[17][2], node, "body", body, true);
+  return node;
 }
 export function forStatement(
   init: t.VariableDeclaration | t.Expression | null | undefined = null,
@@ -199,13 +273,18 @@ export function forStatement(
   update: t.Expression | null | undefined = null,
   body: t.Statement,
 ): t.ForStatement {
-  return validateNode<t.ForStatement>({
+  const node: t.ForStatement = {
     type: "ForStatement",
     init,
     test,
     update,
     body,
-  });
+  };
+  validate(_data[18][0], node, "init", init, true);
+  validate(_data[18][1], node, "test", test, true);
+  validate(_data[18][2], node, "update", update, true);
+  validate(_data[18][3], node, "body", body, true);
+  return node;
 }
 export function functionDeclaration(
   id: t.Identifier | null | undefined = null,
@@ -214,14 +293,20 @@ export function functionDeclaration(
   generator: boolean = false,
   async: boolean = false,
 ): t.FunctionDeclaration {
-  return validateNode<t.FunctionDeclaration>({
+  const node: t.FunctionDeclaration = {
     type: "FunctionDeclaration",
     id,
     params,
     body,
     generator,
     async,
-  });
+  };
+  validate(_data[19][0], node, "id", id, true);
+  validate(_data[19][1], node, "params", params, true);
+  validate(_data[19][2], node, "body", body, true);
+  validate(_data[19][3], node, "generator", generator);
+  validate(_data[19][4], node, "async", async);
+  return node;
 }
 export function functionExpression(
   id: t.Identifier | null | undefined = null,
@@ -230,54 +315,73 @@ export function functionExpression(
   generator: boolean = false,
   async: boolean = false,
 ): t.FunctionExpression {
-  return validateNode<t.FunctionExpression>({
+  const node: t.FunctionExpression = {
     type: "FunctionExpression",
     id,
     params,
     body,
     generator,
     async,
-  });
+  };
+  validate(_data[20][0], node, "id", id, true);
+  validate(_data[20][1], node, "params", params, true);
+  validate(_data[20][2], node, "body", body, true);
+  validate(_data[20][3], node, "generator", generator);
+  validate(_data[20][4], node, "async", async);
+  return node;
 }
 export function identifier(name: string): t.Identifier {
-  return validateNode<t.Identifier>({
+  const node: t.Identifier = {
     type: "Identifier",
     name,
-  });
+  };
+  validate(_data[21][0], node, "name", name);
+  return node;
 }
 export function ifStatement(
   test: t.Expression,
   consequent: t.Statement,
   alternate: t.Statement | null = null,
 ): t.IfStatement {
-  return validateNode<t.IfStatement>({
+  const node: t.IfStatement = {
     type: "IfStatement",
     test,
     consequent,
     alternate,
-  });
+  };
+  validate(_data[22][0], node, "test", test, true);
+  validate(_data[22][1], node, "consequent", consequent, true);
+  validate(_data[22][2], node, "alternate", alternate, true);
+  return node;
 }
 export function labeledStatement(
   label: t.Identifier,
   body: t.Statement,
 ): t.LabeledStatement {
-  return validateNode<t.LabeledStatement>({
+  const node: t.LabeledStatement = {
     type: "LabeledStatement",
     label,
     body,
-  });
+  };
+  validate(_data[23][0], node, "label", label, true);
+  validate(_data[23][1], node, "body", body, true);
+  return node;
 }
 export function stringLiteral(value: string): t.StringLiteral {
-  return validateNode<t.StringLiteral>({
+  const node: t.StringLiteral = {
     type: "StringLiteral",
     value,
-  });
+  };
+  validate(_data[24][0], node, "value", value);
+  return node;
 }
 export function numericLiteral(value: number): t.NumericLiteral {
-  return validateNode<t.NumericLiteral>({
+  const node: t.NumericLiteral = {
     type: "NumericLiteral",
     value,
-  });
+  };
+  validate(_data[25][0], node, "value", value);
+  return node;
 }
 export function nullLiteral(): t.NullLiteral {
   return {
@@ -285,32 +389,41 @@ export function nullLiteral(): t.NullLiteral {
   };
 }
 export function booleanLiteral(value: boolean): t.BooleanLiteral {
-  return validateNode<t.BooleanLiteral>({
+  const node: t.BooleanLiteral = {
     type: "BooleanLiteral",
     value,
-  });
+  };
+  validate(_data[27][0], node, "value", value);
+  return node;
 }
 export function regExpLiteral(
   pattern: string,
   flags: string = "",
 ): t.RegExpLiteral {
-  return validateNode<t.RegExpLiteral>({
+  const node: t.RegExpLiteral = {
     type: "RegExpLiteral",
     pattern,
     flags,
-  });
+  };
+  validate(_data[28][0], node, "pattern", pattern);
+  validate(_data[28][1], node, "flags", flags);
+  return node;
 }
 export function logicalExpression(
   operator: "||" | "&&" | "??",
   left: t.Expression,
   right: t.Expression,
 ): t.LogicalExpression {
-  return validateNode<t.LogicalExpression>({
+  const node: t.LogicalExpression = {
     type: "LogicalExpression",
     operator,
     left,
     right,
-  });
+  };
+  validate(_data[29][0], node, "operator", operator);
+  validate(_data[29][1], node, "left", left, true);
+  validate(_data[29][2], node, "right", right, true);
+  return node;
 }
 export function memberExpression(
   object: t.Expression | t.Super,
@@ -318,23 +431,31 @@ export function memberExpression(
   computed: boolean = false,
   optional: boolean | null = null,
 ): t.MemberExpression {
-  return validateNode<t.MemberExpression>({
+  const node: t.MemberExpression = {
     type: "MemberExpression",
     object,
     property,
     computed,
     optional,
-  });
+  };
+  validate(_data[30][0], node, "object", object, true);
+  validate(_data[30][1], node, "property", property, true);
+  validate(_data[30][2], node, "computed", computed);
+  validate(_data[30][3], node, "optional", optional);
+  return node;
 }
 export function newExpression(
   callee: t.Expression | t.Super | t.V8IntrinsicIdentifier,
   _arguments: Array<t.Expression | t.SpreadElement | t.ArgumentPlaceholder>,
 ): t.NewExpression {
-  return validateNode<t.NewExpression>({
+  const node: t.NewExpression = {
     type: "NewExpression",
     callee,
     arguments: _arguments,
-  });
+  };
+  validate(_data[31][0], node, "callee", callee, true);
+  validate(_data[31][1], node, "arguments", _arguments, true);
+  return node;
 }
 export function program(
   body: Array<t.Statement>,
@@ -342,21 +463,28 @@ export function program(
   sourceType: "script" | "module" = "script",
   interpreter: t.InterpreterDirective | null = null,
 ): t.Program {
-  return validateNode<t.Program>({
+  const node: t.Program = {
     type: "Program",
     body,
     directives,
     sourceType,
     interpreter,
-  });
+  };
+  validate(_data[32][0], node, "body", body, true);
+  validate(_data[32][1], node, "directives", directives, true);
+  validate(_data[32][2], node, "sourceType", sourceType);
+  validate(_data[32][3], node, "interpreter", interpreter, true);
+  return node;
 }
 export function objectExpression(
   properties: Array<t.ObjectMethod | t.ObjectProperty | t.SpreadElement>,
 ): t.ObjectExpression {
-  return validateNode<t.ObjectExpression>({
+  const node: t.ObjectExpression = {
     type: "ObjectExpression",
     properties,
-  });
+  };
+  validate(_data[33][0], node, "properties", properties, true);
+  return node;
 }
 export function objectMethod(
   kind: "method" | "get" | "set" | undefined = "method",
@@ -372,7 +500,7 @@ export function objectMethod(
   generator: boolean = false,
   async: boolean = false,
 ): t.ObjectMethod {
-  return validateNode<t.ObjectMethod>({
+  const node: t.ObjectMethod = {
     type: "ObjectMethod",
     kind,
     key,
@@ -381,7 +509,15 @@ export function objectMethod(
     computed,
     generator,
     async,
-  });
+  };
+  validate(_data[34][0], node, "kind", kind);
+  validate(_data[34][1], node, "key", key, true);
+  validate(_data[34][2], node, "params", params, true);
+  validate(_data[34][3], node, "body", body, true);
+  validate(_data[34][4], node, "computed", computed);
+  validate(_data[34][5], node, "generator", generator);
+  validate(_data[34][6], node, "async", async);
+  return node;
 }
 export function objectProperty(
   key:
@@ -397,64 +533,84 @@ export function objectProperty(
   shorthand: boolean = false,
   decorators: Array<t.Decorator> | null = null,
 ): t.ObjectProperty {
-  return validateNode<t.ObjectProperty>({
+  const node: t.ObjectProperty = {
     type: "ObjectProperty",
     key,
     value,
     computed,
     shorthand,
     decorators,
-  });
+  };
+  validate(_data[35][0], node, "key", key, true);
+  validate(_data[35][1], node, "value", value, true);
+  validate(_data[35][2], node, "computed", computed);
+  validate(_data[35][3], node, "shorthand", shorthand);
+  validate(_data[35][4], node, "decorators", decorators, true);
+  return node;
 }
 export function restElement(argument: t.LVal): t.RestElement {
-  return validateNode<t.RestElement>({
+  const node: t.RestElement = {
     type: "RestElement",
     argument,
-  });
+  };
+  validate(_data[36][0], node, "argument", argument, true);
+  return node;
 }
 export function returnStatement(
   argument: t.Expression | null = null,
 ): t.ReturnStatement {
-  return validateNode<t.ReturnStatement>({
+  const node: t.ReturnStatement = {
     type: "ReturnStatement",
     argument,
-  });
+  };
+  validate(_data[37][0], node, "argument", argument, true);
+  return node;
 }
 export function sequenceExpression(
   expressions: Array<t.Expression>,
 ): t.SequenceExpression {
-  return validateNode<t.SequenceExpression>({
+  const node: t.SequenceExpression = {
     type: "SequenceExpression",
     expressions,
-  });
+  };
+  validate(_data[38][0], node, "expressions", expressions, true);
+  return node;
 }
 export function parenthesizedExpression(
   expression: t.Expression,
 ): t.ParenthesizedExpression {
-  return validateNode<t.ParenthesizedExpression>({
+  const node: t.ParenthesizedExpression = {
     type: "ParenthesizedExpression",
     expression,
-  });
+  };
+  validate(_data[39][0], node, "expression", expression, true);
+  return node;
 }
 export function switchCase(
   test: t.Expression | null | undefined = null,
   consequent: Array<t.Statement>,
 ): t.SwitchCase {
-  return validateNode<t.SwitchCase>({
+  const node: t.SwitchCase = {
     type: "SwitchCase",
     test,
     consequent,
-  });
+  };
+  validate(_data[40][0], node, "test", test, true);
+  validate(_data[40][1], node, "consequent", consequent, true);
+  return node;
 }
 export function switchStatement(
   discriminant: t.Expression,
   cases: Array<t.SwitchCase>,
 ): t.SwitchStatement {
-  return validateNode<t.SwitchStatement>({
+  const node: t.SwitchStatement = {
     type: "SwitchStatement",
     discriminant,
     cases,
-  });
+  };
+  validate(_data[41][0], node, "discriminant", discriminant, true);
+  validate(_data[41][1], node, "cases", cases, true);
+  return node;
 }
 export function thisExpression(): t.ThisExpression {
   return {
@@ -462,86 +618,112 @@ export function thisExpression(): t.ThisExpression {
   };
 }
 export function throwStatement(argument: t.Expression): t.ThrowStatement {
-  return validateNode<t.ThrowStatement>({
+  const node: t.ThrowStatement = {
     type: "ThrowStatement",
     argument,
-  });
+  };
+  validate(_data[43][0], node, "argument", argument, true);
+  return node;
 }
 export function tryStatement(
   block: t.BlockStatement,
   handler: t.CatchClause | null = null,
   finalizer: t.BlockStatement | null = null,
 ): t.TryStatement {
-  return validateNode<t.TryStatement>({
+  const node: t.TryStatement = {
     type: "TryStatement",
     block,
     handler,
     finalizer,
-  });
+  };
+  validate(_data[44][0], node, "block", block, true);
+  validate(_data[44][1], node, "handler", handler, true);
+  validate(_data[44][2], node, "finalizer", finalizer, true);
+  return node;
 }
 export function unaryExpression(
   operator: "void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof",
   argument: t.Expression,
   prefix: boolean = true,
 ): t.UnaryExpression {
-  return validateNode<t.UnaryExpression>({
+  const node: t.UnaryExpression = {
     type: "UnaryExpression",
     operator,
     argument,
     prefix,
-  });
+  };
+  validate(_data[45][0], node, "operator", operator);
+  validate(_data[45][1], node, "argument", argument, true);
+  validate(_data[45][2], node, "prefix", prefix);
+  return node;
 }
 export function updateExpression(
   operator: "++" | "--",
   argument: t.Expression,
   prefix: boolean = false,
 ): t.UpdateExpression {
-  return validateNode<t.UpdateExpression>({
+  const node: t.UpdateExpression = {
     type: "UpdateExpression",
     operator,
     argument,
     prefix,
-  });
+  };
+  validate(_data[46][0], node, "operator", operator);
+  validate(_data[46][1], node, "argument", argument, true);
+  validate(_data[46][2], node, "prefix", prefix);
+  return node;
 }
 export function variableDeclaration(
   kind: "var" | "let" | "const" | "using" | "await using",
   declarations: Array<t.VariableDeclarator>,
 ): t.VariableDeclaration {
-  return validateNode<t.VariableDeclaration>({
+  const node: t.VariableDeclaration = {
     type: "VariableDeclaration",
     kind,
     declarations,
-  });
+  };
+  validate(_data[47][0], node, "kind", kind);
+  validate(_data[47][1], node, "declarations", declarations, true);
+  return node;
 }
 export function variableDeclarator(
   id: t.LVal,
   init: t.Expression | null = null,
 ): t.VariableDeclarator {
-  return validateNode<t.VariableDeclarator>({
+  const node: t.VariableDeclarator = {
     type: "VariableDeclarator",
     id,
     init,
-  });
+  };
+  validate(_data[48][0], node, "id", id, true);
+  validate(_data[48][1], node, "init", init, true);
+  return node;
 }
 export function whileStatement(
   test: t.Expression,
   body: t.Statement,
 ): t.WhileStatement {
-  return validateNode<t.WhileStatement>({
+  const node: t.WhileStatement = {
     type: "WhileStatement",
     test,
     body,
-  });
+  };
+  validate(_data[49][0], node, "test", test, true);
+  validate(_data[49][1], node, "body", body, true);
+  return node;
 }
 export function withStatement(
   object: t.Expression,
   body: t.Statement,
 ): t.WithStatement {
-  return validateNode<t.WithStatement>({
+  const node: t.WithStatement = {
     type: "WithStatement",
     object,
     body,
-  });
+  };
+  validate(_data[50][0], node, "object", object, true);
+  validate(_data[50][1], node, "body", body, true);
+  return node;
 }
 export function assignmentPattern(
   left:
@@ -555,32 +737,41 @@ export function assignmentPattern(
     | t.TSNonNullExpression,
   right: t.Expression,
 ): t.AssignmentPattern {
-  return validateNode<t.AssignmentPattern>({
+  const node: t.AssignmentPattern = {
     type: "AssignmentPattern",
     left,
     right,
-  });
+  };
+  validate(_data[51][0], node, "left", left, true);
+  validate(_data[51][1], node, "right", right, true);
+  return node;
 }
 export function arrayPattern(
   elements: Array<null | t.PatternLike | t.LVal>,
 ): t.ArrayPattern {
-  return validateNode<t.ArrayPattern>({
+  const node: t.ArrayPattern = {
     type: "ArrayPattern",
     elements,
-  });
+  };
+  validate(_data[52][0], node, "elements", elements, true);
+  return node;
 }
 export function arrowFunctionExpression(
   params: Array<t.Identifier | t.Pattern | t.RestElement>,
   body: t.BlockStatement | t.Expression,
   async: boolean = false,
 ): t.ArrowFunctionExpression {
-  return validateNode<t.ArrowFunctionExpression>({
+  const node: t.ArrowFunctionExpression = {
     type: "ArrowFunctionExpression",
     params,
     body,
     async,
     expression: null,
-  });
+  };
+  validate(_data[53][0], node, "params", params, true);
+  validate(_data[53][1], node, "body", body, true);
+  validate(_data[53][2], node, "async", async);
+  return node;
 }
 export function classBody(
   body: Array<
@@ -594,10 +785,12 @@ export function classBody(
     | t.StaticBlock
   >,
 ): t.ClassBody {
-  return validateNode<t.ClassBody>({
+  const node: t.ClassBody = {
     type: "ClassBody",
     body,
-  });
+  };
+  validate(_data[54][0], node, "body", body, true);
+  return node;
 }
 export function classExpression(
   id: t.Identifier | null | undefined = null,
@@ -605,13 +798,18 @@ export function classExpression(
   body: t.ClassBody,
   decorators: Array<t.Decorator> | null = null,
 ): t.ClassExpression {
-  return validateNode<t.ClassExpression>({
+  const node: t.ClassExpression = {
     type: "ClassExpression",
     id,
     superClass,
     body,
     decorators,
-  });
+  };
+  validate(_data[55][0], node, "id", id, true);
+  validate(_data[55][1], node, "superClass", superClass, true);
+  validate(_data[55][2], node, "body", body, true);
+  validate(_data[55][3], node, "decorators", decorators, true);
+  return node;
 }
 export function classDeclaration(
   id: t.Identifier | null | undefined = null,
@@ -619,21 +817,28 @@ export function classDeclaration(
   body: t.ClassBody,
   decorators: Array<t.Decorator> | null = null,
 ): t.ClassDeclaration {
-  return validateNode<t.ClassDeclaration>({
+  const node: t.ClassDeclaration = {
     type: "ClassDeclaration",
     id,
     superClass,
     body,
     decorators,
-  });
+  };
+  validate(_data[56][0], node, "id", id, true);
+  validate(_data[56][1], node, "superClass", superClass, true);
+  validate(_data[56][2], node, "body", body, true);
+  validate(_data[56][3], node, "decorators", decorators, true);
+  return node;
 }
 export function exportAllDeclaration(
   source: t.StringLiteral,
 ): t.ExportAllDeclaration {
-  return validateNode<t.ExportAllDeclaration>({
+  const node: t.ExportAllDeclaration = {
     type: "ExportAllDeclaration",
     source,
-  });
+  };
+  validate(_data[57][0], node, "source", source, true);
+  return node;
 }
 export function exportDefaultDeclaration(
   declaration:
@@ -642,10 +847,12 @@ export function exportDefaultDeclaration(
     | t.ClassDeclaration
     | t.Expression,
 ): t.ExportDefaultDeclaration {
-  return validateNode<t.ExportDefaultDeclaration>({
+  const node: t.ExportDefaultDeclaration = {
     type: "ExportDefaultDeclaration",
     declaration,
-  });
+  };
+  validate(_data[58][0], node, "declaration", declaration, true);
+  return node;
 }
 export function exportNamedDeclaration(
   declaration: t.Declaration | null = null,
@@ -654,22 +861,29 @@ export function exportNamedDeclaration(
   > = [],
   source: t.StringLiteral | null = null,
 ): t.ExportNamedDeclaration {
-  return validateNode<t.ExportNamedDeclaration>({
+  const node: t.ExportNamedDeclaration = {
     type: "ExportNamedDeclaration",
     declaration,
     specifiers,
     source,
-  });
+  };
+  validate(_data[59][0], node, "declaration", declaration, true);
+  validate(_data[59][1], node, "specifiers", specifiers, true);
+  validate(_data[59][2], node, "source", source, true);
+  return node;
 }
 export function exportSpecifier(
   local: t.Identifier,
   exported: t.Identifier | t.StringLiteral,
 ): t.ExportSpecifier {
-  return validateNode<t.ExportSpecifier>({
+  const node: t.ExportSpecifier = {
     type: "ExportSpecifier",
     local,
     exported,
-  });
+  };
+  validate(_data[60][0], node, "local", local, true);
+  validate(_data[60][1], node, "exported", exported, true);
+  return node;
 }
 export function forOfStatement(
   left: t.VariableDeclaration | t.LVal,
@@ -677,13 +891,18 @@ export function forOfStatement(
   body: t.Statement,
   _await: boolean = false,
 ): t.ForOfStatement {
-  return validateNode<t.ForOfStatement>({
+  const node: t.ForOfStatement = {
     type: "ForOfStatement",
     left,
     right,
     body,
     await: _await,
-  });
+  };
+  validate(_data[61][0], node, "left", left, true);
+  validate(_data[61][1], node, "right", right, true);
+  validate(_data[61][2], node, "body", body, true);
+  validate(_data[61][3], node, "await", _await);
+  return node;
 }
 export function importDeclaration(
   specifiers: Array<
@@ -691,57 +910,73 @@ export function importDeclaration(
   >,
   source: t.StringLiteral,
 ): t.ImportDeclaration {
-  return validateNode<t.ImportDeclaration>({
+  const node: t.ImportDeclaration = {
     type: "ImportDeclaration",
     specifiers,
     source,
-  });
+  };
+  validate(_data[62][0], node, "specifiers", specifiers, true);
+  validate(_data[62][1], node, "source", source, true);
+  return node;
 }
 export function importDefaultSpecifier(
   local: t.Identifier,
 ): t.ImportDefaultSpecifier {
-  return validateNode<t.ImportDefaultSpecifier>({
+  const node: t.ImportDefaultSpecifier = {
     type: "ImportDefaultSpecifier",
     local,
-  });
+  };
+  validate(_data[63][0], node, "local", local, true);
+  return node;
 }
 export function importNamespaceSpecifier(
   local: t.Identifier,
 ): t.ImportNamespaceSpecifier {
-  return validateNode<t.ImportNamespaceSpecifier>({
+  const node: t.ImportNamespaceSpecifier = {
     type: "ImportNamespaceSpecifier",
     local,
-  });
+  };
+  validate(_data[64][0], node, "local", local, true);
+  return node;
 }
 export function importSpecifier(
   local: t.Identifier,
   imported: t.Identifier | t.StringLiteral,
 ): t.ImportSpecifier {
-  return validateNode<t.ImportSpecifier>({
+  const node: t.ImportSpecifier = {
     type: "ImportSpecifier",
     local,
     imported,
-  });
+  };
+  validate(_data[65][0], node, "local", local, true);
+  validate(_data[65][1], node, "imported", imported, true);
+  return node;
 }
 export function importExpression(
   source: t.Expression,
   options: t.Expression | null = null,
 ): t.ImportExpression {
-  return validateNode<t.ImportExpression>({
+  const node: t.ImportExpression = {
     type: "ImportExpression",
     source,
     options,
-  });
+  };
+  validate(_data[66][0], node, "source", source, true);
+  validate(_data[66][1], node, "options", options, true);
+  return node;
 }
 export function metaProperty(
   meta: t.Identifier,
   property: t.Identifier,
 ): t.MetaProperty {
-  return validateNode<t.MetaProperty>({
+  const node: t.MetaProperty = {
     type: "MetaProperty",
     meta,
     property,
-  });
+  };
+  validate(_data[67][0], node, "meta", meta, true);
+  validate(_data[67][1], node, "property", property, true);
+  return node;
 }
 export function classMethod(
   kind: "get" | "set" | "method" | "constructor" | undefined = "method",
@@ -760,7 +995,7 @@ export function classMethod(
   generator: boolean = false,
   async: boolean = false,
 ): t.ClassMethod {
-  return validateNode<t.ClassMethod>({
+  const node: t.ClassMethod = {
     type: "ClassMethod",
     kind,
     key,
@@ -770,21 +1005,34 @@ export function classMethod(
     static: _static,
     generator,
     async,
-  });
+  };
+  validate(_data[68][0], node, "kind", kind);
+  validate(_data[68][1], node, "key", key, true);
+  validate(_data[68][2], node, "params", params, true);
+  validate(_data[68][3], node, "body", body, true);
+  validate(_data[68][4], node, "computed", computed);
+  validate(_data[68][5], node, "static", _static);
+  validate(_data[68][6], node, "generator", generator);
+  validate(_data[68][7], node, "async", async);
+  return node;
 }
 export function objectPattern(
   properties: Array<t.RestElement | t.ObjectProperty>,
 ): t.ObjectPattern {
-  return validateNode<t.ObjectPattern>({
+  const node: t.ObjectPattern = {
     type: "ObjectPattern",
     properties,
-  });
+  };
+  validate(_data[69][0], node, "properties", properties, true);
+  return node;
 }
 export function spreadElement(argument: t.Expression): t.SpreadElement {
-  return validateNode<t.SpreadElement>({
+  const node: t.SpreadElement = {
     type: "SpreadElement",
     argument,
-  });
+  };
+  validate(_data[70][0], node, "argument", argument, true);
+  return node;
 }
 function _super(): t.Super {
   return {
@@ -796,47 +1044,61 @@ export function taggedTemplateExpression(
   tag: t.Expression,
   quasi: t.TemplateLiteral,
 ): t.TaggedTemplateExpression {
-  return validateNode<t.TaggedTemplateExpression>({
+  const node: t.TaggedTemplateExpression = {
     type: "TaggedTemplateExpression",
     tag,
     quasi,
-  });
+  };
+  validate(_data[72][0], node, "tag", tag, true);
+  validate(_data[72][1], node, "quasi", quasi, true);
+  return node;
 }
 export function templateElement(
   value: { raw: string; cooked?: string },
   tail: boolean = false,
 ): t.TemplateElement {
-  return validateNode<t.TemplateElement>({
+  const node: t.TemplateElement = {
     type: "TemplateElement",
     value,
     tail,
-  });
+  };
+  validate(_data[73][0], node, "value", value);
+  validate(_data[73][1], node, "tail", tail);
+  return node;
 }
 export function templateLiteral(
   quasis: Array<t.TemplateElement>,
   expressions: Array<t.Expression | t.TSType>,
 ): t.TemplateLiteral {
-  return validateNode<t.TemplateLiteral>({
+  const node: t.TemplateLiteral = {
     type: "TemplateLiteral",
     quasis,
     expressions,
-  });
+  };
+  validate(_data[74][0], node, "quasis", quasis, true);
+  validate(_data[74][1], node, "expressions", expressions, true);
+  return node;
 }
 export function yieldExpression(
   argument: t.Expression | null = null,
   delegate: boolean = false,
 ): t.YieldExpression {
-  return validateNode<t.YieldExpression>({
+  const node: t.YieldExpression = {
     type: "YieldExpression",
     argument,
     delegate,
-  });
+  };
+  validate(_data[75][0], node, "argument", argument, true);
+  validate(_data[75][1], node, "delegate", delegate);
+  return node;
 }
 export function awaitExpression(argument: t.Expression): t.AwaitExpression {
-  return validateNode<t.AwaitExpression>({
+  const node: t.AwaitExpression = {
     type: "AwaitExpression",
     argument,
-  });
+  };
+  validate(_data[76][0], node, "argument", argument, true);
+  return node;
 }
 function _import(): t.Import {
   return {
@@ -845,18 +1107,22 @@ function _import(): t.Import {
 }
 export { _import as import };
 export function bigIntLiteral(value: string): t.BigIntLiteral {
-  return validateNode<t.BigIntLiteral>({
+  const node: t.BigIntLiteral = {
     type: "BigIntLiteral",
     value,
-  });
+  };
+  validate(_data[78][0], node, "value", value);
+  return node;
 }
 export function exportNamespaceSpecifier(
   exported: t.Identifier,
 ): t.ExportNamespaceSpecifier {
-  return validateNode<t.ExportNamespaceSpecifier>({
+  const node: t.ExportNamespaceSpecifier = {
     type: "ExportNamespaceSpecifier",
     exported,
-  });
+  };
+  validate(_data[79][0], node, "exported", exported, true);
+  return node;
 }
 export function optionalMemberExpression(
   object: t.Expression,
@@ -864,25 +1130,34 @@ export function optionalMemberExpression(
   computed: boolean | undefined = false,
   optional: boolean,
 ): t.OptionalMemberExpression {
-  return validateNode<t.OptionalMemberExpression>({
+  const node: t.OptionalMemberExpression = {
     type: "OptionalMemberExpression",
     object,
     property,
     computed,
     optional,
-  });
+  };
+  validate(_data[80][0], node, "object", object, true);
+  validate(_data[80][1], node, "property", property, true);
+  validate(_data[80][2], node, "computed", computed);
+  validate(_data[80][3], node, "optional", optional);
+  return node;
 }
 export function optionalCallExpression(
   callee: t.Expression,
   _arguments: Array<t.Expression | t.SpreadElement | t.ArgumentPlaceholder>,
   optional: boolean,
 ): t.OptionalCallExpression {
-  return validateNode<t.OptionalCallExpression>({
+  const node: t.OptionalCallExpression = {
     type: "OptionalCallExpression",
     callee,
     arguments: _arguments,
     optional,
-  });
+  };
+  validate(_data[81][0], node, "callee", callee, true);
+  validate(_data[81][1], node, "arguments", _arguments, true);
+  validate(_data[81][2], node, "optional", optional);
+  return node;
 }
 export function classProperty(
   key:
@@ -897,7 +1172,7 @@ export function classProperty(
   computed: boolean = false,
   _static: boolean = false,
 ): t.ClassProperty {
-  return validateNode<t.ClassProperty>({
+  const node: t.ClassProperty = {
     type: "ClassProperty",
     key,
     value,
@@ -905,7 +1180,14 @@ export function classProperty(
     decorators,
     computed,
     static: _static,
-  });
+  };
+  validate(_data[82][0], node, "key", key, true);
+  validate(_data[82][1], node, "value", value, true);
+  validate(_data[82][2], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[82][3], node, "decorators", decorators, true);
+  validate(_data[82][4], node, "computed", computed);
+  validate(_data[82][5], node, "static", _static);
+  return node;
 }
 export function classAccessorProperty(
   key:
@@ -921,7 +1203,7 @@ export function classAccessorProperty(
   computed: boolean = false,
   _static: boolean = false,
 ): t.ClassAccessorProperty {
-  return validateNode<t.ClassAccessorProperty>({
+  const node: t.ClassAccessorProperty = {
     type: "ClassAccessorProperty",
     key,
     value,
@@ -929,7 +1211,14 @@ export function classAccessorProperty(
     decorators,
     computed,
     static: _static,
-  });
+  };
+  validate(_data[83][0], node, "key", key, true);
+  validate(_data[83][1], node, "value", value, true);
+  validate(_data[83][2], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[83][3], node, "decorators", decorators, true);
+  validate(_data[83][4], node, "computed", computed);
+  validate(_data[83][5], node, "static", _static);
+  return node;
 }
 export function classPrivateProperty(
   key: t.PrivateName,
@@ -937,13 +1226,18 @@ export function classPrivateProperty(
   decorators: Array<t.Decorator> | null = null,
   _static: boolean = false,
 ): t.ClassPrivateProperty {
-  return validateNode<t.ClassPrivateProperty>({
+  const node: t.ClassPrivateProperty = {
     type: "ClassPrivateProperty",
     key,
     value,
     decorators,
     static: _static,
-  });
+  };
+  validate(_data[84][0], node, "key", key, true);
+  validate(_data[84][1], node, "value", value, true);
+  validate(_data[84][2], node, "decorators", decorators, true);
+  validate(_data[84][3], node, "static", _static);
+  return node;
 }
 export function classPrivateMethod(
   kind: "get" | "set" | "method" | undefined = "method",
@@ -954,26 +1248,36 @@ export function classPrivateMethod(
   body: t.BlockStatement,
   _static: boolean = false,
 ): t.ClassPrivateMethod {
-  return validateNode<t.ClassPrivateMethod>({
+  const node: t.ClassPrivateMethod = {
     type: "ClassPrivateMethod",
     kind,
     key,
     params,
     body,
     static: _static,
-  });
+  };
+  validate(_data[85][0], node, "kind", kind);
+  validate(_data[85][1], node, "key", key, true);
+  validate(_data[85][2], node, "params", params, true);
+  validate(_data[85][3], node, "body", body, true);
+  validate(_data[85][4], node, "static", _static);
+  return node;
 }
 export function privateName(id: t.Identifier): t.PrivateName {
-  return validateNode<t.PrivateName>({
+  const node: t.PrivateName = {
     type: "PrivateName",
     id,
-  });
+  };
+  validate(_data[86][0], node, "id", id, true);
+  return node;
 }
 export function staticBlock(body: Array<t.Statement>): t.StaticBlock {
-  return validateNode<t.StaticBlock>({
+  const node: t.StaticBlock = {
     type: "StaticBlock",
     body,
-  });
+  };
+  validate(_data[87][0], node, "body", body, true);
+  return node;
 }
 export function anyTypeAnnotation(): t.AnyTypeAnnotation {
   return {
@@ -983,10 +1287,12 @@ export function anyTypeAnnotation(): t.AnyTypeAnnotation {
 export function arrayTypeAnnotation(
   elementType: t.FlowType,
 ): t.ArrayTypeAnnotation {
-  return validateNode<t.ArrayTypeAnnotation>({
+  const node: t.ArrayTypeAnnotation = {
     type: "ArrayTypeAnnotation",
     elementType,
-  });
+  };
+  validate(_data[89][0], node, "elementType", elementType, true);
+  return node;
 }
 export function booleanTypeAnnotation(): t.BooleanTypeAnnotation {
   return {
@@ -996,10 +1302,12 @@ export function booleanTypeAnnotation(): t.BooleanTypeAnnotation {
 export function booleanLiteralTypeAnnotation(
   value: boolean,
 ): t.BooleanLiteralTypeAnnotation {
-  return validateNode<t.BooleanLiteralTypeAnnotation>({
+  const node: t.BooleanLiteralTypeAnnotation = {
     type: "BooleanLiteralTypeAnnotation",
     value,
-  });
+  };
+  validate(_data[91][0], node, "value", value);
+  return node;
 }
 export function nullLiteralTypeAnnotation(): t.NullLiteralTypeAnnotation {
   return {
@@ -1010,11 +1318,14 @@ export function classImplements(
   id: t.Identifier,
   typeParameters: t.TypeParameterInstantiation | null = null,
 ): t.ClassImplements {
-  return validateNode<t.ClassImplements>({
+  const node: t.ClassImplements = {
     type: "ClassImplements",
     id,
     typeParameters,
-  });
+  };
+  validate(_data[93][0], node, "id", id, true);
+  validate(_data[93][1], node, "typeParameters", typeParameters, true);
+  return node;
 }
 export function declareClass(
   id: t.Identifier,
@@ -1022,19 +1333,26 @@ export function declareClass(
   _extends: Array<t.InterfaceExtends> | null | undefined = null,
   body: t.ObjectTypeAnnotation,
 ): t.DeclareClass {
-  return validateNode<t.DeclareClass>({
+  const node: t.DeclareClass = {
     type: "DeclareClass",
     id,
     typeParameters,
     extends: _extends,
     body,
-  });
+  };
+  validate(_data[94][0], node, "id", id, true);
+  validate(_data[94][1], node, "typeParameters", typeParameters, true);
+  validate(_data[94][2], node, "extends", _extends, true);
+  validate(_data[94][3], node, "body", body, true);
+  return node;
 }
 export function declareFunction(id: t.Identifier): t.DeclareFunction {
-  return validateNode<t.DeclareFunction>({
+  const node: t.DeclareFunction = {
     type: "DeclareFunction",
     id,
-  });
+  };
+  validate(_data[95][0], node, "id", id, true);
+  return node;
 }
 export function declareInterface(
   id: t.Identifier,
@@ -1042,63 +1360,84 @@ export function declareInterface(
   _extends: Array<t.InterfaceExtends> | null | undefined = null,
   body: t.ObjectTypeAnnotation,
 ): t.DeclareInterface {
-  return validateNode<t.DeclareInterface>({
+  const node: t.DeclareInterface = {
     type: "DeclareInterface",
     id,
     typeParameters,
     extends: _extends,
     body,
-  });
+  };
+  validate(_data[96][0], node, "id", id, true);
+  validate(_data[96][1], node, "typeParameters", typeParameters, true);
+  validate(_data[96][2], node, "extends", _extends, true);
+  validate(_data[96][3], node, "body", body, true);
+  return node;
 }
 export function declareModule(
   id: t.Identifier | t.StringLiteral,
   body: t.BlockStatement,
   kind: "CommonJS" | "ES" | null = null,
 ): t.DeclareModule {
-  return validateNode<t.DeclareModule>({
+  const node: t.DeclareModule = {
     type: "DeclareModule",
     id,
     body,
     kind,
-  });
+  };
+  validate(_data[97][0], node, "id", id, true);
+  validate(_data[97][1], node, "body", body, true);
+  validate(_data[97][2], node, "kind", kind);
+  return node;
 }
 export function declareModuleExports(
   typeAnnotation: t.TypeAnnotation,
 ): t.DeclareModuleExports {
-  return validateNode<t.DeclareModuleExports>({
+  const node: t.DeclareModuleExports = {
     type: "DeclareModuleExports",
     typeAnnotation,
-  });
+  };
+  validate(_data[98][0], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export function declareTypeAlias(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined = null,
   right: t.FlowType,
 ): t.DeclareTypeAlias {
-  return validateNode<t.DeclareTypeAlias>({
+  const node: t.DeclareTypeAlias = {
     type: "DeclareTypeAlias",
     id,
     typeParameters,
     right,
-  });
+  };
+  validate(_data[99][0], node, "id", id, true);
+  validate(_data[99][1], node, "typeParameters", typeParameters, true);
+  validate(_data[99][2], node, "right", right, true);
+  return node;
 }
 export function declareOpaqueType(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null = null,
   supertype: t.FlowType | null = null,
 ): t.DeclareOpaqueType {
-  return validateNode<t.DeclareOpaqueType>({
+  const node: t.DeclareOpaqueType = {
     type: "DeclareOpaqueType",
     id,
     typeParameters,
     supertype,
-  });
+  };
+  validate(_data[100][0], node, "id", id, true);
+  validate(_data[100][1], node, "typeParameters", typeParameters, true);
+  validate(_data[100][2], node, "supertype", supertype, true);
+  return node;
 }
 export function declareVariable(id: t.Identifier): t.DeclareVariable {
-  return validateNode<t.DeclareVariable>({
+  const node: t.DeclareVariable = {
     type: "DeclareVariable",
     id,
-  });
+  };
+  validate(_data[101][0], node, "id", id, true);
+  return node;
 }
 export function declareExportDeclaration(
   declaration: t.Flow | null = null,
@@ -1107,26 +1446,34 @@ export function declareExportDeclaration(
   > | null = null,
   source: t.StringLiteral | null = null,
 ): t.DeclareExportDeclaration {
-  return validateNode<t.DeclareExportDeclaration>({
+  const node: t.DeclareExportDeclaration = {
     type: "DeclareExportDeclaration",
     declaration,
     specifiers,
     source,
-  });
+  };
+  validate(_data[102][0], node, "declaration", declaration, true);
+  validate(_data[102][1], node, "specifiers", specifiers, true);
+  validate(_data[102][2], node, "source", source, true);
+  return node;
 }
 export function declareExportAllDeclaration(
   source: t.StringLiteral,
 ): t.DeclareExportAllDeclaration {
-  return validateNode<t.DeclareExportAllDeclaration>({
+  const node: t.DeclareExportAllDeclaration = {
     type: "DeclareExportAllDeclaration",
     source,
-  });
+  };
+  validate(_data[103][0], node, "source", source, true);
+  return node;
 }
 export function declaredPredicate(value: t.Flow): t.DeclaredPredicate {
-  return validateNode<t.DeclaredPredicate>({
+  const node: t.DeclaredPredicate = {
     type: "DeclaredPredicate",
     value,
-  });
+  };
+  validate(_data[104][0], node, "value", value, true);
+  return node;
 }
 export function existsTypeAnnotation(): t.ExistsTypeAnnotation {
   return {
@@ -1139,33 +1486,44 @@ export function functionTypeAnnotation(
   rest: t.FunctionTypeParam | null | undefined = null,
   returnType: t.FlowType,
 ): t.FunctionTypeAnnotation {
-  return validateNode<t.FunctionTypeAnnotation>({
+  const node: t.FunctionTypeAnnotation = {
     type: "FunctionTypeAnnotation",
     typeParameters,
     params,
     rest,
     returnType,
-  });
+  };
+  validate(_data[106][0], node, "typeParameters", typeParameters, true);
+  validate(_data[106][1], node, "params", params, true);
+  validate(_data[106][2], node, "rest", rest, true);
+  validate(_data[106][3], node, "returnType", returnType, true);
+  return node;
 }
 export function functionTypeParam(
   name: t.Identifier | null | undefined = null,
   typeAnnotation: t.FlowType,
 ): t.FunctionTypeParam {
-  return validateNode<t.FunctionTypeParam>({
+  const node: t.FunctionTypeParam = {
     type: "FunctionTypeParam",
     name,
     typeAnnotation,
-  });
+  };
+  validate(_data[107][0], node, "name", name, true);
+  validate(_data[107][1], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export function genericTypeAnnotation(
   id: t.Identifier | t.QualifiedTypeIdentifier,
   typeParameters: t.TypeParameterInstantiation | null = null,
 ): t.GenericTypeAnnotation {
-  return validateNode<t.GenericTypeAnnotation>({
+  const node: t.GenericTypeAnnotation = {
     type: "GenericTypeAnnotation",
     id,
     typeParameters,
-  });
+  };
+  validate(_data[108][0], node, "id", id, true);
+  validate(_data[108][1], node, "typeParameters", typeParameters, true);
+  return node;
 }
 export function inferredPredicate(): t.InferredPredicate {
   return {
@@ -1176,11 +1534,14 @@ export function interfaceExtends(
   id: t.Identifier | t.QualifiedTypeIdentifier,
   typeParameters: t.TypeParameterInstantiation | null = null,
 ): t.InterfaceExtends {
-  return validateNode<t.InterfaceExtends>({
+  const node: t.InterfaceExtends = {
     type: "InterfaceExtends",
     id,
     typeParameters,
-  });
+  };
+  validate(_data[110][0], node, "id", id, true);
+  validate(_data[110][1], node, "typeParameters", typeParameters, true);
+  return node;
 }
 export function interfaceDeclaration(
   id: t.Identifier,
@@ -1188,31 +1549,41 @@ export function interfaceDeclaration(
   _extends: Array<t.InterfaceExtends> | null | undefined = null,
   body: t.ObjectTypeAnnotation,
 ): t.InterfaceDeclaration {
-  return validateNode<t.InterfaceDeclaration>({
+  const node: t.InterfaceDeclaration = {
     type: "InterfaceDeclaration",
     id,
     typeParameters,
     extends: _extends,
     body,
-  });
+  };
+  validate(_data[111][0], node, "id", id, true);
+  validate(_data[111][1], node, "typeParameters", typeParameters, true);
+  validate(_data[111][2], node, "extends", _extends, true);
+  validate(_data[111][3], node, "body", body, true);
+  return node;
 }
 export function interfaceTypeAnnotation(
   _extends: Array<t.InterfaceExtends> | null | undefined = null,
   body: t.ObjectTypeAnnotation,
 ): t.InterfaceTypeAnnotation {
-  return validateNode<t.InterfaceTypeAnnotation>({
+  const node: t.InterfaceTypeAnnotation = {
     type: "InterfaceTypeAnnotation",
     extends: _extends,
     body,
-  });
+  };
+  validate(_data[112][0], node, "extends", _extends, true);
+  validate(_data[112][1], node, "body", body, true);
+  return node;
 }
 export function intersectionTypeAnnotation(
   types: Array<t.FlowType>,
 ): t.IntersectionTypeAnnotation {
-  return validateNode<t.IntersectionTypeAnnotation>({
+  const node: t.IntersectionTypeAnnotation = {
     type: "IntersectionTypeAnnotation",
     types,
-  });
+  };
+  validate(_data[113][0], node, "types", types, true);
+  return node;
 }
 export function mixedTypeAnnotation(): t.MixedTypeAnnotation {
   return {
@@ -1227,18 +1598,22 @@ export function emptyTypeAnnotation(): t.EmptyTypeAnnotation {
 export function nullableTypeAnnotation(
   typeAnnotation: t.FlowType,
 ): t.NullableTypeAnnotation {
-  return validateNode<t.NullableTypeAnnotation>({
+  const node: t.NullableTypeAnnotation = {
     type: "NullableTypeAnnotation",
     typeAnnotation,
-  });
+  };
+  validate(_data[116][0], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export function numberLiteralTypeAnnotation(
   value: number,
 ): t.NumberLiteralTypeAnnotation {
-  return validateNode<t.NumberLiteralTypeAnnotation>({
+  const node: t.NumberLiteralTypeAnnotation = {
     type: "NumberLiteralTypeAnnotation",
     value,
-  });
+  };
+  validate(_data[117][0], node, "value", value);
+  return node;
 }
 export function numberTypeAnnotation(): t.NumberTypeAnnotation {
   return {
@@ -1252,14 +1627,20 @@ export function objectTypeAnnotation(
   internalSlots: Array<t.ObjectTypeInternalSlot> = [],
   exact: boolean = false,
 ): t.ObjectTypeAnnotation {
-  return validateNode<t.ObjectTypeAnnotation>({
+  const node: t.ObjectTypeAnnotation = {
     type: "ObjectTypeAnnotation",
     properties,
     indexers,
     callProperties,
     internalSlots,
     exact,
-  });
+  };
+  validate(_data[119][0], node, "properties", properties, true);
+  validate(_data[119][1], node, "indexers", indexers, true);
+  validate(_data[119][2], node, "callProperties", callProperties, true);
+  validate(_data[119][3], node, "internalSlots", internalSlots, true);
+  validate(_data[119][4], node, "exact", exact);
+  return node;
 }
 export function objectTypeInternalSlot(
   id: t.Identifier,
@@ -1268,23 +1649,31 @@ export function objectTypeInternalSlot(
   _static: boolean,
   method: boolean,
 ): t.ObjectTypeInternalSlot {
-  return validateNode<t.ObjectTypeInternalSlot>({
+  const node: t.ObjectTypeInternalSlot = {
     type: "ObjectTypeInternalSlot",
     id,
     value,
     optional,
     static: _static,
     method,
-  });
+  };
+  validate(_data[120][0], node, "id", id, true);
+  validate(_data[120][1], node, "value", value, true);
+  validate(_data[120][2], node, "optional", optional);
+  validate(_data[120][3], node, "static", _static);
+  validate(_data[120][4], node, "method", method);
+  return node;
 }
 export function objectTypeCallProperty(
   value: t.FlowType,
 ): t.ObjectTypeCallProperty {
-  return validateNode<t.ObjectTypeCallProperty>({
+  const node: t.ObjectTypeCallProperty = {
     type: "ObjectTypeCallProperty",
     value,
     static: null,
-  });
+  };
+  validate(_data[121][0], node, "value", value, true);
+  return node;
 }
 export function objectTypeIndexer(
   id: t.Identifier | null | undefined = null,
@@ -1292,21 +1681,26 @@ export function objectTypeIndexer(
   value: t.FlowType,
   variance: t.Variance | null = null,
 ): t.ObjectTypeIndexer {
-  return validateNode<t.ObjectTypeIndexer>({
+  const node: t.ObjectTypeIndexer = {
     type: "ObjectTypeIndexer",
     id,
     key,
     value,
     variance,
     static: null,
-  });
+  };
+  validate(_data[122][0], node, "id", id, true);
+  validate(_data[122][1], node, "key", key, true);
+  validate(_data[122][2], node, "value", value, true);
+  validate(_data[122][3], node, "variance", variance, true);
+  return node;
 }
 export function objectTypeProperty(
   key: t.Identifier | t.StringLiteral,
   value: t.FlowType,
   variance: t.Variance | null = null,
 ): t.ObjectTypeProperty {
-  return validateNode<t.ObjectTypeProperty>({
+  const node: t.ObjectTypeProperty = {
     type: "ObjectTypeProperty",
     key,
     value,
@@ -1316,15 +1710,21 @@ export function objectTypeProperty(
     optional: null,
     proto: null,
     static: null,
-  });
+  };
+  validate(_data[123][0], node, "key", key, true);
+  validate(_data[123][1], node, "value", value, true);
+  validate(_data[123][2], node, "variance", variance, true);
+  return node;
 }
 export function objectTypeSpreadProperty(
   argument: t.FlowType,
 ): t.ObjectTypeSpreadProperty {
-  return validateNode<t.ObjectTypeSpreadProperty>({
+  const node: t.ObjectTypeSpreadProperty = {
     type: "ObjectTypeSpreadProperty",
     argument,
-  });
+  };
+  validate(_data[124][0], node, "argument", argument, true);
+  return node;
 }
 export function opaqueType(
   id: t.Identifier,
@@ -1332,31 +1732,41 @@ export function opaqueType(
   supertype: t.FlowType | null | undefined = null,
   impltype: t.FlowType,
 ): t.OpaqueType {
-  return validateNode<t.OpaqueType>({
+  const node: t.OpaqueType = {
     type: "OpaqueType",
     id,
     typeParameters,
     supertype,
     impltype,
-  });
+  };
+  validate(_data[125][0], node, "id", id, true);
+  validate(_data[125][1], node, "typeParameters", typeParameters, true);
+  validate(_data[125][2], node, "supertype", supertype, true);
+  validate(_data[125][3], node, "impltype", impltype, true);
+  return node;
 }
 export function qualifiedTypeIdentifier(
   id: t.Identifier,
   qualification: t.Identifier | t.QualifiedTypeIdentifier,
 ): t.QualifiedTypeIdentifier {
-  return validateNode<t.QualifiedTypeIdentifier>({
+  const node: t.QualifiedTypeIdentifier = {
     type: "QualifiedTypeIdentifier",
     id,
     qualification,
-  });
+  };
+  validate(_data[126][0], node, "id", id, true);
+  validate(_data[126][1], node, "qualification", qualification, true);
+  return node;
 }
 export function stringLiteralTypeAnnotation(
   value: string,
 ): t.StringLiteralTypeAnnotation {
-  return validateNode<t.StringLiteralTypeAnnotation>({
+  const node: t.StringLiteralTypeAnnotation = {
     type: "StringLiteralTypeAnnotation",
     value,
-  });
+  };
+  validate(_data[127][0], node, "value", value);
+  return node;
 }
 export function stringTypeAnnotation(): t.StringTypeAnnotation {
   return {
@@ -1376,89 +1786,114 @@ export function thisTypeAnnotation(): t.ThisTypeAnnotation {
 export function tupleTypeAnnotation(
   types: Array<t.FlowType>,
 ): t.TupleTypeAnnotation {
-  return validateNode<t.TupleTypeAnnotation>({
+  const node: t.TupleTypeAnnotation = {
     type: "TupleTypeAnnotation",
     types,
-  });
+  };
+  validate(_data[131][0], node, "types", types, true);
+  return node;
 }
 export function typeofTypeAnnotation(
   argument: t.FlowType,
 ): t.TypeofTypeAnnotation {
-  return validateNode<t.TypeofTypeAnnotation>({
+  const node: t.TypeofTypeAnnotation = {
     type: "TypeofTypeAnnotation",
     argument,
-  });
+  };
+  validate(_data[132][0], node, "argument", argument, true);
+  return node;
 }
 export function typeAlias(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined = null,
   right: t.FlowType,
 ): t.TypeAlias {
-  return validateNode<t.TypeAlias>({
+  const node: t.TypeAlias = {
     type: "TypeAlias",
     id,
     typeParameters,
     right,
-  });
+  };
+  validate(_data[133][0], node, "id", id, true);
+  validate(_data[133][1], node, "typeParameters", typeParameters, true);
+  validate(_data[133][2], node, "right", right, true);
+  return node;
 }
 export function typeAnnotation(typeAnnotation: t.FlowType): t.TypeAnnotation {
-  return validateNode<t.TypeAnnotation>({
+  const node: t.TypeAnnotation = {
     type: "TypeAnnotation",
     typeAnnotation,
-  });
+  };
+  validate(_data[134][0], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export function typeCastExpression(
   expression: t.Expression,
   typeAnnotation: t.TypeAnnotation,
 ): t.TypeCastExpression {
-  return validateNode<t.TypeCastExpression>({
+  const node: t.TypeCastExpression = {
     type: "TypeCastExpression",
     expression,
     typeAnnotation,
-  });
+  };
+  validate(_data[135][0], node, "expression", expression, true);
+  validate(_data[135][1], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export function typeParameter(
   bound: t.TypeAnnotation | null = null,
   _default: t.FlowType | null = null,
   variance: t.Variance | null = null,
 ): t.TypeParameter {
-  return validateNode<t.TypeParameter>({
+  const node: t.TypeParameter = {
     type: "TypeParameter",
     bound,
     default: _default,
     variance,
     name: null,
-  });
+  };
+  validate(_data[136][0], node, "bound", bound, true);
+  validate(_data[136][1], node, "default", _default, true);
+  validate(_data[136][2], node, "variance", variance, true);
+  return node;
 }
 export function typeParameterDeclaration(
   params: Array<t.TypeParameter>,
 ): t.TypeParameterDeclaration {
-  return validateNode<t.TypeParameterDeclaration>({
+  const node: t.TypeParameterDeclaration = {
     type: "TypeParameterDeclaration",
     params,
-  });
+  };
+  validate(_data[137][0], node, "params", params, true);
+  return node;
 }
 export function typeParameterInstantiation(
   params: Array<t.FlowType>,
 ): t.TypeParameterInstantiation {
-  return validateNode<t.TypeParameterInstantiation>({
+  const node: t.TypeParameterInstantiation = {
     type: "TypeParameterInstantiation",
     params,
-  });
+  };
+  validate(_data[138][0], node, "params", params, true);
+  return node;
 }
 export function unionTypeAnnotation(
   types: Array<t.FlowType>,
 ): t.UnionTypeAnnotation {
-  return validateNode<t.UnionTypeAnnotation>({
+  const node: t.UnionTypeAnnotation = {
     type: "UnionTypeAnnotation",
     types,
-  });
+  };
+  validate(_data[139][0], node, "types", types, true);
+  return node;
 }
 export function variance(kind: "minus" | "plus"): t.Variance {
-  return validateNode<t.Variance>({
+  const node: t.Variance = {
     type: "Variance",
     kind,
-  });
+  };
+  validate(_data[140][0], node, "kind", kind);
+  return node;
 }
 export function voidTypeAnnotation(): t.VoidTypeAnnotation {
   return {
@@ -1473,104 +1908,131 @@ export function enumDeclaration(
     | t.EnumStringBody
     | t.EnumSymbolBody,
 ): t.EnumDeclaration {
-  return validateNode<t.EnumDeclaration>({
+  const node: t.EnumDeclaration = {
     type: "EnumDeclaration",
     id,
     body,
-  });
+  };
+  validate(_data[142][0], node, "id", id, true);
+  validate(_data[142][1], node, "body", body, true);
+  return node;
 }
 export function enumBooleanBody(
   members: Array<t.EnumBooleanMember>,
 ): t.EnumBooleanBody {
-  return validateNode<t.EnumBooleanBody>({
+  const node: t.EnumBooleanBody = {
     type: "EnumBooleanBody",
     members,
     explicitType: null,
     hasUnknownMembers: null,
-  });
+  };
+  validate(_data[143][0], node, "members", members, true);
+  return node;
 }
 export function enumNumberBody(
   members: Array<t.EnumNumberMember>,
 ): t.EnumNumberBody {
-  return validateNode<t.EnumNumberBody>({
+  const node: t.EnumNumberBody = {
     type: "EnumNumberBody",
     members,
     explicitType: null,
     hasUnknownMembers: null,
-  });
+  };
+  validate(_data[144][0], node, "members", members, true);
+  return node;
 }
 export function enumStringBody(
   members: Array<t.EnumStringMember | t.EnumDefaultedMember>,
 ): t.EnumStringBody {
-  return validateNode<t.EnumStringBody>({
+  const node: t.EnumStringBody = {
     type: "EnumStringBody",
     members,
     explicitType: null,
     hasUnknownMembers: null,
-  });
+  };
+  validate(_data[145][0], node, "members", members, true);
+  return node;
 }
 export function enumSymbolBody(
   members: Array<t.EnumDefaultedMember>,
 ): t.EnumSymbolBody {
-  return validateNode<t.EnumSymbolBody>({
+  const node: t.EnumSymbolBody = {
     type: "EnumSymbolBody",
     members,
     hasUnknownMembers: null,
-  });
+  };
+  validate(_data[146][0], node, "members", members, true);
+  return node;
 }
 export function enumBooleanMember(id: t.Identifier): t.EnumBooleanMember {
-  return validateNode<t.EnumBooleanMember>({
+  const node: t.EnumBooleanMember = {
     type: "EnumBooleanMember",
     id,
     init: null,
-  });
+  };
+  validate(_data[147][0], node, "id", id, true);
+  return node;
 }
 export function enumNumberMember(
   id: t.Identifier,
   init: t.NumericLiteral,
 ): t.EnumNumberMember {
-  return validateNode<t.EnumNumberMember>({
+  const node: t.EnumNumberMember = {
     type: "EnumNumberMember",
     id,
     init,
-  });
+  };
+  validate(_data[148][0], node, "id", id, true);
+  validate(_data[148][1], node, "init", init, true);
+  return node;
 }
 export function enumStringMember(
   id: t.Identifier,
   init: t.StringLiteral,
 ): t.EnumStringMember {
-  return validateNode<t.EnumStringMember>({
+  const node: t.EnumStringMember = {
     type: "EnumStringMember",
     id,
     init,
-  });
+  };
+  validate(_data[149][0], node, "id", id, true);
+  validate(_data[149][1], node, "init", init, true);
+  return node;
 }
 export function enumDefaultedMember(id: t.Identifier): t.EnumDefaultedMember {
-  return validateNode<t.EnumDefaultedMember>({
+  const node: t.EnumDefaultedMember = {
     type: "EnumDefaultedMember",
     id,
-  });
+  };
+  validate(_data[150][0], node, "id", id, true);
+  return node;
 }
 export function indexedAccessType(
   objectType: t.FlowType,
   indexType: t.FlowType,
 ): t.IndexedAccessType {
-  return validateNode<t.IndexedAccessType>({
+  const node: t.IndexedAccessType = {
     type: "IndexedAccessType",
     objectType,
     indexType,
-  });
+  };
+  validate(_data[151][0], node, "objectType", objectType, true);
+  validate(_data[151][1], node, "indexType", indexType, true);
+  return node;
 }
 export function optionalIndexedAccessType(
   objectType: t.FlowType,
   indexType: t.FlowType,
 ): t.OptionalIndexedAccessType {
-  return validateNode<t.OptionalIndexedAccessType>({
+  const node: t.OptionalIndexedAccessType = {
     type: "OptionalIndexedAccessType",
     objectType,
     indexType,
     optional: null,
-  });
+  };
+  validate(_data[152][0], node, "objectType", objectType, true);
+  validate(_data[152][1], node, "indexType", indexType, true);
+  return node;
 }
 export function jsxAttribute(
   name: t.JSXIdentifier | t.JSXNamespacedName,
@@ -1581,20 +2043,25 @@ export function jsxAttribute(
     | t.JSXExpressionContainer
     | null = null,
 ): t.JSXAttribute {
-  return validateNode<t.JSXAttribute>({
+  const node: t.JSXAttribute = {
     type: "JSXAttribute",
     name,
     value,
-  });
+  };
+  validate(_data[153][0], node, "name", name, true);
+  validate(_data[153][1], node, "value", value, true);
+  return node;
 }
 export { jsxAttribute as jSXAttribute };
 export function jsxClosingElement(
   name: t.JSXIdentifier | t.JSXMemberExpression | t.JSXNamespacedName,
 ): t.JSXClosingElement {
-  return validateNode<t.JSXClosingElement>({
+  const node: t.JSXClosingElement = {
     type: "JSXClosingElement",
     name,
-  });
+  };
+  validate(_data[154][0], node, "name", name, true);
+  return node;
 }
 export { jsxClosingElement as jSXClosingElement };
 export function jsxElement(
@@ -1609,13 +2076,18 @@ export function jsxElement(
   >,
   selfClosing: boolean | null = null,
 ): t.JSXElement {
-  return validateNode<t.JSXElement>({
+  const node: t.JSXElement = {
     type: "JSXElement",
     openingElement,
     closingElement,
     children,
     selfClosing,
-  });
+  };
+  validate(_data[155][0], node, "openingElement", openingElement, true);
+  validate(_data[155][1], node, "closingElement", closingElement, true);
+  validate(_data[155][2], node, "children", children, true);
+  validate(_data[155][3], node, "selfClosing", selfClosing);
+  return node;
 }
 export { jsxElement as jSXElement };
 export function jsxEmptyExpression(): t.JSXEmptyExpression {
@@ -1627,46 +2099,58 @@ export { jsxEmptyExpression as jSXEmptyExpression };
 export function jsxExpressionContainer(
   expression: t.Expression | t.JSXEmptyExpression,
 ): t.JSXExpressionContainer {
-  return validateNode<t.JSXExpressionContainer>({
+  const node: t.JSXExpressionContainer = {
     type: "JSXExpressionContainer",
     expression,
-  });
+  };
+  validate(_data[157][0], node, "expression", expression, true);
+  return node;
 }
 export { jsxExpressionContainer as jSXExpressionContainer };
 export function jsxSpreadChild(expression: t.Expression): t.JSXSpreadChild {
-  return validateNode<t.JSXSpreadChild>({
+  const node: t.JSXSpreadChild = {
     type: "JSXSpreadChild",
     expression,
-  });
+  };
+  validate(_data[158][0], node, "expression", expression, true);
+  return node;
 }
 export { jsxSpreadChild as jSXSpreadChild };
 export function jsxIdentifier(name: string): t.JSXIdentifier {
-  return validateNode<t.JSXIdentifier>({
+  const node: t.JSXIdentifier = {
     type: "JSXIdentifier",
     name,
-  });
+  };
+  validate(_data[159][0], node, "name", name);
+  return node;
 }
 export { jsxIdentifier as jSXIdentifier };
 export function jsxMemberExpression(
   object: t.JSXMemberExpression | t.JSXIdentifier,
   property: t.JSXIdentifier,
 ): t.JSXMemberExpression {
-  return validateNode<t.JSXMemberExpression>({
+  const node: t.JSXMemberExpression = {
     type: "JSXMemberExpression",
     object,
     property,
-  });
+  };
+  validate(_data[160][0], node, "object", object, true);
+  validate(_data[160][1], node, "property", property, true);
+  return node;
 }
 export { jsxMemberExpression as jSXMemberExpression };
 export function jsxNamespacedName(
   namespace: t.JSXIdentifier,
   name: t.JSXIdentifier,
 ): t.JSXNamespacedName {
-  return validateNode<t.JSXNamespacedName>({
+  const node: t.JSXNamespacedName = {
     type: "JSXNamespacedName",
     namespace,
     name,
-  });
+  };
+  validate(_data[161][0], node, "namespace", namespace, true);
+  validate(_data[161][1], node, "name", name, true);
+  return node;
 }
 export { jsxNamespacedName as jSXNamespacedName };
 export function jsxOpeningElement(
@@ -1674,28 +2158,36 @@ export function jsxOpeningElement(
   attributes: Array<t.JSXAttribute | t.JSXSpreadAttribute>,
   selfClosing: boolean = false,
 ): t.JSXOpeningElement {
-  return validateNode<t.JSXOpeningElement>({
+  const node: t.JSXOpeningElement = {
     type: "JSXOpeningElement",
     name,
     attributes,
     selfClosing,
-  });
+  };
+  validate(_data[162][0], node, "name", name, true);
+  validate(_data[162][1], node, "attributes", attributes, true);
+  validate(_data[162][2], node, "selfClosing", selfClosing);
+  return node;
 }
 export { jsxOpeningElement as jSXOpeningElement };
 export function jsxSpreadAttribute(
   argument: t.Expression,
 ): t.JSXSpreadAttribute {
-  return validateNode<t.JSXSpreadAttribute>({
+  const node: t.JSXSpreadAttribute = {
     type: "JSXSpreadAttribute",
     argument,
-  });
+  };
+  validate(_data[163][0], node, "argument", argument, true);
+  return node;
 }
 export { jsxSpreadAttribute as jSXSpreadAttribute };
 export function jsxText(value: string): t.JSXText {
-  return validateNode<t.JSXText>({
+  const node: t.JSXText = {
     type: "JSXText",
     value,
-  });
+  };
+  validate(_data[164][0], node, "value", value);
+  return node;
 }
 export { jsxText as jSXText };
 export function jsxFragment(
@@ -1709,12 +2201,16 @@ export function jsxFragment(
     | t.JSXFragment
   >,
 ): t.JSXFragment {
-  return validateNode<t.JSXFragment>({
+  const node: t.JSXFragment = {
     type: "JSXFragment",
     openingFragment,
     closingFragment,
     children,
-  });
+  };
+  validate(_data[165][0], node, "openingFragment", openingFragment, true);
+  validate(_data[165][1], node, "closingFragment", closingFragment, true);
+  validate(_data[165][2], node, "children", children, true);
+  return node;
 }
 export { jsxFragment as jSXFragment };
 export function jsxOpeningFragment(): t.JSXOpeningFragment {
@@ -1746,17 +2242,22 @@ export function placeholder(
     | "Pattern",
   name: t.Identifier,
 ): t.Placeholder {
-  return validateNode<t.Placeholder>({
+  const node: t.Placeholder = {
     type: "Placeholder",
     expectedNode,
     name,
-  });
+  };
+  validate(_data[169][0], node, "expectedNode", expectedNode);
+  validate(_data[169][1], node, "name", name, true);
+  return node;
 }
 export function v8IntrinsicIdentifier(name: string): t.V8IntrinsicIdentifier {
-  return validateNode<t.V8IntrinsicIdentifier>({
+  const node: t.V8IntrinsicIdentifier = {
     type: "V8IntrinsicIdentifier",
     name,
-  });
+  };
+  validate(_data[170][0], node, "name", name);
+  return node;
 }
 export function argumentPlaceholder(): t.ArgumentPlaceholder {
   return {
@@ -1767,73 +2268,94 @@ export function bindExpression(
   object: t.Expression,
   callee: t.Expression,
 ): t.BindExpression {
-  return validateNode<t.BindExpression>({
+  const node: t.BindExpression = {
     type: "BindExpression",
     object,
     callee,
-  });
+  };
+  validate(_data[172][0], node, "object", object, true);
+  validate(_data[172][1], node, "callee", callee, true);
+  return node;
 }
 export function importAttribute(
   key: t.Identifier | t.StringLiteral,
   value: t.StringLiteral,
 ): t.ImportAttribute {
-  return validateNode<t.ImportAttribute>({
+  const node: t.ImportAttribute = {
     type: "ImportAttribute",
     key,
     value,
-  });
+  };
+  validate(_data[173][0], node, "key", key, true);
+  validate(_data[173][1], node, "value", value, true);
+  return node;
 }
 export function decorator(expression: t.Expression): t.Decorator {
-  return validateNode<t.Decorator>({
+  const node: t.Decorator = {
     type: "Decorator",
     expression,
-  });
+  };
+  validate(_data[174][0], node, "expression", expression, true);
+  return node;
 }
 export function doExpression(
   body: t.BlockStatement,
   async: boolean = false,
 ): t.DoExpression {
-  return validateNode<t.DoExpression>({
+  const node: t.DoExpression = {
     type: "DoExpression",
     body,
     async,
-  });
+  };
+  validate(_data[175][0], node, "body", body, true);
+  validate(_data[175][1], node, "async", async);
+  return node;
 }
 export function exportDefaultSpecifier(
   exported: t.Identifier,
 ): t.ExportDefaultSpecifier {
-  return validateNode<t.ExportDefaultSpecifier>({
+  const node: t.ExportDefaultSpecifier = {
     type: "ExportDefaultSpecifier",
     exported,
-  });
+  };
+  validate(_data[176][0], node, "exported", exported, true);
+  return node;
 }
 export function recordExpression(
   properties: Array<t.ObjectProperty | t.SpreadElement>,
 ): t.RecordExpression {
-  return validateNode<t.RecordExpression>({
+  const node: t.RecordExpression = {
     type: "RecordExpression",
     properties,
-  });
+  };
+  validate(_data[177][0], node, "properties", properties, true);
+  return node;
 }
 export function tupleExpression(
   elements: Array<t.Expression | t.SpreadElement> = [],
 ): t.TupleExpression {
-  return validateNode<t.TupleExpression>({
+  const node: t.TupleExpression = {
     type: "TupleExpression",
     elements,
-  });
+  };
+  validate(_data[178][0], node, "elements", elements, true);
+  return node;
 }
 export function decimalLiteral(value: string): t.DecimalLiteral {
-  return validateNode<t.DecimalLiteral>({
+  const node: t.DecimalLiteral = {
     type: "DecimalLiteral",
     value,
-  });
+  };
+  validate(_data[179][0], node, "value", value);
+  return node;
 }
 export function moduleExpression(body: t.Program): t.ModuleExpression {
-  return validateNode<t.ModuleExpression>({
+  const node: t.ModuleExpression = {
     type: "ModuleExpression",
     body,
-  });
+  };
+  validate(_data[180][0], node, "body", body, true);
+  return node;
 }
 export function topicReference(): t.TopicReference {
   return {
@@ -1843,18 +2365,22 @@ export function topicReference(): t.TopicReference {
 export function pipelineTopicExpression(
   expression: t.Expression,
 ): t.PipelineTopicExpression {
-  return validateNode<t.PipelineTopicExpression>({
+  const node: t.PipelineTopicExpression = {
     type: "PipelineTopicExpression",
     expression,
-  });
+  };
+  validate(_data[182][0], node, "expression", expression, true);
+  return node;
 }
 export function pipelineBareFunction(
   callee: t.Expression,
 ): t.PipelineBareFunction {
-  return validateNode<t.PipelineBareFunction>({
+  const node: t.PipelineBareFunction = {
     type: "PipelineBareFunction",
     callee,
-  });
+  };
+  validate(_data[183][0], node, "callee", callee, true);
+  return node;
 }
 export function pipelinePrimaryTopicReference(): t.PipelinePrimaryTopicReference {
   return {
@@ -1864,10 +2390,12 @@ export function pipelinePrimaryTopicReference(): t.PipelinePrimaryTopicReference
 export function tsParameterProperty(
   parameter: t.Identifier | t.AssignmentPattern,
 ): t.TSParameterProperty {
-  return validateNode<t.TSParameterProperty>({
+  const node: t.TSParameterProperty = {
     type: "TSParameterProperty",
     parameter,
-  });
+  };
+  validate(_data[185][0], node, "parameter", parameter, true);
+  return node;
 }
 export { tsParameterProperty as tSParameterProperty };
 export function tsDeclareFunction(
@@ -1880,13 +2408,18 @@ export function tsDeclareFunction(
   params: Array<t.Identifier | t.Pattern | t.RestElement>,
   returnType: t.TSTypeAnnotation | t.Noop | null = null,
 ): t.TSDeclareFunction {
-  return validateNode<t.TSDeclareFunction>({
+  const node: t.TSDeclareFunction = {
     type: "TSDeclareFunction",
     id,
     typeParameters,
     params,
     returnType,
-  });
+  };
+  validate(_data[186][0], node, "id", id, true);
+  validate(_data[186][1], node, "typeParameters", typeParameters, true);
+  validate(_data[186][2], node, "params", params, true);
+  validate(_data[186][3], node, "returnType", returnType, true);
+  return node;
 }
 export { tsDeclareFunction as tSDeclareFunction };
 export function tsDeclareMethod(
@@ -1907,25 +2440,34 @@ export function tsDeclareMethod(
   >,
   returnType: t.TSTypeAnnotation | t.Noop | null = null,
 ): t.TSDeclareMethod {
-  return validateNode<t.TSDeclareMethod>({
+  const node: t.TSDeclareMethod = {
     type: "TSDeclareMethod",
     decorators,
     key,
     typeParameters,
     params,
     returnType,
-  });
+  };
+  validate(_data[187][0], node, "decorators", decorators, true);
+  validate(_data[187][1], node, "key", key, true);
+  validate(_data[187][2], node, "typeParameters", typeParameters, true);
+  validate(_data[187][3], node, "params", params, true);
+  validate(_data[187][4], node, "returnType", returnType, true);
+  return node;
 }
 export { tsDeclareMethod as tSDeclareMethod };
 export function tsQualifiedName(
   left: t.TSEntityName,
   right: t.Identifier,
 ): t.TSQualifiedName {
-  return validateNode<t.TSQualifiedName>({
+  const node: t.TSQualifiedName = {
     type: "TSQualifiedName",
     left,
     right,
-  });
+  };
+  validate(_data[188][0], node, "left", left, true);
+  validate(_data[188][1], node, "right", right, true);
+  return node;
 }
 export { tsQualifiedName as tSQualifiedName };
 export function tsCallSignatureDeclaration(
@@ -1935,12 +2477,16 @@ export function tsCallSignatureDeclaration(
   >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSCallSignatureDeclaration {
-  return validateNode<t.TSCallSignatureDeclaration>({
+  const node: t.TSCallSignatureDeclaration = {
     type: "TSCallSignatureDeclaration",
     typeParameters,
     parameters,
     typeAnnotation,
-  });
+  };
+  validate(_data[189][0], node, "typeParameters", typeParameters, true);
+  validate(_data[189][1], node, "parameters", parameters, true);
+  validate(_data[189][2], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsCallSignatureDeclaration as tSCallSignatureDeclaration };
 export function tsConstructSignatureDeclaration(
@@ -1950,24 +2496,31 @@ export function tsConstructSignatureDeclaration(
   >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSConstructSignatureDeclaration {
-  return validateNode<t.TSConstructSignatureDeclaration>({
+  const node: t.TSConstructSignatureDeclaration = {
     type: "TSConstructSignatureDeclaration",
     typeParameters,
     parameters,
     typeAnnotation,
-  });
+  };
+  validate(_data[190][0], node, "typeParameters", typeParameters, true);
+  validate(_data[190][1], node, "parameters", parameters, true);
+  validate(_data[190][2], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsConstructSignatureDeclaration as tSConstructSignatureDeclaration };
 export function tsPropertySignature(
   key: t.Expression,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSPropertySignature {
-  return validateNode<t.TSPropertySignature>({
+  const node: t.TSPropertySignature = {
     type: "TSPropertySignature",
     key,
     typeAnnotation,
     kind: null,
-  });
+  };
+  validate(_data[191][0], node, "key", key, true);
+  validate(_data[191][1], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsPropertySignature as tSPropertySignature };
 export function tsMethodSignature(
@@ -1978,25 +2531,33 @@ export function tsMethodSignature(
   >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSMethodSignature {
-  return validateNode<t.TSMethodSignature>({
+  const node: t.TSMethodSignature = {
     type: "TSMethodSignature",
     key,
     typeParameters,
     parameters,
     typeAnnotation,
     kind: null,
-  });
+  };
+  validate(_data[192][0], node, "key", key, true);
+  validate(_data[192][1], node, "typeParameters", typeParameters, true);
+  validate(_data[192][2], node, "parameters", parameters, true);
+  validate(_data[192][3], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsMethodSignature as tSMethodSignature };
 export function tsIndexSignature(
   parameters: Array<t.Identifier>,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSIndexSignature {
-  return validateNode<t.TSIndexSignature>({
+  const node: t.TSIndexSignature = {
     type: "TSIndexSignature",
     parameters,
     typeAnnotation,
-  });
+  };
+  validate(_data[193][0], node, "parameters", parameters, true);
+  validate(_data[193][1], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsIndexSignature as tSIndexSignature };
 export function tsAnyKeyword(): t.TSAnyKeyword {
@@ -2090,12 +2651,16 @@ export function tsFunctionType(
   >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSFunctionType {
-  return validateNode<t.TSFunctionType>({
+  const node: t.TSFunctionType = {
     type: "TSFunctionType",
     typeParameters,
     parameters,
     typeAnnotation,
-  });
+  };
+  validate(_data[208][0], node, "typeParameters", typeParameters, true);
+  validate(_data[208][1], node, "parameters", parameters, true);
+  validate(_data[208][2], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsFunctionType as tSFunctionType };
 export function tsConstructorType(
@@ -2105,23 +2670,30 @@ export function tsConstructorType(
   >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSConstructorType {
-  return validateNode<t.TSConstructorType>({
+  const node: t.TSConstructorType = {
     type: "TSConstructorType",
     typeParameters,
     parameters,
     typeAnnotation,
-  });
+  };
+  validate(_data[209][0], node, "typeParameters", typeParameters, true);
+  validate(_data[209][1], node, "parameters", parameters, true);
+  validate(_data[209][2], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsConstructorType as tSConstructorType };
 export function tsTypeReference(
   typeName: t.TSEntityName,
   typeParameters: t.TSTypeParameterInstantiation | null = null,
 ): t.TSTypeReference {
-  return validateNode<t.TSTypeReference>({
+  const node: t.TSTypeReference = {
     type: "TSTypeReference",
     typeName,
     typeParameters,
-  });
+  };
+  validate(_data[210][0], node, "typeName", typeName, true);
+  validate(_data[210][1], node, "typeParameters", typeParameters, true);
+  return node;
 }
 export { tsTypeReference as tSTypeReference };
 export function tsTypePredicate(
@@ -2129,62 +2701,79 @@ export function tsTypePredicate(
   typeAnnotation: t.TSTypeAnnotation | null = null,
   asserts: boolean | null = null,
 ): t.TSTypePredicate {
-  return validateNode<t.TSTypePredicate>({
+  const node: t.TSTypePredicate = {
     type: "TSTypePredicate",
     parameterName,
     typeAnnotation,
     asserts,
-  });
+  };
+  validate(_data[211][0], node, "parameterName", parameterName, true);
+  validate(_data[211][1], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[211][2], node, "asserts", asserts);
+  return node;
 }
 export { tsTypePredicate as tSTypePredicate };
 export function tsTypeQuery(
   exprName: t.TSEntityName | t.TSImportType,
   typeParameters: t.TSTypeParameterInstantiation | null = null,
 ): t.TSTypeQuery {
-  return validateNode<t.TSTypeQuery>({
+  const node: t.TSTypeQuery = {
     type: "TSTypeQuery",
     exprName,
     typeParameters,
-  });
+  };
+  validate(_data[212][0], node, "exprName", exprName, true);
+  validate(_data[212][1], node, "typeParameters", typeParameters, true);
+  return node;
 }
 export { tsTypeQuery as tSTypeQuery };
 export function tsTypeLiteral(
   members: Array<t.TSTypeElement>,
 ): t.TSTypeLiteral {
-  return validateNode<t.TSTypeLiteral>({
+  const node: t.TSTypeLiteral = {
     type: "TSTypeLiteral",
     members,
-  });
+  };
+  validate(_data[213][0], node, "members", members, true);
+  return node;
 }
 export { tsTypeLiteral as tSTypeLiteral };
 export function tsArrayType(elementType: t.TSType): t.TSArrayType {
-  return validateNode<t.TSArrayType>({
+  const node: t.TSArrayType = {
     type: "TSArrayType",
     elementType,
-  });
+  };
+  validate(_data[214][0], node, "elementType", elementType, true);
+  return node;
 }
 export { tsArrayType as tSArrayType };
 export function tsTupleType(
   elementTypes: Array<t.TSType | t.TSNamedTupleMember>,
 ): t.TSTupleType {
-  return validateNode<t.TSTupleType>({
+  const node: t.TSTupleType = {
     type: "TSTupleType",
     elementTypes,
-  });
+  };
+  validate(_data[215][0], node, "elementTypes", elementTypes, true);
+  return node;
 }
 export { tsTupleType as tSTupleType };
 export function tsOptionalType(typeAnnotation: t.TSType): t.TSOptionalType {
-  return validateNode<t.TSOptionalType>({
+  const node: t.TSOptionalType = {
     type: "TSOptionalType",
     typeAnnotation,
-  });
+  };
+  validate(_data[216][0], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsOptionalType as tSOptionalType };
 export function tsRestType(typeAnnotation: t.TSType): t.TSRestType {
-  return validateNode<t.TSRestType>({
+  const node: t.TSRestType = {
     type: "TSRestType",
     typeAnnotation,
-  });
+  };
+  validate(_data[217][0], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsRestType as tSRestType };
 export function tsNamedTupleMember(
@@ -2192,28 +2781,36 @@ export function tsNamedTupleMember(
   elementType: t.TSType,
   optional: boolean = false,
 ): t.TSNamedTupleMember {
-  return validateNode<t.TSNamedTupleMember>({
+  const node: t.TSNamedTupleMember = {
     type: "TSNamedTupleMember",
     label,
     elementType,
     optional,
-  });
+  };
+  validate(_data[218][0], node, "label", label, true);
+  validate(_data[218][1], node, "elementType", elementType, true);
+  validate(_data[218][2], node, "optional", optional);
+  return node;
 }
 export { tsNamedTupleMember as tSNamedTupleMember };
 export function tsUnionType(types: Array<t.TSType>): t.TSUnionType {
-  return validateNode<t.TSUnionType>({
+  const node: t.TSUnionType = {
     type: "TSUnionType",
     types,
-  });
+  };
+  validate(_data[219][0], node, "types", types, true);
+  return node;
 }
 export { tsUnionType as tSUnionType };
 export function tsIntersectionType(
   types: Array<t.TSType>,
 ): t.TSIntersectionType {
-  return validateNode<t.TSIntersectionType>({
+  const node: t.TSIntersectionType = {
     type: "TSIntersectionType",
     types,
-  });
+  };
+  validate(_data[220][0], node, "types", types, true);
+  return node;
 }
 export { tsIntersectionType as tSIntersectionType };
 export function tsConditionalType(
@@ -2222,48 +2819,62 @@ export function tsConditionalType(
   trueType: t.TSType,
   falseType: t.TSType,
 ): t.TSConditionalType {
-  return validateNode<t.TSConditionalType>({
+  const node: t.TSConditionalType = {
     type: "TSConditionalType",
     checkType,
     extendsType,
     trueType,
     falseType,
-  });
+  };
+  validate(_data[221][0], node, "checkType", checkType, true);
+  validate(_data[221][1], node, "extendsType", extendsType, true);
+  validate(_data[221][2], node, "trueType", trueType, true);
+  validate(_data[221][3], node, "falseType", falseType, true);
+  return node;
 }
 export { tsConditionalType as tSConditionalType };
 export function tsInferType(typeParameter: t.TSTypeParameter): t.TSInferType {
-  return validateNode<t.TSInferType>({
+  const node: t.TSInferType = {
     type: "TSInferType",
     typeParameter,
-  });
+  };
+  validate(_data[222][0], node, "typeParameter", typeParameter, true);
+  return node;
 }
 export { tsInferType as tSInferType };
 export function tsParenthesizedType(
   typeAnnotation: t.TSType,
 ): t.TSParenthesizedType {
-  return validateNode<t.TSParenthesizedType>({
+  const node: t.TSParenthesizedType = {
     type: "TSParenthesizedType",
     typeAnnotation,
-  });
+  };
+  validate(_data[223][0], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsParenthesizedType as tSParenthesizedType };
 export function tsTypeOperator(typeAnnotation: t.TSType): t.TSTypeOperator {
-  return validateNode<t.TSTypeOperator>({
+  const node: t.TSTypeOperator = {
     type: "TSTypeOperator",
     typeAnnotation,
     operator: null,
-  });
+  };
+  validate(_data[224][0], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsTypeOperator as tSTypeOperator };
 export function tsIndexedAccessType(
   objectType: t.TSType,
   indexType: t.TSType,
 ): t.TSIndexedAccessType {
-  return validateNode<t.TSIndexedAccessType>({
+  const node: t.TSIndexedAccessType = {
     type: "TSIndexedAccessType",
     objectType,
     indexType,
-  });
+  };
+  validate(_data[225][0], node, "objectType", objectType, true);
+  validate(_data[225][1], node, "indexType", indexType, true);
+  return node;
 }
 export { tsIndexedAccessType as tSIndexedAccessType };
 export function tsMappedType(
@@ -2271,12 +2882,16 @@ export function tsMappedType(
   typeAnnotation: t.TSType | null = null,
   nameType: t.TSType | null = null,
 ): t.TSMappedType {
-  return validateNode<t.TSMappedType>({
+  const node: t.TSMappedType = {
     type: "TSMappedType",
     typeParameter,
     typeAnnotation,
     nameType,
-  });
+  };
+  validate(_data[226][0], node, "typeParameter", typeParameter, true);
+  validate(_data[226][1], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[226][2], node, "nameType", nameType, true);
+  return node;
 }
 export { tsMappedType as tSMappedType };
 export function tsLiteralType(
@@ -2288,21 +2903,26 @@ export function tsLiteralType(
     | t.TemplateLiteral
     | t.UnaryExpression,
 ): t.TSLiteralType {
-  return validateNode<t.TSLiteralType>({
+  const node: t.TSLiteralType = {
     type: "TSLiteralType",
     literal,
-  });
+  };
+  validate(_data[227][0], node, "literal", literal, true);
+  return node;
 }
 export { tsLiteralType as tSLiteralType };
 export function tsExpressionWithTypeArguments(
   expression: t.TSEntityName,
   typeParameters: t.TSTypeParameterInstantiation | null = null,
 ): t.TSExpressionWithTypeArguments {
-  return validateNode<t.TSExpressionWithTypeArguments>({
+  const node: t.TSExpressionWithTypeArguments = {
     type: "TSExpressionWithTypeArguments",
     expression,
     typeParameters,
-  });
+  };
+  validate(_data[228][0], node, "expression", expression, true);
+  validate(_data[228][1], node, "typeParameters", typeParameters, true);
+  return node;
 }
 export { tsExpressionWithTypeArguments as tSExpressionWithTypeArguments };
 export function tsInterfaceDeclaration(
@@ -2311,22 +2931,29 @@ export function tsInterfaceDeclaration(
   _extends: Array<t.TSExpressionWithTypeArguments> | null | undefined = null,
   body: t.TSInterfaceBody,
 ): t.TSInterfaceDeclaration {
-  return validateNode<t.TSInterfaceDeclaration>({
+  const node: t.TSInterfaceDeclaration = {
     type: "TSInterfaceDeclaration",
     id,
     typeParameters,
     extends: _extends,
     body,
-  });
+  };
+  validate(_data[229][0], node, "id", id, true);
+  validate(_data[229][1], node, "typeParameters", typeParameters, true);
+  validate(_data[229][2], node, "extends", _extends, true);
+  validate(_data[229][3], node, "body", body, true);
+  return node;
 }
 export { tsInterfaceDeclaration as tSInterfaceDeclaration };
 export function tsInterfaceBody(
   body: Array<t.TSTypeElement>,
 ): t.TSInterfaceBody {
-  return validateNode<t.TSInterfaceBody>({
+  const node: t.TSInterfaceBody = {
     type: "TSInterfaceBody",
     body,
-  });
+  };
+  validate(_data[230][0], node, "body", body, true);
+  return node;
 }
 export { tsInterfaceBody as tSInterfaceBody };
 export function tsTypeAliasDeclaration(
@@ -2334,96 +2961,123 @@ export function tsTypeAliasDeclaration(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined = null,
   typeAnnotation: t.TSType,
 ): t.TSTypeAliasDeclaration {
-  return validateNode<t.TSTypeAliasDeclaration>({
+  const node: t.TSTypeAliasDeclaration = {
     type: "TSTypeAliasDeclaration",
     id,
     typeParameters,
     typeAnnotation,
-  });
+  };
+  validate(_data[231][0], node, "id", id, true);
+  validate(_data[231][1], node, "typeParameters", typeParameters, true);
+  validate(_data[231][2], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsTypeAliasDeclaration as tSTypeAliasDeclaration };
 export function tsInstantiationExpression(
   expression: t.Expression,
   typeParameters: t.TSTypeParameterInstantiation | null = null,
 ): t.TSInstantiationExpression {
-  return validateNode<t.TSInstantiationExpression>({
+  const node: t.TSInstantiationExpression = {
     type: "TSInstantiationExpression",
     expression,
     typeParameters,
-  });
+  };
+  validate(_data[232][0], node, "expression", expression, true);
+  validate(_data[232][1], node, "typeParameters", typeParameters, true);
+  return node;
 }
 export { tsInstantiationExpression as tSInstantiationExpression };
 export function tsAsExpression(
   expression: t.Expression,
   typeAnnotation: t.TSType,
 ): t.TSAsExpression {
-  return validateNode<t.TSAsExpression>({
+  const node: t.TSAsExpression = {
     type: "TSAsExpression",
     expression,
     typeAnnotation,
-  });
+  };
+  validate(_data[233][0], node, "expression", expression, true);
+  validate(_data[233][1], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsAsExpression as tSAsExpression };
 export function tsSatisfiesExpression(
   expression: t.Expression,
   typeAnnotation: t.TSType,
 ): t.TSSatisfiesExpression {
-  return validateNode<t.TSSatisfiesExpression>({
+  const node: t.TSSatisfiesExpression = {
     type: "TSSatisfiesExpression",
     expression,
     typeAnnotation,
-  });
+  };
+  validate(_data[234][0], node, "expression", expression, true);
+  validate(_data[234][1], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsSatisfiesExpression as tSSatisfiesExpression };
 export function tsTypeAssertion(
   typeAnnotation: t.TSType,
   expression: t.Expression,
 ): t.TSTypeAssertion {
-  return validateNode<t.TSTypeAssertion>({
+  const node: t.TSTypeAssertion = {
     type: "TSTypeAssertion",
     typeAnnotation,
     expression,
-  });
+  };
+  validate(_data[235][0], node, "typeAnnotation", typeAnnotation, true);
+  validate(_data[235][1], node, "expression", expression, true);
+  return node;
 }
 export { tsTypeAssertion as tSTypeAssertion };
 export function tsEnumDeclaration(
   id: t.Identifier,
   members: Array<t.TSEnumMember>,
 ): t.TSEnumDeclaration {
-  return validateNode<t.TSEnumDeclaration>({
+  const node: t.TSEnumDeclaration = {
     type: "TSEnumDeclaration",
     id,
     members,
-  });
+  };
+  validate(_data[236][0], node, "id", id, true);
+  validate(_data[236][1], node, "members", members, true);
+  return node;
 }
 export { tsEnumDeclaration as tSEnumDeclaration };
 export function tsEnumMember(
   id: t.Identifier | t.StringLiteral,
   initializer: t.Expression | null = null,
 ): t.TSEnumMember {
-  return validateNode<t.TSEnumMember>({
+  const node: t.TSEnumMember = {
     type: "TSEnumMember",
     id,
     initializer,
-  });
+  };
+  validate(_data[237][0], node, "id", id, true);
+  validate(_data[237][1], node, "initializer", initializer, true);
+  return node;
 }
 export { tsEnumMember as tSEnumMember };
 export function tsModuleDeclaration(
   id: t.Identifier | t.StringLiteral,
   body: t.TSModuleBlock | t.TSModuleDeclaration,
 ): t.TSModuleDeclaration {
-  return validateNode<t.TSModuleDeclaration>({
+  const node: t.TSModuleDeclaration = {
     type: "TSModuleDeclaration",
     id,
     body,
-  });
+  };
+  validate(_data[238][0], node, "id", id, true);
+  validate(_data[238][1], node, "body", body, true);
+  return node;
 }
 export { tsModuleDeclaration as tSModuleDeclaration };
 export function tsModuleBlock(body: Array<t.Statement>): t.TSModuleBlock {
-  return validateNode<t.TSModuleBlock>({
+  const node: t.TSModuleBlock = {
     type: "TSModuleBlock",
     body,
-  });
+  };
+  validate(_data[239][0], node, "body", body, true);
+  return node;
 }
 export { tsModuleBlock as tSModuleBlock };
 export function tsImportType(
@@ -2431,85 +3085,106 @@ export function tsImportType(
   qualifier: t.TSEntityName | null = null,
   typeParameters: t.TSTypeParameterInstantiation | null = null,
 ): t.TSImportType {
-  return validateNode<t.TSImportType>({
+  const node: t.TSImportType = {
     type: "TSImportType",
     argument,
     qualifier,
     typeParameters,
-  });
+  };
+  validate(_data[240][0], node, "argument", argument, true);
+  validate(_data[240][1], node, "qualifier", qualifier, true);
+  validate(_data[240][2], node, "typeParameters", typeParameters, true);
+  return node;
 }
 export { tsImportType as tSImportType };
 export function tsImportEqualsDeclaration(
   id: t.Identifier,
   moduleReference: t.TSEntityName | t.TSExternalModuleReference,
 ): t.TSImportEqualsDeclaration {
-  return validateNode<t.TSImportEqualsDeclaration>({
+  const node: t.TSImportEqualsDeclaration = {
     type: "TSImportEqualsDeclaration",
     id,
     moduleReference,
     isExport: null,
-  });
+  };
+  validate(_data[241][0], node, "id", id, true);
+  validate(_data[241][1], node, "moduleReference", moduleReference, true);
+  return node;
 }
 export { tsImportEqualsDeclaration as tSImportEqualsDeclaration };
 export function tsExternalModuleReference(
   expression: t.StringLiteral,
 ): t.TSExternalModuleReference {
-  return validateNode<t.TSExternalModuleReference>({
+  const node: t.TSExternalModuleReference = {
     type: "TSExternalModuleReference",
     expression,
-  });
+  };
+  validate(_data[242][0], node, "expression", expression, true);
+  return node;
 }
 export { tsExternalModuleReference as tSExternalModuleReference };
 export function tsNonNullExpression(
   expression: t.Expression,
 ): t.TSNonNullExpression {
-  return validateNode<t.TSNonNullExpression>({
+  const node: t.TSNonNullExpression = {
     type: "TSNonNullExpression",
     expression,
-  });
+  };
+  validate(_data[243][0], node, "expression", expression, true);
+  return node;
 }
 export { tsNonNullExpression as tSNonNullExpression };
 export function tsExportAssignment(
   expression: t.Expression,
 ): t.TSExportAssignment {
-  return validateNode<t.TSExportAssignment>({
+  const node: t.TSExportAssignment = {
     type: "TSExportAssignment",
     expression,
-  });
+  };
+  validate(_data[244][0], node, "expression", expression, true);
+  return node;
 }
 export { tsExportAssignment as tSExportAssignment };
 export function tsNamespaceExportDeclaration(
   id: t.Identifier,
 ): t.TSNamespaceExportDeclaration {
-  return validateNode<t.TSNamespaceExportDeclaration>({
+  const node: t.TSNamespaceExportDeclaration = {
     type: "TSNamespaceExportDeclaration",
     id,
-  });
+  };
+  validate(_data[245][0], node, "id", id, true);
+  return node;
 }
 export { tsNamespaceExportDeclaration as tSNamespaceExportDeclaration };
 export function tsTypeAnnotation(typeAnnotation: t.TSType): t.TSTypeAnnotation {
-  return validateNode<t.TSTypeAnnotation>({
+  const node: t.TSTypeAnnotation = {
     type: "TSTypeAnnotation",
     typeAnnotation,
-  });
+  };
+  validate(_data[246][0], node, "typeAnnotation", typeAnnotation, true);
+  return node;
 }
 export { tsTypeAnnotation as tSTypeAnnotation };
 export function tsTypeParameterInstantiation(
   params: Array<t.TSType>,
 ): t.TSTypeParameterInstantiation {
-  return validateNode<t.TSTypeParameterInstantiation>({
+  const node: t.TSTypeParameterInstantiation = {
     type: "TSTypeParameterInstantiation",
     params,
-  });
+  };
+  validate(_data[247][0], node, "params", params, true);
+  return node;
 }
 export { tsTypeParameterInstantiation as tSTypeParameterInstantiation };
 export function tsTypeParameterDeclaration(
   params: Array<t.TSTypeParameter>,
 ): t.TSTypeParameterDeclaration {
-  return validateNode<t.TSTypeParameterDeclaration>({
+  const node: t.TSTypeParameterDeclaration = {
     type: "TSTypeParameterDeclaration",
     params,
-  });
+  };
+  validate(_data[248][0], node, "params", params, true);
+  return node;
 }
 export { tsTypeParameterDeclaration as tSTypeParameterDeclaration };
 export function tsTypeParameter(
@@ -2517,12 +3192,16 @@ export function tsTypeParameter(
   _default: t.TSType | null | undefined = null,
   name: string,
 ): t.TSTypeParameter {
-  return validateNode<t.TSTypeParameter>({
+  const node: t.TSTypeParameter = {
     type: "TSTypeParameter",
     constraint,
     default: _default,
     name,
-  });
+  };
+  validate(_data[249][0], node, "constraint", constraint, true);
+  validate(_data[249][1], node, "default", _default, true);
+  validate(_data[249][2], node, "name", name);
+  return node;
 }
 export { tsTypeParameter as tSTypeParameter };
 /** @deprecated */

--- a/packages/babel-types/src/builders/validateNode.ts
+++ b/packages/babel-types/src/builders/validateNode.ts
@@ -1,12 +1,17 @@
-import validate from "../validators/validate.ts";
+import { validateInternal } from "../validators/validate.ts";
 import type * as t from "../index.ts";
-import { BUILDER_KEYS } from "../index.ts";
+import { BUILDER_KEYS, NODE_FIELDS } from "../index.ts";
 
 export default function validateNode<N extends t.Node>(node: N) {
+  if (node == null || typeof node !== "object") return;
+  const fields = NODE_FIELDS[node.type];
+  if (!fields) return;
+
   // todo: because keys not in BUILDER_KEYS are not validated - this actually allows invalid nodes in some cases
   const keys = BUILDER_KEYS[node.type] as (keyof N & string)[];
   for (const key of keys) {
-    validate(node, key, node[key]);
+    const field = fields[key];
+    if (field != null) validateInternal(field, node, key, node[key]);
   }
   return node;
 }

--- a/packages/babel-types/src/validators/validate.ts
+++ b/packages/babel-types/src/validators/validate.ts
@@ -33,7 +33,7 @@ export function validateInternal(
   field.validate(node, key, val);
 
   if (maybeNode) {
-    const type = node?.type;
+    const type = (val as t.Node).type;
     if (type == null) return;
     NODE_PARENT_VALIDATIONS[type]?.(node, key, val);
   }
@@ -56,7 +56,7 @@ export function validateChild(
   key: string,
   val?: unknown,
 ) {
-  const type = node?.type;
+  const type = (val as t.Node)?.type;
   if (type == null) return;
   NODE_PARENT_VALIDATIONS[type]?.(node, key, val);
 }

--- a/packages/babel-types/src/validators/validate.ts
+++ b/packages/babel-types/src/validators/validate.ts
@@ -8,7 +8,7 @@ import type * as t from "../index.ts";
 export default function validate(
   node: t.Node | undefined | null,
   key: string,
-  val: any,
+  val: unknown,
 ): void {
   if (!node) return;
 
@@ -20,10 +20,29 @@ export default function validate(
   validateChild(node, key, val);
 }
 
+export function validateInternal(
+  field: FieldOptions,
+  node: t.Node | undefined | null,
+  key: string,
+  val: unknown,
+  maybeNode?: boolean,
+): void {
+  if (!field?.validate) return;
+  if (field.optional && val == null) return;
+
+  field.validate(node, key, val);
+
+  if (maybeNode) {
+    const type = node?.type;
+    if (type == null) return;
+    NODE_PARENT_VALIDATIONS[type]?.(node, key, val);
+  }
+}
+
 export function validateField(
   node: t.Node | undefined | null,
   key: string,
-  val: any,
+  val: unknown,
   field: FieldOptions | undefined | null,
 ): void {
   if (!field?.validate) return;
@@ -35,10 +54,9 @@ export function validateField(
 export function validateChild(
   node: t.Node | undefined | null,
   key: string,
-  val?: t.Node | undefined | null,
+  val?: unknown,
 ) {
-  if (val == null) return;
-  const validate = NODE_PARENT_VALIDATIONS[val.type];
-  if (!validate) return;
-  validate(node, key, val);
+  const type = node?.type;
+  if (type == null) return;
+  NODE_PARENT_VALIDATIONS[type]?.(node, key, val);
 }

--- a/scripts/utils/formatCode.js
+++ b/scripts/utils/formatCode.js
@@ -3,7 +3,11 @@ import * as prettier from "prettier";
 export default async function formatCode(code, filename) {
   const prettierConfig = await prettier.resolveConfig(filename);
   prettierConfig.filepath = filename;
-  prettierConfig.parser = filename.endsWith(".ts") ? "babel-ts" : "babel";
+  prettierConfig.parser = filename.endsWith(".json")
+    ? "json"
+    : filename.endsWith(".ts")
+      ? "babel-ts"
+      : "babel";
 
   return prettier.format(code, prettierConfig);
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Some discussion is needed.
Because it's a breaking change.
Ref: https://github.com/babel/babel/issues/13868

This PR makes `fields` and `builderKeys` only lookup once on initialization.
```
PS F:\babel\benchmark\babel-types\builders> node .\memberExpression.mjs
baseline memberExpression builder: 804_478 ops/sec ±0.52% (0.001ms)
current memberExpression builder: 7_391_582 ops/sec ±0.26% (0ms)
PS F:\babel\benchmark\babel-types\builders> node .\stringLiteral.mjs
baseline stringLiteral builder: 32_462_576 ops/sec ±0.42% (0ms)
current stringLiteral builder: 81_001_155 ops/sec ±0.6% (0ms)
```


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15843"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

