### PR TITLE
fix: `__esModule` is missing from published `@babel/parser`

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -509,6 +509,7 @@ function buildRollup(packages, buildStandalone) {
 
         const outputFile = path.join(src, dest, filename || "index.js");
         await bundle.write({
+          esModule: true,
           file: outputFile,
           format,
           name,
@@ -557,6 +558,7 @@ function buildRollup(packages, buildStandalone) {
         await bundle.write({
           file: outputFile.replace(/\.js$/, ".min.js"),
           format,
+          esModule: true,
           interop: "compat",
           name,
           sourcemap: sourcemap,

--- a/packages/babel-parser/src/index.ts
+++ b/packages/babel-parser/src/index.ts
@@ -20,7 +20,6 @@ import {
   tt as internalTokenTypes,
   type InternalTokenTypes,
 } from "./tokenizer/types.ts";
-import "./tokenizer/context.ts";
 
 import type { Expression, File } from "./types.ts";
 

--- a/packages/babel-parser/test/commonjs.bundled.js
+++ b/packages/babel-parser/test/commonjs.bundled.js
@@ -1,0 +1,12 @@
+import { itNoESM, itESM, commonJS } from "$repo-utils";
+
+describe("commonjs bundle", () => {
+  itESM("dummy", () => {});
+
+  itNoESM("has an __esModule export", () => {
+    const { require } = commonJS(import.meta.url);
+
+    // This will require the bundle when running the tests when publishing
+    expect(require("../lib/index.js").__esModule).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/15934 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
ref: https://github.com/babel/babel/pull/15038

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15935"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

