### PR TITLE
update compat-table to d5e9c83b96b23f15318e6b2dc3f5bf51314aa340

### DIFF
--- a/.github/workflows/update-compat-data.yml
+++ b/.github/workflows/update-compat-data.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Update tests (Babel 8)
         if: steps.updated.outputs.updated == 'true'
         continue-on-error: true
-        run: yarn jest
+        run: |
+          make use-esm
+          yarn jest
         env:
           OVERWRITE: true
           BABEL_8_BREAKING: true

--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -4,6 +4,7 @@
     "opera": "98",
     "edge": "112",
     "firefox": "116",
+    "safari": "tp",
     "node": "20",
     "deno": "1.32",
     "opera_mobile": "75",

--- a/packages/babel-compat-data/scripts/data/plugin-features.js
+++ b/packages/babel-compat-data/scripts/data/plugin-features.js
@@ -138,7 +138,7 @@ const es2018 = {
   "transform-object-rest-spread": "object rest/spread properties",
 
   "transform-dotall-regex": "s (dotAll) flag for regular expressions",
-  "transform-unicode-property-regex": "RegExp Unicode Property Escapes",
+  "transform-unicode-property-regex": "RegExp Unicode Property Escapes / basic",
   "transform-named-capturing-groups-regex": "RegExp named capture groups",
 };
 
@@ -175,7 +175,14 @@ const es2022 = {
 };
 
 const es2024 = {
-  "transform-unicode-sets-regex": "RegExp `v` flag",
+  "transform-unicode-sets-regex": {
+    features: [
+      "RegExp `v` flag / set notations",
+      "RegExp `v` flag / properties of Strings",
+      "RegExp `v` flag / constructor supports it",
+      "RegExp `v` flag / shows up in flags",
+    ],
+  },
 };
 
 const shippedProposal = {};

--- a/packages/babel-compat-data/scripts/download-compat-table.sh
+++ b/packages/babel-compat-data/scripts/download-compat-table.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-COMPAT_TABLE_COMMIT=61b6d112578c21827e702360553424b4effabdaa
+COMPAT_TABLE_COMMIT=d5e9c83b96b23f15318e6b2dc3f5bf51314aa340
 GIT_HEAD=build/compat-table/.git/HEAD
 
 if [ -d "build/compat-table" ]; then

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-babel-7/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-babel-7/stdout.txt
@@ -17,7 +17,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios < 16.4, node < 16.11, opera < 80, safari < 16.4, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes-babel-7/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes-babel-7/stdout.txt
@@ -17,7 +17,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios < 16.4, node < 16.11, opera < 80, safari < 16.4, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules-no-bugfixes/stdout.txt
@@ -17,7 +17,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios < 16.4, node < 16.11, opera < 80, safari < 16.4, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }
@@ -42,6 +42,5 @@ Using plugins:
   transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios < 14.5, opera < 60, safari < 14.1, samsung < 11.0 }
   transform-modules-commonjs
   transform-dynamic-import
-  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/_esmodules/stdout.txt
@@ -17,7 +17,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios < 16.4, node < 16.11, opera < 80, safari < 16.4, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }
@@ -44,6 +44,5 @@ Using plugins:
   bugfix/transform-tagged-template-caching { ios < 13, safari < 13 }
   transform-modules-commonjs
   transform-dynamic-import
-  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10-no-bugfixes/stdout.txt
@@ -8,7 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { safari }
+  transform-unicode-sets-regex { safari < tp }
   transform-class-static-block { safari < 16.4 }
   transform-private-property-in-object { safari < 15 }
   transform-class-properties { safari < 14.1 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-10/stdout.txt
@@ -8,7 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { safari }
+  transform-unicode-sets-regex { safari < tp }
   transform-class-static-block { safari < 16.4 }
   transform-private-property-in-object { safari < 15 }
   transform-class-properties { safari < 14.1 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-11/stdout.txt
@@ -8,7 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { safari }
+  transform-unicode-sets-regex { safari < tp }
   transform-class-static-block { safari < 16.4 }
   transform-private-property-in-object { safari < 15 }
   transform-class-properties { safari < 14.1 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-block-scoping-safari-9/stdout.txt
@@ -8,7 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { safari }
+  transform-unicode-sets-regex { safari < tp }
   transform-class-static-block { safari < 16.4 }
   transform-private-property-in-object { safari < 15 }
   transform-class-properties { safari < 14.1 }

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15-no-bugfixes/stdout.txt
@@ -8,7 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { safari }
+  transform-unicode-sets-regex { safari < tp }
   transform-class-static-block { safari < 16.4 }
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15/stdout.txt
@@ -8,7 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { safari }
+  transform-unicode-sets-regex { safari < tp }
   transform-class-static-block { safari < 16.4 }
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -17,7 +17,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios < 16.4, node < 16.11, opera < 80, safari < 16.4, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -17,7 +17,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios < 16.4, node < 16.11, opera < 80, safari < 16.4, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }
@@ -42,8 +42,6 @@ Using plugins:
   bugfix/transform-safari-for-shadowing { ios < 11, safari < 11 }
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios < 16.3, safari < 16.3 }
   bugfix/transform-tagged-template-caching { ios < 13, safari < 13 }
-  syntax-dynamic-import
-  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -17,7 +17,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios < 16.4, node < 16.11, opera < 80, safari < 16.4, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -17,7 +17,7 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
-  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios, node < 20, opera < 98, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios < 16.4, node < 16.11, opera < 80, safari < 16.4, samsung < 17 }
   transform-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
   transform-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }
