### PR TITLE
Make `ClassDeclaration["id"]` optional in babel-types

### DIFF
--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -789,7 +789,7 @@ export interface ClassExpression extends BaseNode {
 
 export interface ClassDeclaration extends BaseNode {
   type: "ClassDeclaration";
-  id: Identifier;
+  id?: Identifier | null;
   superClass?: Expression | null;
   body: ClassBody;
   decorators?: Array<Decorator> | null;

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -619,7 +619,7 @@ export function classExpression(
   });
 }
 export function classDeclaration(
-  id: t.Identifier,
+  id: t.Identifier | null | undefined = null,
   superClass: t.Expression | null | undefined = null,
   body: t.ClassBody,
   decorators: Array<t.Decorator> | null = null,

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -1378,8 +1378,6 @@ defineType("ClassExpression", {
   fields: {
     id: {
       validate: assertNodeType("Identifier"),
-      // In declarations, this is missing if this is the
-      // child of an ExportDefaultDeclaration.
       optional: true,
     },
     typeParameters: {
@@ -1439,6 +1437,9 @@ defineType("ClassDeclaration", {
   fields: {
     id: {
       validate: assertNodeType("Identifier"),
+      // The id may be omitted if this is the child of an
+      // ExportDefaultDeclaration.
+      optional: true,
     },
     typeParameters: {
       validate: process.env.BABEL_8_BREAKING


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15918
| Patch: Bug Fix?          |  👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When a class is a default export, it is not required to have an identifier, so `parse` correctly outputs a `ClassDeclaration` with its `id` property set to `null` when the identifier is omitted. However, the `ClassDeclaration` type from `@babel/types` does not have an optional `id` property. This results in situations where TypeScript users will be confident that the `id` of a `ClassDeclaration` is non-null when it might not be.

See https://tc39.es/ecma262/2023/multipage/ecmascript-language-functions-and-classes.html#prod-ClassDeclaration

This PR resolves this issue by making `ClassDeclaration["id"]` an optional property.

I also moved and reworded a comment regarding the optional id from the `ClassExpression` definition to the `ClassDeclaration` definition since it made more sense to have it there.

I did not add a test for this as I didn't see many other related tests in this package. If a test is required, please let me know.