### PR TITLE
Rewrite `.tsx` extension when using `rewriteImportExtensions`

### DIFF
--- a/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
+++ b/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
@@ -16,7 +16,9 @@ export default declare(function ({ types: t }) {
           ? node.importKind
           : node.exportKind;
         if (kind === "value" && source && /[\\/]/.test(source.value)) {
-          source.value = source.value.replace(/(\.[mc]?)tsx?$/, "$1js");
+          source.value = source.value
+            .replace(/(\.[mc]?)ts$/, "$1js")
+            .replace(/\.tsx$/, ".js");
         }
       },
     },

--- a/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
+++ b/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
@@ -16,7 +16,7 @@ export default declare(function ({ types: t }) {
           ? node.importKind
           : node.exportKind;
         if (kind === "value" && source && /[\\/]/.test(source.value)) {
-          source.value = source.value.replace(/(\.[mc]?)ts$/, "$1js");
+          source.value = source.value.replace(/(\.[mc]?)tsx?$/, "$1js");
         }
       },
     },

--- a/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/input.ts
+++ b/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/input.ts
@@ -1,6 +1,7 @@
 import "./a.ts";
 import "./a.mts";
 import "./a.cts";
+import "./react.tsx";
 import "a-package/file.ts";
 // Bare import, it's either a node package or remapped by an import map
 import "soundcloud.ts";

--- a/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/input.ts
+++ b/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/input.ts
@@ -2,6 +2,9 @@ import "./a.ts";
 import "./a.mts";
 import "./a.cts";
 import "./react.tsx";
+// .mtsx and .ctsx are not valid and should not be transformed.
+import "./react.mtsx";
+import "./react.ctsx";
 import "a-package/file.ts";
 // Bare import, it's either a node package or remapped by an import map
 import "soundcloud.ts";

--- a/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/output.mjs
+++ b/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/output.mjs
@@ -1,6 +1,7 @@
 import "./a.js";
 import "./a.mjs";
 import "./a.cjs";
+import "./react.js";
 import "a-package/file.js";
 // Bare import, it's either a node package or remapped by an import map
 import "soundcloud.ts";

--- a/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/output.mjs
+++ b/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/output.mjs
@@ -2,6 +2,9 @@ import "./a.js";
 import "./a.mjs";
 import "./a.cjs";
 import "./react.js";
+// .mtsx and .ctsx are not valid and should not be transformed.
+import "./react.mtsx";
+import "./react.ctsx";
 import "a-package/file.js";
 // Bare import, it's either a node package or remapped by an import map
 import "soundcloud.ts";


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16021
| Patch: Bug Fix?          | Not sure
| Major: Breaking Change?  | Not sure
| Minor: New Feature?      |  Not sure
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Include `.tsx` in the file extensions which are rewritten when using `rewriteImportExtensions` option of the TS preset.
