### PR TITLE
Only perform config loading re-entrancy check for cjs

### DIFF
--- a/packages/babel-core/test/fixtures/config/config-files/babel-config-mjs-object/babel.config.mjs
+++ b/packages/babel-core/test/fixtures/config/config-files/babel-config-mjs-object/babel.config.mjs
@@ -1,0 +1,3 @@
+export default {
+  plugins: [() => ({})],
+};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15916
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The re-entrancy check was breaking ESM config loading, because given that ESM loading is asynchronous it was possible for two `imports()` to be running at the same time.

Given that re-entrancy problems causing infinite config loading loops can only happen with require hooks, this PR moves the check to only apply to CJS config loading.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15923"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

