### PR TITLE
Do not run flaky cli tests locally by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
         run: |
           make -j test-ci-coverage
           yarn test:esm
+        env:
+          BABEL_CLI_FLAKY_TESTS: true
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
 
@@ -100,6 +102,7 @@ jobs:
         env:
           BABEL_ENV: test
           USE_ESM: true
+          BABEL_CLI_FLAKY_TESTS: trues
 
   build:
     name: Build Babel Artifacts
@@ -247,6 +250,7 @@ jobs:
         run: |
           BABEL_ENV=test node --max-old-space-size=4096 ./node_modules/.bin/jest --ci
         env:
+          BABEL_CLI_FLAKY_TESTS: true
           TEST_FUZZ: "${{ (matrix.node-version == '6' || matrix.node-version == '8' || matrix.node-version == '10') && 'false' || 'true' }}"
       - name: Use Node.js latest # For `yarn version` in post actions of the first actions/setup-node
         if: matrix.node-version == '6' || matrix.node-version == '8' || matrix.node-version == '10'
@@ -327,6 +331,7 @@ jobs:
           BABEL_ENV: test
           BABEL_8_BREAKING: true
           BABEL_TYPES_8_BREAKING: true
+          BABEL_CLI_FLAKY_TESTS: true
 
   test-windows:
     name: Test on Windows
@@ -352,6 +357,7 @@ jobs:
         run: yarn jest --ci
         env:
           BABEL_ENV: test
+          BABEL_CLI_FLAKY_TESTS: true
 
   external-parser-tests:
     name: Third-party Parser Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,6 +219,9 @@ In case you're not able to reproduce an error on CI locally, it may be due to
 
 - Node Version: Travis CI runs the tests against all major node versions. If your tests use JavaScript features unsupported by lower versions of node, then use [minNodeVersion option](#writing-tests) in options.json.
 - Timeout: Check the CI log and if the only errors are timeout errors and you are sure that it's not related to the changes you made, ask someone in the slack channel to trigger rebuild on the CI build and it might be resolved
+- Some `@babel/cli` tests are known to be flaky and thus we do not run them by
+  default locally. You can run them by setting the `BABEL_CLI_FLAKY_TESTS=true`
+  env variable.
 
 In case you're locally getting errors which are not on the CI, it may be due to
 

--- a/packages/babel-cli/test/fixtures/babel/dir --out-dir --watch multiple dir/options.json
+++ b/packages/babel-cli/test/fixtures/babel/dir --out-dir --watch multiple dir/options.json
@@ -2,5 +2,6 @@
   "args": ["*/src", "--out-dir", "../lib", "--relative", "--watch"],
   "noBabelrc": true,
   "noDefaultPlugins": true,
-  "minNodeVersion": 10
+  "minNodeVersion": 10,
+  "flaky": true
 }

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -316,8 +316,13 @@ fs.readdirSync(fixtureLoc).forEach(function (binName) {
       }
 
       const skip =
-        opts.minNodeVersion &&
-        parseInt(process.versions.node, 10) < opts.minNodeVersion;
+        (opts.minNodeVersion &&
+          parseInt(process.versions.node, 10) < opts.minNodeVersion) ||
+        (opts.flaky && !process.env.BABEL_CLI_FLAKY_TESTS);
+
+      if (opts.flaky) {
+        testName += " (flaky)";
+      }
 
       // eslint-disable-next-line jest/valid-title
       (skip ? it.skip : it)(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

There is this very annoying test that fails whenever I run all the tests locally, but not if I run it individually. I'm not the only one affected by this: https://github.com/babel/babel/pull/14599#issuecomment-1138565030

We are trying to run Babel as part of Node.js' smoke tests suite (https://github.com/nodejs/citgm/pull/628), and it triggers this error. Let's disable it by default, and only run it on CI. There is an env flag to run it locally.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15928"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

