### PR TITLE
enable allowAutomaticSingleRunInference option

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,7 @@ module.exports = [
         languageOptions: {
           parser: parserTypeScriptESLint,
           parserOptions: {
+            allowAutomaticSingleRunInference: true,
             project: "./tsconfig.eslint.json",
           },
         },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Per https://typescript-eslint.io/packages/typescript-estree/#parsing

> ESLint (and therefore typescript-eslint) is used in both "single run"/one-time contexts,
> such as an ESLint CLI invocation, and long-running sessions (such as continuous feedback
> on a file in an IDE).
> 
> When typescript-eslint handles TypeScript Program management behind the scenes, this distinction
> is important because there is significant overhead to managing the so called Watch Programs
> needed for the long-running use-case.
> 
> When allowAutomaticSingleRunInference is enabled, we will use common heuristics to infer
> whether or not ESLint is being used as part of a single run.

we enable the `allowAutomaticSingleRunInference` option so that the linter job is slightly faster (80s vs 70s in my local environment).

When compared with [the main branch](https://github.com/babel/babel/actions/runs/6464370319/job/17548925446), the lint step time is reduced from 3m42s to 2m21s.

Currently it takes around 10% of time to setup the TS program, 70% to query type info for the given AST node via `ts.getTypeOfNode`, and the remaining 20% for linter rule logics. So TS is the bottleneck of our linter runtime.