### PR TITLE
fix: definition of TS function type params

### DIFF
--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -1718,14 +1718,14 @@ export interface TSQualifiedName extends BaseNode {
 export interface TSCallSignatureDeclaration extends BaseNode {
   type: "TSCallSignatureDeclaration";
   typeParameters?: TSTypeParameterDeclaration | null;
-  parameters: Array<Identifier | RestElement>;
+  parameters: Array<ArrayPattern | Identifier | ObjectPattern | RestElement>;
   typeAnnotation?: TSTypeAnnotation | null;
 }
 
 export interface TSConstructSignatureDeclaration extends BaseNode {
   type: "TSConstructSignatureDeclaration";
   typeParameters?: TSTypeParameterDeclaration | null;
-  parameters: Array<Identifier | RestElement>;
+  parameters: Array<ArrayPattern | Identifier | ObjectPattern | RestElement>;
   typeAnnotation?: TSTypeAnnotation | null;
 }
 
@@ -1744,7 +1744,7 @@ export interface TSMethodSignature extends BaseNode {
   type: "TSMethodSignature";
   key: Expression;
   typeParameters?: TSTypeParameterDeclaration | null;
-  parameters: Array<Identifier | RestElement>;
+  parameters: Array<ArrayPattern | Identifier | ObjectPattern | RestElement>;
   typeAnnotation?: TSTypeAnnotation | null;
   computed?: boolean;
   kind: "method" | "get" | "set";
@@ -1818,14 +1818,14 @@ export interface TSThisType extends BaseNode {
 export interface TSFunctionType extends BaseNode {
   type: "TSFunctionType";
   typeParameters?: TSTypeParameterDeclaration | null;
-  parameters: Array<Identifier | RestElement>;
+  parameters: Array<ArrayPattern | Identifier | ObjectPattern | RestElement>;
   typeAnnotation?: TSTypeAnnotation | null;
 }
 
 export interface TSConstructorType extends BaseNode {
   type: "TSConstructorType";
   typeParameters?: TSTypeParameterDeclaration | null;
-  parameters: Array<Identifier | RestElement>;
+  parameters: Array<ArrayPattern | Identifier | ObjectPattern | RestElement>;
   typeAnnotation?: TSTypeAnnotation | null;
   abstract?: boolean | null;
 }
@@ -2915,8 +2915,13 @@ export interface ParentMaps {
     | ObjectMethod
     | ObjectProperty
     | RestElement
+    | TSCallSignatureDeclaration
+    | TSConstructSignatureDeclaration
+    | TSConstructorType
     | TSDeclareFunction
     | TSDeclareMethod
+    | TSFunctionType
+    | TSMethodSignature
     | VariableDeclarator;
   ArrayTypeAnnotation:
     | ArrayTypeAnnotation
@@ -5626,8 +5631,13 @@ export interface ParentMaps {
     | ObjectMethod
     | ObjectProperty
     | RestElement
+    | TSCallSignatureDeclaration
+    | TSConstructSignatureDeclaration
+    | TSConstructorType
     | TSDeclareFunction
     | TSDeclareMethod
+    | TSFunctionType
+    | TSMethodSignature
     | VariableDeclarator;
   ObjectProperty: ObjectExpression | ObjectPattern | RecordExpression;
   ObjectTypeAnnotation:

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -1927,7 +1927,9 @@ export function tsQualifiedName(
 export { tsQualifiedName as tSQualifiedName };
 export function tsCallSignatureDeclaration(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined = null,
-  parameters: Array<t.Identifier | t.RestElement>,
+  parameters: Array<
+    t.ArrayPattern | t.Identifier | t.ObjectPattern | t.RestElement
+  >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSCallSignatureDeclaration {
   return validateNode<t.TSCallSignatureDeclaration>({
@@ -1940,7 +1942,9 @@ export function tsCallSignatureDeclaration(
 export { tsCallSignatureDeclaration as tSCallSignatureDeclaration };
 export function tsConstructSignatureDeclaration(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined = null,
-  parameters: Array<t.Identifier | t.RestElement>,
+  parameters: Array<
+    t.ArrayPattern | t.Identifier | t.ObjectPattern | t.RestElement
+  >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSConstructSignatureDeclaration {
   return validateNode<t.TSConstructSignatureDeclaration>({
@@ -1968,7 +1972,9 @@ export { tsPropertySignature as tSPropertySignature };
 export function tsMethodSignature(
   key: t.Expression,
   typeParameters: t.TSTypeParameterDeclaration | null | undefined = null,
-  parameters: Array<t.Identifier | t.RestElement>,
+  parameters: Array<
+    t.ArrayPattern | t.Identifier | t.ObjectPattern | t.RestElement
+  >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSMethodSignature {
   return validateNode<t.TSMethodSignature>({
@@ -2078,7 +2084,9 @@ export function tsThisType(): t.TSThisType {
 export { tsThisType as tSThisType };
 export function tsFunctionType(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined = null,
-  parameters: Array<t.Identifier | t.RestElement>,
+  parameters: Array<
+    t.ArrayPattern | t.Identifier | t.ObjectPattern | t.RestElement
+  >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSFunctionType {
   return validateNode<t.TSFunctionType>({
@@ -2091,7 +2099,9 @@ export function tsFunctionType(
 export { tsFunctionType as tSFunctionType };
 export function tsConstructorType(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined = null,
-  parameters: Array<t.Identifier | t.RestElement>,
+  parameters: Array<
+    t.ArrayPattern | t.Identifier | t.ObjectPattern | t.RestElement
+  >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSConstructorType {
   return validateNode<t.TSConstructorType>({

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -97,7 +97,7 @@ defineType("TSQualifiedName", {
 const signatureDeclarationCommon = () => ({
   typeParameters: validateOptionalType("TSTypeParameterDeclaration"),
   [process.env.BABEL_8_BREAKING ? "params" : "parameters"]: validateArrayOfType(
-    ["Identifier", "RestElement"],
+    ["ArrayPattern", "Identifier", "ObjectPattern", "RestElement"],
   ),
   [process.env.BABEL_8_BREAKING ? "returnType" : "typeAnnotation"]:
     validateOptionalType("TSTypeAnnotation"),


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | ⛔️ (changes to TS types can always be breaking though)
| Minor: New Feature?      | ⛔️
| Tests Added + Pass?      | 👍
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | ⛔️
| License                  | MIT

Function type params can also be array or object patterns. They can NOT be assignment patterns.

Examples (all valid): 

```ts
interface Props {
  onUpdate?: ({ visibleItemsCount }: { visibleItemsCount: number }) => void // TSFunctionType
  
  onUpdate2?: new ({ visibleItemsCount }: { visibleItemsCount: number }) => void // TSConstructorType
  
  asd({ visibleItemsCount }: { visibleItemsCount: number }): void // TSMethodSignature
  
  new ({ visibleItemsCount }: { visibleItemsCount: number }): void // TSConstructSignatureDeclaration
  
  ({ visibleItemsCount }: { visibleItemsCount: number }): void // TSCallSignatureDeclaration
}
```
[TS Playground](https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgApQPYAcDOyDeAUMshiAKpYAmckA-AFzIAU+yAbsDsAEYA2EAJKQAtjgDCGAK7hkAXyZtO3fkNETp4JiCkie0eQEpkAXgB8HDMCrIA9LeQAVAMoAxGQjDAyjgJ5YIYmQgskoaSAAmRmQQCAB3FiUuXgFhCDFJGTB5RQ5k1TSMzTBtXX0oI1MLdisbeydnSRAcMCgpTwwoPwCgoLgcKlY8lVT1TNkFAmGUtXSNLNK9AzlDJhrrOwcXAFkIMAALDCpnYABzEFopKECSINiEoeUZwvmJ3KeCseLF8qM12s2DSaLTanhO50u1wAIhAEHw4FBaN4QL0SI98qM5uNspMkiNZkUFjEystVpYNvUXOI4Hw+OCLmArhAYXCEUiyIQ5IQgA)

The parser as well as generator already handle these cases perfectly fine. In the parser there is even [an error message](https://github.com/babel/babel/blob/8c68dfe0f85a9a926c7d09ecd8a10e64ce4c99c7/packages/babel-parser/src/plugins/typescript/index.ts#L229) saying exactly this. 


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15867"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

