### PR TITLE
Provide better error message when allowDeclareFields is enabled

### DIFF
--- a/packages/babel-preset-typescript/src/normalize-options.ts
+++ b/packages/babel-preset-typescript/src/normalize-options.ts
@@ -36,7 +36,7 @@ export default function normalizeOptions(options: Options = {}) {
   if (process.env.BABEL_8_BREAKING) {
     v.invariant(
       !("allowDeclareFields" in options),
-      "The .allowDeclareFields options have been removed. Please remove it from your config.",
+      "The .allowDeclareFields option has been removed and it's now always enabled. Please remove it from your config.",
     );
     v.invariant(
       !("allExtensions" in options) && !("isTSX" in options),

--- a/packages/babel-preset-typescript/src/normalize-options.ts
+++ b/packages/babel-preset-typescript/src/normalize-options.ts
@@ -35,6 +35,10 @@ export default function normalizeOptions(options: Options = {}) {
 
   if (process.env.BABEL_8_BREAKING) {
     v.invariant(
+      !("allowDeclareFields" in options),
+      "The .allowDeclareFields options have been removed. Please remove it from your config.",
+    );
+    v.invariant(
       !("allExtensions" in options) && !("isTSX" in options),
       "The .allExtensions and .isTSX options have been removed.\n" +
         "If you want to disable JSX detection based on file extensions, " +

--- a/packages/babel-preset-typescript/test/fixtures/opts/allowDeclareFields/options.json
+++ b/packages/babel-preset-typescript/test/fixtures/opts/allowDeclareFields/options.json
@@ -1,5 +1,5 @@
 {
   "BABEL_8_BREAKING": true,
   "presets": [["typescript", { "allowDeclareFields": true }]],
-  "throws": "The .allowDeclareFields options have been removed. Please remove it from your config."
+  "throws": "The .allowDeclareFields option has been removed. Please remove it from your config."
 }

--- a/packages/babel-preset-typescript/test/fixtures/opts/allowDeclareFields/options.json
+++ b/packages/babel-preset-typescript/test/fixtures/opts/allowDeclareFields/options.json
@@ -1,5 +1,5 @@
 {
   "BABEL_8_BREAKING": true,
   "presets": [["typescript", { "allowDeclareFields": true }]],
-  "throws": "The .allowDeclareFields option has been removed. Please remove it from your config."
+  "throws": "The .allowDeclareFields option has been removed and it's now always enabled. Please remove it from your config."
 }

--- a/packages/babel-preset-typescript/test/fixtures/opts/allowDeclareFields/options.json
+++ b/packages/babel-preset-typescript/test/fixtures/opts/allowDeclareFields/options.json
@@ -1,0 +1,5 @@
+{
+  "BABEL_8_BREAKING": true,
+  "presets": [["typescript", { "allowDeclareFields": true }]],
+  "throws": "The .allowDeclareFields options have been removed. Please remove it from your config."
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Provide better error message when `allowDeclareFields` is provided in Babel 8
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Currently we are throwing `Did you mean "allowNamespaces"?`, which could be quite confusing if users are upgrading from Babel 7. Here we provide a better message.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15847"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

