### PR TITLE
Fix optional chain optimization in sequence expression

### DIFF
--- a/packages/babel-plugin-transform-optional-chaining/src/transform.ts
+++ b/packages/babel-plugin-transform-optional-chaining/src/transform.ts
@@ -6,6 +6,9 @@ import {
 } from "@babel/helper-skip-transparent-expression-wrappers";
 import { willPathCastToBoolean, findOutermostTransparentParent } from "./util";
 
+// TODO(Babel 9): Use .at(-1)
+const last = <T>(arr: T[]) => arr[arr.length - 1];
+
 function isSimpleMemberExpression(
   expression: t.Expression | t.Super,
 ): expression is t.Identifier | t.Super | t.MemberExpression {
@@ -209,9 +212,10 @@ export function transformOptionalChain(
     !ifNullishBoolean && t.isUnaryExpression(ifNullish, { operator: "void" });
 
   const isEvaluationValueIgnored =
-    (t.isExpressionStatement(replacementPath.parent) ||
-      t.isSequenceExpression(replacementPath.parent)) &&
-    !replacementPath.isCompletionRecord();
+    (t.isExpressionStatement(replacementPath.parent) &&
+      !replacementPath.isCompletionRecord()) ||
+    (t.isSequenceExpression(replacementPath.parent) &&
+      last(replacementPath.parent.expressions) !== replacementPath.node);
 
   // prettier-ignore
   const tpl = ifNullishFalse

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/member-access/output.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/member-access/output.js
@@ -7,5 +7,5 @@ var _foo, _a, _a$b, _a$b$c, _orders, _orders2, _client, _orders$client$key, _a2,
 (_orders2 = orders) === null || _orders2 === void 0 || (_orders2 = _orders2[0]) === null || _orders2 === void 0 || _orders2.price;
 orders[(_client = client) === null || _client === void 0 ? void 0 : _client.key].price;
 (_orders$client$key = orders[client.key]) === null || _orders$client$key === void 0 || _orders$client$key.price;
-(0, (_a2 = a) === null || _a2 === void 0 || _a2.b).c;
+(0, (_a2 = a) === null || _a2 === void 0 ? void 0 : _a2.b).c;
 (0, (_c = (0, (_a3 = a) === null || _a3 === void 0 ? void 0 : _a3.b).c) === null || _c === void 0 ? void 0 : _c.d).e;

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/regression/15887/exec.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/regression/15887/exec.js
@@ -1,0 +1,3 @@
+let a = (0, null?.prop);
+
+expect(a).toBe(undefined);

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/regression/15887/input.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/regression/15887/input.js
@@ -1,0 +1,3 @@
+let a = (null?.prop1, null?.prop2);
+
+expect(a).toBe(undefined);

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/regression/15887/output.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/regression/15887/output.js
@@ -1,0 +1,3 @@
+var _ref, _ref2;
+let a = ((_ref = null) !== null && _ref !== void 0 && _ref.prop1, (_ref2 = null) === null || _ref2 === void 0 ? void 0 : _ref2.prop2);
+expect(a).toBe(undefined);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15887
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The problem is that `isCompletionRecord` in the test code is returning false, because the sequence expression was not in a completion record position.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15888"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

