### PR TITLE
fix(standalone): strip archived syntax plugins

### DIFF
--- a/packages/babel-plugin-transform-async-generator-functions/src/index.ts
+++ b/packages/babel-plugin-transform-async-generator-functions/src/index.ts
@@ -96,6 +96,8 @@ export default declare(api => {
     name: "transform-async-generator-functions",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-async-generators").default,
 

--- a/packages/babel-plugin-transform-class-static-block/src/index.ts
+++ b/packages/babel-plugin-transform-class-static-block/src/index.ts
@@ -31,6 +31,8 @@ export default declare(({ types: t, template, assertVersion }) => {
     name: "transform-class-static-block",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-class-static-block").default,
 

--- a/packages/babel-plugin-transform-dynamic-import/src/index.ts
+++ b/packages/babel-plugin-transform-dynamic-import/src/index.ts
@@ -22,6 +22,8 @@ export default declare(api => {
     name: "transform-dynamic-import",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-dynamic-import").default,
 

--- a/packages/babel-plugin-transform-export-namespace-from/src/index.ts
+++ b/packages/babel-plugin-transform-export-namespace-from/src/index.ts
@@ -8,6 +8,8 @@ export default declare(api => {
     name: "transform-export-namespace-from",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-export-namespace-from").default,
 

--- a/packages/babel-plugin-transform-json-strings/src/index.ts
+++ b/packages/babel-plugin-transform-json-strings/src/index.ts
@@ -19,6 +19,8 @@ export default declare(api => {
     name: "transform-json-strings",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-json-strings").default,
 

--- a/packages/babel-plugin-transform-logical-assignment-operators/src/index.ts
+++ b/packages/babel-plugin-transform-logical-assignment-operators/src/index.ts
@@ -8,6 +8,8 @@ export default declare(api => {
     name: "transform-logical-assignment-operators",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-logical-assignment-operators").default,
 

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/src/index.ts
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/src/index.ts
@@ -13,6 +13,8 @@ export default declare((api, { loose = false }: Options) => {
     name: "transform-nullish-coalescing-operator",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-nullish-coalescing-operator").default,
 

--- a/packages/babel-plugin-transform-numeric-separator/src/index.ts
+++ b/packages/babel-plugin-transform-numeric-separator/src/index.ts
@@ -24,6 +24,8 @@ export default declare(api => {
     name: "transform-numeric-separator",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-numeric-separator").default,
 

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.ts
@@ -286,6 +286,8 @@ export default declare((api, opts: Options) => {
     name: "transform-object-rest-spread",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-object-rest-spread").default,
 

--- a/packages/babel-plugin-transform-optional-catch-binding/src/index.ts
+++ b/packages/babel-plugin-transform-optional-catch-binding/src/index.ts
@@ -7,6 +7,8 @@ export default declare(api => {
     name: "transform-optional-catch-binding",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-optional-catch-binding").default,
 

--- a/packages/babel-plugin-transform-optional-chaining/src/index.ts
+++ b/packages/babel-plugin-transform-optional-chaining/src/index.ts
@@ -17,6 +17,8 @@ export default declare((api, options: Options) => {
     name: "transform-optional-chaining",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-optional-chaining").default,
 

--- a/packages/babel-plugin-transform-private-property-in-object/src/index.ts
+++ b/packages/babel-plugin-transform-private-property-in-object/src/index.ts
@@ -114,6 +114,8 @@ export default declare((api, opt: Options) => {
     name: "transform-private-property-in-object",
     inherits: USE_ESM
       ? undefined
+      : IS_STANDALONE
+      ? undefined
       : // eslint-disable-next-line no-restricted-globals
         require("@babel/plugin-syntax-private-property-in-object").default,
     pre() {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The `@babel/standalone` main contains unsound dependency of archived syntax plugins
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes a recent regression. Currently the `@babel/standalone` contains dynamic import of archived syntax plugins such as
```js
    Error message: "[BABEL] unknown file: Cannot find module '@babel/plugin-syntax-export-namespace-from'
    Require stack:
    - /home/circleci/babel/packages/babel-standalone/babel.js
    - /home/circleci/babel/packages/babel-standalone/test/babel.js (While processing: \"base$0$0$0$0$6\")"
    
          83666 |     return {
          83667 |       name: "transform-export-namespace-from",
        > 83668 |       inherits: require("@babel/plugin-syntax-export-namespace-from")["default"],
                |                 ^
          83669 |       visitor: {
          83670 |         ExportNamedDeclaration: function ExportNamedDeclaration(path) {
          83671 |           var _exported$name;
``` 
because we changed static import to dynamic import in #15823. This bug is not caught by our current pipeline because those plugins are in the root node_modules.

Luckily this issue surfaces in https://github.com/babel/babel/pull/15846 since we bumped to Babel 8. Here I follow the vibe of https://github.com/babel/babel/pull/15023 and strip such plugins when bundling `@babel/standalone`.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15858"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

