### PR TITLE
Update `jest-light-runner`, enable `source-map-support`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -37,6 +37,8 @@ module.exports = {
     "<rootDir>/packages/babel-core/.*/vendor/.*",
   ],
 
+  setupFiles: ["source-map-support/register"],
+
   // The eslint/* packages is tested against ESLint v8, which has dropped support for Node v10.
   // TODO: Remove this process.version check in Babel 8.
   testRegex: `./(packages|codemods${

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 const semver = require("semver");
-const shell = require("shelljs");
 
 const nodeVersion = process.versions.node;
 const supportsESMAndJestLightRunner = semver.satisfies(
@@ -9,11 +8,6 @@ const supportsESMAndJestLightRunner = semver.satisfies(
   "^12.22 || ^13.7 || >=14.17"
 );
 const isPublishBundle = process.env.IS_PUBLISH;
-
-if (!supportsESMAndJestLightRunner) {
-  //Avoid source maps from breaking stack tests.
-  shell.rm("-rf", "packages/babel-core/lib/**/*.js.map");
-}
 
 module.exports = {
   runner: supportsESMAndJestLightRunner ? "jest-light-runner" : "jest-runner",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "import-meta-resolve": "^3.0.0",
     "is-ci": "^3.0.1",
     "jest": "^29.6.2",
-    "jest-light-runner": "^0.5.0",
+    "jest-light-runner": "^0.5.1",
     "jest-worker": "^29.6.2",
     "lint-staged": "^13.2.3",
     "mergeiterator": "^1.4.4",
@@ -76,6 +76,7 @@
     "rollup-plugin-polyfill-node": "^0.12.0",
     "semver": "^6.3.1",
     "shelljs": "^0.8.5",
+    "source-map-support": "^0.5.21",
     "test262-stream": "^1.4.0",
     "through2": "^4.0.0",
     "typescript": "^5.1.6"

--- a/packages/babel-core/test/errors-stacks.js
+++ b/packages/babel-core/test/errors-stacks.js
@@ -4,6 +4,10 @@ import { commonJS, itGte } from "$repo-utils";
 import path from "path";
 import { spawnSync } from "child_process";
 
+// TODO: This can be removed when we stop using old Jest, since it's also
+// included in the Jest config.
+import "source-map-support/register.js";
+
 const { __dirname } = commonJS(import.meta.url);
 
 const nodeGte12 = itGte("12.0.0");
@@ -86,7 +90,7 @@ describe("@babel/core errors", function () {
     }).toMatchInlineSnapshot(`
       "Error: Error inside config!
           at myConfig (<CWD>/packages/babel-core/test/fixtures/errors/error-config-function/babel.config.js:_:_)
