### PR TITLE
Remove nullish check from `api.caller`

### DIFF
--- a/packages/babel-core/src/config/helpers/config-api.ts
+++ b/packages/babel-core/src/config/helpers/config-api.ts
@@ -20,9 +20,14 @@ type EnvFunction = {
   (envVars: Array<string>): boolean;
 };
 
-type CallerFactory = (
-  extractor: (callerMetadata: CallerMetadata | undefined) => unknown,
-) => SimpleType;
+type CallerFactory = {
+  <T extends SimpleType>(
+    extractor: (callerMetadata: CallerMetadata | undefined) => T,
+  ): T;
+  (
+    extractor: (callerMetadata: CallerMetadata | undefined) => unknown,
+  ): SimpleType;
+};
 type TargetsFunction = () => Targets;
 type AssumptionFunction = (name: AssumptionName) => boolean | undefined;
 

--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -355,7 +355,7 @@ option \`forceAllTransforms: true\` instead.
 
   const compatData = getPluginList(shippedProposals, bugfixes);
   const shouldSkipExportNamespaceFrom =
-    (modules === "auto" && api.caller?.(supportsExportNamespaceFrom)) ||
+    (modules === "auto" && api.caller(supportsExportNamespaceFrom)) ||
     (modules === false &&
       !isRequired("transform-export-namespace-from", transformTargets, {
         compatData,
@@ -365,11 +365,9 @@ option \`forceAllTransforms: true\` instead.
   const modulesPluginNames = getModulesPluginNames({
     modules,
     transformations: moduleTransformations,
-    // TODO: Remove the 'api.caller' check eventually. Just here to prevent
-    // unnecessary breakage in the short term for users on older betas/RCs.
-    shouldTransformESM: modules !== "auto" || !api.caller?.(supportsStaticESM),
+    shouldTransformESM: modules !== "auto" || !api.caller(supportsStaticESM),
     shouldTransformDynamicImport:
-      modules !== "auto" || !api.caller?.(supportsDynamicImport),
+      modules !== "auto" || !api.caller(supportsDynamicImport),
     shouldTransformExportNamespaceFrom: !shouldSkipExportNamespaceFrom,
   });
 

--- a/packages/babel-preset-env/src/module-transformations.ts
+++ b/packages/babel-preset-env/src/module-transformations.ts
@@ -1,7 +1,6 @@
 type AvailablePlugins = typeof import("./available-plugins").default;
 
 export default {
-  auto: "transform-modules-commonjs",
   amd: "transform-modules-amd",
   commonjs: "transform-modules-commonjs",
   cjs: "transform-modules-commonjs",

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15-no-bugfixes/stdout.txt
@@ -22,7 +22,7 @@ Using plugins:
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { safari < 16.3 }
   transform-modules-commonjs
   transform-dynamic-import
-  transform-export-namespace-from { }
+  syntax-export-namespace-from
   syntax-top-level-await
   syntax-import-meta
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15/stdout.txt
@@ -22,7 +22,7 @@ Using plugins:
   syntax-object-rest-spread
   transform-modules-commonjs
   transform-dynamic-import
-  transform-export-namespace-from { }
+  syntax-export-namespace-from
   syntax-top-level-await
   syntax-import-meta
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/stdout.txt
@@ -21,7 +21,7 @@ Using plugins:
   syntax-object-rest-spread
   transform-modules-commonjs
   transform-dynamic-import
-  transform-export-namespace-from { }
+  syntax-export-namespace-from
   syntax-top-level-await
   syntax-import-meta
 

--- a/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/stdout.txt
@@ -22,7 +22,7 @@ Using plugins:
   bugfix/transform-v8-spread-parameters-in-optional-chaining { chrome < 91 }
   transform-modules-commonjs
   transform-dynamic-import
-  transform-export-namespace-from { }
+  syntax-export-namespace-from
   syntax-top-level-await
   syntax-import-meta
 

--- a/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -40,6 +40,7 @@ Using plugins:
   transform-unicode-regex { ios < 12, safari < 12 }
   transform-block-scoping { ios < 11, safari < 11 }
   transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios < 14.5, opera < 60, safari < 14.1, samsung < 11.0 }
+  syntax-dynamic-import
   syntax-top-level-await
   syntax-import-meta
 corejs2: `DEBUG` option

--- a/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3-babel-7/usage-browserslist-config-ignore/stdout.txt
@@ -40,6 +40,7 @@ Using plugins:
   transform-unicode-regex { ios < 12, safari < 12 }
   transform-block-scoping { ios < 11, safari < 11 }
   transform-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios < 14.5, opera < 60, safari < 14.1, samsung < 11.0 }
+  syntax-dynamic-import
   syntax-top-level-await
   syntax-import-meta
 corejs3: `DEBUG` option

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
@@ -30,7 +30,7 @@ Using plugins:
   syntax-object-rest-spread
   transform-modules-commonjs
   transform-dynamic-import
-  transform-export-namespace-from { }
+  syntax-export-namespace-from
   syntax-top-level-await
   syntax-import-meta
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
@@ -30,7 +30,7 @@ Using plugins:
   syntax-object-rest-spread
   transform-modules-commonjs
   transform-dynamic-import
-  transform-export-namespace-from { }
+  syntax-export-namespace-from
   syntax-top-level-await
   syntax-import-meta
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
@@ -29,7 +29,7 @@ Using plugins:
   syntax-object-rest-spread
   transform-modules-commonjs
   transform-dynamic-import
-  transform-export-namespace-from { }
+  syntax-export-namespace-from
   syntax-top-level-await
   syntax-import-meta
 

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-force-all-transforms/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-property-literals { }
   transform-reserved-words { }
   transform-export-namespace-from { chrome < 72 }
+  syntax-dynamic-import
   syntax-top-level-await
   syntax-import-meta
 corejs2: `DEBUG` option

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-force-all-transforms/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-property-literals { }
   transform-reserved-words { }
   transform-export-namespace-from { chrome < 72 }
+  syntax-dynamic-import
   syntax-top-level-await
   syntax-import-meta
 corejs3: `DEBUG` option

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-no-corejs-uglify/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-property-literals { }
   transform-reserved-words { }
   transform-export-namespace-from { chrome < 72 }
+  syntax-dynamic-import
   syntax-top-level-await
   syntax-import-meta
 corejs2: `DEBUG` option

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-80/stdout.txt
@@ -23,7 +23,7 @@ Using plugins:
   syntax-object-rest-spread
   transform-modules-commonjs
   transform-dynamic-import
-  transform-export-namespace-from { }
+  syntax-export-namespace-from
   syntax-top-level-await
   syntax-import-meta
   syntax-import-attributes

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/shippedProposals-chrome-84/stdout.txt
@@ -22,7 +22,7 @@ Using plugins:
   syntax-object-rest-spread
   transform-modules-commonjs
   transform-dynamic-import
-  transform-export-namespace-from { }
+  syntax-export-namespace-from
   syntax-top-level-await
   syntax-import-meta
   syntax-import-attributes

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/top-level-targets/stdout.txt
@@ -23,7 +23,7 @@ Using plugins:
   syntax-object-rest-spread
   transform-modules-commonjs
   transform-dynamic-import
-  transform-export-namespace-from { }
+  syntax-export-namespace-from
   syntax-top-level-await
   syntax-import-meta
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
@@ -51,6 +51,7 @@ Using plugins:
   transform-property-literals { }
   transform-reserved-words { }
   transform-export-namespace-from { chrome < 72 }
+  syntax-dynamic-import
   syntax-top-level-await
   syntax-import-meta
 corejs2: `DEBUG` option


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Every Babel 7 version provides `api.caller`. This was only needed during the beta period.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15986"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

