### PR TITLE
disallow createConfigItem,loadPartialConfig,loadOptions sync usage

### DIFF
--- a/eslint/babel-eslint-parser/src/worker/babel-core.cjs
+++ b/eslint/babel-eslint-parser/src/worker/babel-core.cjs
@@ -7,7 +7,14 @@ function initialize(babel) {
   exports.parseSync = babel.parseSync;
   exports.loadPartialConfigSync = babel.loadPartialConfigSync;
   exports.loadPartialConfigAsync = babel.loadPartialConfigAsync;
-  exports.createConfigItem = babel.createConfigItem;
+  if (process.env.BABEL_8_BREAKING) {
+    exports.createConfigItemSync = babel.createConfigItemSync;
+  } else {
+    // babel.createConfigItemSync is available on 7.13+
+    // we support Babel 7.11+
+    exports.createConfigItemSync =
+      babel.createConfigItemSync || babel.createConfigItem;
+  }
 }
 
 if (USE_ESM) {

--- a/eslint/babel-eslint-parser/src/worker/maybeParse.cjs
+++ b/eslint/babel-eslint-parser/src/worker/maybeParse.cjs
@@ -10,7 +10,7 @@ const MULTIPLE_OVERRIDES = /More than one plugin attempted to override parsing/;
 
 module.exports = function maybeParse(code, options) {
   if (!extractParserOptionsConfigItem) {
-    extractParserOptionsConfigItem = babel.createConfigItem(
+    extractParserOptionsConfigItem = babel.createConfigItemSync(
       [extractParserOptionsPlugin, ref],
       { dirname: __dirname, type: "plugin" },
     );

--- a/packages/babel-core/src/config/index.ts
+++ b/packages/babel-core/src/config/index.ts
@@ -1,4 +1,4 @@
-import gensync, { type Handler, type Callback } from "gensync";
+import gensync, { type Handler } from "gensync";
 
 export type {
   ResolvedConfig,
@@ -24,7 +24,10 @@ export type {
 } from "./validation/options";
 
 import loadFullConfig, { type ResolvedConfig } from "./full";
-import { loadPartialConfig as loadPartialConfigRunner } from "./partial";
+import {
+  type PartialConfig,
+  loadPartialConfig as loadPartialConfigImpl,
+} from "./partial";
 
 export { loadFullConfig as default };
 export type { PartialConfig } from "./partial";
@@ -34,60 +37,112 @@ import type { ConfigItem } from "./item";
 
 import { beginHiddenCallStack } from "../errors/rewrite-stack-trace";
 
-const loadOptionsRunner = gensync(function* (
-  opts: unknown,
-): Handler<ResolvedConfig | null> {
+const loadPartialConfigRunner = gensync(loadPartialConfigImpl);
+export function loadPartialConfigAsync(
+  ...args: Parameters<typeof loadPartialConfigRunner.async>
+) {
+  return beginHiddenCallStack(loadPartialConfigRunner.async)(...args);
+}
+export function loadPartialConfigSync(
+  ...args: Parameters<typeof loadPartialConfigRunner.sync>
+) {
+  return beginHiddenCallStack(loadPartialConfigRunner.sync)(...args);
+}
+export function loadPartialConfig(
+  opts: Parameters<typeof loadPartialConfigImpl>[0],
+  callback?: (err: Error, val: PartialConfig | null) => void,
+) {
+  if (callback !== undefined) {
+    beginHiddenCallStack(loadPartialConfigRunner.errback)(opts, callback);
+  } else if (typeof opts === "function") {
+    beginHiddenCallStack(loadPartialConfigRunner.errback)(
+      undefined,
+      opts as (err: Error, val: PartialConfig | null) => void,
+    );
+  } else {
+    if (process.env.BABEL_8_BREAKING) {
+      throw new Error(
+        "Starting from Babel 8.0.0, the 'loadPartialConfig' function expects a callback. If you need to call it synchronously, please use 'loadPartialConfigSync'.",
+      );
+    } else {
+      return loadPartialConfigSync(opts);
+    }
+  }
+}
+
+function* loadOptionsImpl(opts: unknown): Handler<ResolvedConfig | null> {
   const config = yield* loadFullConfig(opts);
   // NOTE: We want to return "null" explicitly, while ?. alone returns undefined
   return config?.options ?? null;
-});
+}
+const loadOptionsRunner = gensync(loadOptionsImpl);
+export function loadOptionsAsync(
+  ...args: Parameters<typeof loadOptionsRunner.async>
+) {
+  return beginHiddenCallStack(loadOptionsRunner.async)(...args);
+}
+export function loadOptionsSync(
+  ...args: Parameters<typeof loadOptionsRunner.sync>
+) {
+  return beginHiddenCallStack(loadOptionsRunner.sync)(...args);
+}
+export function loadOptions(
+  opts: Parameters<typeof loadOptionsImpl>[0],
+  callback?: (err: Error, val: ResolvedConfig | null) => void,
+) {
+  if (callback !== undefined) {
+    beginHiddenCallStack(loadOptionsRunner.errback)(opts, callback);
+  } else if (typeof opts === "function") {
+    beginHiddenCallStack(loadOptionsRunner.errback)(
+      undefined,
+      opts as (err: Error, val: ResolvedConfig | null) => void,
+    );
+  } else {
+    if (process.env.BABEL_8_BREAKING) {
+      throw new Error(
+        "Starting from Babel 8.0.0, the 'loadOptions' function expects a callback. If you need to call it synchronously, please use 'loadOptionsSync'.",
+      );
+    } else {
+      return loadOptionsSync(opts);
+    }
+  }
+}
 
 const createConfigItemRunner = gensync(createConfigItemImpl);
-
-const maybeErrback =
-  <Arg, Return>(runner: gensync.Gensync<[Arg], Return>) =>
-  (argOrCallback: Arg | Callback<Return>, maybeCallback?: Callback<Return>) => {
-    let arg: Arg | undefined;
-    let callback: Callback<Return>;
-    if (maybeCallback === undefined && typeof argOrCallback === "function") {
-      callback = argOrCallback as Callback<Return>;
-      arg = undefined;
-    } else {
-      callback = maybeCallback;
-      arg = argOrCallback as Arg;
-    }
-    if (!callback) {
-      return runner.sync(arg);
-    }
-    runner.errback(arg, callback);
-  };
-
-export const loadPartialConfig = maybeErrback(loadPartialConfigRunner);
-export const loadPartialConfigSync = loadPartialConfigRunner.sync;
-export const loadPartialConfigAsync = loadPartialConfigRunner.async;
-
-export const loadOptions = maybeErrback(loadOptionsRunner);
-export const loadOptionsSync = loadOptionsRunner.sync;
-export const loadOptionsAsync = loadOptionsRunner.async;
-
-export const createConfigItemSync = createConfigItemRunner.sync;
-export const createConfigItemAsync = createConfigItemRunner.async;
+export function createConfigItemAsync(
+  ...args: Parameters<typeof createConfigItemRunner.async>
+) {
+  return beginHiddenCallStack(createConfigItemRunner.async)(...args);
+}
+export function createConfigItemSync(
+  ...args: Parameters<typeof createConfigItemRunner.sync>
+) {
+  return beginHiddenCallStack(createConfigItemRunner.sync)(...args);
+}
 export function createConfigItem(
   target: PluginTarget,
   options: Parameters<typeof createConfigItemImpl>[1],
   callback?: (err: Error, val: ConfigItem<PluginAPI> | null) => void,
 ) {
   if (callback !== undefined) {
-    createConfigItemRunner.errback(target, options, callback);
+    beginHiddenCallStack(createConfigItemRunner.errback)(
+      target,
+      options,
+      callback,
+    );
   } else if (typeof options === "function") {
-    createConfigItemRunner.errback(target, undefined, callback);
+    beginHiddenCallStack(createConfigItemRunner.errback)(
+      target,
+      undefined,
+      callback,
+    );
   } else {
     if (process.env.BABEL_8_BREAKING) {
       throw new Error(
         "Starting from Babel 8.0.0, the 'createConfigItem' function expects a callback. If you need to call it synchronously, please use 'createConfigItemSync'.",
       );
     } else {
-      return beginHiddenCallStack(createConfigItemRunner.sync)(target, options);
+      return createConfigItemSync(target, options);
     }
   }
 }

--- a/packages/babel-core/src/config/partial.ts
+++ b/packages/babel-core/src/config/partial.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import gensync from "gensync";
 import type { Handler } from "gensync";
 import Plugin from "./plugin";
 import { mergeOptions } from "./util";
@@ -159,7 +158,7 @@ type LoadPartialConfigOpts = {
   showIgnoredFiles?: boolean;
 };
 
-export const loadPartialConfig = gensync(function* (
+export function* loadPartialConfig(
   opts?: LoadPartialConfigOpts,
 ): Handler<PartialConfig | null> {
   let showIgnoredFiles = false;
@@ -197,7 +196,7 @@ export const loadPartialConfig = gensync(function* (
     fileHandling,
     files,
   );
-});
+}
 
 export type { PartialConfig };
 

--- a/packages/babel-core/test/assumptions.js
+++ b/packages/babel-core/test/assumptions.js
@@ -1,16 +1,19 @@
 import path from "path";
 import { fileURLToPath } from "url";
-import { loadOptions as loadOptionsOrig, transformSync } from "../lib/index.js";
+import {
+  loadOptionsSync as loadOptionsSyncOrig,
+  transformSync,
+} from "../lib/index.js";
 import pluginCommonJS from "@babel/plugin-transform-modules-commonjs";
 
 const cwd = path.dirname(fileURLToPath(import.meta.url));
 
-function loadOptions(opts) {
-  return loadOptionsOrig({ cwd, ...opts });
+function loadOptionsSync(opts) {
+  return loadOptionsSyncOrig({ cwd, ...opts });
 }
 
 function withAssumptions(assumptions) {
-  return loadOptions({ assumptions });
+  return loadOptionsSync({ assumptions });
 }
 
 describe("assumptions", () => {
@@ -35,7 +38,7 @@ describe("assumptions", () => {
 
   it("can be enabled by presets", () => {
     expect(
-      loadOptions({
+      loadOptionsSync({
         assumptions: {
           setPublicClassFields: true,
         },
@@ -49,7 +52,7 @@ describe("assumptions", () => {
 
   it("cannot be disabled by presets", () => {
     expect(() =>
-      loadOptions({
+      loadOptionsSync({
         presets: [() => ({ assumptions: { mutableTemplateObject: false } })],
       }),
     ).toThrow(
@@ -116,7 +119,7 @@ describe("assumptions", () => {
     it("plugin defined outside preset", () => {
       const ref = {};
 
-      loadOptions({
+      loadOptionsSync({
         configFile: false,
         presets: [presetEnumerableModuleMeta],
         plugins: [[pluginExtractEnumerableModuleMeta, ref]],
@@ -128,7 +131,7 @@ describe("assumptions", () => {
     it("plugin defined inside preset", () => {
       const ref = {};
 
-      loadOptions({
+      loadOptionsSync({
         configFile: false,
         presets: [
           () => ({

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -51,8 +51,8 @@ function fixture(...args) {
   return path.join(dirname, "fixtures", "config", ...args);
 }
 
-function loadOptions(opts) {
-  return babel.loadOptions({ cwd: dirname, ...opts });
+function loadOptionsSync(opts) {
+  return babel.loadOptionsSync({ cwd: dirname, ...opts });
 }
 
 function pairs(items) {
@@ -91,7 +91,7 @@ describe("buildConfigChain", function () {
   describe("test", () => {
     describe("single", () => {
       it("should process matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -103,7 +103,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -115,7 +115,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -127,7 +127,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -139,7 +139,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -151,7 +151,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -165,7 +165,7 @@ describe("buildConfigChain", function () {
 
     describe("array", () => {
       it("should process matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -177,7 +177,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -189,7 +189,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -201,7 +201,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -213,7 +213,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -225,7 +225,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -247,7 +247,7 @@ describe("buildConfigChain", function () {
       describe("in config", () => {
         it("requires filename if string", () => {
           expect(() =>
-            loadOptions({
+            loadOptionsSync({
               ...BASE_OPTS,
               test: fixture("nonexistent-fake"),
             }),
@@ -256,7 +256,7 @@ describe("buildConfigChain", function () {
 
         it("requires filename if RegExp", () => {
           expect(() =>
-            loadOptions({
+            loadOptionsSync({
               ...BASE_OPTS,
               test: /file/,
             }),
@@ -267,7 +267,7 @@ describe("buildConfigChain", function () {
           const mock = jest.fn().mockReturnValue(true);
 
           expect(() =>
-            loadOptions({
+            loadOptionsSync({
               ...BASE_OPTS,
               test: mock,
             }),
@@ -275,7 +275,7 @@ describe("buildConfigChain", function () {
           expect(mock).toHaveBeenCalledWith(undefined, expect.anything());
 
           expect(() =>
-            loadOptions({
+            loadOptionsSync({
               ...BASE_OPTS,
               filename: "some-filename",
               test: mock,
@@ -288,7 +288,7 @@ describe("buildConfigChain", function () {
       describe("in preset", () => {
         it("requires filename if string", () => {
           expect(() =>
-            loadOptions({
+            loadOptionsSync({
               ...BASE_OPTS,
               presets: [() => ({ test: fixture("nonexistent-fake") })],
             }),
@@ -297,7 +297,7 @@ describe("buildConfigChain", function () {
 
         it("requires filename if RegExp", () => {
           expect(() =>
-            loadOptions({
+            loadOptionsSync({
               ...BASE_OPTS,
               presets: [() => ({ test: /file/ })],
             }),
@@ -308,7 +308,7 @@ describe("buildConfigChain", function () {
           const mock = jest.fn().mockReturnValue(true);
 
           expect(() =>
-            loadOptions({
+            loadOptionsSync({
               ...BASE_OPTS,
               presets: [() => ({ test: mock })],
             }),
@@ -316,7 +316,7 @@ describe("buildConfigChain", function () {
           expect(mock).toHaveBeenCalledWith(undefined, expect.anything());
 
           expect(() =>
-            loadOptions({
+            loadOptionsSync({
               ...BASE_OPTS,
               filename: "some-filename",
               presets: [() => ({ test: mock })],
@@ -331,7 +331,7 @@ describe("buildConfigChain", function () {
   describe("include", () => {
     describe("single", () => {
       it("should process matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -343,7 +343,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -355,7 +355,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -367,7 +367,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -379,7 +379,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -391,7 +391,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -405,7 +405,7 @@ describe("buildConfigChain", function () {
 
     describe("array", () => {
       it("should process matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -417,7 +417,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -429,7 +429,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -441,7 +441,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -453,7 +453,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -465,7 +465,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -481,7 +481,7 @@ describe("buildConfigChain", function () {
   describe("exclude", () => {
     describe("single", () => {
       it("should process matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -493,7 +493,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -505,7 +505,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -517,7 +517,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -529,7 +529,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -541,7 +541,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -555,7 +555,7 @@ describe("buildConfigChain", function () {
 
     describe("array", () => {
       it("should process matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -567,7 +567,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -579,7 +579,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -591,7 +591,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching string values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -603,7 +603,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching RegExp values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -615,7 +615,7 @@ describe("buildConfigChain", function () {
       });
 
       it("should process non-matching function values", () => {
-        const opts = loadOptions({
+        const opts = loadOptionsSync({
           cwd: fixture("nonexistent-fake"),
           filename: fixture("nonexistent-fake", "src.js"),
           babelrc: false,
@@ -630,7 +630,7 @@ describe("buildConfigChain", function () {
 
   describe("ignore", () => {
     it("should ignore files that match", () => {
-      const opts = loadOptions({
+      const opts = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -648,7 +648,7 @@ describe("buildConfigChain", function () {
     });
 
     it("should not ignore files that don't match", () => {
-      const opts = loadOptions({
+      const opts = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -664,7 +664,7 @@ describe("buildConfigChain", function () {
 
   describe("only", () => {
     it("should ignore files that don't match", () => {
-      const opts = loadOptions({
+      const opts = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -678,7 +678,7 @@ describe("buildConfigChain", function () {
     });
 
     it("should not ignore files that match", () => {
-      const opts = loadOptions({
+      const opts = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -694,7 +694,7 @@ describe("buildConfigChain", function () {
 
   describe("ignore/only", () => {
     it("should ignore files that match ignore and don't match only", () => {
-      const opts = loadOptions({
+      const opts = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -706,7 +706,7 @@ describe("buildConfigChain", function () {
     });
 
     it("should ignore files that match ignore and also only", () => {
-      const opts = loadOptions({
+      const opts = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -718,7 +718,7 @@ describe("buildConfigChain", function () {
     });
 
     it("should not ignore files that match only and not ignore", () => {
-      const opts = loadOptions({
+      const opts = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -729,7 +729,7 @@ describe("buildConfigChain", function () {
     });
 
     it("should not ignore files when no ignore/only are specified", () => {
-      const opts = loadOptions({
+      const opts = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -739,7 +739,7 @@ describe("buildConfigChain", function () {
     });
 
     it("should allow negation of only", () => {
-      const opts1 = loadOptions({
+      const opts1 = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -750,7 +750,7 @@ describe("buildConfigChain", function () {
       });
       expect(opts1).toBeNull();
 
-      const opts2 = loadOptions({
+      const opts2 = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -761,7 +761,7 @@ describe("buildConfigChain", function () {
       });
       expect(opts2).not.toBeNull();
 
-      const opts3 = loadOptions({
+      const opts3 = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "folder", "src.js"),
         babelrc: false,
@@ -774,7 +774,7 @@ describe("buildConfigChain", function () {
     });
 
     it("should allow negation of ignore", () => {
-      const opts1 = loadOptions({
+      const opts1 = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -786,7 +786,7 @@ describe("buildConfigChain", function () {
       expect(opts1).toBeNull();
 
       // Tests disabled pending https://github.com/babel/babel/issues/6907
-      // const opts2 = loadOptions({
+      // const opts2 = loadOptionsSync({
       //   cwd: fixture("nonexistent-fake"),
       //   filename: fixture("nonexistent-fake", "src.js"),
       //   babelrc: false,
@@ -797,7 +797,7 @@ describe("buildConfigChain", function () {
       // });
       // expect(opts2).not.toBeNull();
       //
-      // const opts3 = loadOptions({
+      // const opts3 = loadOptionsSync({
       //   cwd: fixture("nonexistent-fake"),
       //   filename: fixture("nonexistent-fake", "folder", "src.js"),
       //   babelrc: false,
@@ -818,10 +818,10 @@ describe("buildConfigChain", function () {
       it("should not cache the input options by identity", () => {
         const inputOpts = { plugins: plugins1 };
 
-        const opts1 = loadOptions(inputOpts);
+        const opts1 = loadOptionsSync(inputOpts);
 
         inputOpts.plugins = plugins2;
-        const opts2 = loadOptions(inputOpts);
+        const opts2 = loadOptionsSync(inputOpts);
 
         expect(opts1.plugins).toHaveLength(1);
         expect(opts2.plugins).toHaveLength(1);
@@ -831,7 +831,7 @@ describe("buildConfigChain", function () {
       it("should cache the env plugins by identity", () => {
         const plugins = [() => ({})];
 
-        const opts1 = loadOptions({
+        const opts1 = loadOptionsSync({
           envName: "foo",
           env: {
             foo: {
@@ -839,7 +839,7 @@ describe("buildConfigChain", function () {
             },
           },
         });
-        const opts2 = loadOptions({
+        const opts2 = loadOptionsSync({
           envName: "foo",
           env: {
             foo: {
@@ -856,7 +856,7 @@ describe("buildConfigChain", function () {
       it("should cache the env presets by identity", () => {
         const presets = [() => ({ plugins: [() => ({})] })];
 
-        const opts1 = loadOptions({
+        const opts1 = loadOptionsSync({
           envName: "foo",
           env: {
             foo: {
@@ -864,7 +864,7 @@ describe("buildConfigChain", function () {
             },
           },
         });
-        const opts2 = loadOptions({
+        const opts2 = loadOptionsSync({
           envName: "foo",
           env: {
             foo: {
@@ -881,8 +881,8 @@ describe("buildConfigChain", function () {
       it("should cache the plugin options by identity", () => {
         const plugins = [() => ({})];
 
-        const opts1 = loadOptions({ plugins });
-        const opts2 = loadOptions({ plugins });
+        const opts1 = loadOptionsSync({ plugins });
+        const opts2 = loadOptionsSync({ plugins });
 
         expect(opts1.plugins).toHaveLength(1);
         expect(opts2.plugins).toHaveLength(1);
@@ -892,8 +892,8 @@ describe("buildConfigChain", function () {
       it("should cache the presets options by identity", () => {
         const presets = [() => ({ plugins: [() => ({})] })];
 
-        const opts1 = loadOptions({ presets });
-        const opts2 = loadOptions({ presets });
+        const opts1 = loadOptionsSync({ presets });
+        const opts2 = loadOptionsSync({ presets });
 
         expect(opts1.plugins).toHaveLength(1);
         expect(opts2.plugins).toHaveLength(1);
@@ -903,9 +903,9 @@ describe("buildConfigChain", function () {
       it("should not cache the presets options with passPerPreset", () => {
         const presets = [() => ({ plugins: [() => ({})] })];
 
-        const opts1 = loadOptions({ presets });
-        const opts2 = loadOptions({ presets, passPerPreset: true });
-        const opts3 = loadOptions({ presets, passPerPreset: false });
+        const opts1 = loadOptionsSync({ presets });
+        const opts2 = loadOptionsSync({ presets, passPerPreset: true });
+        const opts3 = loadOptionsSync({ presets, passPerPreset: false });
 
         expect(opts1.plugins).toHaveLength(1);
         expect(opts2.plugins).toHaveLength(0);
@@ -939,13 +939,25 @@ describe("buildConfigChain", function () {
           "package.json",
         );
 
-        const opts1 = loadOptions({ filename, cwd: path.dirname(filename) });
-        const opts2 = loadOptions({ filename, cwd: path.dirname(filename) });
+        const opts1 = loadOptionsSync({
+          filename,
+          cwd: path.dirname(filename),
+        });
+        const opts2 = loadOptionsSync({
+          filename,
+          cwd: path.dirname(filename),
+        });
 
         touch(pkgJSON);
 
-        const opts3 = loadOptions({ filename, cwd: path.dirname(filename) });
-        const opts4 = loadOptions({ filename, cwd: path.dirname(filename) });
+        const opts3 = loadOptionsSync({
+          filename,
+          cwd: path.dirname(filename),
+        });
+        const opts4 = loadOptionsSync({
+          filename,
+          cwd: path.dirname(filename),
+        });
 
         expect(opts1.plugins).toHaveLength(1);
         expect(opts2.plugins).toHaveLength(1);
@@ -973,13 +985,25 @@ describe("buildConfigChain", function () {
           ".babelrc",
         );
 
-        const opts1 = loadOptions({ filename, cwd: path.dirname(filename) });
-        const opts2 = loadOptions({ filename, cwd: path.dirname(filename) });
+        const opts1 = loadOptionsSync({
+          filename,
+          cwd: path.dirname(filename),
+        });
+        const opts2 = loadOptionsSync({
+          filename,
+          cwd: path.dirname(filename),
+        });
 
         touch(babelrcFile);
 
-        const opts3 = loadOptions({ filename, cwd: path.dirname(filename) });
-        const opts4 = loadOptions({ filename, cwd: path.dirname(filename) });
+        const opts3 = loadOptionsSync({
+          filename,
+          cwd: path.dirname(filename),
+        });
+        const opts4 = loadOptionsSync({
+          filename,
+          cwd: path.dirname(filename),
+        });
 
         expect(opts1.plugins).toHaveLength(1);
         expect(opts2.plugins).toHaveLength(1);
@@ -1001,15 +1025,21 @@ describe("buildConfigChain", function () {
           "src.js",
         );
 
-        const opts1 = loadOptions({ filename, cwd: path.dirname(filename) });
-        const opts2 = loadOptions({ filename, cwd: path.dirname(filename) });
+        const opts1 = loadOptionsSync({
+          filename,
+          cwd: path.dirname(filename),
+        });
+        const opts2 = loadOptionsSync({
+          filename,
+          cwd: path.dirname(filename),
+        });
 
-        const opts3 = loadOptions({
+        const opts3 = loadOptionsSync({
           filename,
           envName: "new-env",
           cwd: path.dirname(filename),
         });
-        const opts4 = loadOptions({
+        const opts4 = loadOptionsSync({
           filename,
           envName: "new-env",
           cwd: path.dirname(filename),
@@ -1031,7 +1061,7 @@ describe("buildConfigChain", function () {
 
   describe("overrides merging", () => {
     it("should apply matching overrides over base configs", () => {
-      const opts = loadOptions({
+      const opts = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -1048,7 +1078,7 @@ describe("buildConfigChain", function () {
     });
 
     it("should not apply non-matching overrides over base configs", () => {
-      const opts = loadOptions({
+      const opts = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -1065,7 +1095,7 @@ describe("buildConfigChain", function () {
     });
 
     it("should remove the overrides and filtering fields from the options", () => {
-      const opts = loadOptions({
+      const opts = loadOptionsSync({
         cwd: fixture("nonexistent-fake"),
         filename: fixture("nonexistent-fake", "src.js"),
         babelrc: false,
@@ -1124,7 +1154,7 @@ describe("buildConfigChain", function () {
 
           await config(name);
 
-          expect(loadOptions({ filename, cwd })).toEqual({
+          expect(loadOptionsSync({ filename, cwd })).toEqual({
             ...getDefaults(),
             filename,
             cwd,
@@ -1142,7 +1172,7 @@ describe("buildConfigChain", function () {
 
         await config("babel.config.mjs");
 
-        expect(() => loadOptions({ filename, cwd })).toThrow(
+        expect(() => loadOptionsSync({ filename, cwd })).toThrow(
           /is only supported when running Babel asynchronously/,
         );
       });
@@ -1221,7 +1251,7 @@ describe("buildConfigChain", function () {
 
         await config(name);
 
-        expect(loadOptions({ filename, cwd })).toEqual({
+        expect(loadOptionsSync({ filename, cwd })).toEqual({
           ...getDefaults(),
           filename,
           cwd,
@@ -1238,7 +1268,7 @@ describe("buildConfigChain", function () {
 
         await config(".babelrc.mjs");
 
-        expect(() => loadOptions({ filename, cwd })).toThrow(
+        expect(() => loadOptionsSync({ filename, cwd })).toThrow(
           /is only supported when running Babel asynchronously/,
         );
       });
@@ -1279,7 +1309,7 @@ describe("buildConfigChain", function () {
         const filename = fixture("config-files", "babelignore", "src.js");
 
         expect(
-          loadOptions({ filename, cwd: path.dirname(filename) }),
+          loadOptionsSync({ filename, cwd: path.dirname(filename) }),
         ).toBeNull();
       });
 
@@ -1317,7 +1347,9 @@ describe("buildConfigChain", function () {
       it("should ignore package.json without a 'babel' property", () => {
         const filename = fixture("config-files", "pkg-ignored", "src.js");
 
-        expect(loadOptions({ filename, cwd: path.dirname(filename) })).toEqual({
+        expect(
+          loadOptionsSync({ filename, cwd: path.dirname(filename) }),
+        ).toEqual({
           ...getDefaults(),
           filename: filename,
           cwd: path.dirname(filename),
@@ -1353,11 +1385,14 @@ describe("buildConfigChain", function () {
         },
       );
 
-      it("loadPartialConfig should return a list of files that were extended", () => {
+      it("loadPartialConfigSync should return a list of files that were extended", () => {
         const filename = fixture("config-files", "babelrc-extended", "src.js");
 
         expect(
-          babel.loadPartialConfig({ filename, cwd: path.dirname(filename) }),
+          babel.loadPartialConfigSync({
+            filename,
+            cwd: path.dirname(filename),
+          }),
         ).toEqual({
           babelignore: fixture("config-files", ".babelignore"),
           babelrc: fixture("config-files", "babelrc-extended", ".babelrc"),
@@ -1378,19 +1413,22 @@ describe("buildConfigChain", function () {
         });
       });
 
-      it("loadPartialConfig should return null when ignored", () => {
+      it("loadPartialConfigSync should return null when ignored", () => {
         const filename = fixture("config-files", "babelignore", "src.js");
 
         expect(
-          babel.loadPartialConfig({ filename, cwd: path.dirname(filename) }),
+          babel.loadPartialConfigSync({
+            filename,
+            cwd: path.dirname(filename),
+          }),
         ).toBeNull();
       });
 
-      it("loadPartialConfig should return a list of files when ignored with showIgnoredFiles option", () => {
+      it("loadPartialConfigSync should return a list of files when ignored with showIgnoredFiles option", () => {
         const filename = fixture("config-files", "babelignore", "src.js");
 
         expect(
-          babel.loadPartialConfig({
+          babel.loadPartialConfigSync({
             filename,
             cwd: path.dirname(filename),
             showIgnoredFiles: true,
@@ -1412,12 +1450,12 @@ describe("buildConfigChain", function () {
         });
       });
 
-      it("loadPartialConfig can be called with no arguments", () => {
+      it("loadPartialConfigSync can be called with no arguments", () => {
         const cwd = process.cwd();
 
         try {
           process.chdir(fixture("config-files", "babelrc-extended"));
-          expect(() => babel.loadPartialConfig()).not.toThrow();
+          expect(() => babel.loadPartialConfigSync()).not.toThrow();
         } finally {
           process.chdir(cwd);
         }
@@ -1425,14 +1463,14 @@ describe("buildConfigChain", function () {
     });
 
     it("should throw when `test` presents but `filename` is not passed", () => {
-      expect(() => loadOptions({ test: /\.ts$/, plugins: [] })).toThrow(
+      expect(() => loadOptionsSync({ test: /\.ts$/, plugins: [] })).toThrow(
         /Configuration contains string\/RegExp pattern/,
       );
     });
 
     it("should throw when `preset` requires `filename` but it was not passed", () => {
       expect(() => {
-        loadOptions({
+        loadOptionsSync({
           presets: ["./fixtures/config-loading/preset4"],
         });
       }).toThrow(/Preset \/\* your preset \*\/ requires a filename/);
@@ -1440,7 +1478,7 @@ describe("buildConfigChain", function () {
 
     it("should throw when `preset.overrides` requires `filename` but it was not passed", () => {
       expect(() => {
-        loadOptions({
+        loadOptionsSync({
           presets: ["./fixtures/config-loading/preset5"],
         });
       }).toThrow(/Preset \/\* your preset \*\/ requires a filename/);
@@ -1453,7 +1491,7 @@ describe("buildConfigChain", function () {
         "babel.config.json",
       );
       expect(() => {
-        babel.loadPartialConfig({
+        babel.loadPartialConfigSync({
           filename,
           cwd: path.dirname(filename),
         });

--- a/packages/babel-core/test/config-loading.js
+++ b/packages/babel-core/test/config-loading.js
@@ -2,6 +2,7 @@ import {
   loadOptionsSync,
   loadOptionsAsync,
   loadPartialConfigSync,
+  createConfigItem,
   createConfigItemSync,
 } from "../lib/index.js";
 import path from "path";
@@ -9,6 +10,8 @@ import { fileURLToPath } from "url";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
+
+const itBabel8 = process.env.BABEL_8_BREAKING ? it : it.skip;
 
 describe("@babel/core config loading", () => {
   const FILEPATH = path.join(
@@ -44,6 +47,15 @@ describe("@babel/core config loading", () => {
         : [[require("./fixtures/config-loading/plugin6.js"), {}]],
     };
   }
+
+  itBabel8("createConfigItem throws on undefined callback", () => {
+    function myPlugin() {
+      return {};
+    }
+    expect(() => createConfigItem(myPlugin)).toThrowErrorMatchingInlineSnapshot(
+      `"Starting from Babel 8.0.0, the 'createConfigItem' function expects a callback. If you need to call it synchronously, please use 'createConfigItemSync'."`,
+    );
+  });
 
   describe("createConfigItemSync", () => {
     // Windows uses different file paths

--- a/packages/babel-core/test/config-loading.js
+++ b/packages/babel-core/test/config-loading.js
@@ -1,6 +1,8 @@
 import {
+  loadOptions,
   loadOptionsSync,
   loadOptionsAsync,
+  loadPartialConfig,
   loadPartialConfigSync,
   createConfigItem,
   createConfigItemSync,
@@ -48,13 +50,17 @@ describe("@babel/core config loading", () => {
     };
   }
 
-  itBabel8("createConfigItem throws on undefined callback", () => {
-    function myPlugin() {
-      return {};
-    }
-    expect(() => createConfigItem(myPlugin)).toThrowErrorMatchingInlineSnapshot(
-      `"Starting from Babel 8.0.0, the 'createConfigItem' function expects a callback. If you need to call it synchronously, please use 'createConfigItemSync'."`,
-    );
+  describe("createConfigItem", () => {
+    itBabel8("throws on undefined callback", () => {
+      function myPlugin() {
+        return {};
+      }
+      expect(() =>
+        createConfigItem(myPlugin),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Starting from Babel 8.0.0, the 'createConfigItem' function expects a callback. If you need to call it synchronously, please use 'createConfigItemSync'."`,
+      );
+    });
   });
 
   describe("createConfigItemSync", () => {
@@ -89,6 +95,20 @@ describe("@babel/core config loading", () => {
         options: undefined,
         value: myPlugin,
       });
+    });
+  });
+
+  describe("loadPartialConfig", () => {
+    itBabel8("throws on undefined callback", () => {
+      expect(() =>
+        loadPartialConfig({
+          ...makeOpts(true),
+          babelrc: false,
+          configFile: false,
+        }),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Starting from Babel 8.0.0, the 'loadPartialConfig' function expects a callback. If you need to call it synchronously, please use 'loadPartialConfigSync'."`,
+      );
     });
   });
 
@@ -140,7 +160,7 @@ describe("@babel/core config loading", () => {
         "nested",
       );
 
-      const { options } = await loadPartialConfigSync({
+      const { options } = loadPartialConfigSync({
         cwd,
         filename: path.join(cwd, "file.js"),
         rootMode: "upward",
@@ -148,6 +168,16 @@ describe("@babel/core config loading", () => {
 
       expect(options.root).toBe(path.join(cwd, ".."));
       expect(options.rootMode).toBe("root");
+    });
+  });
+
+  describe("loadOptions", () => {
+    itBabel8("throws on undefined callback", () => {
+      const opts = makeOpts();
+
+      expect(() => loadOptions(opts)).toThrowErrorMatchingInlineSnapshot(
+        `"Starting from Babel 8.0.0, the 'loadOptions' function expects a callback. If you need to call it synchronously, please use 'loadOptionsSync'."`,
+      );
     });
   });
 

--- a/packages/babel-core/test/targets.js
+++ b/packages/babel-core/test/targets.js
@@ -1,15 +1,15 @@
-import { loadOptions as loadOptionsOrig } from "../lib/index.js";
+import { loadOptionsSync as loadOptionsSyncOrig } from "../lib/index.js";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
 const cwd = dirname(fileURLToPath(import.meta.url));
 
-function loadOptions(opts) {
-  return loadOptionsOrig({ cwd, ...opts });
+function loadOptionsSync(opts) {
+  return loadOptionsSyncOrig({ cwd, ...opts });
 }
 
 function withTargets(targets) {
-  return loadOptions({ targets });
+  return loadOptionsSync({ targets });
 }
 
 describe("targets", () => {
@@ -85,7 +85,7 @@ describe("targets", () => {
 describe("browserslist", () => {
   it("loads .browserslistrc by default", () => {
     expect(
-      loadOptions({
+      loadOptionsSync({
         cwd: join(cwd, "fixtures", "targets"),
       }).targets,
     ).toEqual({ chrome: "80.0.0" });
@@ -93,7 +93,7 @@ describe("browserslist", () => {
 
   it("loads .browserslistrc relative to the root", () => {
     expect(
-      loadOptions({
+      loadOptionsSync({
         cwd: join(cwd, "fixtures", "targets"),
         filename: "./node_modules/dep/test.js",
       }).targets,
@@ -103,7 +103,7 @@ describe("browserslist", () => {
   describe("browserslistConfigFile", () => {
     it("can disable config loading", () => {
       expect(
-        loadOptions({
+        loadOptionsSync({
           cwd: join(cwd, "fixtures", "targets"),
           browserslistConfigFile: false,
         }).targets,
@@ -112,7 +112,7 @@ describe("browserslist", () => {
 
     it("can specify a custom file", () => {
       expect(
-        loadOptions({
+        loadOptionsSync({
           cwd: join(cwd, "fixtures", "targets"),
           browserslistConfigFile: "./.browserslistrc-firefox",
         }).targets,
@@ -121,7 +121,7 @@ describe("browserslist", () => {
 
     it("is relative to the cwd even if specifying 'root'", () => {
       expect(
-        loadOptions({
+        loadOptionsSync({
           cwd: join(cwd, "fixtures", "targets"),
           root: "..",
           filename: "./nested/test.js",
@@ -132,7 +132,7 @@ describe("browserslist", () => {
 
     it("is relative to the config files that defines it", () => {
       expect(
-        loadOptions({
+        loadOptionsSync({
           cwd: join(cwd, "fixtures", "targets"),
           filename: "./node_modules/dep/test.js",
           babelrcRoots: ["./node_modules/dep/"],
@@ -144,7 +144,7 @@ describe("browserslist", () => {
   describe("browserslistEnv", () => {
     it("is forwarded to browserslist", () => {
       expect(
-        loadOptions({
+        loadOptionsSync({
           cwd: join(cwd, "fixtures", "targets"),
           browserslistEnv: "browserslist-loading-test",
         }).targets,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/15839
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Y
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2813
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As a follow-up to https://github.com/babel/babel/pull/12695, in this PR we disable the sync usage of `createConfigItem`, to align with other API's usage.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15869"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

