### PR TITLE
Allow TS tuples to have both labeled and unlabeled elements

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -1050,7 +1050,6 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       // Validate the elementTypes to ensure that no mandatory elements
       // follow optional elements
       let seenOptionalElement = false;
-      let labeledElements: boolean | null = null;
       node.elementTypes.forEach(elementNode => {
         const { type } = elementNode;
 
@@ -1068,21 +1067,6 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         seenOptionalElement ||=
           (type === "TSNamedTupleMember" && elementNode.optional) ||
           type === "TSOptionalType";
-
-        // When checking labels, check the argument of the spread operator
-        let checkType = type;
-        if (type === "TSRestType") {
-          elementNode = elementNode.typeAnnotation;
-          checkType = elementNode.type;
-        }
-
-        const isLabeled = checkType === "TSNamedTupleMember";
-        labeledElements ??= isLabeled;
-        if (labeledElements !== isLabeled) {
-          this.raise(TSErrors.MixedLabeledAndUnlabeledElements, {
-            at: elementNode,
-          });
-        }
       });
 
       return this.finishNode(node, "TSTupleType");

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -164,8 +164,6 @@ const TSErrors = ParseErrorEnum`typescript`({
     "Tuple members must be labeled with a simple identifier.",
   MissingInterfaceName:
     "'interface' declarations must be followed by an identifier.",
-  MixedLabeledAndUnlabeledElements:
-    "Tuple members must all have names or all not have names.",
   NonAbstractClassHasAbstractMethod:
     "Abstract methods can only appear within an abstract class.",
   NonClassMethodPropertyHasAbstractModifer:

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-after-unlabeled/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-after-unlabeled/output.json
@@ -1,9 +1,6 @@
 {
   "type": "File",
   "start":0,"end":19,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":19,"index":19}},
-  "errors": [
-    "SyntaxError: Tuple members must all have names or all not have names. (1:13)"
-  ],
   "program": {
     "type": "Program",
     "start":0,"end":19,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":19,"index":19}},

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-before-unlabeled/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-before-unlabeled/output.json
@@ -1,9 +1,6 @@
 {
   "type": "File",
   "start":0,"end":19,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":19,"index":19}},
-  "errors": [
-    "SyntaxError: Tuple members must all have names or all not have names. (1:16)"
-  ],
   "program": {
     "type": "Program",
     "start":0,"end":19,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":19,"index":19}},

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-unlabeled-spread-after-labeled/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-unlabeled-spread-after-labeled/output.json
@@ -1,9 +1,6 @@
 {
   "type": "File",
   "start":0,"end":22,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":22,"index":22}},
-  "errors": [
-    "SyntaxError: Tuple members must all have names or all not have names. (1:19)"
-  ],
   "program": {
     "type": "Program",
     "start":0,"end":22,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":22,"index":22}},

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-unlabeled-spread-before-labeled/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-unlabeled-spread-before-labeled/output.json
@@ -1,9 +1,6 @@
 {
   "type": "File",
   "start":0,"end":22,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":22,"index":22}},
-  "errors": [
-    "SyntaxError: Tuple members must all have names or all not have names. (1:16)"
-  ],
   "program": {
     "type": "Program",
     "start":0,"end":22,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":22,"index":22}},


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Part of #15894
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15896"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

