### PR TITLE
Revert Node.js 20.6.0 bug workaround

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -303,15 +303,6 @@ module.exports = function (api) {
         ].map(normalize),
         plugins: [pluginImportMetaUrl],
       },
-      // See comment in the plugin
-      convertESM && {
-        test: [
-          "./packages/babel-core/src/index.ts",
-          "./packages/babel-types/src/index.ts",
-          "./packages/babel-traverse/src/index.ts",
-        ],
-        plugins: [pluginInjectErrorBugNode_20_6_0],
-      },
       {
         test: sources.map(source => normalize(source.replace("/src", "/test"))),
         plugins: [
@@ -960,48 +951,6 @@ function pluginReplaceNavigator({ template }) {
           );
         }
       },
-    },
-  };
-}
-
-// Workaround for https://github.com/nodejs/node/issues/49497, since
-// Node.js is taking ages to release the fix.
-// This bug only affects CJS packages that are imported from ESM. We only apply
-// it to packages that have cycles in their entrypoint. They can be easily
-// caught by our CI in ESM mode on Node.js 20.6.0:
-// - @babel/core
-// - @babel/types
-// - @babel/traverse
-//
-// We will remove this workaround after one week that Node.js 20.6.1 has been
-// released, so that all CIs using `node:latest` will be using the new version.
-function pluginInjectErrorBugNode_20_6_0({ template }) {
-  const flag = "___internal__alreadyRunning";
-
-  return {
-    post({ path }) {
-      path.unshiftContainer(
-        "body",
-        // We use `"${flag}" + ""` so that the Node.js ESM-CJS
-        // integration does not detect it as an export.
-        template.statement.ast`
-          if (typeof process === "object" && process.version === "v20.6.0") {
-            if (exports["${flag}" + ""]) return;
-            Object.defineProperty(exports, "${flag}", {
-              value: true,
-              enumerable: false,
-              configurable: true,
-            });
-          }
-        `
-      );
-      path.pushContainer(
-        "body",
-        template.statement.ast`
-          if (typeof process === "object" && process.version === "v20.6.0")
-            delete exports["${flag}" + ""];
-          `
-      );
     },
   };
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes https://github.com/babel/babel/issues/15964, closes https://github.com/babel/babel/issues/15960, closes https://github.com/babel/babel/issues/15958
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The 20.6.0 bug was fixed in 20.6.1, released 5 days ago. In addition to that, 20.7.0 is scheduled to be released today (https://github.com/nodejs/Release/issues/855).

It should be safe to remove the workaround now, given that users can upgrade to 20.6.1 or 20.7.0. The workaround, while temporarily solved the huge breakage in the ecosystem, is now causing problems with multiple tools that are not configured to properly support CommonJS (i.e. they are parsing our released files as modules or as classic scripts without top-level return support).

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15965"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

