### PR TITLE
Exclude redundant files from publish process

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -264,7 +264,7 @@ function createWorker(useWorker) {
 async function buildBabel(useWorker, ignore = []) {
   const worker = createWorker(useWorker);
   const files = new Glob(defaultSourcesGlob, {
-    ignore: ignore.map(p => `./${p.src}/**`),
+    ignore: ignore.map(p => `${p.src}/**`),
     posix: true,
   });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Redundant files are published since 7.22.0
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
If we compare https://unpkg.com/browse/@babel/parser@7.21.5/lib/ with https://unpkg.com/browse/@babel/parser@7.22.0/lib/, we will notice that there are redundant files, such as `lib/options.js`. They should not have been published.

This setback was likely introduced at https://github.com/babel/babel/pull/15615. The `node-glob` v9 is a completely rewrite, which might break the `ignore` pattern starting with `./` here. Anyway I am happy for the shorter globs here so no complains.