-          at Module.parseSync (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at Module.parseSync (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
           at expectError (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
@@ -104,7 +108,7 @@ describe("@babel/core errors", function () {
           at f (<CWD>/packages/babel-core/test/fixtures/errors/error-config-function-more-frames/babel.config.js:_:_)
           at g (<CWD>/packages/babel-core/test/fixtures/errors/error-config-function-more-frames/babel.config.js:_:_)
           at myConfig (<CWD>/packages/babel-core/test/fixtures/errors/error-config-function-more-frames/babel.config.js:_:_)
-          at Module.parseSync (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at Module.parseSync (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
           at expectError (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
@@ -121,7 +125,7 @@ describe("@babel/core errors", function () {
       "Error: Error inside config!
           at <CWD>/packages/babel-core/test/fixtures/errors/error-config-file/babel.config.js:_:_
           at require (... internal node frames ...)
-          at Module.parseSync (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at Module.parseSync (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
           at expectError (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
@@ -140,7 +144,7 @@ describe("@babel/core errors", function () {
           at g (<CWD>/packages/babel-core/test/fixtures/errors/error-config-file-more-frames/babel.config.js:_:_)
           at <CWD>/packages/babel-core/test/fixtures/errors/error-config-file-more-frames/babel.config.js:_:_
           at require (... internal node frames ...)
-          at Module.parseSync (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at Module.parseSync (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
           at expectError (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
@@ -156,7 +160,7 @@ describe("@babel/core errors", function () {
     }).toMatchInlineSnapshot(`
       "Error: Error while parsing config - JSON5: invalid character '}' at 3:1
           at <CWD>/packages/babel-core/test/fixtures/errors/invalid-json/babel.config.json
-          at Module.parseSync (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at Module.parseSync (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
           at expectError (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
@@ -172,7 +176,7 @@ describe("@babel/core errors", function () {
     }).toMatchInlineSnapshot(`
       "Error: Configuration contains string/RegExp pattern, but no filename was passed to Babel
           at <CWD>/packages/babel-core/test/fixtures/errors/use-exclude/babel.config.js
-          at Module.parseSync (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at Module.parseSync (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
           at expectError (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
@@ -188,7 +192,7 @@ describe("@babel/core errors", function () {
       });
     }).toMatchInlineSnapshot(`
       "Error: Configuration contains string/RegExp pattern, but no filename was passed to Babel
-          at Module.parseSync (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at Module.parseSync (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
           at expectError (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
@@ -207,7 +211,7 @@ describe("@babel/core errors", function () {
       babel.transformSync(code, { filename: 'file.ts', presets: [/* your preset */] });
       \`\`\`
       See https://babeljs.io/docs/en/options#filename for more information.
-          at Module.parseSync (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at Module.parseSync (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
           at expectError (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
@@ -223,7 +227,7 @@ describe("@babel/core errors", function () {
     }).toMatchInlineSnapshot(`
       "Error: .sourceType must be \\"module\\", \\"script\\", \\"unambiguous\\", or undefined
           at <CWD>/packages/babel-core/test/fixtures/errors/invalid-option/babel.config.json
-          at Module.parseSync (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at Module.parseSync (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
           at expectError (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
@@ -239,7 +243,7 @@ describe("@babel/core errors", function () {
       }),
     ).toMatchInlineSnapshot(`
       "Error: .sourceType must be \\"module\\", \\"script\\", \\"unambiguous\\", or undefined
-          at Module.parseSync (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at Module.parseSync (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
           at expectError (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
@@ -263,20 +267,20 @@ describe("@babel/core errors", function () {
     }).toMatchInlineSnapshot(`
       "Error: Internal error! This is a fake bug :)
           at Array.map (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
-          at loadOneConfig (<CWD>/packages/babel-core/lib/config/files/configuration.js:_:_)
+          at loadOneConfig (<CWD>/packages/babel-core/src/config/files/configuration.ts:_:_)
           at loadOneConfig.next (<anonymous>)
-          at buildRootChain (<CWD>/packages/babel-core/lib/config/config-chain.js:_:_)
+          at buildRootChain (<CWD>/packages/babel-core/src/config/config-chain.ts:_:_)
           at buildRootChain.next (<anonymous>)
-          at loadPrivatePartialConfig (<CWD>/packages/babel-core/lib/config/partial.js:_:_)
+          at loadPrivatePartialConfig (<CWD>/packages/babel-core/src/config/partial.ts:_:_)
           at loadPrivatePartialConfig.next (<anonymous>)
-          at loadFullConfig (<CWD>/packages/babel-core/lib/config/full.js:_:_)
+          at loadFullConfig (<CWD>/packages/babel-core/src/config/full.ts:_:_)
           at loadFullConfig.next (<anonymous>)
-          at parse (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at parse (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at parse.next (<anonymous>)
           at evaluateSync (<CWD>/node_modules/gensync/index.js:_:_)
-          at sync (<CWD>/node_modules/gensync/index.js:_:_)
-          at stopHiding - secret - don't use this - v1 (<CWD>/packages/babel-core/lib/errors/rewrite-stack-trace.js:_:_)
-          at Module.parseSync (<CWD>/packages/babel-core/lib/parse.js:_:_)
+          at fn (<CWD>/node_modules/gensync/index.js:_:_)
+          at stopHiding - secret - don't use this - v1 (<CWD>/packages/babel-core/src/errors/rewrite-stack-trace.ts:_:_)
+          at Module.parseSync (<CWD>/packages/babel-core/src/parse.ts:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_
           at expectError (<CWD>/packages/babel-core/test/errors-stacks.js:_:_)
           at <CWD>/packages/babel-core/test/errors-stacks.js:_:_

--- a/packages/babel-core/test/errors-stacks.js
+++ b/packages/babel-core/test/errors-stacks.js
@@ -4,10 +4,6 @@ import { commonJS, itGte } from "$repo-utils";
 import path from "path";
 import { spawnSync } from "child_process";
 
-// TODO: This can be removed when we stop using old Jest, since it's also
-// included in the Jest config.
-import "source-map-support/register.js";
-
 const { __dirname } = commonJS(import.meta.url);
 
 const nodeGte12 = itGte("12.0.0");

--- a/yarn.lock
+++ b/yarn.lock
@@ -6725,7 +6725,7 @@ __metadata:
     import-meta-resolve: ^3.0.0
     is-ci: ^3.0.1
     jest: ^29.6.2
-    jest-light-runner: ^0.5.0
+    jest-light-runner: ^0.5.1
     jest-worker: ^29.6.2
     lint-staged: ^13.2.3
     mergeiterator: ^1.4.4
@@ -6735,6 +6735,7 @@ __metadata:
     rollup-plugin-polyfill-node: ^0.12.0
     semver: ^6.3.1
     shelljs: ^0.8.5
+    source-map-support: ^0.5.21
     test262-stream: ^1.4.0
     through2: ^4.0.0
     typescript: ^5.1.6
@@ -11308,9 +11309,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-light-runner@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "jest-light-runner@npm:0.5.0"
+"jest-light-runner@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "jest-light-runner@npm:0.5.1"
   dependencies:
     "@jest/expect": ^29.0.1
     "@jest/fake-timers": ^29.2.2
@@ -11322,7 +11323,7 @@ __metadata:
     supports-color: ^9.2.1
   peerDependencies:
     jest: ^27.5.0 || ^28.0.0 || ^29.0.0
-  checksum: 9a572e175ccadaaa67073ea6e3caf02c20e937f4e6a1dc7c4f8ccafcbed47b475375694f1f87e980da85af79d120830ff133f73831f294439f3125f9eb5f93a7
+  checksum: ef7ce093835f51396308ce488401fc0cce4fa2f278b0420bf4b2f6bedd469d97264db53f3a5fca3df28ff4f72714782406a0bc425b0fa473e8572bf83b738ed2
   languageName: node
   linkType: hard
 
@@ -14857,7 +14858,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:^0.5.16, source-map-support@npm:~0.5.12, source-map-support@npm:~0.5.20":
+"source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.21, source-map-support@npm:~0.5.12, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

With this change, errors thrown in `lib` while running our tests will point to the original `.ts` files rather than to the compiled `.js` files :)

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15883"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

