### PR TITLE
ignore "PR: Breaking Change" label when generating changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,7 @@
     "cacheDir": ".changelog",
     "labels": {
       "PR: Spec Compliance :eyeglasses:": ":eyeglasses: Spec Compliance",
-      "(remove me when generating breaking changes of major versions)PR: Breaking Change :boom:": ":boom: Breaking Change",
-      "PR: Deprecation: :loudspeaker:": ":loudspeaker: Deprecation",
+      "PR: Deprecation :loudspeaker:": ":loudspeaker: Deprecation",
       "PR: New Feature :rocket:": ":rocket: New Feature",
       "PR: Bug Fix :bug:": ":bug: Bug Fix",
       "PR: Polish :nail_care:": ":nail_care: Polish",
@@ -123,6 +122,19 @@
       "PR: Performance :running_woman:": ":running_woman: Performance",
       "PR: Revert :leftwards_arrow_with_hook:": ":leftwards_arrow_with_hook: Revert",
       "PR: Output optimization :microscope:": ":microscope: Output optimization"
+    },
+    "labels_breaking": {
+      "PR: Spec Compliance (Next major only) :eyeglasses:": ":eyeglasses: Spec Compliance",
+      "PR: Breaking Change :boom:": ":boom: Breaking Change",
+      "PR: Deprecation (Next major only) :loudspeaker:": ":loudspeaker: Deprecation",
+      "PR: New Feature (Next major only) :rocket:": ":rocket: New Feature",
+      "PR: Bug Fix (Next major only) :bug:": ":bug: Bug Fix",
+      "PR: Polish (Next major only) :nail_care:": ":nail_care: Polish",
+      "PR: Docs (Next major only) :memo:": ":memo: Documentation",
+      "PR: Internal (Next major only) :house:": ":house: Internal",
+      "PR: Performance (Next major only) :running_woman:": ":running_woman: Performance",
+      "PR: Revert (Next major only) :leftwards_arrow_with_hook:": ":leftwards_arrow_with_hook: Revert",
+      "PR: Output optimization (Next major only) :microscope:": ":microscope: Output optimization"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "cacheDir": ".changelog",
     "labels": {
       "PR: Spec Compliance :eyeglasses:": ":eyeglasses: Spec Compliance",
-      "PR: Breaking Change :boom:": ":boom: Breaking Change",
+      "(remove me when generating breaking changes of major versions)PR: Breaking Change :boom:": ":boom: Breaking Change",
       "PR: Deprecation: :loudspeaker:": ":loudspeaker: Deprecation",
       "PR: New Feature :rocket:": ":rocket: New Feature",
       "PR: Bug Fix :bug:": ":bug: Bug Fix",

--- a/package.json
+++ b/package.json
@@ -124,17 +124,17 @@
       "PR: Output optimization :microscope:": ":microscope: Output optimization"
     },
     "labels_breaking": {
-      "PR: Spec Compliance (Next major only) :eyeglasses:": ":eyeglasses: Spec Compliance",
+      "PR: Spec Compliance (next major) :eyeglasses:": ":eyeglasses: Spec Compliance",
       "PR: Breaking Change :boom:": ":boom: Breaking Change",
-      "PR: Deprecation (Next major only) :loudspeaker:": ":loudspeaker: Deprecation",
-      "PR: New Feature (Next major only) :rocket:": ":rocket: New Feature",
-      "PR: Bug Fix (Next major only) :bug:": ":bug: Bug Fix",
-      "PR: Polish (Next major only) :nail_care:": ":nail_care: Polish",
-      "PR: Docs (Next major only) :memo:": ":memo: Documentation",
-      "PR: Internal (Next major only) :house:": ":house: Internal",
-      "PR: Performance (Next major only) :running_woman:": ":running_woman: Performance",
-      "PR: Revert (Next major only) :leftwards_arrow_with_hook:": ":leftwards_arrow_with_hook: Revert",
-      "PR: Output optimization (Next major only) :microscope:": ":microscope: Output optimization"
+      "PR: Deprecation (next major) :loudspeaker:": ":loudspeaker: Deprecation",
+      "PR: New Feature (next major) :rocket:": ":rocket: New Feature",
+      "PR: Bug Fix (next major) :bug:": ":bug: Bug Fix",
+      "PR: Polish (next major) :nail_care:": ":nail_care: Polish",
+      "PR: Docs (next major) :memo:": ":memo: Documentation",
+      "PR: Internal (next major) :house:": ":house: Internal",
+      "PR: Performance (next major) :running_woman:": ":running_woman: Performance",
+      "PR: Revert (next major) :leftwards_arrow_with_hook:": ":leftwards_arrow_with_hook: Revert",
+      "PR: Output optimization (next major) :microscope:": ":microscope: Output optimization"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
       "PR: Docs (next major) :memo:": ":memo: Documentation",
       "PR: Internal (next major) :house:": ":house: Internal",
       "PR: Performance (next major) :running_woman:": ":running_woman: Performance",
-      "PR: Revert (next major) :leftwards_arrow_with_hook:": ":leftwards_arrow_with_hook: Revert",
+      "PR: Revert (next major)": ":leftwards_arrow_with_hook: Revert",
       "PR: Output optimization (next major) :microscope:": ":microscope: Output optimization"
     }
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
After we release Babel 8, I expect the flag `BABEL_8_BREAKING` will simply evolve to `BABEL_9_BREAKING`,  but I am not sure we are going to create the PR label `babel 9` and `babel 9 -> main` again. In this PR I suggest we revive the `PR: Breaking Change :boom:` label, these PRs will be merged only if they are implemented after a breaking-major env flag. They will be ignored by our release changelog, as they are merged but never shipped.

If we want to generate breaking changes between major versions, we can rename the `labels_breaking` to `labels` and `labels` to `labels_disabled`, and then manually run `lerna-changelog` from the first version of this major to the next major, e.g.

```
node ./node_modules/.bin/lerna-changelog --tag-from 8.0.0 --tag-to 9.0.0
```

It should then generate a complete changelog including all changes shipped to 9.0.0.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15848"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

