### PR TITLE
Use just `lru-cache` instead of also `quick-lru`

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -19,7 +19,7 @@
     "@babel/core": "workspace:^",
     "@babel/helper-check-duplicate-nodes": "workspace:^",
     "@babel/helper-fixtures": "workspace:^",
-    "quick-lru": "5.1.0"
+    "lru-cache": "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -18,7 +18,7 @@ import assert from "assert";
 import fs from "fs";
 import path from "path";
 import vm from "vm";
-import QuickLRU from "quick-lru";
+import LruCache from "lru-cache";
 import { fileURLToPath } from "url";
 
 import { createRequire } from "module";
@@ -53,10 +53,10 @@ if (!process.env.BABEL_8_BREAKING) {
 
 const EXTERNAL_HELPERS_VERSION = "7.100.0";
 
-const cachedScripts = new QuickLRU<
+const cachedScripts = new LruCache<
   string,
   { code: string; cachedData?: Buffer }
->({ maxSize: 10 });
+>({ max: 10 });
 const contextModuleCache = new WeakMap();
 const sharedTestContext = createContext();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -976,7 +976,7 @@ __metadata:
     "@babel/core": "workspace:^"
     "@babel/helper-check-duplicate-nodes": "workspace:^"
     "@babel/helper-fixtures": "workspace:^"
-    quick-lru: 5.1.0
+    lru-cache: "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1"
   languageName: unknown
   linkType: soft
 
@@ -13663,13 +13663,6 @@ fsevents@^1.2.7:
   version: 0.2.0
   resolution: "querystring@npm:0.2.0"
   checksum: 8258d6734f19be27e93f601758858c299bdebe71147909e367101ba459b95446fbe5b975bf9beb76390156a592b6f4ac3a68b6087cea165c259705b8b4e56a69
-  languageName: node
-  linkType: hard
-
-"quick-lru@npm:5.1.0":
-  version: 5.1.0
-  resolution: "quick-lru@npm:5.1.0"
-  checksum: 48e42823990a274764f611800debe3024d93685039b2becbbe824f7841658e13462b1138ab72d664de1754f0636761b607e6b5b392cc286b8322ee563c5ed33b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We are already using `lru-cache` in `@babel/helper-compilation-targets`, and it's used multiple times in our dependencies.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15849"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

