### PR TITLE
Refine `LetInLexicalBinding` error message

### DIFF
--- a/packages/babel-parser/src/parse-error/standard-errors.ts
+++ b/packages/babel-parser/src/parse-error/standard-errors.ts
@@ -164,8 +164,7 @@ export default {
   InvalidRestAssignmentPattern: "Invalid rest operator's argument.",
   LabelRedeclaration: ({ labelName }: { labelName: string }) =>
     `Label '${labelName}' is already declared.`,
-  LetInLexicalBinding:
-    "'let' is not allowed to be used as a name in 'let' or 'const' declarations.",
+  LetInLexicalBinding: "'let' is disallowed as a lexically bound name.",
   LineTerminatorBeforeArrow: "No line break is allowed before '=>'.",
   MalformedRegExpFlags: "Invalid regular expression flag.",
   MissingClassName: "A class name is required.",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-1/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-1/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":17,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":17,"index":17}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:6)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-10/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-10/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":22,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":22,"index":22}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:7)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:7)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-11/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-11/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":18,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":18,"index":18}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:8)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:8)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-12/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-12/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":20,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":20,"index":20}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:10)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:10)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-2/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-2/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":19,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":19,"index":19}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:8)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:8)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-3/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-3/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":15,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":15,"index":15}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:5)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:5)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-4/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-4/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":17,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":17,"index":17}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:7)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:7)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-5/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-5/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":7,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":7,"index":7}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:4)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:4)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-6/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-6/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:6)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-7/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-7/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":22,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":22,"index":22}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:6)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-8/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-8/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":24,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":24,"index":24}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:8)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:8)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-9/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-9/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":20,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":20,"index":20}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (1:5)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (1:5)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-catch-block/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-catch-block/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":33,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":33}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (2:6)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (2:6)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/async-explicit-resource-management/invalid-using-binding-let/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/async-explicit-resource-management/invalid-using-binding-let/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":47,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":47}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (2:14)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (2:14)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-using-binding-let/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-using-binding-let/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":22,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":22}},
   "errors": [
-    "SyntaxError: 'let' is not allowed to be used as a name in 'let' or 'const' declarations. (2:8)"
+    "SyntaxError: 'let' is disallowed as a lexically bound name. (2:8)"
   ],
   "program": {
     "type": "Program",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Resolves #15905 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we align the error message of `LetInLexicalBinding` to current V8's, so the broader term lexically bound name should cover the case of `"using"` and `"await using"`. I am cool with including the binding keyword in the error message because the binding keyword should be easily noticeable when the error is printed with the code frame. After all, `const let` and `using let` is an edge parser case that won't be triggered that often.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15910"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

