### PR TITLE
Add `rewriteImportExtensions` option to TS preset

### DIFF
--- a/packages/babel-preset-typescript/src/index.ts
+++ b/packages/babel-preset-typescript/src/index.ts
@@ -4,6 +4,7 @@ import syntaxJSX from "@babel/plugin-syntax-jsx";
 import transformModulesCommonJS from "@babel/plugin-transform-modules-commonjs";
 import normalizeOptions from "./normalize-options.ts";
 import type { Options } from "./normalize-options.ts";
+import pluginRewriteTSImports from "./plugin-rewrite-ts-imports.ts";
 
 export default declarePreset((api, opts: Options) => {
   api.assertVersion(7);
@@ -18,6 +19,7 @@ export default declarePreset((api, opts: Options) => {
     jsxPragmaFrag,
     onlyRemoveTypeImports,
     optimizeConstEnums,
+    rewriteImportExtensions,
   } = normalizeOptions(opts);
 
   const pluginOptions = process.env.BABEL_8_BREAKING
@@ -59,6 +61,7 @@ export default declarePreset((api, opts: Options) => {
   const disableExtensionDetect = allExtensions || ignoreExtensions;
 
   return {
+    plugins: rewriteImportExtensions ? [pluginRewriteTSImports] : [],
     overrides: disableExtensionDetect
       ? [{ plugins: getPlugins(isTSX, disallowAmbiguousJSXLike) }]
       : // Only set 'test' if explicitly requested, since it requires that

--- a/packages/babel-preset-typescript/src/normalize-options.ts
+++ b/packages/babel-preset-typescript/src/normalize-options.ts
@@ -10,6 +10,7 @@ export interface Options {
   jsxPragmaFrag?: string;
   onlyRemoveTypeImports?: boolean;
   optimizeConstEnums?: boolean;
+  rewriteImportExtensions?: boolean;
 
   // TODO: Remove in Babel 8
   allExtensions?: boolean;
@@ -19,7 +20,9 @@ export interface Options {
 export default function normalizeOptions(options: Options = {}) {
   let { allowNamespaces = true, jsxPragma, onlyRemoveTypeImports } = options;
 
-  const TopLevelOptions = {
+  const TopLevelOptions: {
+    [Key in keyof Omit<Options, "allowDeclareFields">]-?: Key;
+  } = {
     ignoreExtensions: "ignoreExtensions",
     allowNamespaces: "allowNamespaces",
     disallowAmbiguousJSXLike: "disallowAmbiguousJSXLike",
@@ -27,6 +30,7 @@ export default function normalizeOptions(options: Options = {}) {
     jsxPragmaFrag: "jsxPragmaFrag",
     onlyRemoveTypeImports: "onlyRemoveTypeImports",
     optimizeConstEnums: "optimizeConstEnums",
+    rewriteImportExtensions: "rewriteImportExtensions",
 
     // TODO: Remove in Babel 8
     allExtensions: "allExtensions",
@@ -121,6 +125,12 @@ export default function normalizeOptions(options: Options = {}) {
     false,
   );
 
+  const rewriteImportExtensions = v.validateBooleanOption(
+    TopLevelOptions.rewriteImportExtensions,
+    options.rewriteImportExtensions,
+    false,
+  );
+
   const normalized: Options = {
     ignoreExtensions,
     allowNamespaces,
@@ -129,6 +139,7 @@ export default function normalizeOptions(options: Options = {}) {
     jsxPragmaFrag,
     onlyRemoveTypeImports,
     optimizeConstEnums,
+    rewriteImportExtensions,
   };
   if (!process.env.BABEL_8_BREAKING) {
     normalized.allExtensions = allExtensions;

--- a/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
+++ b/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
@@ -2,18 +2,20 @@ import { declare } from "@babel/helper-plugin-utils";
 import type { types as t } from "@babel/core";
 import type { NodePath } from "@babel/traverse";
 
-export default declare(function () {
+export default declare(function ({ types: t }) {
   return {
+    name: "preset-typescript/plugin-rewrite-ts-imports",
     visitor: {
-      "ImportDeclaration|ExportAllDeclaration|ExportNamedDeclaration"(
-        path: NodePath<
-          | t.ImportDeclaration
-          | t.ExportAllDeclaration
-          | t.ExportNamedDeclaration
-        >,
-      ) {
-        const { source } = path.node;
-        if (source) {
+      "ImportDeclaration|ExportAllDeclaration|ExportNamedDeclaration"({
+        node,
+      }: NodePath<
+        t.ImportDeclaration | t.ExportAllDeclaration | t.ExportNamedDeclaration
+      >) {
+        const { source } = node;
+        const kind = t.isImportDeclaration(node)
+          ? node.importKind
+          : node.exportKind;
+        if (kind === "value" && source && /[\\/]/.test(source.value)) {
           source.value = source.value.replace(/(\.[mc]?)ts$/, "$1js");
         }
       },

--- a/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
+++ b/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
@@ -1,0 +1,22 @@
+import { declare } from "@babel/helper-plugin-utils";
+import type { types as t } from "@babel/core";
+import type { NodePath } from "@babel/traverse";
+
+export default declare(function () {
+  return {
+    visitor: {
+      "ImportDeclaration|ExportAllDeclaration|ExportNamedDeclaration"(
+        path: NodePath<
+          | t.ImportDeclaration
+          | t.ExportAllDeclaration
+          | t.ExportNamedDeclaration
+        >,
+      ) {
+        const { source } = path.node;
+        if (source) {
+          source.value = source.value.replace(/(\.[mc]?)ts$/, "$1js");
+        }
+      },
+    },
+  };
+});

--- a/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/input.ts
+++ b/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/input.ts
@@ -1,0 +1,3 @@
+import "./a.ts";
+import "./a.mts";
+import "./a.cts";

--- a/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/input.ts
+++ b/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/input.ts
@@ -1,3 +1,6 @@
 import "./a.ts";
 import "./a.mts";
 import "./a.cts";
+import "a-package/file.ts";
+// Bare import, it's either a node package or remapped by an import map
+import "soundcloud.ts";

--- a/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/options.json
+++ b/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "presets": [["typescript", { "rewriteImportExtensions": true }]]
+}

--- a/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/output.mjs
+++ b/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/output.mjs
@@ -1,3 +1,6 @@
 import "./a.js";
 import "./a.mjs";
 import "./a.cjs";
+import "a-package/file.js";
+// Bare import, it's either a node package or remapped by an import map
+import "soundcloud.ts";

--- a/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/output.mjs
+++ b/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/output.mjs
@@ -1,0 +1,3 @@
+import "./a.js";
+import "./a.mjs";
+import "./a.cjs";

--- a/packages/babel-preset-typescript/test/normalize-options.skip-bundled.js
+++ b/packages/babel-preset-typescript/test/normalize-options.skip-bundled.js
@@ -48,6 +48,7 @@ describe("normalize options", () => {
           "jsxPragmaFrag": "React.Fragment",
           "onlyRemoveTypeImports": true,
           "optimizeConstEnums": false,
+          "rewriteImportExtensions": false,
         }
       `);
     });

--- a/packages/babel-preset-typescript/test/normalize-options.skip-bundled.js
+++ b/packages/babel-preset-typescript/test/normalize-options.skip-bundled.js
@@ -96,6 +96,7 @@ describe("normalize options", () => {
           "jsxPragmaFrag": "React.Fragment",
           "onlyRemoveTypeImports": undefined,
           "optimizeConstEnums": false,
+          "rewriteImportExtensions": false,
         }
       `);
     });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2825
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR moves the plugin introduced in #15892 to the TS preset, so that our users can use it too (rather than keeping it just for ourselves :P).

How do you feel about doing this? Technically it's a divergence from `tsc` (which never rewrites imports), but it's opt-in behind an option.

It's a quite popular TS feature request (https://github.com/microsoft/TypeScript/issues/55346, https://github.com/microsoft/TypeScript/issues/49083, https://github.com/microsoft/TypeScript/issues/37582, and many others), and now that TS provides the [allowImportingTsExtensions](https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions) option we are in a position of allowing it.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15913"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