@@ -42,8 +42,6 @@ Using plugins:
   bugfix/transform-safari-for-shadowing { ios < 11, safari < 11 }
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios < 16.3, safari < 16.3 }
   bugfix/transform-tagged-template-caching { ios < 13, safari < 13 }
-  syntax-dynamic-import
-  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
@@ -16,7 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { ios < 16.4, safari < 16.4 }
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
@@ -16,7 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { ios < 16.4, safari < 16.4 }
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
@@ -16,7 +16,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { firefox < 116, ios, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { firefox < 116, ios, opera_mobile < 75, safari < tp, samsung }
   syntax-class-static-block
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-specific-targets/stdout.txt
@@ -13,7 +13,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, edge < 112, firefox < 116, ie, ios, safari }
+  transform-unicode-sets-regex { chrome < 112, edge < 112, firefox < 116, ie, ios, safari < tp }
   transform-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios < 16.4, safari < 16.4 }
   transform-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
   transform-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 14.5, safari < 14.1 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-specific-targets/stdout.txt
@@ -13,7 +13,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, edge < 112, firefox < 116, ie, ios, safari }
+  transform-unicode-sets-regex { chrome < 112, edge < 112, firefox < 116, ie, ios, safari < tp }
   transform-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios < 16.4, safari < 16.4 }
   transform-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
   transform-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 14.5, safari < 14.1 }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -16,21 +16,11 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { ios < 16.4, safari < 16.4 }
-  syntax-private-property-in-object
-  syntax-class-properties
-  syntax-numeric-separator
-  syntax-nullish-coalescing-operator
-  syntax-optional-chaining
-  syntax-json-strings
-  syntax-optional-catch-binding
-  syntax-async-generators
-  syntax-object-rest-spread
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios < 16.3, safari < 16.3 }
   transform-modules-commonjs
   transform-dynamic-import
   transform-export-namespace-from { }
-  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -16,21 +16,11 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile < 75, safari, samsung }
+  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios, opera_mobile < 75, safari < tp, samsung }
   transform-class-static-block { ios < 16.4, safari < 16.4 }
-  syntax-private-property-in-object
-  syntax-class-properties
-  syntax-numeric-separator
-  syntax-nullish-coalescing-operator
-  syntax-optional-chaining
-  syntax-json-strings
-  syntax-optional-catch-binding
-  syntax-async-generators
-  syntax-object-rest-spread
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios < 16.3, safari < 16.3 }
   transform-modules-commonjs
   transform-dynamic-import
   transform-export-namespace-from { }
-  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -16,20 +16,9 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { firefox < 116, ios, opera_mobile < 75, safari, samsung }
-  syntax-class-static-block
-  syntax-private-property-in-object
-  syntax-class-properties
-  syntax-numeric-separator
-  syntax-nullish-coalescing-operator
-  syntax-optional-chaining
-  syntax-json-strings
-  syntax-optional-catch-binding
-  syntax-async-generators
-  syntax-object-rest-spread
+  transform-unicode-sets-regex { firefox < 116, ios, opera_mobile < 75, safari < tp, samsung }
   transform-modules-commonjs
   transform-dynamic-import
   transform-export-namespace-from { }
-  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -13,7 +13,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, edge < 112, firefox < 116, ie, ios, safari }
+  transform-unicode-sets-regex { chrome < 112, edge < 112, firefox < 116, ie, ios, safari < tp }
   transform-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios < 16.4, safari < 16.4 }
   transform-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
   transform-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 14.5, safari < 14.1 }
@@ -55,7 +55,6 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios < 14.5, safari < 14.1 }
   transform-modules-commonjs
   transform-dynamic-import
-  syntax-import-meta
 corejs2: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
@@ -13,7 +13,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { chrome < 112, edge < 112, firefox < 116, ie, ios, safari }
+  transform-unicode-sets-regex { chrome < 112, edge < 112, firefox < 116, ie, ios, safari < tp }
   transform-class-static-block { chrome < 94, edge < 94, firefox < 93, ie, ios < 16.4, safari < 16.4 }
   transform-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ie, ios < 15, safari < 15 }
   transform-class-properties { chrome < 74, edge < 79, firefox < 90, ie, ios < 14.5, safari < 14.1 }
@@ -55,7 +55,6 @@ Using plugins:
   transform-export-namespace-from { chrome < 72, edge < 79, firefox < 80, ie, ios < 14.5, safari < 14.1 }
   transform-modules-commonjs
   transform-dynamic-import
-  syntax-import-meta
 corejs3: `DEBUG` option
 
 Using targets: {

--- a/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options-babel-7/safari-10_3-block-scoped/stdout.txt
@@ -8,7 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { safari }
+  transform-unicode-sets-regex { safari < tp }
   transform-class-static-block { safari < 16.4 }
   transform-private-property-in-object { safari < 15 }
   transform-class-properties { safari < 14.1 }

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
@@ -8,7 +8,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-unicode-sets-regex { safari }
+  transform-unicode-sets-regex { safari < tp }
   transform-class-static-block { safari < 16.4 }
   transform-private-property-in-object { safari < 15 }
   transform-class-properties { safari < 14.1 }
@@ -34,6 +34,5 @@ Using plugins:
   bugfix/transform-tagged-template-caching { safari < 13 }
   transform-modules-commonjs
   transform-dynamic-import
-  syntax-import-meta
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | update compat-table to d5e9c83b96b23f15318e6b2dc3f5bf51314aa340
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Updated the compat-data scripts. We can discuss how to use the Unicode versions compat data in our regexp transforms later.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15970"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

