### PR TITLE
Fix: fallback to typeof when toString is applied to incompatible object

### DIFF
--- a/packages/babel-helpers/src/helpers.ts
+++ b/packages/babel-helpers/src/helpers.ts
@@ -314,7 +314,12 @@ helpers.construct = helper("7.0.0-beta.0")`
 helpers.isNativeFunction = helper("7.0.0-beta.0")`
   export default function _isNativeFunction(fn) {
     // Note: This function returns "true" for core-js functions.
-    return Function.toString.call(fn).indexOf("[native code]") !== -1;
+    try {
+      return Function.toString.call(fn).indexOf("[native code]") !== -1;
+    } catch (e) {
+      // Firefox 31 throws when "toString" is applied to an HTMLElement
+      return typeof fn === "function";
+    }
   }
 `;
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12609
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Firefox 31 will throw when `toString` is applied to an HTMLElement. Here we handle the error as suggested in https://github.com/babel/babel/issues/12609#issuecomment-808823218.