### PR TITLE
Do not look for `.babelrc`/`.browserslistrc` in our config

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -429,9 +429,8 @@ function buildRollup(packages, buildStandalone) {
             }),
             rollupBabel({
               envName,
-              babelrc: false,
               babelHelpers: "bundled",
-              extends: "./babel.config.js",
+              configFile: "./babel.config.js",
               extensions: [".ts", ".js", ".mjs", ".cjs"],
               ignore: ["packages/babel-runtime/helpers/*.js"],
             }),

--- a/babel.config.js
+++ b/babel.config.js
@@ -165,6 +165,8 @@ module.exports = function (api) {
   const config = {
     targets,
     assumptions,
+    babelrc: false,
+    browserslistConfigFile: false,
 
     // Our dependencies are all standard CommonJS, along with all sorts of
     // other random files in Babel's codebase, so we use script as the default,

--- a/scripts/integration-tests/e2e-babel-old-version.sh
+++ b/scripts/integration-tests/e2e-babel-old-version.sh
@@ -41,7 +41,6 @@ node -e "
 node -e "
   var config = fs.readFileSync('./babel.config.js', 'utf8')
     .replace(/browserslistConfigFile:[^,]*,/g, '')
-    .replace(/assumptions,/, '')
     .replace(/targets,/g, '')
     .replace(/assumptions,/g, '')
     .replace(/assumptions:[^,]*,/g, '')

--- a/scripts/integration-tests/e2e-babel-old-version.sh
+++ b/scripts/integration-tests/e2e-babel-old-version.sh
@@ -36,10 +36,11 @@ node -e "
   fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2));
 "
 
-# Older @babel/core versions don't support "targets" and "assumptions"
-# Let's just remove them when running this e2e test.
+# Older @babel/core versions don't support "browserslistConfigFile", "targets".
+# and "assumptions". Let's just remove them when running this e2e test.
 node -e "
   var config = fs.readFileSync('./babel.config.js', 'utf8')
+    .replace(/browserslistConfigFile:[^,]*,/g, '')
     .replace(/assumptions,/, '')
     .replace(/targets,/g, '')
     .replace(/assumptions,/g, '')


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

With this change, the total time spent running `transformAsync` in [our build script](https://github.com/babel/babel/blob/feef4b1c2f4666e91d612273cd7bfdc2ca3df5b6/babel-worker.cjs#L35) goes down from 10.364s to 8.784s (note: these are the sums of the time in each thread).

Related: https://github.com/babel/babel/issues/15975

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15976"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

