### PR TITLE
Avoid dynamic dispatch when calling wrapCheck

### DIFF
--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -334,7 +334,7 @@ function wrapCheck(nodeType: VIRTUAL_TYPES, fn: Function) {
   const fnKey = `is${nodeType}`;
   const validator = virtualTypesValidators[fnKey];
   const newFn = function (this: unknown, path: NodePath) {
-    if (validator.call(path) {
+    if (validator.call(path)) {
       return fn.apply(this, arguments);
     }
   };

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -1,4 +1,5 @@
 import * as virtualTypes from "./path/lib/virtual-types.ts";
+import * as virtualTypesValidators from "./path/lib/virtual-types-validator.ts"
 import type { Node } from "@babel/types";
 import {
   DEPRECATED_KEYS,
@@ -330,9 +331,10 @@ function ensureCallbackArrays(obj: Visitor) {
 }
 
 function wrapCheck(nodeType: VIRTUAL_TYPES, fn: Function) {
+  const fnKey = `is${nodeType}`;
+  const validator = virtualTypesValidators[fnKey];
   const newFn = function (this: unknown, path: NodePath) {
-    // @ts-expect-error: Expression produces a union type that is too complex to represent.
-    if (path[`is${nodeType}`]()) {
+    if (validator.call(path) {
       return fn.apply(this, arguments);
     }
   };

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -1,5 +1,5 @@
 import * as virtualTypes from "./path/lib/virtual-types.ts";
-import * as virtualTypesValidators from "./path/lib/virtual-types-validator.ts"
+import * as virtualTypesValidators from "./path/lib/virtual-types-validator.ts";
 import type { Node } from "@babel/types";
 import {
   DEPRECATED_KEYS,

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -332,6 +332,7 @@ function ensureCallbackArrays(obj: Visitor) {
 
 function wrapCheck(nodeType: VIRTUAL_TYPES, fn: Function) {
   const fnKey = `is${nodeType}`;
+  // @ts-expect-error we know virtualTypesValidators will contain `fnKey`, but TS doesn't
   const validator = virtualTypesValidators[fnKey];
   const newFn = function (this: unknown, path: NodePath) {
     if (validator.call(path)) {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Micro-optimization to avoid dynamic function dispatch in wrapCheck, which is in the hot path of babel transforms. The current code interpolates a string and looks up a function at runtime during every visitor function invocation, whereas this PR looks up the function once while building the visitor and just calls it during visitor function invocation. 

I couldn't find any docs on babel benchmarking, so I used swc's benchmark and modified it to only run babel. Here are the before/after results:

Before:
```
[es3] Running single thread benchmarks
babel (preset-env) x 149 ops/sec ±2.92% (79 runs sampled)
[es3] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es5] Running single thread benchmarks
babel (preset-env) x 159 ops/sec ±2.71% (83 runs sampled)
[es5] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2015] Running single thread benchmarks
babel (preset-env) x 162 ops/sec ±2.29% (76 runs sampled)
[es2015] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2016] Running single thread benchmarks
babel (preset-env) x 163 ops/sec ±2.24% (77 runs sampled)
[es2016] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2017] Running single thread benchmarks
babel (preset-env) x 162 ops/sec ±2.77% (84 runs sampled)
[es2017] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2018] Running single thread benchmarks
babel (preset-env) x 162 ops/sec ±2.78% (84 runs sampled)
[es2018] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2019] Running single thread benchmarks
babel (preset-env) x 161 ops/sec ±2.56% (84 runs sampled)
[es2019] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2020] Running single thread benchmarks
babel (preset-env) x 163 ops/sec ±2.25% (84 runs sampled)
[es2020] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
```

After:
```
[es3] Running single thread benchmarks
babel (preset-env) x 160 ops/sec ±3.17% (83 runs sampled)
[es3] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es5] Running single thread benchmarks
babel (preset-env) x 169 ops/sec ±2.78% (79 runs sampled)
[es5] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2015] Running single thread benchmarks
babel (preset-env) x 171 ops/sec ±2.28% (81 runs sampled)
[es2015] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2016] Running single thread benchmarks
babel (preset-env) x 170 ops/sec ±2.96% (81 runs sampled)
[es2016] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2017] Running single thread benchmarks
babel (preset-env) x 171 ops/sec ±2.88% (81 runs sampled)
[es2017] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2018] Running single thread benchmarks
babel (preset-env) x 173 ops/sec ±2.61% (82 runs sampled)
[es2018] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2019] Running single thread benchmarks
babel (preset-env) x 173 ops/sec ±2.37% (81 runs sampled)
[es2019] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
[es2020] Running single thread benchmarks
babel (preset-env) x 171 ops/sec ±2.53% (81 runs sampled)
[es2020] Transform rxjs/Observable.ts benchmark bench suite: Fastest is babel (preset-env)
```

It's roughly a 5-6% improvement. 