### PR TITLE
Implement `import defer` proposal transform support

### DIFF
--- a/packages/babel-helper-module-transforms/src/lazy-modules.ts
+++ b/packages/babel-helper-module-transforms/src/lazy-modules.ts
@@ -1,0 +1,37 @@
+// TODO: Move `lazy` implementation logic into the CommonJS plugin, since other
+// modules systems do not support `lazy`.
+
+import { types as t } from "@babel/core";
+import {
+  type SourceModuleMetadata,
+  isSideEffectImport,
+} from "./normalize-and-load-metadata.ts";
+
+export type Lazy = boolean | string[] | ((source: string) => boolean);
+
+export function toGetWrapperPayload(lazy: Lazy) {
+  return (source: string, metadata: SourceModuleMetadata): null | "lazy" => {
+    if (lazy === false) return null;
+    if (isSideEffectImport(metadata) || metadata.reexportAll) return null;
+    if (lazy === true) {
+      // 'true' means that local relative files are eagerly loaded and
+      // dependency modules are loaded lazily.
+      return /\./.test(source) ? null : "lazy";
+    }
+    if (Array.isArray(lazy)) {
+      return lazy.indexOf(source) === -1 ? null : "lazy";
+    }
+    if (typeof lazy === "function") {
+      return lazy(source) ? "lazy" : null;
+    }
+    throw new Error(`.lazy must be a boolean, string array, or function`);
+  };
+}
+
+export function wrapReference(
+  ref: t.Identifier,
+  payload: unknown,
+): t.Expression | null {
+  if (payload === "lazy") return t.callExpression(ref, []);
+  return null;
+}

