### PR TITLE
[babel 8] Remove `-d`/`-gc` babel-node aliases

### DIFF
--- a/packages/babel-node/src/babel-node.ts
+++ b/packages/babel-node/src/babel-node.ts
@@ -39,13 +39,6 @@ function getNormalizedV8Flag(arg: string) {
   return arg;
 }
 
-// These are aliases for node options defined by babel-node.
-// TODO(Babel 8): Consider removing these
-const aliases = new Map([
-  ["-d", "--debug"],
-  ["-gc", "--expose-gc"],
-]);
-
 getV8Flags(async function (err, v8Flags) {
   if (!process.env.BABEL_8_BREAKING) {
     // The version of v8flags used by Babel 7 uses _, while the one used
@@ -62,11 +55,18 @@ getV8Flags(async function (err, v8Flags) {
     const arg = babelArgs[i];
     const flag = arg.split("=")[0];
 
+    if (!process.env.BABEL_8_BREAKING) {
+      if (flag === "-d") {
+        args.unshift("--debug");
+        continue;
+      } else if (flag === "-gc") {
+        args.unshift("--expose-gc");
+        continue;
+      }
+    }
     if (flag === "-r" || flag === "--require") {
       args.push(flag);
       args.push(babelArgs[++i]);
-    } else if (aliases.has(flag)) {
-      args.unshift(aliases.get(flag));
     } else if (
       flag === "debug" || // node debug foo.js
       flag === "inspect" ||

--- a/packages/babel-node/test/fixtures.js
+++ b/packages/babel-node/test/fixtures.js
@@ -6,6 +6,7 @@ import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
+import { itBabel8, itBabel7 } from "$repo-utils";
 
 const require = createRequire(import.meta.url);
 
@@ -198,7 +199,11 @@ describe("bin/babel-node", function () {
       opts.inFiles["package.json"] = `{ "type": "commonjs" }`;
     }
 
-    // eslint-disable-next-line jest/valid-title
-    it(testName, buildTest(testName, opts), 20000);
+    let run = it;
+    if (typeof opts.BABEL_8_BREAKING === "boolean") {
+      run = opts.BABEL_8_BREAKING ? itBabel8 : itBabel7;
+    }
+
+    run(testName, buildTest(testName, opts), 20000);
   });
 });

--- a/packages/babel-node/test/fixtures/cli/node_-gc_alias_--expose-gc/options.json
+++ b/packages/babel-node/test/fixtures/cli/node_-gc_alias_--expose-gc/options.json
@@ -1,4 +1,5 @@
 {
   "args": ["-gc", "--eval", "console.log(typeof global.gc)"],
-  "stdout": "function"
+  "stdout": "function",
+  "BABEL_8_BREAKING": false
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

These aliases are not defined by Node.js, they were just hard-coded by us.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15956"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

