### PR TITLE
Remove extra identifier in computed properties transform

### DIFF
--- a/packages/babel-plugin-transform-computed-properties/src/index.ts
+++ b/packages/babel-plugin-transform-computed-properties/src/index.ts
@@ -250,7 +250,9 @@ export default declare((api, options: Options) => {
           if (single) {
             path.replaceWith(single);
           } else {
-            body.push(t.expressionStatement(t.cloneNode(objId)));
+            if (setComputedProperties) {
+              body.push(t.expressionStatement(t.cloneNode(objId)));
+            }
             path.replaceWithMultiple(body);
           }
         },

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/regression/7144/output.mjs
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/regression/7144/output.mjs
@@ -1,2 +1,2 @@
 var _a$c;
-export default (_a$c = {}, babelHelpers.defineProperty(_a$c, a, b), babelHelpers.defineProperty(_a$c, c, d), _a$c);
+export default (_a$c = {}, babelHelpers.defineProperty(_a$c, a, b), babelHelpers.defineProperty(_a$c, c, d));

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/accessors/output.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/accessors/output.js
@@ -7,4 +7,4 @@ var obj = (_obj = {}, babelHelpers.defineAccessor("get", _obj, foobar, function 
   return "regular getter after computed property";
 }), babelHelpers.defineAccessor("set", _obj, "test", function (x) {
   console.log(x);
-}), _obj);
+}));

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/definition-order/output.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/definition-order/output.js
@@ -1,14 +1,14 @@
 var _a, _b, _y;
 var a = (_a = {}, babelHelpers.defineAccessor("get", _a, "x", function () {
   return 0;
-}), babelHelpers.defineProperty(_a, "y", 1), _a);
+}), babelHelpers.defineProperty(_a, "y", 1));
 var b = (_b = {}, babelHelpers.defineAccessor("get", _b, "x", function () {
   return 0;
-}), babelHelpers.defineProperty(_b, "x", 1), _b);
+}), babelHelpers.defineProperty(_b, "x", 1));
 var x = 1;
 var y = (_y = {
   x
 }, babelHelpers.defineAccessor("get", _y, "x", function () {
   return 0;
-}), babelHelpers.defineProperty(_y, "x", x), _y);
+}), babelHelpers.defineProperty(_y, "x", x));
 y.x = 2;

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/method/output.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/method/output.js
@@ -3,4 +3,4 @@ var obj = (_obj = {}, babelHelpers.defineProperty(_obj, foobar, function () {
   return "foobar";
 }), babelHelpers.defineProperty(_obj, "test", function () {
   return "regular method after computed property";
-}), _obj);
+}));

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/mixed/output.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/mixed/output.js
@@ -1,2 +1,2 @@
 var _obj;
-var obj = (_obj = {}, babelHelpers.defineProperty(_obj, "x" + foo, "heh"), babelHelpers.defineProperty(_obj, "y" + bar, "noo"), babelHelpers.defineProperty(_obj, "foo", "foo"), babelHelpers.defineProperty(_obj, "bar", "bar"), _obj);
+var obj = (_obj = {}, babelHelpers.defineProperty(_obj, "x" + foo, "heh"), babelHelpers.defineProperty(_obj, "y" + bar, "noo"), babelHelpers.defineProperty(_obj, "foo", "foo"), babelHelpers.defineProperty(_obj, "bar", "bar"));

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/multiple/output.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/multiple/output.js
@@ -1,2 +1,2 @@
 var _obj;
-var obj = (_obj = {}, babelHelpers.defineProperty(_obj, "x" + foo, "heh"), babelHelpers.defineProperty(_obj, "y" + bar, "noo"), _obj);
+var obj = (_obj = {}, babelHelpers.defineProperty(_obj, "x" + foo, "heh"), babelHelpers.defineProperty(_obj, "y" + bar, "noo"));

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/symbol/output.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/symbol/output.js
@@ -2,4 +2,4 @@ var _foo;
 var k = Symbol();
 var foo = (_foo = {}, babelHelpers.defineProperty(_foo, Symbol.iterator, "foobar"), babelHelpers.defineAccessor("get", _foo, k, function () {
   return k;
-}), _foo);
+}));


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`defineProperty` and `defineAccessor` already return the object.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15904"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