--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
@@ -7,7 +7,6 @@ import type { ModuleMetadata } from "./normalize-and-load-metadata.ts";
 
 const {
   assignmentExpression,
-  callExpression,
   cloneNode,
   expressionStatement,
   getOuterBindingIdentifiers,
@@ -72,6 +71,7 @@ function isInType(path: NodePath) {
 export default function rewriteLiveReferences(
   programPath: NodePath<t.Program>,
   metadata: ModuleMetadata,
+  wrapReference: (ref: t.Expression, payload: unknown) => null | t.Expression,
 ) {
   const imported = new Map();
   const exported = new Map();
@@ -135,23 +135,22 @@ export default function rewriteLiveReferences(
     scope: programPath.scope,
     imported, // local / import
     exported, // local name => exported name list
-    buildImportReference: ([source, importName, localName], identNode) => {
+    buildImportReference([source, importName, localName], identNode) {
       const meta = metadata.source.get(source);
       meta.referenced = true;
 
       if (localName) {
-        if (meta.lazy) {
-          identNode = callExpression(
-            // @ts-expect-error Fixme: we should handle the case when identNode is a JSXIdentifier
-            identNode,
-            [],
-          );
+        if (meta.wrap) {
+          // @ts-expect-error Fixme: we should handle the case when identNode is a JSXIdentifier
+          identNode = wrapReference(identNode, meta.wrap) ?? identNode;
         }
         return identNode;
       }
 
       let namespace: t.Expression = identifier(meta.name);
-      if (meta.lazy) namespace = callExpression(namespace, []);
+      if (meta.wrap) {
+        namespace = wrapReference(namespace, meta.wrap) ?? namespace;
+      }
 
       if (importName === "default" && meta.interop === "node-default") {
         return namespace;

--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -65,6 +65,10 @@ export default Object.freeze({
     "7.22.0",
     'function dispose_SuppressedError(r,e){return"undefined"!=typeof SuppressedError?dispose_SuppressedError=SuppressedError:(dispose_SuppressedError=function(r,e){this.suppressed=r,this.error=e,this.stack=(new Error).stack},dispose_SuppressedError.prototype=Object.create(Error.prototype,{constructor:{value:dispose_SuppressedError,writable:!0,configurable:!0}})),new dispose_SuppressedError(r,e)}export default function _dispose(r,e,s){function next(){for(;r.length>0;)try{var o=r.pop(),p=o.d.call(o.v);if(o.a)return Promise.resolve(p).then(next,err)}catch(r){return err(r)}if(s)throw e}function err(r){return e=s?new dispose_SuppressedError(r,e):r,s=!0,next()}return next()}',
   ),
+  importDeferProxy: helper(
+    "7.22.0",
+    "export default function _importDeferProxy(e){var t=null,constValue=function(e){return function(){return e}},proxy=function(r){return function(n,o,f){return null===t&&(t=e()),r(t,o,f)}};return new Proxy({},{defineProperty:constValue(!1),deleteProperty:constValue(!1),get:proxy(Reflect.get),getOwnPropertyDescriptor:proxy(Reflect.getOwnPropertyDescriptor),getPrototypeOf:constValue(null),isExtensible:constValue(!1),has:proxy(Reflect.has),ownKeys:proxy(Reflect.ownKeys),preventExtensions:constValue(!0),set:constValue(!1),setPrototypeOf:constValue(!1)})}",
+  ),
   iterableToArrayLimit: helper(
     "7.0.0-beta.0",
     'export default function _iterableToArrayLimit(r,l){var t=null==r?null:"undefined"!=typeof Symbol&&r[Symbol.iterator]||r["@@iterator"];if(null!=t){var e,n,i,u,a=[],f=!0,o=!1;try{if(i=(t=t.call(r)).next,0===l){if(Object(t)!==t)return;f=!1}else for(;!(f=(e=i.call(t)).done)&&(a.push(e.value),a.length!==l);f=!0);}catch(r){o=!0,n=r}finally{try{if(!f&&null!=t.return&&(u=t.return(),Object(u)!==u))return}finally{if(o)throw n}}return a}}',

--- a/packages/babel-helpers/src/helpers/importDeferProxy.js
+++ b/packages/babel-helpers/src/helpers/importDeferProxy.js
@@ -1,0 +1,31 @@
+/* @minVersion 7.22.0 */
+export default function _importDeferProxy(init) {
+  var ns = null;
+  var constValue = function (v) {
+    return function () {
+      return v;
+    };
+  };
+  var proxy = function (run) {
+    return function (arg1, arg2, arg3) {
+      if (ns === null) ns = init();
+      return run(ns, arg2, arg3);
+    };
+  };
+  return new Proxy(
+    {},
+    {
+      defineProperty: constValue(false),
+      deleteProperty: constValue(false),
+      get: proxy(Reflect.get),
+      getOwnPropertyDescriptor: proxy(Reflect.getOwnPropertyDescriptor),
+      getPrototypeOf: constValue(null),
+      isExtensible: constValue(false),
+      has: proxy(Reflect.has),
+      ownKeys: proxy(Reflect.ownKeys),
+      preventExtensions: constValue(true),
+      set: constValue(false),
+      setPrototypeOf: constValue(false),
+    }
+  );
+}

--- a/packages/babel-plugin-proposal-import-defer/.npmignore
+++ b/packages/babel-plugin-proposal-import-defer/.npmignore
@@ -1,0 +1,3 @@
+src
+test
+*.log

--- a/packages/babel-plugin-proposal-import-defer/README.md
+++ b/packages/babel-plugin-proposal-import-defer/README.md
@@ -1,0 +1,19 @@
+# @babel/plugin-proposal-import-defer
+
+> Support `import defer` when compiling to CommonJS
+
+See our website [@babel/plugin-proposal-import-defer](https://babeljs.io/docs/babel-plugin-proposal-import-defer) for more information.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @babel/plugin-proposal-import-defer
+```
+
+or using yarn:
+
+```sh
+yarn add @babel/plugin-proposal-import-defer --dev
+```

--- a/packages/babel-plugin-proposal-import-defer/package.json
+++ b/packages/babel-plugin-proposal-import-defer/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@babel/plugin-proposal-import-defer",
+  "version": "7.22.5",
+  "description": "Support `import defer` when compiling to CommonJS",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-proposal-import-defer"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "workspace:^",
+    "@babel/plugin-syntax-import-defer": "workspace:^",
+    "@babel/plugin-transform-modules-commonjs": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+  },
+  "devDependencies": {
+    "@babel/core": "workspace:^",
+    "@babel/helper-plugin-test-runner": "workspace:^"
+  },
+  "engines": {
+    "node": ">=6.9.0"
+  },
+  "author": "The Babel Team (https://babel.dev/team)",
+  "conditions": {
+    "BABEL_8_BREAKING": [
+      {
+        "engines": {
+          "node": "^16.20.0 || ^18.16.0 || >=20.0.0"
+        }
+      },
+      {
+        "exports": null
+      }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  },
+  "exports": {
+    ".": "./lib/index.js",
+    "./package.json": "./package.json"
+  },
+  "type": "commonjs"
+}

--- a/packages/babel-plugin-proposal-import-defer/src/index.ts
+++ b/packages/babel-plugin-proposal-import-defer/src/index.ts
@@ -55,10 +55,9 @@ export default declare(api => {
           if (payload === "defer/function") {
             if (!referenced) return false;
             return template.statement.ast`
-              function ${name}() {
-                const data = ${init};
+              function ${name}(data) {
                 ${name} = () => data;
-                return data;
+                return data = ${init};
               }
             `;
           }

--- a/packages/babel-plugin-proposal-import-defer/src/index.ts
+++ b/packages/babel-plugin-proposal-import-defer/src/index.ts
@@ -1,0 +1,121 @@
+import { declare } from "@babel/helper-plugin-utils";
+import type { types as t } from "@babel/core";
+import type { Scope } from "@babel/traverse";
+import { defineCommonJSHook } from "@babel/plugin-transform-modules-commonjs";
+
+import syntaxImportDefer from "@babel/plugin-syntax-import-defer";
+
+export default declare(api => {
+  api.assertVersion(7);
+  // We need the explicit type annotation otherwise when using t.assert* ts
+  // reports that 'Assertions require every name in the call target to be
+  // declared with an explicit type annotation'
+  const t: typeof api.types = api.types;
+  const { template } = api;
+
+  function allReferencesAreProps(scope: Scope, node: t.ImportDeclaration) {
+    const specifier = node.specifiers[0];
+    t.assertImportNamespaceSpecifier(specifier);
+
+    const binding = scope.getOwnBinding(specifier.local.name);
+    return !!binding?.referencePaths.every(path =>
+      path.parentPath.isMemberExpression({ object: path.node }),
+    );
+  }
+
+  return {
+    name: "proposal-import-defer",
+
+    inherits: syntaxImportDefer,
+
+    pre() {
+      const { file } = this;
+
+      defineCommonJSHook(file, {
+        name: PACKAGE_JSON.name,
+        version: PACKAGE_JSON.version,
+        getWrapperPayload(source, metadata, importNodes) {
+          let needsProxy = false;
+          for (const node of importNodes) {
+            if (!t.isImportDeclaration(node)) return null;
+            if (node.phase !== "defer") return null;
+            if (!allReferencesAreProps(file.scope, node)) needsProxy = true;
+          }
+          return needsProxy ? "defer/proxy" : "defer/function";
+        },
+        buildRequireWrapper(name, init, payload, referenced) {
+          if (payload === "defer/proxy") {
+            if (!referenced) return false;
+            return template.statement.ast`
+              var ${name} = ${file.addHelper("importDeferProxy")}(
+                () => ${init}
+              )
+            `;
+          }
+          if (payload === "defer/function") {
+            if (!referenced) return false;
+            return template.statement.ast`
+              function ${name}() {
+                const data = ${init};
+                ${name} = () => data;
+                return data;
+              }
+            `;
+          }
+        },
+        wrapReference(ref, payload) {
+          if (payload === "defer/function") return t.callExpression(ref, []);
+        },
+      });
+    },
+
+    visitor: {
+      Program(path) {
+        if (this.file.get("@babel/plugin-transform-modules-*") !== "commonjs") {
+          throw new Error(
+            `@babel/plugin-proposal-import-defer can only be used when` +
+              ` transpiling modules to CommonJS.`,
+          );
+        }
+
+        // Move all deferred imports to the end, so that in case of
+        //   import defer * as a from "a"
+        //   import "b"
+        //   import "a"
+        // we have the correct evaluation order
+
+        const eagerImports = new Map();
+
+        for (const child of path.get("body")) {
+          if (
+            (child.isImportDeclaration() && child.node.phase == null) ||
+            (child.isExportNamedDeclaration() && child.node.source !== null) ||
+            child.isExportAllDeclaration()
+          ) {
+            const specifier = child.node.source!.value;
+            if (!eagerImports.has(specifier)) {
+              eagerImports.set(specifier, child);
+            }
+          }
+        }
+
+        const importsToPush = [];
+        for (const child of path.get("body")) {
+          if (child.isImportDeclaration({ phase: "defer" })) {
+            const specifier = child.node.source.value;
+            if (!eagerImports.has(specifier)) continue;
+
+            child.node.phase = null;
+            importsToPush.push(child.node);
+            child.remove();
+          }
+        }
+        if (importsToPush.length) {
+          path.pushContainer("body", importsToPush);
+          // Re-collect references to moved imports
+          path.scope.crawl();
+        }
+      },
+    },
+  };
+});

--- a/packages/babel-plugin-proposal-import-defer/src/index.ts
+++ b/packages/babel-plugin-proposal-import-defer/src/index.ts
@@ -84,7 +84,7 @@ export default declare(api => {
         //   import "a"
         // we have the correct evaluation order
 
-        const eagerImports = new Map();
+        const eagerImports = new Set();
 
         for (const child of path.get("body")) {
           if (
@@ -94,7 +94,7 @@ export default declare(api => {
           ) {
             const specifier = child.node.source!.value;
             if (!eagerImports.has(specifier)) {
-              eagerImports.set(specifier, child);
+              eagerImports.add(specifier);
             }
           }
         }

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/esm-to-commonjs-lazy/integration/input.mjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/esm-to-commonjs-lazy/integration/input.mjs
@@ -1,0 +1,7 @@
+import defer * as a from "a";
+import defer * as b from "b";
+import * as c from "lazy";
+
+later(() => {
+  use(a.x, b, c);
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/esm-to-commonjs-lazy/integration/options.json
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/esm-to-commonjs-lazy/integration/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "proposal-import-defer",
+    ["transform-modules-commonjs", { "lazy": ["lazy"] }]
+  ]
+}

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/esm-to-commonjs-lazy/integration/output.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/esm-to-commonjs-lazy/integration/output.js
@@ -1,9 +1,8 @@
 "use strict";
 
-function a() {
-  const data = babelHelpers.interopRequireWildcard(require("a"));
+function a(data) {
   a = () => data;
-  return data;
+  return data = babelHelpers.interopRequireWildcard(require("a"));
 }
 var b = babelHelpers.importDeferProxy(() => babelHelpers.interopRequireWildcard(require("b")));
 function c() {

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/esm-to-commonjs-lazy/integration/output.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/esm-to-commonjs-lazy/integration/output.js
@@ -1,0 +1,18 @@
+"use strict";
+
+function a() {
+  const data = babelHelpers.interopRequireWildcard(require("a"));
+  a = () => data;
+  return data;
+}
+var b = babelHelpers.importDeferProxy(() => babelHelpers.interopRequireWildcard(require("b")));
+function c() {
+  const data = babelHelpers.interopRequireWildcard(require("lazy"));
+  c = function () {
+    return data;
+  };
+  return data;
+}
+later(() => {
+  use(a().x, b, c());
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/get-own-property-names/dep.cjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/get-own-property-names/dep.cjs
@@ -1,0 +1,4 @@
+require("./side-channel.cjs").executed = true;
+
+exports.__esModule = true;
+exports.prop = 3;

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/get-own-property-names/exec.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/get-own-property-names/exec.js
@@ -1,0 +1,14 @@
+import defer * as ns from "./dep.cjs";
+import sideChannel from "./side-channel.cjs";
+
+expect(sideChannel.executed).toBe(false);
+
+// NOTE: In the current proposal, Object.getOwnPropertyNames does
+// not trigger evaluation. However, this behavior is impossible
+// to emulate given that we are importing a CommonJS module.
+// In the proposal, Object.keys does tirgger evaluation because
+// it internally performs .[[Get]] on the namespace object.
+
+const names = Object.getOwnPropertyNames(ns);
+expect(sideChannel.executed).toBe(true);
+expect(names).toEqual(["__esModule", "prop"]);

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/get-own-property-names/side-channel.cjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/get-own-property-names/side-channel.cjs
@@ -1,0 +1,1 @@
+exports.executed = false;

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/not-referenced/dep.cjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/not-referenced/dep.cjs
@@ -1,0 +1,1 @@
+require("./side-channel.cjs").executed = true;

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/not-referenced/exec.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/not-referenced/exec.js
@@ -1,0 +1,4 @@
+import defer * as ns from "./dep.cjs";
+import sideChannel from "./side-channel.cjs";
+
+expect(sideChannel.executed).toBe(false);

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/not-referenced/side-channel.cjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/not-referenced/side-channel.cjs
@@ -1,0 +1,1 @@
+exports.executed = false;

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/options.json
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["proposal-import-defer", "transform-modules-commonjs"]
+}

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-plain-only/dep.cjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-plain-only/dep.cjs
@@ -1,0 +1,4 @@
+require("./side-channel.cjs").executed = true;
+
+exports.__esModule = true;
+exports.prop = 3;

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-plain-only/exec.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-plain-only/exec.js
@@ -1,0 +1,13 @@
+import defer * as ns from "./dep.cjs";
+import sideChannel from "./side-channel.cjs";
+
+expect(sideChannel.executed).toBe(false);
+
+const copy = ns;
+expect(typeof copy).toBe("object");
+expect(sideChannel.executed).toBe(false);
+
+const val = Reflect.get(ns, "prop");
+expect(val).toBe(3);
+
+expect(sideChannel.executed).toBe(true);

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-plain-only/side-channel.cjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-plain-only/side-channel.cjs
@@ -1,0 +1,1 @@
+exports.executed = false;

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-property-only/dep.cjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-property-only/dep.cjs
@@ -1,0 +1,4 @@
+require("./side-channel.cjs").executed = true;
+
+exports.__esModule = true;
+exports.prop = 3;

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-property-only/exec.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-property-only/exec.js
@@ -1,0 +1,9 @@
+import defer * as ns from "./dep.cjs";
+import sideChannel from "./side-channel.cjs";
+
+expect(sideChannel.executed).toBe(false);
+
+const val = ns.prop;
+expect(val).toBe(3);
+
+expect(sideChannel.executed).toBe(true);

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-property-only/side-channel.cjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/exec/reference-property-only/side-channel.cjs
@@ -1,0 +1,1 @@
+exports.executed = false;

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/not-referenced/input.mjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/not-referenced/input.mjs
@@ -1,0 +1,1 @@
+import defer * as ns from "x";

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/not-referenced/output.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/not-referenced/output.js
@@ -1,0 +1,1 @@
+"use strict";

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/options.json
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["proposal-import-defer", "transform-modules-commonjs"]
+}

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-plain-and-property/input.mjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-plain-and-property/input.mjs
@@ -1,0 +1,6 @@
+import defer * as ns from "x";
+
+later(() => {
+  use(ns);
+  ns.prop;
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-plain-and-property/output.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-plain-and-property/output.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var ns = babelHelpers.importDeferProxy(() => babelHelpers.interopRequireWildcard(require("x")));
+later(() => {
+  use(ns);
+  ns.prop;
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-plain-only/input.mjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-plain-only/input.mjs
@@ -1,0 +1,5 @@
+import defer * as ns from "x";
+
+later(() => {
+  use(ns);
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-plain-only/output.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-plain-only/output.js
@@ -1,0 +1,6 @@
+"use strict";
+
+var ns = babelHelpers.importDeferProxy(() => babelHelpers.interopRequireWildcard(require("x")));
+later(() => {
+  use(ns);
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-property-and-plain/input.mjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-property-and-plain/input.mjs
@@ -1,0 +1,6 @@
+import defer * as ns from "x";
+
+later(() => {
+  ns.prop;
+  use(ns);
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-property-and-plain/output.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-property-and-plain/output.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var ns = babelHelpers.importDeferProxy(() => babelHelpers.interopRequireWildcard(require("x")));
+later(() => {
+  ns.prop;
+  use(ns);
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-property-only/input.mjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-property-only/input.mjs
@@ -1,0 +1,5 @@
+import defer * as ns from "x";
+
+later(() => {
+  ns.prop;
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-property-only/output.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-property-only/output.js
@@ -1,9 +1,8 @@
 "use strict";
 
-function ns() {
-  const data = babelHelpers.interopRequireWildcard(require("x"));
+function ns(data) {
   ns = () => data;
-  return data;
+  return data = babelHelpers.interopRequireWildcard(require("x"));
 }
 later(() => {
   ns().prop;

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-property-only/output.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/reference-property-only/output.js
@@ -1,0 +1,10 @@
+"use strict";
+
+function ns() {
+  const data = babelHelpers.interopRequireWildcard(require("x"));
+  ns = () => data;
+  return data;
+}
+later(() => {
+  ns().prop;
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/with-full-import-after/input.mjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/with-full-import-after/input.mjs
@@ -1,0 +1,7 @@
+import defer * as x1 from "x";
+import * as y from "y";
+import * as x2 from "x";
+
+later(() => {
+  use(x1, x2, y);
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/with-full-import-after/output.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/with-full-import-after/output.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var y = babelHelpers.interopRequireWildcard(require("y"));
+var x2 = babelHelpers.interopRequireWildcard(require("x"));
+var x1 = x2;
+later(() => {
+  use(x1, x2, y);
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/with-full-import-before/input.mjs
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/with-full-import-before/input.mjs
@@ -1,0 +1,7 @@
+import * as x1 from "x";
+import * as y from "y";
+import defer * as x2 from "x";
+
+later(() => {
+  use(x1, x2, y);
+});

--- a/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/with-full-import-before/output.js
+++ b/packages/babel-plugin-proposal-import-defer/test/fixtures/transform/with-full-import-before/output.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var x1 = babelHelpers.interopRequireWildcard(require("x"));
+var x2 = x1;
+var y = babelHelpers.interopRequireWildcard(require("y"));
+later(() => {
+  use(x1, x2, y);
+});

--- a/packages/babel-plugin-proposal-import-defer/test/index.js
+++ b/packages/babel-plugin-proposal-import-defer/test/index.js
@@ -1,0 +1,3 @@
+import runner from "@babel/helper-plugin-test-runner";
+
+runner(import.meta.url);

--- a/packages/babel-plugin-proposal-import-defer/test/package.json
+++ b/packages/babel-plugin-proposal-import-defer/test/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/packages/babel-plugin-syntax-import-defer/README.md
+++ b/packages/babel-plugin-syntax-import-defer/README.md
@@ -1,0 +1,19 @@
+# @babel/plugin-syntax-import-defer
+
+> Allow parsing of the `import defer` syntax in import statement
+
+See our website [@babel/plugin-syntax-import-defer](https://babeljs.io/docs/babel-plugin-syntax-import-defer) for more information.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @babel/plugin-syntax-import-defer
+```
+
+or using yarn:
+
+```sh
+yarn add @babel/plugin-syntax-import-defer --dev
+```

--- a/packages/babel-plugin-syntax-import-defer/package.json
+++ b/packages/babel-plugin-syntax-import-defer/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@babel/plugin-syntax-import-defer",
+  "version": "7.22.5",
+  "description": "Allow parsing of the `import defer` syntax in import statement",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/babel/babel.git",
+    "directory": "packages/babel-plugin-syntax-import-defer"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "workspace:^"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+  },
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  },
+  "engines": {
+    "node": ">=6.9.0"
+  },
+  "author": "The Babel Team (https://babel.dev/team)",
+  "conditions": {
+    "BABEL_8_BREAKING": [
+      {
+        "engines": {
+          "node": "^16.20.0 || ^18.16.0 || >=20.0.0"
+        }
+      },
+      {
+        "exports": null
+      }
+    ],
+    "USE_ESM": [
+      {
+        "type": "module"
+      },
+      null
+    ]
+  },
+  "exports": {
+    ".": "./lib/index.js",
+    "./package.json": "./package.json"
+  },
+  "type": "commonjs"
+}

--- a/packages/babel-plugin-syntax-import-defer/src/index.ts
+++ b/packages/babel-plugin-syntax-import-defer/src/index.ts
@@ -1,0 +1,13 @@
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
+  return {
+    name: "syntax-import-defer",
+
+    manipulateOptions(_, parserOpts) {
+      parserOpts.plugins.push("deferredImportEvaluation");
+    },
+  };
+});

--- a/packages/babel-plugin-transform-modules-commonjs/src/hooks.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/hooks.ts
@@ -1,0 +1,60 @@
+import type { types as t, File } from "@babel/core";
+import type { isSideEffectImport } from "@babel/helper-module-transforms";
+
+const commonJSHooksKey =
+  "@babel/plugin-transform-modules-commonjs/customWrapperPlugin";
+
+type SourceMetadata = Parameters<typeof isSideEffectImport>[0];
+
+export interface CommonJSHook {
+  name: string;
+  version: string;
+  wrapReference?(ref: t.Expression, payload: unknown): t.CallExpression | null;
+  buildRequireWrapper?(
+    name: string,
+    init: t.Expression,
+    payload: unknown,
+    referenced: boolean,
+  ): t.Statement | false | null;
+  getWrapperPayload?(
+    source: string,
+    metadata: SourceMetadata,
+    importNodes: t.Node[],
+  ): string | null;
+}
+
+export function defineCommonJSHook(file: File, hook: CommonJSHook) {
+  let hooks = file.get(commonJSHooksKey);
+  if (!hooks) file.set(commonJSHooksKey, (hooks = []));
+  hooks.push(hook);
+}
+
+function findMap<T, U>(arr: T[] | null, cb: (el: T) => U): U | null {
+  if (arr) {
+    for (const el of arr) {
+      const res = cb(el);
+      if (res != null) return res;
+    }
+  }
+}
+
+export function makeInvokers(
+  file: File,
+): Pick<
+  CommonJSHook,
+  "wrapReference" | "getWrapperPayload" | "buildRequireWrapper"
+> {
+  const hooks: CommonJSHook[] | null = file.get(commonJSHooksKey);
+
+  return {
+    getWrapperPayload(...args) {
+      return findMap(hooks, hook => hook.getWrapperPayload?.(...args));
+    },
+    wrapReference(...args) {
+      return findMap(hooks, hook => hook.wrapReference?.(...args));
+    },
+    buildRequireWrapper(...args) {
+      return findMap(hooks, hook => hook.buildRequireWrapper?.(...args));
+    },
+  };
+}

--- a/packages/babel-plugin-transform-modules-commonjs/src/hooks.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/hooks.ts
@@ -6,10 +6,15 @@ const commonJSHooksKey =
 
 type SourceMetadata = Parameters<typeof isSideEffectImport>[0];
 
+// A hook exposes a set of function that can customize how `require()` calls and
+// references to the imported bindings are handled. These functions can either
+// return a result, or return `null` to delegate to the next hook.
 export interface CommonJSHook {
   name: string;
   version: string;
   wrapReference?(ref: t.Expression, payload: unknown): t.CallExpression | null;
+  // Optionally wrap a `require` call. If this function returns `false`, the
+  // `require` call is removed from the generated code.
   buildRequireWrapper?(
     name: string,
     init: t.Expression,

--- a/packages/babel-plugin-transform-modules-commonjs/src/lazy.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/lazy.ts
@@ -1,0 +1,41 @@
+import { template, types as t } from "@babel/core";
+import { isSideEffectImport } from "@babel/helper-module-transforms";
+import type { CommonJSHook } from "./hooks.ts";
+
+type Lazy = boolean | string[] | ((source: string) => boolean);
+
+export const lazyImportsHook = (lazy: Lazy): CommonJSHook => ({
+  name: `${PACKAGE_JSON.name}/lazy`,
+  version: PACKAGE_JSON.version,
+  getWrapperPayload(source, metadata) {
+    if (isSideEffectImport(metadata) || metadata.reexportAll) {
+      return null;
+    }
+    if (lazy === true) {
+      // 'true' means that local relative files are eagerly loaded and
+      // dependency modules are loaded lazily.
+      return /\./.test(source) ? null : "lazy/function";
+    }
+    if (Array.isArray(lazy)) {
+      return lazy.indexOf(source) === -1 ? null : "lazy/function";
+    }
+    if (typeof lazy === "function") {
+      return lazy(source) ? "lazy/function" : null;
+    }
+  },
+  buildRequireWrapper(name, init, payload, referenced) {
+    if (payload === "lazy/function") {
+      if (!referenced) return false;
+      return template.statement.ast`
+        function ${name}() {
+          const data = ${init};
+          ${name} = function(){ return data; };
+          return data;
+        }
+      `;
+    }
+  },
+  wrapReference(ref, payload) {
+    if (payload === "lazy/function") return t.callExpression(ref, []);
+  },
+});

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -135,6 +135,15 @@
       "./helpers/dispose.js"
     ],
     "./helpers/esm/dispose": "./helpers/esm/dispose.js",
+    "./helpers/importDeferProxy": [
+      {
+        "node": "./helpers/importDeferProxy.js",
+        "import": "./helpers/esm/importDeferProxy.js",
+        "default": "./helpers/importDeferProxy.js"
+      },
+      "./helpers/importDeferProxy.js"
+    ],
+    "./helpers/esm/importDeferProxy": "./helpers/esm/importDeferProxy.js",
     "./helpers/iterableToArrayLimit": [
       {
         "node": "./helpers/iterableToArrayLimit.js",

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -134,6 +134,15 @@
       "./helpers/dispose.js"
     ],
     "./helpers/esm/dispose": "./helpers/esm/dispose.js",
+    "./helpers/importDeferProxy": [
+      {
+        "node": "./helpers/importDeferProxy.js",
+        "import": "./helpers/esm/importDeferProxy.js",
+        "default": "./helpers/importDeferProxy.js"
+      },
+      "./helpers/importDeferProxy.js"
+    ],
+    "./helpers/esm/importDeferProxy": "./helpers/esm/importDeferProxy.js",
     "./helpers/iterableToArrayLimit": [
       {
         "node": "./helpers/iterableToArrayLimit.js",

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -134,6 +134,15 @@
       "./helpers/dispose.js"
     ],
     "./helpers/esm/dispose": "./helpers/esm/dispose.js",
+    "./helpers/importDeferProxy": [
+      {
+        "node": "./helpers/importDeferProxy.js",
+        "import": "./helpers/esm/importDeferProxy.js",
+        "default": "./helpers/importDeferProxy.js"
+      },
+      "./helpers/importDeferProxy.js"
+    ],
+    "./helpers/esm/importDeferProxy": "./helpers/esm/importDeferProxy.js",
     "./helpers/iterableToArrayLimit": [
       {
         "node": "./helpers/iterableToArrayLimit.js",

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -20,6 +20,7 @@
     "@babel/plugin-proposal-export-default-from": "workspace:^",
     "@babel/plugin-proposal-function-bind": "workspace:^",
     "@babel/plugin-proposal-function-sent": "workspace:^",
+    "@babel/plugin-proposal-import-defer": "workspace:^",
     "@babel/plugin-proposal-pipeline-operator": "workspace:^",
     "@babel/plugin-proposal-record-and-tuple": "workspace:^",
     "@babel/plugin-proposal-regexp-modifiers": "workspace:^",

--- a/packages/babel-standalone/scripts/pluginConfig.json
+++ b/packages/babel-standalone/scripts/pluginConfig.json
@@ -115,6 +115,7 @@
     "transform-typescript",
     "transform-unicode-escapes",
     "transform-unicode-regex",
-    "proposal-explicit-resource-management"
+    "proposal-explicit-resource-management",
+    "proposal-import-defer"
   ]
 }

--- a/packages/babel-standalone/src/generated/plugins.ts
+++ b/packages/babel-standalone/src/generated/plugins.ts
@@ -100,6 +100,7 @@ import transformTypescript from "@babel/plugin-transform-typescript";
 import transformUnicodeEscapes from "@babel/plugin-transform-unicode-escapes";
 import transformUnicodeRegex from "@babel/plugin-transform-unicode-regex";
 import proposalExplicitResourceManagement from "@babel/plugin-proposal-explicit-resource-management";
+import proposalImportDefer from "@babel/plugin-proposal-import-defer";
 export const syntaxAsyncGenerators = makeNoopPlugin(),
   syntaxClassProperties = makeNoopPlugin(),
   syntaxClassStaticBlock = makeNoopPlugin(),
@@ -205,6 +206,7 @@ export {
   transformUnicodeEscapes,
   transformUnicodeRegex,
   proposalExplicitResourceManagement,
+  proposalImportDefer,
 };
 export const all: { [k: string]: any } = {
   "syntax-async-generators": syntaxAsyncGenerators,
@@ -313,4 +315,5 @@ export const all: { [k: string]: any } = {
   "transform-unicode-escapes": transformUnicodeEscapes,
   "transform-unicode-regex": transformUnicodeRegex,
   "proposal-explicit-resource-management": proposalExplicitResourceManagement,
+  "proposal-import-defer": proposalImportDefer,
 };

--- a/packages/babel-standalone/src/preset-stage-2.ts
+++ b/packages/babel-standalone/src/preset-stage-2.ts
@@ -22,7 +22,6 @@ export default (_: any, opts: any = {}) => {
         babelPlugins.proposalRecordAndTuple,
         { syntaxType: recordAndTupleSyntax },
       ],
-      babelPlugins.proposalImportDefer,
       babelPlugins.syntaxModuleBlocks,
       babelPlugins.syntaxImportReflection,
     ],

--- a/packages/babel-standalone/src/preset-stage-2.ts
+++ b/packages/babel-standalone/src/preset-stage-2.ts
@@ -22,6 +22,7 @@ export default (_: any, opts: any = {}) => {
         babelPlugins.proposalRecordAndTuple,
         { syntaxType: recordAndTupleSyntax },
       ],
+      babelPlugins.proposalImportDefer,
       babelPlugins.syntaxModuleBlocks,
       babelPlugins.syntaxImportReflection,
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,6 +51,7 @@
     "./packages/babel-plugin-proposal-function-bind/src/**/*.ts",
     "./packages/babel-plugin-proposal-function-sent/src/**/*.ts",
     "./packages/babel-plugin-proposal-import-attributes-to-assertions/src/**/*.ts",
+    "./packages/babel-plugin-proposal-import-defer/src/**/*.ts",
     "./packages/babel-plugin-proposal-partial-application/src/**/*.ts",
     "./packages/babel-plugin-proposal-pipeline-operator/src/**/*.ts",
     "./packages/babel-plugin-proposal-record-and-tuple/src/**/*.ts",
@@ -323,6 +324,9 @@
       ],
       "@babel/plugin-proposal-import-attributes-to-assertions": [
         "./packages/babel-plugin-proposal-import-attributes-to-assertions/src"
+      ],
+      "@babel/plugin-proposal-import-defer": [
+        "./packages/babel-plugin-proposal-import-defer/src"
       ],
       "@babel/plugin-proposal-partial-application": [
         "./packages/babel-plugin-proposal-partial-application/src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -68,6 +68,7 @@
     "./packages/babel-plugin-syntax-function-sent/src/**/*.ts",
     "./packages/babel-plugin-syntax-import-assertions/src/**/*.ts",
     "./packages/babel-plugin-syntax-import-attributes/src/**/*.ts",
+    "./packages/babel-plugin-syntax-import-defer/src/**/*.ts",
     "./packages/babel-plugin-syntax-import-reflection/src/**/*.ts",
     "./packages/babel-plugin-syntax-jsx/src/**/*.ts",
     "./packages/babel-plugin-syntax-module-blocks/src/**/*.ts",
@@ -373,6 +374,9 @@
       ],
       "@babel/plugin-syntax-import-attributes": [
         "./packages/babel-plugin-syntax-import-attributes/src"
+      ],
+      "@babel/plugin-syntax-import-defer": [
+        "./packages/babel-plugin-syntax-import-defer/src"
       ],
       "@babel/plugin-syntax-import-reflection": [
         "./packages/babel-plugin-syntax-import-reflection/src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,6 +1562,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@babel/plugin-proposal-import-defer@workspace:packages/babel-plugin-proposal-import-defer":
+  version: 0.0.0-use.local
+  resolution: "@babel/plugin-proposal-import-defer@workspace:packages/babel-plugin-proposal-import-defer"
+  dependencies:
+    "@babel/core": "workspace:^"
+    "@babel/helper-plugin-test-runner": "workspace:^"
+    "@babel/helper-plugin-utils": "workspace:^"
+    "@babel/plugin-syntax-import-defer": "workspace:^"
+    "@babel/plugin-transform-modules-commonjs": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  languageName: unknown
+  linkType: soft
+
 "@babel/plugin-proposal-partial-application@workspace:packages/babel-plugin-proposal-partial-application":
   version: 0.0.0-use.local
   resolution: "@babel/plugin-proposal-partial-application@workspace:packages/babel-plugin-proposal-partial-application"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,7 +1562,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/plugin-proposal-import-defer@workspace:packages/babel-plugin-proposal-import-defer":
+"@babel/plugin-proposal-import-defer@workspace:^, @babel/plugin-proposal-import-defer@workspace:packages/babel-plugin-proposal-import-defer":
   version: 0.0.0-use.local
   resolution: "@babel/plugin-proposal-import-defer@workspace:packages/babel-plugin-proposal-import-defer"
   dependencies:
@@ -4131,6 +4131,7 @@ __metadata:
     "@babel/plugin-proposal-export-default-from": "workspace:^"
     "@babel/plugin-proposal-function-bind": "workspace:^"
     "@babel/plugin-proposal-function-sent": "workspace:^"
+    "@babel/plugin-proposal-import-defer": "workspace:^"
     "@babel/plugin-proposal-pipeline-operator": "workspace:^"
     "@babel/plugin-proposal-record-and-tuple": "workspace:^"
     "@babel/plugin-proposal-regexp-modifiers": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,6 +1911,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@babel/plugin-syntax-import-defer@workspace:^, @babel/plugin-syntax-import-defer@workspace:packages/babel-plugin-syntax-import-defer":
+  version: 0.0.0-use.local
+  resolution: "@babel/plugin-syntax-import-defer@workspace:packages/babel-plugin-syntax-import-defer"
+  dependencies:
+    "@babel/core": "workspace:^"
+    "@babel/helper-plugin-utils": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  languageName: unknown
+  linkType: soft
+
 "@babel/plugin-syntax-import-meta-BABEL_8_BREAKING-false@npm:@babel/plugin-syntax-import-meta@^7.10.4, @babel/plugin-syntax-import-meta@npm:^7.8.3":
   version: 7.10.4
   resolution: "@babel/plugin-syntax-import-meta@npm:7.10.4"


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR implements transform support for the Stage 2 [Deferred Import Evaluation](https://github.com/tc39/proposal-defer-import-eval/) (`import defer`), for which parsing support has been implemented in https://github.com/babel/babel/pull/15845. It is only supported when compiling modules to CommonJS.

This PR can be reviewed commit-by-commit, and after each commit tests&linting were green:
- _[[helper-module-transforms] Support customizing require&reference](https://github.com/babel/babel/commit/f74e48516fcca461444bb4f145fc88af37f8646c)_ allows passing two functions to `@babel/helper-module-transforms` to customize how references to imported modules are transformed:
  - `getWrapperPayload` allow computing some opaque payload given some metadata representing the imported module. This payload is then both used to decide how to transform references to imported bindings, and exposed to callers of this helper package.
  - `wrapReference` allows wrapping the AST node referencing the imported bindings, given the payload computed by the function above.
  
   The implementation of [lazy imports](https://babeljs.io/docs/babel-plugin-transform-modules-commonjs#lazy), supported when compiling ESM to CJS, has been rewritten on top of these two new customization functions and extracted to `packages/babel-helper-module-transforms/src/lazy-modules.ts`, rather than being mixed with the main transform logic.
- _[Support hooks in commonjs plugin, and implement `lazy` as a hook](https://github.com/babel/babel/commit/5a1bf6d457e3e52924da08cfe5f241e775075297)_ allows other plugins to hook into the ESM->CJS transform process. "Hooks" (or "plugins for the plugin" 😅) can provide their own implementation of `getWrapperPayload` and `wrappReference`, as well as a third function:
  - `buildRequireWrapper` allows wrapping the `require()` AST node, given the payload computed by `getWrapperPayload`.
  
   The `lazy` option has been re-implemented on top of use this new "hooks" system, so that it's now entirely contained in `@babel/plugin-transform-modules-commonjs` (which is the only modules transform that supports it) rather than half there and half in `@babel/helper-module-transforms`. `@babel/helper-module-transforms` still needs its own implementation for compatibility with older `@babel/plugin-transform-modules-commonjs` versions, but that code is not used when using newer `@babel/plugin-transform-modules-commonjs` and it can be easily removed in Babel 8.

  Maybe this hooks system could also be used for transforming `import source` when compiling to CJS.
- _[Add @babel/plugin-syntax-import-defer](https://github.com/babel/babel/commit/c089abecc389b5bfc3a35f80e7309a4689018273)_
- _[Implement `import defer` proposal transform support](https://github.com/babel/babel/commit/0e36a0f1e0d2f7a8c216ca091ce66ea192cb21ed)_ implements `import defer` as a hook for `@babel/plugin-transform-modules-commonjs`. This uses an optimized version when possible, by mirroring the `lazy` implementation (i.e. put `require()` in a function and call it when needed to read a property from the module), falling back to a proxy-based version when the module namespace is referenced in other ways. Note that evaluation should only happen when reading the namespace's properties, and not when simply referencing it.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15878"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

