### PR TITLE
fix Babel types docs workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,9 +301,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: babel-types.md
-          path: docs/types.md
       - name: Commit Babel website changes
         run: |
+          mv babel-types.md docs/types.md
           git config user.name "Babel Bot"
           git config user.email "babel-bot@users.noreply.github.com"
           git checkout -b update-types-docs


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The babel types docs workflow is still failing in our recent release: https://github.com/babel/babel/actions/runs/6486436409/job/17615646144
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The `download-artifact` workflow does not support renaming the artifacts, so we have to download it to the working directory and move it to the destination. Hopefully the docs update should work in our next release.