### PR TITLE
Remove nullish check from `api.caller`

### DIFF
--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -355,7 +355,7 @@ option \`forceAllTransforms: true\` instead.
 
   const compatData = getPluginList(shippedProposals, bugfixes);
   const shouldSkipExportNamespaceFrom =
-    (modules === "auto" && api.caller?.(supportsExportNamespaceFrom)) ||
+    (modules === "auto" && api.caller(supportsExportNamespaceFrom)) ||
     (modules === false &&
       !isRequired("transform-export-namespace-from", transformTargets, {
         compatData,
@@ -365,11 +365,9 @@ option \`forceAllTransforms: true\` instead.
   const modulesPluginNames = getModulesPluginNames({
     modules,
     transformations: moduleTransformations,
-    // TODO: Remove the 'api.caller' check eventually. Just here to prevent
-    // unnecessary breakage in the short term for users on older betas/RCs.
-    shouldTransformESM: modules !== "auto" || !api.caller?.(supportsStaticESM),
+    shouldTransformESM: modules !== "auto" || !api.caller(supportsStaticESM),
     shouldTransformDynamicImport:
-      modules !== "auto" || !api.caller?.(supportsDynamicImport),
+      modules !== "auto" || !api.caller(supportsDynamicImport),
     shouldTransformExportNamespaceFrom: !shouldSkipExportNamespaceFrom,
   });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Every Babel 7 version provides `api.caller`. This was only needed during the beta period.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/15987"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

